### PR TITLE
Travis Boost: C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 env:
   global:
     - BUILD: ~/buildTmp
-    - CXXFLAGS: "-Wall -Wextra -Woverloaded-virtual -Wshadow"
+    - CXXFLAGS: "-std=c++11 -Wall -Wextra -Woverloaded-virtual -Wshadow"
     - SPACK_ROOT: $HOME/.cache/spack
     - PATH: $PATH:$HOME/.cache/spack/bin
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 #
 # TODO: LEGACY! Use CMake TOOLCHAINS instead!
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,memory,undefined")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,memory,undefined")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables -Wno-padded -Wno-switch-enum -Wno-undefined-func-template")
     #Silence BOOST_TEST

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE(structure_test)
 
     BOOST_TEST(o.IOHandler);
     BOOST_TEST(o.iterations.IOHandler);
-    BOOST_TEST(o.parent == nullptr);
+    BOOST_TEST(!o.parent);
     BOOST_TEST(o.iterations.parent == static_cast< Writable* >(&o));
 
     Iteration i = o.iterations[1];

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(git_hdf5_sample_structure_test)
     Series o = Series::read("samples/git-sample/",
                             "data00000100.h5");
 
-    BOOST_TEST(o.parent == nullptr);
+    BOOST_TEST(!o.parent);
     BOOST_TEST(o.iterations.parent == static_cast< Writable* >(&o));
     BOOST_TEST(o.iterations[100].parent == static_cast< Writable* >(&o.iterations));
     BOOST_TEST(o.iterations[100].meshes.parent == static_cast< Writable* >(&o.iterations[100]));


### PR DESCRIPTION
Trigger the boost build with C++11 flags.
Avoids issues with older versions of boost and older (C++98-default) compilers.

Also fixes that `-fsanitize=address` and `-fsanitize=memory` can not be enabled at the same time in clang 5.0.

Also fixes two `BOOST_TEST(something == nullptr);` compares, which are not allowed:
https://stackoverflow.com/questions/37673724/boost-test-check-whether-a-pointer-is-null

Tests are still broken (fail or segfault).