### PR TITLE
Simplify Series APIs.

### DIFF
--- a/include/Series.hpp
+++ b/include/Series.hpp
@@ -40,29 +40,10 @@
 class Series : public Attributable
 {
 public:
-    /** Detailed constructor for series of iterations.
-     *
-     * @param path  Directory of the data, relative(!) to the current working directory.
-     * @param name  Pattern for file names. Should include iteration regex %T if iterationEncoding is filesBased.
-     * @param ie    <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series">iterationEncoding</A> of multiple iterations in this series.
-     * @param f     File format and IO backend to use for this series.
-     * @param at    Access permissions for every file in this series.
-     */
-    static Series create(std::string const& path,
-                         std::string const& name,
-                         IterationEncoding ie,
-                         Format f,
+    static Series create(std::string const& filepath,
                          AccessType at = AccessType::CREATE);
-    /** Convenience constructor for read-only data.
-     *
-     * @param path      Directory of the data, relative(!) to the current working directory.
-     * @param name      Concrete name of one file in series (fileBased series will be loaded according to iterationFormat). Must include file extension.
-     * @param parallel  Flag indicating whether this series should be read with an MPI-compatible backend. If <CODE>true</CODE>, <CODE>MPI_init()</CODE> must be called before.
-     */
-    static Series read(std::string const& path,
-                       std::string const& name,
-                       bool readonly = true,
-                       bool parallel = false);
+    static Series read(std::string const& filepath,
+                       AccessType at = AccessType::READ_ONLY);
     ~Series();
 
     /**
@@ -214,17 +195,8 @@ public:
 
 private:
     // TODO replace entirely with factory
-    Series(std::string const& path,
-           std::string const& name,
-           IterationEncoding ie,
-           Format f,
+    Series(std::string const& filepath,
            AccessType at);
-
-    // TODO replace entirely with factory
-    Series(std::string path,
-           std::string const& name,
-           bool readonly,
-           bool parallel);
 
     void flushFileBased();
     void flushGroupBased();

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -372,7 +372,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     using namespace boost::filesystem;
     path dir(m_handler->directory);
     if( !exists(dir) )
-        throw std::runtime_error("Supplied directory is not valid");
+        throw no_such_file_error("Supplied directory is not valid");
 
     std::string name = m_handler->directory + parameters.at("name").get< std::string >();
     if( !ends_with(name, ".h5") )

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -67,11 +67,7 @@ BOOST_AUTO_TEST_CASE(attribute_dtype_test)
 BOOST_AUTO_TEST_CASE(output_default_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "new_openpmd_output_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./new_openpmd_output_%T.dummy");
 
     BOOST_TEST(o.openPMD() == "1.0.1");
     BOOST_TEST(o.openPMDextension() == static_cast<uint32_t>(0));
@@ -90,11 +86,7 @@ BOOST_AUTO_TEST_CASE(output_default_test)
 BOOST_AUTO_TEST_CASE(output_constructor_test)
 {
     using IE = IterationEncoding;
-    Series o1 = Series::create("./",
-                               "MyOutput_%T",
-                               IE::fileBased,
-                               Format::DUMMY,
-                               AccessType::CREATE);
+    Series o1 = Series::create("./MyOutput_%T.dummy");
 
     BOOST_TEST(o1.openPMD() == "1.0.1");
     BOOST_TEST(o1.openPMDextension() == static_cast<uint32_t>(0));
@@ -109,11 +101,7 @@ BOOST_AUTO_TEST_CASE(output_constructor_test)
 
     o1.iterations[0];
 
-    Series o2 = Series::create("./",
-                               "MyCustomOutput",
-                               IE::groupBased,
-                               Format::DUMMY,
-                               AccessType::CREATE);
+    Series o2 = Series::create("./MyCustomOutput.dummy");
 
     o2.setMeshesPath("customMeshesPath").setParticlesPath("customParticlesPath");
 
@@ -132,11 +120,7 @@ BOOST_AUTO_TEST_CASE(output_constructor_test)
 BOOST_AUTO_TEST_CASE(output_modification_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     o.setOpenPMD("1.0.0");
     BOOST_TEST(o.openPMD() == "1.0.0");
@@ -162,11 +146,7 @@ BOOST_AUTO_TEST_CASE(output_modification_test)
 BOOST_AUTO_TEST_CASE(iteration_default_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     Iteration& i = o.iterations[42];
 
@@ -181,11 +161,7 @@ BOOST_AUTO_TEST_CASE(iteration_default_test)
 BOOST_AUTO_TEST_CASE(iteration_modification_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     Iteration& i = o.iterations[42];
 
@@ -204,11 +180,7 @@ BOOST_AUTO_TEST_CASE(iteration_modification_test)
 BOOST_AUTO_TEST_CASE(particleSpecies_modification_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     auto& particles = o.iterations[42].particles;
     BOOST_TEST(0 == particles.numAttributes());
@@ -247,11 +219,7 @@ BOOST_AUTO_TEST_CASE(particleSpecies_modification_test)
 BOOST_AUTO_TEST_CASE(record_constructor_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     Record& r = o.iterations[42].particles["species"]["record"];
 
@@ -270,11 +238,7 @@ BOOST_AUTO_TEST_CASE(record_constructor_test)
 BOOST_AUTO_TEST_CASE(record_modification_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     Record& r = o.iterations[42].particles["species"]["record"];
 
@@ -299,11 +263,7 @@ BOOST_AUTO_TEST_CASE(record_modification_test)
 BOOST_AUTO_TEST_CASE(recordComponent_modification_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     Record& r = o.iterations[42].particles["species"]["record"];
 
@@ -322,11 +282,7 @@ BOOST_AUTO_TEST_CASE(recordComponent_modification_test)
 BOOST_AUTO_TEST_CASE(mesh_constructor_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     Mesh &m = o.iterations[42].meshes["E"];
 
@@ -355,11 +311,7 @@ BOOST_AUTO_TEST_CASE(mesh_constructor_test)
 BOOST_AUTO_TEST_CASE(mesh_modification_test)
 {
     using IE = IterationEncoding;
-    Series o = Series::create("./",
-                              "MyOutput_%T",
-                              IE::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./MyOutput_%T.dummy");
 
     Mesh &m = o.iterations[42].meshes["E"];
     m["x"];
@@ -398,11 +350,7 @@ BOOST_AUTO_TEST_CASE(mesh_modification_test)
 
 BOOST_AUTO_TEST_CASE(structure_test)
 {
-    Series o = Series::create("./",
-                              "new_openpmd_output_%T",
-                              IterationEncoding::fileBased,
-                              Format::DUMMY,
-                              AccessType::CREATE);
+    Series o = Series::create("./new_openpmd_output_%T.dummy");
 
     BOOST_TEST(o.IOHandler);
     BOOST_TEST(o.iterations.IOHandler);

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -35,9 +35,7 @@ BOOST_AUTO_TEST_CASE(git_hdf5_sample_content_test)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
     /* only a 3x3x3 chunk of the actual data is hardcoded. every worker reads 1/3 */
     uint64_t rank = mpi_rank % 3;
-    Series o = Series::read("samples/git-sample/",
-                            "data00000%T.h5",
-                            true);
+    Series o = Series::read("../samples/git-sample/data00000%T.h5");
 
 
     {
@@ -86,11 +84,7 @@ BOOST_AUTO_TEST_CASE(hdf5_write_test)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_r);
     uint64_t mpi_size = static_cast<uint64_t>(mpi_s);
     uint64_t mpi_rank = static_cast<uint64_t>(mpi_r);
-    Series o = Series::create("samples",
-                              "parallel_write",
-                              IterationEncoding::groupBased,
-                              Format::PARALLEL_HDF5,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/parallel_write.h5");
 
     o.setAuthor("Parallel HDF5");
     ParticleSpecies& e = o.iterations[1].particles["e"];
@@ -119,10 +113,6 @@ BOOST_AUTO_TEST_CASE(hdf5_write_test)
 #ifdef LIBOPENPMD_WITH_PARALLEL_ADIOS1
 BOOST_AUTO_TEST_CASE(adios_wrtie_test)
 {
-    Output o = Output("../samples",
-                      "parallel_write",
-                      IterationEncoding::groupBased,
-                      Format::PARALLEL_ADIOS,
-                      AccessType::CREATE);
+    Output o = Output("../samples/"parallel_write.bp");
 }
 #endif

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -10,8 +10,7 @@
 #ifdef LIBOPENPMD_WITH_HDF5
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_structure_test)
 {
-    Series o = Series::read("samples/git-sample/",
-                            "data00000100.h5");
+    Series o = Series::read("../samples/git-sample/data00000100.h5");
 
     BOOST_TEST(!o.parent);
     BOOST_TEST(o.iterations.parent == static_cast< Writable* >(&o));
@@ -47,8 +46,7 @@ BOOST_AUTO_TEST_CASE(git_hdf5_sample_structure_test)
 
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_attribute_test)
 {
-    Series o = Series::read("samples/git-sample/",
-                            "data00000100.h5");
+    Series o = Series::read("../samples/git-sample/data00000100.h5");
 
     BOOST_TEST(o.openPMD() == "1.0.0");
     BOOST_TEST(o.openPMDextension() == 1);
@@ -290,8 +288,7 @@ BOOST_AUTO_TEST_CASE(git_hdf5_sample_attribute_test)
 
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_content_test)
 {
-    Series o = Series::read("samples/git-sample/",
-                            "data00000100.h5");
+    Series o = Series::read("../samples/git-sample/data00000100.h5");
 
     {
         double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
@@ -334,8 +331,7 @@ BOOST_AUTO_TEST_CASE(git_hdf5_sample_content_test)
 
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_fileBased_read_test)
 {
-    Series o = Series::read("samples/git-sample/",
-                            "data%T.h5");
+    Series o = Series::read("../samples/git-sample/data%T.h5");
 
     BOOST_TEST(o.iterations.size() == 5);
     BOOST_TEST(o.iterations.count(100) == 1);
@@ -351,8 +347,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
     try
     {
         /* development/huebl/lwfa-openPMD-062-smallLWFA-h5 */
-        Series o = Series::read("samples/hzdr-sample/",
-                                "simData_0.h5");
+        Series o = Series::read("../samples/hzdr-sample/simData_0.h5");
 
         BOOST_TEST(o.openPMD() == "1.0.0");
         BOOST_TEST(o.openPMDextension() == 1);
@@ -672,8 +667,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(e_weighting_scalar.getDimensionality() == 1);
     } catch (no_such_file_error& e)
     {
-        std::cerr << e.what() << '\n';
-        std::cerr << "HZDR sample not accessible.\n";
+        std::cerr << "HZDR sample not accessible. (" << e.what() << ")\n";
         return;
     }
 }
@@ -681,11 +675,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
 BOOST_AUTO_TEST_CASE(hdf5_dtype_test)
 {
     {
-        Series s = Series::create("samples",
-                                  "dtype_test",
-                                  IterationEncoding::groupBased,
-                                  Format::HDF5,
-                                  AccessType::CREATE);
+        Series s = Series::create("../samples/dtype_test.h5");
 
         char c = 'c';
         s.setAttribute("char", c);
@@ -725,8 +715,7 @@ BOOST_AUTO_TEST_CASE(hdf5_dtype_test)
         s.setAttribute("vecString", std::vector< std::string >({"vector", "of", "strings"}));
     }
     
-    Series s = Series::read("samples",
-                            "dtype_test.h5");
+    Series s = Series::read("../samples/dtype_test.h5");
 
     BOOST_TEST(s.getAttribute("char").get< char >() == 'c');
     BOOST_TEST(s.getAttribute("uchar").get< unsigned char >() == 'u');
@@ -756,11 +745,7 @@ BOOST_AUTO_TEST_CASE(hdf5_dtype_test)
 
 BOOST_AUTO_TEST_CASE(hdf5_write_test)
 {
-    Series o = Series::create("samples",
-                              "serial_write",
-                              IterationEncoding::groupBased,
-                              Format::HDF5,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/serial_write.h5");
 
     o.setAuthor("Serial HDF5");
     ParticleSpecies& e = o.iterations[1].particles["e"];
@@ -798,11 +783,7 @@ BOOST_AUTO_TEST_CASE(hdf5_write_test)
 
 BOOST_AUTO_TEST_CASE(hdf5_fileBased_write_test)
 {
-    Series o = Series::create("samples",
-                              "serial_fileBased_write%T",
-                              IterationEncoding::fileBased,
-                              Format::HDF5,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/serial_fileBased_write%T.h5");
 
     ParticleSpecies& e_1 = o.iterations[1].particles["e"];
 
@@ -889,33 +870,21 @@ BOOST_AUTO_TEST_CASE(hdf5_fileBased_write_test)
 
 BOOST_AUTO_TEST_CASE(hdf5_bool_test)
 {
-    Series o = Series::create("samples",
-                              "serial_bool",
-                              IterationEncoding::groupBased,
-                              Format::HDF5,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/serial_bool.h5");
 
     o.setAttribute("Bool attribute", true);
 }
 
 BOOST_AUTO_TEST_CASE(hdf5_patch_test)
 {
-    Series o = Series::create("samples",
-                              "serial_patch",
-                              IterationEncoding::groupBased,
-                              Format::HDF5,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/serial_patch.h5");
 
     o.iterations[1].particles["e"].particlePatches["offset"]["x"].setUnitSI(42);
 }
 
 BOOST_AUTO_TEST_CASE(hdf5_deletion_test)
 {
-    Series o = Series::create("samples",
-                              "serial_deletion",
-                              IterationEncoding::groupBased,
-                              Format::HDF5,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/serial_deletion.h5");
 
 
     o.setAttribute("removed",

--- a/writer.cpp
+++ b/writer.cpp
@@ -7,11 +7,7 @@
 void
 write()
 {
-    Series o = Series::create("../samples",
-                              "serial_write.h5",
-                              IterationEncoding::groupBased,
-                              Format::HDF5,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/serial_write.h5");
 
     ParticleSpecies& e = o.iterations[1].particles["e"];
 
@@ -47,11 +43,7 @@ write()
 void
 write2()
 {
-    Series f = Series::create("./working/directory/",
-                              "2D_simData",
-                              IterationEncoding::groupBased,
-                              Format::HDF5,
-                              AccessType::CREATE);
+    Series f = Series::create("./working/directory/2D_simData.h5");
 
     // all required openPMD attributes will be set to reasonable default values (all ones, all zeros, empty strings,...)
     // manually setting them enforces the openPMD standard
@@ -205,11 +197,7 @@ write2()
 void
 w()
 {
-    Series o = Series::create("../samples",
-                              "serial_write%T",
-                              IterationEncoding::groupBased,
-                              Format::ADIOS,
-                              AccessType::CREATE);
+    Series o = Series::create("../samples/serial_write_%T.h5");
 }
 
 int


### PR DESCRIPTION
User now only supplies a string encoding previously included variables plus an optional AccessType.
Now you can focus on what you want your output to look like rather than what the API expects.