### PR TITLE
Split the library into serial and parallel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,11 +103,11 @@ script:
   - mkdir -p $HOME/build 
   - cd $HOME/build
   - if [ ! -d samples/git-sample/ ]; then
-       mkdir -p samples/git-sample/
-       wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz
-       tar -xf example-3d.tar.gz
-       cp example-3d/hdf5/* samples/git-sample/
-       chmod 777 samples/
+       mkdir -p samples/git-sample/ &&
+       wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz &&
+       tar -xf example-3d.tar.gz &&
+       cp example-3d/hdf5/* samples/git-sample/ &&
+       chmod 777 samples/ &&
        rm -rf example-3d.* example-3d;
     fi
   - CXXFLAGS=$CXXFLAGS CXX=$CXX CC=$CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,19 +99,17 @@ install:
     fi
   - spack clean -a
 
-before_script:
-  - if [ ! -d samples/git-sample/ ]; then \
-       mkdir -p samples/git-sample/; \
-       wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz; \
-       tar -xf example-3d.tar.gz; \
-       cp example-3d/hdf5/* samples/git-sample/; \
-       chmod 777 samples/; \
-       rm -rf example-3d.* example-3d; \
-    fi
-
 script:
   - mkdir -p $HOME/build 
   - cd $HOME/build
+  - if [ ! -d samples/git-sample/ ]; then
+       mkdir -p samples/git-sample/
+       wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz
+       tar -xf example-3d.tar.gz
+       cp example-3d/hdf5/* samples/git-sample/
+       chmod 777 samples/
+       rm -rf example-3d.* example-3d;
+    fi
   - CXXFLAGS=$CXXFLAGS CXX=$CXX CC=$CC
     cmake
       -DCMAKE_BUILD_TYPE=Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,13 +102,11 @@ install:
 before_script:
   - if [ ! -d samples/git-sample/ ]; then \
        mkdir -p samples/git-sample/; \
-       cd samples/git-sample/; \
        wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz; \
        tar -xf example-3d.tar.gz; \
        cp example-3d/hdf5/* samples/git-sample/; \
        chmod 777 samples/; \
        rm -rf example-3d.* example-3d; \
-       cd ../.. \
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,18 @@ install:
     fi
   - spack clean -a
 
+before_script:
+  - if [ ! -d samples/git-sample/ ]; then \
+       mkdir -p samples/git-sample/; \
+       cd samples/git-sample/; \
+       wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz; \
+       tar -xf example-3d.tar.gz; \
+       cp example-3d/hdf5/* samples/git-sample/; \
+       chmod 777 samples/; \
+       rm -rf example-3d.* example-3d; \
+       cd ../.. \
+    fi
+
 script:
   - mkdir -p $HOME/build 
   - cd $HOME/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-disabled-macro-expansion -Wno-c++98-compat-pedantic -Wno-global-constructors -Wno-conversion")
     #Silence HDF5
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reserved-id-macro -Wno-deprecated -Wno-old-style-cast")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cpp")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+    #silence BOOST filesystem
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cpp")
 endif ()
 
 
@@ -221,29 +224,26 @@ if(openPMD_HAVE_MPI)
     target_link_libraries(openPMD.core PUBLIC MPI::MPI_C MPI::MPI_CXX)
     target_link_libraries(openPMD.io PUBLIC MPI::MPI_C MPI::MPI_CXX)
 
-    target_compile_definitions(openPMD.core PUBLIC "-DopenPMD_HAVE_MPI=ON")
-    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_MPI=ON")
-else()
-    target_compile_definitions(openPMD.core PUBLIC "-D_NOMPI=ON")
-    target_compile_definitions(openPMD.io PUBLIC "-D_NOMPI=ON")
+    target_compile_definitions(openPMD.core PUBLIC "-DopenPMD_HAVE_MPI=1")
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_MPI=1")
 endif()
 
 if(openPMD_HAVE_HDF5)
     target_link_libraries(openPMD.io PUBLIC ${HDF5_LIBRARIES})
     target_include_directories(openPMD.io SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
     target_compile_definitions(openPMD.io PUBLIC ${HDF5_DEFINITIONS})
-    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_HDF5=ON")
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_HDF5=1")
 endif()
 
 if(openPMD_HAVE_ADIOS1)
     target_link_libraries(openPMD.io PUBLIC ${ADIOS_LIBRARIES})
     target_include_directories(openPMD.io SYSTEM PUBLIC ${ADIOS_INCLUDE_DIRS})
-    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_ADIOS1=ON")
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_ADIOS1=1")
 endif()
 
 if(openPMD_HAVE_ADIOS2)
     target_link_libraries(openPMD.io PUBLIC ADIOS2::ADIOS2)
-    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_ADIOS2=ON")
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_ADIOS2=1")
 endif()
 
 # tests
@@ -261,21 +261,21 @@ set(openPMD_EXAMPLE_NAMES
 foreach(testname ${openPMD_TEST_NAMES})
     add_executable(${testname}Tests test/${testname}Test.cpp)
     if(openPMD_HAVE_MPI)
-        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_MPI=ON")
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_MPI=1")
     else()
-        target_compile_definitions(${testname}Tests PUBLIC "-D_NOMPI=ON")
+        target_compile_definitions(${testname}Tests PUBLIC "-D_NOMPI=1")
     endif()
 
     if(openPMD_HAVE_HDF5)
-        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_HDF5=ON")
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_HDF5=1")
     endif()
 
     if(openPMD_HAVE_ADIOS1)
-        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS1=ON")
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS1=1")
     endif()
 
     if(openPMD_HAVE_ADIOS2)
-        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS2=ON")
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS2=1")
     endif()
     target_link_libraries(${testname}Tests PRIVATE openPMD.core openPMD.io)
     if(TARGET Boost::unit_test_framework)
@@ -347,14 +347,14 @@ endif()
 set(MPI_TEST_EXE
     ${MPIEXEC_EXECUTABLE}
     ${MPI_ALLOW_ROOT}
-    ${MPIEXEC_NUMPROC_FLAG} 4
+    ${MPIEXEC_NUMPROC_FLAG} 2
 )
 
 foreach(testname ${openPMD_TEST_NAMES})
     if(${testname} MATCHES "^Parallel.*$")
         if(openPMD_HAVE_MPI)
             add_test(NAME MPI.${testname}
-                COMMAND ${MPI_TEST_EXE} --oversubscribe ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
+                COMMAND ${MPI_TEST_EXE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,8 +221,8 @@ if(openPMD_HAVE_MPI)
     target_link_libraries(openPMD.core PUBLIC MPI::MPI_C MPI::MPI_CXX)
     target_link_libraries(openPMD.io PUBLIC MPI::MPI_C MPI::MPI_CXX)
 
-    target_compile_definitions(openPMD.core PUBLIC "-DLIBOPENPMD_WITH_MPI=ON")
-    target_compile_definitions(openPMD.io PUBLIC "-DLIBOPENPMD_WITH_MPI=ON")
+    target_compile_definitions(openPMD.core PUBLIC "-DopenPMD_HAVE_MPI=ON")
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_MPI=ON")
 else()
     target_compile_definitions(openPMD.core PUBLIC "-D_NOMPI=ON")
     target_compile_definitions(openPMD.io PUBLIC "-D_NOMPI=ON")
@@ -232,30 +232,18 @@ if(openPMD_HAVE_HDF5)
     target_link_libraries(openPMD.io PUBLIC ${HDF5_LIBRARIES})
     target_include_directories(openPMD.io SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
     target_compile_definitions(openPMD.io PUBLIC ${HDF5_DEFINITIONS})
-    target_compile_definitions(openPMD.io PUBLIC "-DLIBOPENPMD_WITH_HDF5=ON")
-    if(openPMD_HAVE_MPI)
-        # TODO: remove and just rely on "WITH_MPI"
-        target_compile_definitions(openPMD.io PUBLIC "-DLIBOPENPMD_WITH_PARALLEL_HDF5=ON")
-    endif()
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_HDF5=ON")
 endif()
 
 if(openPMD_HAVE_ADIOS1)
     target_link_libraries(openPMD.io PUBLIC ${ADIOS_LIBRARIES})
     target_include_directories(openPMD.io SYSTEM PUBLIC ${ADIOS_INCLUDE_DIRS})
-    target_compile_definitions(openPMD.io PUBLIC "-DLIBOPENPMD_WITH_ADIOS1=ON")
-    if(openPMD_HAVE_MPI)
-        # TODO: remove and just rely on "WITH_MPI"
-        target_compile_definitions(openPMD.io PUBLIC "-DLIBOPENPMD_WITH_PARALLEL_ADIOS1=ON")
-    endif()
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_ADIOS1=ON")
 endif()
 
 if(openPMD_HAVE_ADIOS2)
     target_link_libraries(openPMD.io PUBLIC ADIOS2::ADIOS2)
-    target_compile_definitions(openPMD.io PUBLIC "-DLIBOPENPMD_WITH_ADIOS2=ON")
-    if(openPMD_HAVE_MPI)
-        # TODO: remove and just rely on "WITH_MPI"
-        target_compile_definitions(openPMD.io PUBLIC "-DLIBOPENPMD_WITH_PARALLEL_ADIOS2=ON")
-    endif()
+    target_compile_definitions(openPMD.io PUBLIC "-DopenPMD_HAVE_ADIOS2=ON")
 endif()
 
 # tests
@@ -272,6 +260,23 @@ set(openPMD_EXAMPLE_NAMES
 )
 foreach(testname ${openPMD_TEST_NAMES})
     add_executable(${testname}Tests test/${testname}Test.cpp)
+    if(openPMD_HAVE_MPI)
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_MPI=ON")
+    else()
+        target_compile_definitions(${testname}Tests PUBLIC "-D_NOMPI=ON")
+    endif()
+
+    if(openPMD_HAVE_HDF5)
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_HDF5=ON")
+    endif()
+
+    if(openPMD_HAVE_ADIOS1)
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS1=ON")
+    endif()
+
+    if(openPMD_HAVE_ADIOS2)
+        target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS2=ON")
+    endif()
     target_link_libraries(${testname}Tests PRIVATE openPMD.core openPMD.io)
     if(TARGET Boost::unit_test_framework)
         target_link_libraries(${testname}Tests PRIVATE Boost::unit_test_framework)
@@ -342,19 +347,21 @@ endif()
 set(MPI_TEST_EXE
     ${MPIEXEC_EXECUTABLE}
     ${MPI_ALLOW_ROOT}
-    ${MPIEXEC_NUMPROC_FLAG} 4
+    ${MPIEXEC_NUMPROC_FLAG} 4 -oversubscribe
 )
 
 foreach(testname ${openPMD_TEST_NAMES})
     if(${testname} MATCHES "^Parallel.*$")
         if(openPMD_HAVE_MPI)
             add_test(NAME MPI.${testname}
-                COMMAND ${MPI_TEST_EXE} ${testname}Tests
+                COMMAND ${MPI_TEST_EXE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
+                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
         endif()
     else()
         add_test(NAME Serial.${testname}
-            COMMAND ${testname}Tests
+            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
     endif()
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,14 +347,14 @@ endif()
 set(MPI_TEST_EXE
     ${MPIEXEC_EXECUTABLE}
     ${MPI_ALLOW_ROOT}
-    ${MPIEXEC_NUMPROC_FLAG} 4 -oversubscribe
+    ${MPIEXEC_NUMPROC_FLAG} 4
 )
 
 foreach(testname ${openPMD_TEST_NAMES})
     if(${testname} MATCHES "^Parallel.*$")
         if(openPMD_HAVE_MPI)
             add_test(NAME MPI.${testname}
-                COMMAND ${MPI_TEST_EXE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
+                COMMAND ${MPI_TEST_EXE} --oversubscribe ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
         endif()

--- a/examples/1_structure.cpp
+++ b/examples/1_structure.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Series.hpp"
+
+int main(int argc, char *argv[])
+{
+  auto f = Series::create("sample/1.h5");
+
+  return 0;
+}

--- a/include/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -1,11 +1,68 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 
 #include <memory>
 
-#include <IO/AbstractIOHandler.hpp>
+#include "IO/AbstractIOHandler.hpp"
 
-class ADIOS1IOHandlerImpl;
+
+#if defined(openPMD_HAVE_ADIOS1)
+class ADIOS1IOHandler;
+
+class ADIOS1IOHandlerImpl
+{
+public:
+    ADIOS1IOHandlerImpl(AbstractIOHandler*);
+    virtual ~ADIOS1IOHandlerImpl();
+
+    virtual std::future< void > flush();
+
+    using ArgumentMap = std::map< std::string, ParameterArgument >;
+    virtual void createFile(Writable*, ArgumentMap const&);
+    virtual void createPath(Writable*, ArgumentMap const&);
+    virtual void createDataset(Writable*, ArgumentMap const&);
+    virtual void extendDataset(Writable*, ArgumentMap const&);
+    virtual void openFile(Writable*, ArgumentMap const&);
+    virtual void openPath(Writable*, ArgumentMap const&);
+    virtual void openDataset(Writable*, ArgumentMap &);
+    virtual void deleteFile(Writable*, ArgumentMap const&);
+    virtual void deletePath(Writable*, ArgumentMap const&);
+    virtual void deleteDataset(Writable*, ArgumentMap const&);
+    virtual void deleteAttribute(Writable*, ArgumentMap const&);
+    virtual void writeDataset(Writable*, ArgumentMap const&);
+    virtual void writeAttribute(Writable*, ArgumentMap const&);
+    virtual void readDataset(Writable*, ArgumentMap &);
+    virtual void readAttribute(Writable*, ArgumentMap &);
+    virtual void listPaths(Writable*, ArgumentMap &);
+    virtual void listDatasets(Writable*, ArgumentMap &);
+    virtual void listAttributes(Writable*, ArgumentMap &);
+
+    AbstractIOHandler* m_handler;
+};  //ADIOS1IOHandlerImpl
+#else
+class ADIOS1IOHandlerImpl
+{ };
+#endif
 
 class ADIOS1IOHandler : public AbstractIOHandler
 {

--- a/include/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -1,11 +1,70 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 
 #include <memory>
 
-#include <IO/AbstractIOHandler.hpp>
+#include "IO/AbstractIOHandler.hpp"
 
-class ADIOS2IOHandlerImpl;
+
+#if defined(openPMD_HAVE_ADIOS2)
+
+
+class ADIOS2IOHandler;
+
+class ADIOS2IOHandlerImpl
+{
+public:
+    ADIOS2IOHandlerImpl(AbstractIOHandler*);
+    virtual ~ADIOS2IOHandlerImpl();
+
+    virtual std::future< void > flush();
+
+    using ArgumentMap = std::map< std::string, ParameterArgument >;
+    virtual void createFile(Writable*, ArgumentMap const&);
+    virtual void createPath(Writable*, ArgumentMap const&);
+    virtual void createDataset(Writable*, ArgumentMap const&);
+    virtual void extendDataset(Writable*, ArgumentMap const&);
+    virtual void openFile(Writable*, ArgumentMap const&);
+    virtual void openPath(Writable*, ArgumentMap const&);
+    virtual void openDataset(Writable*, ArgumentMap &);
+    virtual void deleteFile(Writable*, ArgumentMap const&);
+    virtual void deletePath(Writable*, ArgumentMap const&);
+    virtual void deleteDataset(Writable*, ArgumentMap const&);
+    virtual void deleteAttribute(Writable*, ArgumentMap const&);
+    virtual void writeDataset(Writable*, ArgumentMap const&);
+    virtual void writeAttribute(Writable*, ArgumentMap const&);
+    virtual void readDataset(Writable*, ArgumentMap &);
+    virtual void readAttribute(Writable*, ArgumentMap &);
+    virtual void listPaths(Writable*, ArgumentMap &);
+    virtual void listDatasets(Writable*, ArgumentMap &);
+    virtual void listAttributes(Writable*, ArgumentMap &);
+
+    AbstractIOHandler* m_handler;
+};  //ADIOS2IOHandlerImpl
+#else
+class ADIOS2IOHandlerImpl
+{ };
+#endif
 
 class ADIOS2IOHandler : public AbstractIOHandler
 {

--- a/include/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -26,7 +26,7 @@
 #include "IO/AbstractIOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_ADIOS1) && defined(openPMD_HAVE_MPI)
+#if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
 #include <mpi.h>
 
 #include "IO/ADIOS1/ADIOS1IOHandler.hpp"
@@ -51,7 +51,7 @@ class ParallelADIOS1IOHandlerImpl
 class ParallelADIOS1IOHandler : public AbstractIOHandler
 {
 public:
-#if defined(openPMD_HAVE_ADIOS1) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
     ParallelADIOS1IOHandler(std::string const& path, AccessType, MPI_Comm);
 #else
     ParallelADIOS1IOHandler(std::string const& path, AccessType);

--- a/include/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -1,21 +1,64 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 
 #include <memory>
 
-#include <IO/AbstractIOHandler.hpp>
+#include "IO/AbstractIOHandler.hpp"
 
-class ParallelADIOS1IOHandlerImpl;
+
+#if defined(openPMD_HAVE_ADIOS1) && defined(openPMD_HAVE_MPI)
+#include <mpi.h>
+
+#include "IO/ADIOS1/ADIOS1IOHandler.hpp"
+
+
+class ParallelADIOS1IOHandler;
+
+class ParallelADIOS1IOHandlerImpl : public ADIOS1IOHandlerImpl
+{
+public:
+    ParallelADIOS1IOHandlerImpl(AbstractIOHandler*, MPI_Comm);
+    virtual ~ParallelADIOS1IOHandlerImpl();
+
+    MPI_Comm m_mpiComm;
+    MPI_Info m_mpiInfo;
+};  //ParallelADIOS1IOHandlerImpl
+#else
+class ParallelADIOS1IOHandlerImpl
+{ };
+#endif
 
 class ParallelADIOS1IOHandler : public AbstractIOHandler
 {
-    friend class ParallelADIOS1IOHandlerImpl;
-
 public:
+#if defined(openPMD_HAVE_ADIOS1) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+    ParallelADIOS1IOHandler(std::string const& path, AccessType, MPI_Comm);
+#else
     ParallelADIOS1IOHandler(std::string const& path, AccessType);
+#endif
     virtual ~ParallelADIOS1IOHandler();
 
-    std::future< void > flush();
+    std::future< void > flush() override;
 
 private:
     std::unique_ptr< ParallelADIOS1IOHandlerImpl > m_impl;

--- a/include/IO/AbstractFilePosition.hpp
+++ b/include/IO/AbstractFilePosition.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 

--- a/include/IO/AbstractIOHandler.hpp
+++ b/include/IO/AbstractIOHandler.hpp
@@ -25,6 +25,10 @@
 #include <future>
 #include <queue>
 
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#include <mpi.h>
+#endif
+
 #include "AccessType.hpp"
 #include "Format.hpp"
 #include "IOTask.hpp"
@@ -66,6 +70,22 @@ public:
 class AbstractIOHandler
 {
 public:
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+    /** Construct an appropriate specific IOHandler for the desired IO mode.
+     *
+     * @param   path        Path to root folder for all operations associated with the desired handler.
+     * @param   accessType  AccessType describing desired operations and permissions of the desired handler.
+     * @param   format      Format describing the IO backend of the desired handler.
+     * @param   comm        MPI communicator used for IO.
+     * @return  Smart pointer to created IOHandler.
+     */
+    static std::shared_ptr< AbstractIOHandler > createIOHandler(std::string const& path,
+                                                                AccessType accessType,
+                                                                Format format,
+                                                                MPI_Comm comm = MPI_COMM_WORLD);
+
+    AbstractIOHandler(std::string const& path, AccessType, MPI_Comm);
+#else
     /** Construct an appropriate specific IOHandler for the desired IO mode.
      *
      * @param   path        Path to root folder for all operations associated with the desired handler.
@@ -78,6 +98,7 @@ public:
                                                                 Format format);
 
     AbstractIOHandler(std::string const& path, AccessType);
+#endif
     virtual ~AbstractIOHandler();
 
     /** Add provided task to queue according to FIFO.

--- a/include/IO/AbstractIOHandler.hpp
+++ b/include/IO/AbstractIOHandler.hpp
@@ -25,7 +25,7 @@
 #include <future>
 #include <queue>
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
 #include <mpi.h>
 #endif
 
@@ -70,7 +70,7 @@ public:
 class AbstractIOHandler
 {
 public:
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
     /** Construct an appropriate specific IOHandler for the desired IO mode.
      *
      * @param   path        Path to root folder for all operations associated with the desired handler.
@@ -95,7 +95,7 @@ public:
                                                                 AccessType accessType,
                                                                 Format format);
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
     AbstractIOHandler(std::string const& path, AccessType, MPI_Comm);
 #endif
     AbstractIOHandler(std::string const& path, AccessType);

--- a/include/IO/AbstractIOHandler.hpp
+++ b/include/IO/AbstractIOHandler.hpp
@@ -82,10 +82,8 @@ public:
     static std::shared_ptr< AbstractIOHandler > createIOHandler(std::string const& path,
                                                                 AccessType accessType,
                                                                 Format format,
-                                                                MPI_Comm comm = MPI_COMM_WORLD);
-
-    AbstractIOHandler(std::string const& path, AccessType, MPI_Comm);
-#else
+                                                                MPI_Comm comm);
+#endif
     /** Construct an appropriate specific IOHandler for the desired IO mode.
      *
      * @param   path        Path to root folder for all operations associated with the desired handler.
@@ -97,8 +95,10 @@ public:
                                                                 AccessType accessType,
                                                                 Format format);
 
-    AbstractIOHandler(std::string const& path, AccessType);
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+    AbstractIOHandler(std::string const& path, AccessType, MPI_Comm);
 #endif
+    AbstractIOHandler(std::string const& path, AccessType);
     virtual ~AbstractIOHandler();
 
     /** Add provided task to queue according to FIFO.

--- a/include/IO/Format.hpp
+++ b/include/IO/Format.hpp
@@ -26,10 +26,7 @@
 enum class Format
 {
     HDF5,
-    PARALLEL_HDF5,
-    ADIOS,
-    PARALLEL_ADIOS,
+    ADIOS1,
     ADIOS2,
-    PARALLEL_ADIOS2,
     DUMMY
 };  //Format

--- a/include/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/IO/HDF5/HDF5Auxiliary.hpp
@@ -1,13 +1,35 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
+
 
 #include <stack>
 
 #include <hdf5.h>
 
-#include "backend/Attribute.hpp"
 #include "auxiliary/StringManip.hpp"
-#include "HDF5FilePosition.hpp"
+#include "backend/Attribute.hpp"
 #include "backend/Writable.hpp"
+#include "HDF5FilePosition.hpp"
+
 
 inline hid_t
 getH5DataType(Attribute const& att)

--- a/include/IO/HDF5/HDF5FilePosition.hpp
+++ b/include/IO/HDF5/HDF5FilePosition.hpp
@@ -1,6 +1,27 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
-#include <IO/AbstractFilePosition.hpp>
+
+#include "IO/AbstractFilePosition.hpp"
 
 
 struct HDF5FilePosition : public AbstractFilePosition

--- a/include/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/IO/HDF5/HDF5IOHandler.hpp
@@ -1,15 +1,37 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 
 #include <memory>
 
-#include <IO/AbstractIOHandler.hpp>
+#include "IO/AbstractIOHandler.hpp"
 
-#ifdef LIBOPENPMD_WITH_HDF5
+
+#if defined(openPMD_HAVE_HDF5)
 #include <unordered_map>
 #include <unordered_set>
 
 #include <hdf5.h>
+
 
 class HDF5IOHandler;
 

--- a/include/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -26,7 +26,7 @@
 #include "IO/AbstractIOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_HDF5) && defined(openPMD_HAVE_MPI)
+#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
 #include <mpi.h>
 
 #include "IO/HDF5/HDF5IOHandler.hpp"
@@ -51,7 +51,7 @@ class ParallelHDF5IOHandlerImpl
 class ParallelHDF5IOHandler : public AbstractIOHandler
 {
 public:
-#if defined(openPMD_HAVE_HDF5) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
     ParallelHDF5IOHandler(std::string const& path, AccessType, MPI_Comm);
 #else
     ParallelHDF5IOHandler(std::string const& path, AccessType);

--- a/include/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -1,16 +1,43 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
-#include <IO/AbstractIOHandler.hpp>
 
-#ifdef LIBOPENPMD_WITH_PARALLEL_HDF5
-#include <IO/HDF5/HDF5IOHandler.hpp>
+#include <memory>
+
+#include "IO/AbstractIOHandler.hpp"
+
+
+#if defined(openPMD_HAVE_HDF5) && defined(openPMD_HAVE_MPI)
+#include <mpi.h>
+
+#include "IO/HDF5/HDF5IOHandler.hpp"
+
 
 class ParallelHDF5IOHandler;
 
 class ParallelHDF5IOHandlerImpl : public HDF5IOHandlerImpl
 {
 public:
-    ParallelHDF5IOHandlerImpl(AbstractIOHandler*);
+    ParallelHDF5IOHandlerImpl(AbstractIOHandler*, MPI_Comm);
     virtual ~ParallelHDF5IOHandlerImpl();
 
     MPI_Comm m_mpiComm;
@@ -24,7 +51,11 @@ class ParallelHDF5IOHandlerImpl
 class ParallelHDF5IOHandler : public AbstractIOHandler
 {
 public:
+#if defined(openPMD_HAVE_HDF5) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+    ParallelHDF5IOHandler(std::string const& path, AccessType, MPI_Comm);
+#else
     ParallelHDF5IOHandler(std::string const& path, AccessType);
+#endif
     virtual ~ParallelHDF5IOHandler();
 
     std::future< void > flush() override;

--- a/include/Series.hpp
+++ b/include/Series.hpp
@@ -21,6 +21,10 @@
 #pragma once
 
 
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#include <mpi.h>
+#endif
+
 #include "backend/Attributable.hpp"
 #include "backend/Container.hpp"
 #include "IO/AbstractIOHandler.hpp"
@@ -40,10 +44,23 @@
 class Series : public Attributable
 {
 public:
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+    static Series create(std::string const& filepath,
+                         MPI_Comm comm,
+                         AccessType at = AccessType::CREATE);
+#else
     static Series create(std::string const& filepath,
                          AccessType at = AccessType::CREATE);
+
+#endif
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+    static Series read(std::string const& filepath,
+                       MPI_Comm comm,
+                       AccessType at = AccessType::READ_ONLY);
+#else
     static Series read(std::string const& filepath,
                        AccessType at = AccessType::READ_ONLY);
+#endif
     ~Series();
 
     /**
@@ -194,9 +211,14 @@ public:
     Container< Iteration, uint64_t > iterations;
 
 private:
-    // TODO replace entirely with factory
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+    Series(std::string const& filepath,
+           AccessType at,
+           MPI_Comm comm);
+#else
     Series(std::string const& filepath,
            AccessType at);
+#endif
 
     void flushFileBased();
     void flushGroupBased();

--- a/include/Series.hpp
+++ b/include/Series.hpp
@@ -21,7 +21,7 @@
 #pragma once
 
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
 #include <mpi.h>
 #endif
 
@@ -44,7 +44,7 @@
 class Series : public Attributable
 {
 public:
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
     static Series create(std::string const& filepath,
                          MPI_Comm comm,
                          AccessType at = AccessType::CREATE);
@@ -52,7 +52,7 @@ public:
     static Series create(std::string const& filepath,
                          AccessType at = AccessType::CREATE);
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
     static Series read(std::string const& filepath,
                        MPI_Comm comm,
                        AccessType at = AccessType::READ_ONLY);
@@ -209,7 +209,7 @@ public:
     Container< Iteration, uint64_t > iterations;
 
 private:
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
     Series(std::string const& filepath,
            AccessType at,
            MPI_Comm comm);

--- a/include/Series.hpp
+++ b/include/Series.hpp
@@ -48,19 +48,17 @@ public:
     static Series create(std::string const& filepath,
                          MPI_Comm comm,
                          AccessType at = AccessType::CREATE);
-#else
+#endif
     static Series create(std::string const& filepath,
                          AccessType at = AccessType::CREATE);
 
-#endif
 #if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
     static Series read(std::string const& filepath,
                        MPI_Comm comm,
                        AccessType at = AccessType::READ_ONLY);
-#else
+#endif
     static Series read(std::string const& filepath,
                        AccessType at = AccessType::READ_ONLY);
-#endif
     ~Series();
 
     /**
@@ -215,10 +213,9 @@ private:
     Series(std::string const& filepath,
            AccessType at,
            MPI_Comm comm);
-#else
+#endif
     Series(std::string const& filepath,
            AccessType at);
-#endif
 
     void flushFileBased();
     void flushGroupBased();

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -21,7 +21,7 @@
 #include "IO/ADIOS/ADIOS1IOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_ADIOS1)
+#if openPMD_HAVE_ADIOS1
 ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
           m_impl{new ADIOS1IOHandlerImpl(this)}
@@ -37,7 +37,7 @@ ADIOS1IOHandler::flush()
 }
 #endif
 
-#if defined(openPMD_HAVE_ADIOS1) && !defined(openPMD_HAVE_MPI) && defined(_NOMPI)
+#if openPMD_HAVE_ADIOS1 && !openPMD_HAVE_MPI
 ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
           m_impl{new ADIOS1IOHandlerImpl(this)}
@@ -53,7 +53,7 @@ ADIOS1IOHandler::flush()
 }
 #else
 ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
         : AbstractIOHandler(path, at, MPI_COMM_NULL)
 #else
 : AbstractIOHandler(path, at)

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -1,37 +1,27 @@
-#include <IO/ADIOS/ADIOS1IOHandler.hpp>
-#ifdef LIBOPENPMD_WITH_ADIOS1
-#include <iostream>
-#include <unordered_map>
-#include <unordered_set>
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "IO/ADIOS/ADIOS1IOHandler.hpp"
 
-#include <adios.h>
 
-#include <boost/filesystem.hpp>
-
-#include <Auxiliary.hpp>
-#include <IO/ADIOS/ADIOS1FilePosition.hpp>
-
-
-class ADIOS1IOHandlerImpl
-{
-public:
-    ADIOS1IOHandlerImpl(ADIOS1IOHandler*);
-    virtual ~ADIOS1IOHandlerImpl();
-
-    std::future< void > flush();
-
-    using ArgumentMap = std::map< std::string, ParameterArgument >;
-    void createFile(Writable*, ArgumentMap const&);
-
-    MPI_Comm m_mpiComm;
-    MPI_Info m_mpiInfo;
-
-    ADIOS1IOHandler* m_handler;
-    std::unordered_map< Writable*, int64_t > m_files;
-    std::unordered_set< int64_t > m_openFiles;
-    int64_t m_groupID;
-};  //ADIOS1IOHandlerImpl
-
+#if defined(openPMD_HAVE_ADIOS1)
 ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
           m_impl{new ADIOS1IOHandlerImpl(this)}
@@ -45,134 +35,31 @@ ADIOS1IOHandler::flush()
 {
     return m_impl->flush();
 }
+#endif
 
-ADIOS1IOHandlerImpl::ADIOS1IOHandlerImpl(ADIOS1IOHandler* handler)
-        : m_mpiComm{MPI_COMM_WORLD},
-          m_mpiInfo{MPI_INFO_NULL},
-          m_handler{handler}
-{
-    adios_init_noxml(m_mpiComm);
-    std::string groupName{""};
-    std::string timeIndex{""};
-    adios_declare_group(&m_groupID,
-                        groupName.c_str(),
-                        timeIndex.c_str(),
-                        ADIOS_STATISTICS_FLAG::adios_stat_default);
-}
+#if defined(openPMD_HAVE_ADIOS1) && !defined(openPMD_HAVE_MPI) && defined(_NOMPI)
+ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
+        : AbstractIOHandler(path, at),
+          m_impl{new ADIOS1IOHandlerImpl(this)}
+{ }
 
-ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
-{
-    for( auto const& file : m_openFiles )
-        adios_close(file);
-
-    adios_free_group(m_groupID);
-
-    int mpiRank{-1};
-    MPI_Comm_rank(m_mpiComm, &mpiRank);
-    adios_finalize(mpiRank);
-}
+ADIOS1IOHandler::~ADIOS1IOHandler()
+{ }
 
 std::future< void >
-ADIOS1IOHandlerImpl::flush()
+ADIOS1IOHandler::flush()
 {
-    while( !(m_handler->m_work.empty()) )
-    {
-        IOTask& i = m_handler->m_work.front();
-        switch( i.operation )
-        {
-            using O = Operation;
-            case O::CREATE_FILE:
-                createFile(i.writable, i.parameter);
-                break;
-            case O::CREATE_PATH:
-                //createPath(i.writable, i.parameter);
-                //break;
-            case O::CREATE_DATASET:
-                //createDataset(i.writable, i.parameter);
-                //break;
-            case O::OPEN_FILE:
-                //openFile(i.writable, i.parameter);
-                //break;
-            case O::OPEN_PATH:
-                //openPath(i.writable, i.parameter);
-                //break;
-            case O::OPEN_DATASET:
-                //openDataset(i.writable, i.parameter);
-                //break;
-            case O::DELETE_FILE:
-                //deleteFile(i.writable, i.parameter);
-                //break;
-            case O::DELETE_PATH:
-                //deletePath(i.writable, i.parameter);
-                //break;
-            case O::DELETE_DATASET:
-                //deleteDataset(i.writable, i.parameter);
-                //break;
-            case O::DELETE_ATT:
-                //deleteAttribute(i.writable, i.parameter);
-                //break;
-            case O::WRITE_DATASET:
-                //writeDataset(i.writable, i.parameter);
-                //break;
-            case O::WRITE_ATT:
-                //writeAttribute(i.writable, i.parameter);
-                //break;
-            case O::READ_DATASET:
-                //readDataset(i.writable, i.parameter);
-                //break;
-            case O::READ_ATT:
-                //readAttribute(i.writable, i.parameter);
-                //break;
-            case O::LIST_PATHS:
-                //listPaths(i.writable, i.parameter);
-                //break;
-            case O::LIST_DATASETS:
-                //listDatasets(i.writable, i.parameter);
-                //break;
-            case O::LIST_ATTS:
-                //listAttributes(i.writable, i.parameter);
-                std::cerr << "Not implemented in ParallelADIOS1 backend yet\n";
-                break;
-        }
-        m_handler->m_work.pop();
-    }
-    return std::future< void >();
-}
-
-void ADIOS1IOHandlerImpl::createFile(Writable* writable,
-                                     ArgumentMap const& parameters)
-{
-    if( !writable->written )
-    {
-        using namespace boost::filesystem;
-        path dir(m_handler->directory);
-        if( !exists(dir) )
-            create_directories(dir);
-
-        /* Create a new file. */
-        std::string name = m_handler->directory + parameters.at("name").get< std::string >();
-        if( !ends_with(name, ".bp") )
-            name += ".bp";
-        int64_t file;
-        adios_open(&file, "", name.c_str(), "w", m_mpiComm);
-
-        writable->written = true;
-        writable->abstractFilePosition = std::make_shared< ADIOS1FilePosition >();
-
-        m_files.insert({writable, file});
-        m_openFiles.insert(file);
-        while( (writable = writable->parent) )
-            m_files.insert({writable, file});
-    }
+    return m_impl->flush();
 }
 #else
-class ADIOS1IOHandlerImpl
-{ };
-
 ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at)
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+        : AbstractIOHandler(path, at, MPI_COMM_NULL)
+#else
+: AbstractIOHandler(path, at)
+#endif
 {
-    throw std::runtime_error("libopenPMD built without ADIOS support");
+    throw std::runtime_error("libopenPMD built without parallel ADIOS1 support");
 }
 
 ADIOS1IOHandler::~ADIOS1IOHandler()

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1,34 +1,28 @@
-#include <IO/ADIOS/ADIOS2IOHandler.hpp>
-#ifdef LIBOPENPMD_WITH_ADIOS2
-#include <iostream>
-#include <unordered_map>
-#include <unordered_set>
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "IO/ADIOS/ADIOS2IOHandler.hpp"
 
-#include <adios2.h>
 
-#include <boost/filesystem.hpp>
+#if defined(openPMD_HAVE_ADIOS2)
 
-#include <Auxiliary.hpp>
-#include <IO/ADIOS/ADIOS2FilePosition.hpp>
-
-
-class ADIOS2IOHandlerImpl
-{
-public:
-    ADIOS2IOHandlerImpl(ADIOS2IOHandler*);
-    virtual ~ADIOS2IOHandlerImpl();
-
-    std::future< void > flush();
-
-    using ArgumentMap = std::map< std::string, ParameterArgument >;
-    void createFile(Writable*, ArgumentMap const&);
-
-    ADIOS2IOHandler* m_handler;
-    std::unordered_map< Writable*, std::shared_ptr< adios2::Engine > > m_files;
-    std::unordered_set< std::shared_ptr< adios2::Engine > > m_openFiles;
-
-    adios2::ADIOS m_adiosFactory;
-};  //ADIOS2IOHandlerImpl
 
 ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
@@ -44,123 +38,31 @@ ADIOS2IOHandler::flush()
     return m_impl->flush();
 }
 
-ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(ADIOS2IOHandler* handler)
-        : m_handler{handler},
-          m_adiosFactory(true)
+#endif
+
+#if defined(openPMD_HAVE_ADIOS2) && !defined(openPMD_HAVE_MPI) && defined(_NOMPI)
+ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
+        : AbstractIOHandler(path, at),
+          m_impl{new ADIOS2IOHandlerImpl(this)}
 { }
 
-ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
-{
-    for( auto& file : m_openFiles )
-        if( file )
-            file->Close();
-}
+ADIOS2IOHandler::~ADIOS2IOHandler()
+{ }
 
 std::future< void >
-ADIOS2IOHandlerImpl::flush()
+ADIOS2IOHandler::flush()
 {
-    while( !(m_handler->m_work.empty()) )
-    {
-        IOTask& i = m_handler->m_work.front();
-        switch( i.operation )
-        {
-            using O = Operation;
-            case O::CREATE_FILE:
-                createFile(i.writable, i.parameter);
-                break;
-            case O::CREATE_PATH:
-                //createPath(i.writable, i.parameter);
-                //break;
-            case O::CREATE_DATASET:
-                //createDataset(i.writable, i.parameter);
-                //break;
-            case O::OPEN_FILE:
-                //openFile(i.writable, i.parameter);
-                //break;
-            case O::OPEN_PATH:
-                //openPath(i.writable, i.parameter);
-                //break;
-            case O::OPEN_DATASET:
-                //openDataset(i.writable, i.parameter);
-                //break;
-            case O::DELETE_FILE:
-                //deleteFile(i.writable, i.parameter);
-                //break;
-            case O::DELETE_PATH:
-                //deletePath(i.writable, i.parameter);
-                //break;
-            case O::DELETE_DATASET:
-                //deleteDataset(i.writable, i.parameter);
-                //break;
-            case O::DELETE_ATT:
-                //deleteAttribute(i.writable, i.parameter);
-                //break;
-            case O::WRITE_DATASET:
-                //writeDataset(i.writable, i.parameter);
-                //break;
-            case O::WRITE_ATT:
-                //writeAttribute(i.writable, i.parameter);
-                //break;
-            case O::READ_DATASET:
-                //readDataset(i.writable, i.parameter);
-                //break;
-            case O::READ_ATT:
-                //readAttribute(i.writable, i.parameter);
-                //break;
-            case O::LIST_PATHS:
-                //listPaths(i.writable, i.parameter);
-                //break;
-            case O::LIST_DATASETS:
-                //listDatasets(i.writable, i.parameter);
-                //break;
-            case O::LIST_ATTS:
-                //listAttributes(i.writable, i.parameter);
-                std::cerr << "Not implemented in ADIOS2 backend yet\n";
-                break;
-        }
-        m_handler->m_work.pop();
-    }
-    return std::future< void >();
-}
-
-void ADIOS2IOHandlerImpl::createFile(Writable* writable,
-                                     ArgumentMap const& parameters)
-{
-    if( !writable->written )
-    {
-        using namespace boost::filesystem;
-        path dir(m_handler->directory);
-        if( !exists(dir) )
-            create_directories(dir);
-
-        /* Create a new file using MPI properties. */
-        std::string name = m_handler->directory + parameters.at("name").get< std::string >();
-        if( !ends_with(name, ".bp") )
-            name += ".bp";
-        adios2::IO &bpIO = m_adiosFactory.DeclareIO("BPFile_N2N");
-        bpIO.SetEngine("BPFileWriter");
-        auto bpWriter = bpIO.Open(name, adios2::OpenMode::Write);
-
-        if (!bpWriter)
-            throw std::runtime_error("Interal error: Failed to write ADIOS2 file");
-
-        writable->written = true;
-        writable->abstractFilePosition = std::make_shared< ADIOS2FilePosition >();
-
-        m_files.insert({writable, bpWriter});
-        m_openFiles.insert(bpWriter);
-        while( (writable = writable->parent) )
-            m_files.insert({writable, bpWriter});
-    }
+    return m_impl->flush();
 }
 #else
-class ADIOS2IOHandlerImpl
-{ };
-
 ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at)
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+        : AbstractIOHandler(path, at, MPI_COMM_NULL)
+#else
+: AbstractIOHandler(path, at)
+#endif
 {
-    throw std::runtime_error("libopenPMD built without ADIOS2 support");
+    throw std::runtime_error("libopenPMD built without parallel ADIOS2 support");
 }
 
 ADIOS2IOHandler::~ADIOS2IOHandler()

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -21,7 +21,7 @@
 #include "IO/ADIOS/ADIOS2IOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_ADIOS2)
+#if openPMD_HAVE_ADIOS2
 
 
 ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
@@ -40,7 +40,7 @@ ADIOS2IOHandler::flush()
 
 #endif
 
-#if defined(openPMD_HAVE_ADIOS2) && !defined(openPMD_HAVE_MPI) && defined(_NOMPI)
+#if openPMD_HAVE_ADIOS2 && !openPMD_HAVE_MPI
 ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
           m_impl{new ADIOS2IOHandlerImpl(this)}
@@ -56,7 +56,7 @@ ADIOS2IOHandler::flush()
 }
 #else
 ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
         : AbstractIOHandler(path, at, MPI_COMM_NULL)
 #else
 : AbstractIOHandler(path, at)

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -21,7 +21,7 @@
 #include "IO/ADIOS/ParallelADIOS1IOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_ADIOS1) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
                                              AccessType at,
                                              MPI_Comm comm)
@@ -40,7 +40,7 @@ ParallelHDF5IOHandler::flush()
 #else
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string const& path,
                                                  AccessType at)
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
         : AbstractIOHandler(path, at, MPI_COMM_NULL)
 #else
 : AbstractIOHandler(path, at)

--- a/src/IO/AbstractIOHandler.cpp
+++ b/src/IO/AbstractIOHandler.cpp
@@ -25,7 +25,7 @@
 #include "IO/HDF5/ParallelHDF5IOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
 std::shared_ptr< AbstractIOHandler >
 AbstractIOHandler::createIOHandler(std::string const& path,
                                    AccessType at,

--- a/src/IO/AbstractIOHandler.cpp
+++ b/src/IO/AbstractIOHandler.cpp
@@ -57,7 +57,7 @@ AbstractIOHandler::AbstractIOHandler(std::string const& path,
         : directory{path},
           accessType{at}
 { }
-#else
+#endif
 std::shared_ptr< AbstractIOHandler >
 AbstractIOHandler::createIOHandler(std::string const& path,
                                    AccessType at,
@@ -87,7 +87,6 @@ AbstractIOHandler::AbstractIOHandler(std::string const& path,
         : directory{path},
           accessType{at}
 { }
-#endif
 
 AbstractIOHandler::~AbstractIOHandler()
 { }
@@ -99,11 +98,7 @@ AbstractIOHandler::enqueue(IOTask const& i)
 }
 
 DummyIOHandler::DummyIOHandler(std::string const& path, AccessType at)
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
-        : AbstractIOHandler(path, at, MPI_COMM_NULL)
-#else
         : AbstractIOHandler(path, at)
-#endif
 { }
 
 DummyIOHandler::~DummyIOHandler()

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -386,7 +386,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     using namespace boost::filesystem;
     path dir(m_handler->directory);
     if( !exists(dir) )
-        throw no_such_file_error("Supplied directory is not valid");
+        throw no_such_file_error("Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.at("name").get< std::string >();
     if( !ends_with(name, ".h5") )

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -21,7 +21,7 @@
 #include "IO/HDF5/ParallelHDF5IOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_HDF5) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
 #include <iostream>
 
 #include <mpi.h>

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -1,11 +1,33 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of libopenPMD.
+ *
+ * libopenPMD is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libopenPMD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libopenPMD.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "IO/HDF5/ParallelHDF5IOHandler.hpp"
-#ifdef LIBOPENPMD_WITH_PARALLEL_HDF5
+
+
+#if defined(openPMD_HAVE_HDF5) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
 #include <iostream>
 
 #include <mpi.h>
 #include <boost/filesystem.hpp>
 
-#include <auxiliary/StringManip.hpp>
+#include "auxiliary/StringManip.hpp"
 
 
 #ifdef DEBUG
@@ -16,9 +38,10 @@
 
 
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
-                                             AccessType at)
-        : AbstractIOHandler(path, at),
-          m_impl{new ParallelHDF5IOHandlerImpl(this)}
+                                             AccessType at,
+                                             MPI_Comm comm)
+        : AbstractIOHandler(path, at, comm),
+          m_impl{new ParallelHDF5IOHandlerImpl(this, comm)}
 { }
 
 ParallelHDF5IOHandler::~ParallelHDF5IOHandler()
@@ -30,9 +53,10 @@ ParallelHDF5IOHandler::flush()
     return m_impl->flush();
 }
 
-ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(AbstractIOHandler* handler)
+ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(AbstractIOHandler* handler,
+                                                     MPI_Comm comm)
         : HDF5IOHandlerImpl{handler},
-          m_mpiComm{MPI_COMM_WORLD},
+          m_mpiComm{comm},
           m_mpiInfo{MPI_INFO_NULL}
 {
     /*
@@ -68,7 +92,11 @@ ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
 #else
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
                                              AccessType at)
+#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+        : AbstractIOHandler(path, at, MPI_COMM_NULL)
+#else
         : AbstractIOHandler(path, at)
+#endif
 {
     throw std::runtime_error("libopenPMD built without parallel HDF5 support");
 }

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -80,23 +80,11 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(AbstractIOHandler* handler,
 }
 
 ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
-{
-    herr_t status;
-    status = H5Pclose(m_datasetTransferProperty);
-    if( status != 0 )
-        std::cerr <<  "Interal error: Failed to close HDF5 dataset transfer property\n";
-    status = H5Pclose(m_fileAccessProperty);
-    if( status != 0 )
-        std::cerr << "Interal error: Failed to close HDF5 file access property\n";
-}
+{ }
 #else
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
                                              AccessType at)
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
-        : AbstractIOHandler(path, at, MPI_COMM_NULL)
-#else
         : AbstractIOHandler(path, at)
-#endif
 {
     throw std::runtime_error("libopenPMD built without parallel HDF5 support");
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -37,7 +37,7 @@ check_extension(std::string const& filepath)
                                  "Did you append a correct filename extension?");
 }
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
 Series
 Series::create(std::string const& filepath,
                MPI_Comm comm,
@@ -64,7 +64,7 @@ Series::create(std::string const& filepath,
     return Series(filepath, at);
 }
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
 Series
 Series::read(std::string const& filepath,
              MPI_Comm comm,
@@ -92,7 +92,7 @@ Series::read(std::string const& filepath,
 }
 
 
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
 Series::Series(std::string const& filepath,
                AccessType at,
                MPI_Comm comm)

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -519,7 +519,9 @@ Series::readFileBased()
     Parameter< Operation::READ_ATT > aRead;
 
     using namespace boost::filesystem;
-    path dir(IOHandler->directory);
+    path dir = path(IOHandler->directory);
+    if( !exists(dir) )
+        throw no_such_file_error("Supplied directory is not valid: " + IOHandler->directory);
     for( path const& entry : directory_iterator(dir) )
     {
         if( std::regex_search(entry.filename().string(), pattern) )

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -381,6 +381,7 @@ Series::setIterationEncoding(IterationEncoding ie)
     if( written )
         throw std::runtime_error("A files iterationEncoding can not (yet) be changed after it has been written.");
 
+    m_iterationEncoding = ie;
     switch( ie )
     {
         case IterationEncoding::fileBased:
@@ -392,7 +393,6 @@ Series::setIterationEncoding(IterationEncoding ie)
             setAttribute("iterationEncoding", std::string("groupBased"));
             break;
     }
-    m_iterationEncoding = ie;
     dirty = true;
     return *this;
 }

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -5,7 +5,7 @@
 #define BOOST_TEST_MODULE libopenpmd_parallel_io_test
 
 #include <boost/test/included/unit_test.hpp>
-#if defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_MPI
 #include <mpi.h>
 
 #include "Series.hpp"
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(none)
 { }
 #endif
 
-#if defined(openPMD_HAVE_HDF5) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_content_test)
 {
     int mpi_rank{-1};
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(no_parallel_hdf5)
     BOOST_TEST(true);
 }
 #endif
-#if defined(openPMD_HAVE_ADIOS1) && defined(openPMD_HAVE_MPI) && !defined(_NOMPI)
+#if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
 BOOST_AUTO_TEST_CASE(adios_wrtie_test)
 {
     Output o = Output("../samples/parallel_write.bp");

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -35,45 +35,52 @@ BOOST_AUTO_TEST_CASE(git_hdf5_sample_content_test)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
     /* only a 3x3x3 chunk of the actual data is hardcoded. every worker reads 1/3 */
     uint64_t rank = mpi_rank % 3;
-    Series o = Series::read("../samples/git-sample/data00000%T.h5", MPI_COMM_WORLD);
+  try
+  {
+      Series o = Series::read("../samples/git-sample/data00000%T.h5", MPI_COMM_WORLD);
 
 
-    {
-        double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
-                                   {-1.9979540244463578e-09, -2.5512036927466397e-10, 1.0402234629225404e-09},
-                                   {-1.7353589676361025e-09, -8.0899198451334087e-10, -1.6443779671249104e-10}},
+      {
+          double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
+                                     {-1.9979540244463578e-09, -2.5512036927466397e-10, 1.0402234629225404e-09},
+                                     {-1.7353589676361025e-09, -8.0899198451334087e-10, -1.6443779671249104e-10}},
 
-                                  {{-2.0029988778702545e-09, -1.9543477947081556e-10, 1.0916454407094989e-09},
-                                   {-2.3890367462087170e-09, -4.7158010829662089e-10, 9.0026075483251589e-10},
-                                   {-1.9033881137886510e-09, -7.5192119197708962e-10, 5.0038861942880430e-10}},
+                                    {{-2.0029988778702545e-09, -1.9543477947081556e-10, 1.0916454407094989e-09},
+                                     {-2.3890367462087170e-09, -4.7158010829662089e-10, 9.0026075483251589e-10},
+                                     {-1.9033881137886510e-09, -7.5192119197708962e-10, 5.0038861942880430e-10}},
 
-                                  {{-1.3271805876513554e-09, -5.9243276950837753e-10, -2.2445734160214670e-10},
-                                   {-7.4578609954301101e-10, -1.1995737736469891e-10, 2.5611823772919706e-10},
-                                   {-9.4806251738077663e-10, -1.5472800818372434e-10, -3.6461900165818406e-10}}};
-        MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
-        Offset offset{20 + rank, 20, 190};
-        Extent extent{1, 3, 3};
-        std::unique_ptr< double[] > data;
-        rho.loadChunk(offset, extent, data);
-        double* raw_ptr = data.get();
+                                    {{-1.3271805876513554e-09, -5.9243276950837753e-10, -2.2445734160214670e-10},
+                                     {-7.4578609954301101e-10, -1.1995737736469891e-10, 2.5611823772919706e-10},
+                                     {-9.4806251738077663e-10, -1.5472800818372434e-10, -3.6461900165818406e-10}}};
+          MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
+          Offset offset{20 + rank, 20, 190};
+          Extent extent{1, 3, 3};
+          std::unique_ptr< double[] > data;
+          rho.loadChunk(offset, extent, data);
+          double* raw_ptr = data.get();
 
-        for( int j = 0; j < 3; ++j )
-            for( int k = 0; k < 3; ++k )
-                BOOST_TEST(raw_ptr[j*3 + k] == actual[rank][j][k]);
-    }
+          for( int j = 0; j < 3; ++j )
+              for( int k = 0; k < 3; ++k )
+                  BOOST_TEST(raw_ptr[j*3 + k] == actual[rank][j][k]);
+      }
 
-    {
-        double constant_value = 9.1093829099999999e-31;
-        RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
-        Offset offset{(rank+1) * 5};
-        Extent extent{3};
-        std::unique_ptr< double[] > data;
-        electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
-        double* raw_ptr = data.get();
+      {
+          double constant_value = 9.1093829099999999e-31;
+          RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
+          Offset offset{(rank+1) * 5};
+          Extent extent{3};
+          std::unique_ptr< double[] > data;
+          electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+          double* raw_ptr = data.get();
 
-        for( int i = 0; i < 3; ++i )
-            BOOST_TEST(raw_ptr[i] == constant_value);
-    }
+          for( int i = 0; i < 3; ++i )
+              BOOST_TEST(raw_ptr[i] == constant_value);
+      }
+  } catch (no_such_file_error& e)
+  {
+      std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+      return;
+  }
 }
 
 BOOST_AUTO_TEST_CASE(hdf5_write_test)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -10,335 +10,363 @@
 #if defined(openPMD_HAVE_HDF5)
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_structure_test)
 {
-    Series o = Series::read("../samples/git-sample/data00000100.h5");
+    try
+    {
+        Series o = Series::read("../samples/git-sample/data00000100.h5");
 
-    BOOST_TEST(!o.parent);
-    BOOST_TEST(o.iterations.parent == static_cast< Writable* >(&o));
-    BOOST_TEST(o.iterations[100].parent == static_cast< Writable* >(&o.iterations));
-    BOOST_TEST(o.iterations[100].meshes.parent == static_cast< Writable* >(&o.iterations[100]));
-    BOOST_TEST(o.iterations[100].meshes["E"].parent == static_cast< Writable* >(&o.iterations[100].meshes));
-    BOOST_TEST(o.iterations[100].meshes["E"]["x"].parent == static_cast< Writable* >(&o.iterations[100].meshes["E"]));
-    BOOST_TEST(o.iterations[100].meshes["E"]["y"].parent == static_cast< Writable* >(&o.iterations[100].meshes["E"]));
-    BOOST_TEST(o.iterations[100].meshes["E"]["z"].parent == static_cast< Writable* >(&o.iterations[100].meshes["E"]));
-    BOOST_TEST(o.iterations[100].meshes["rho"].parent == static_cast< Writable* >(&o.iterations[100].meshes));
-    BOOST_TEST(o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].meshes));
-    BOOST_TEST(o.iterations[100].particles.parent == static_cast< Writable* >(&o.iterations[100]));
-    BOOST_TEST(o.iterations[100].particles["electrons"].parent == static_cast< Writable* >(&o.iterations[100].particles));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["charge"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["charge"][RecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["mass"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"]["x"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["momentum"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"]["y"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["momentum"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"]["z"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["momentum"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["position"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["position"]["x"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["position"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["position"]["y"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["position"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["position"]["z"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["position"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"]["x"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["positionOffset"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"]["y"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["positionOffset"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"]["z"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["positionOffset"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["weighting"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
-    BOOST_TEST(o.iterations[100].particles["electrons"]["weighting"][RecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(!o.parent);
+        BOOST_TEST(o.iterations.parent == static_cast< Writable* >(&o));
+        BOOST_TEST(o.iterations[100].parent == static_cast< Writable* >(&o.iterations));
+        BOOST_TEST(o.iterations[100].meshes.parent == static_cast< Writable* >(&o.iterations[100]));
+        BOOST_TEST(o.iterations[100].meshes["E"].parent == static_cast< Writable* >(&o.iterations[100].meshes));
+        BOOST_TEST(o.iterations[100].meshes["E"]["x"].parent == static_cast< Writable* >(&o.iterations[100].meshes["E"]));
+        BOOST_TEST(o.iterations[100].meshes["E"]["y"].parent == static_cast< Writable* >(&o.iterations[100].meshes["E"]));
+        BOOST_TEST(o.iterations[100].meshes["E"]["z"].parent == static_cast< Writable* >(&o.iterations[100].meshes["E"]));
+        BOOST_TEST(o.iterations[100].meshes["rho"].parent == static_cast< Writable* >(&o.iterations[100].meshes));
+        BOOST_TEST(o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].meshes));
+        BOOST_TEST(o.iterations[100].particles.parent == static_cast< Writable* >(&o.iterations[100]));
+        BOOST_TEST(o.iterations[100].particles["electrons"].parent == static_cast< Writable* >(&o.iterations[100].particles));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["charge"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["charge"][RecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["mass"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"]["x"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["momentum"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"]["y"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["momentum"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["momentum"]["z"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["momentum"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["position"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["position"]["x"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["position"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["position"]["y"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["position"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["position"]["z"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["position"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"]["x"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["positionOffset"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"]["y"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["positionOffset"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["positionOffset"]["z"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]["positionOffset"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["weighting"].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+        BOOST_TEST(o.iterations[100].particles["electrons"]["weighting"][RecordComponent::SCALAR].parent == static_cast< Writable* >(&o.iterations[100].particles["electrons"]));
+    } catch (no_such_file_error& e)
+    {
+        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+        return;
+    }
 }
 
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_attribute_test)
 {
-    Series o = Series::read("../samples/git-sample/data00000100.h5");
+    try
+    {
+        Series o = Series::read("../samples/git-sample/data00000100.h5");
 
-    BOOST_TEST(o.openPMD() == "1.0.0");
-    BOOST_TEST(o.openPMDextension() == 1);
-    BOOST_TEST(o.basePath() == "/data/%T/");
-    BOOST_TEST(o.meshesPath() == "fields/");
-    BOOST_TEST(o.particlesPath() == "particles/");
-    BOOST_TEST(o.iterationEncoding() == IterationEncoding::fileBased);
-    BOOST_TEST(o.iterationFormat() == "data%T.h5");
-    BOOST_TEST(o.name() == "data00000100");
+        BOOST_TEST(o.openPMD() == "1.0.0");
+        BOOST_TEST(o.openPMDextension() == 1);
+        BOOST_TEST(o.basePath() == "/data/%T/");
+        BOOST_TEST(o.meshesPath() == "fields/");
+        BOOST_TEST(o.particlesPath() == "particles/");
+        BOOST_TEST(o.iterationEncoding() == IterationEncoding::fileBased);
+        BOOST_TEST(o.iterationFormat() == "data%T.h5");
+        BOOST_TEST(o.name() == "data00000100");
 
-    BOOST_TEST(o.iterations.size() == 1);
-    BOOST_TEST(o.iterations.count(100) == 1);
+        BOOST_TEST(o.iterations.size() == 1);
+        BOOST_TEST(o.iterations.count(100) == 1);
 
-    Iteration& iteration_100 = o.iterations[100];
-    BOOST_TEST(iteration_100.time< double >() == 3.2847121452090077e-14);
-    BOOST_TEST(iteration_100.dt< double >() == 3.2847121452090093e-16);
-    BOOST_TEST(iteration_100.timeUnitSI() == 1.0);
+        Iteration& iteration_100 = o.iterations[100];
+        BOOST_TEST(iteration_100.time< double >() == 3.2847121452090077e-14);
+        BOOST_TEST(iteration_100.dt< double >() == 3.2847121452090093e-16);
+        BOOST_TEST(iteration_100.timeUnitSI() == 1.0);
 
-    BOOST_TEST(iteration_100.meshes.size() == 2);
-    BOOST_TEST(iteration_100.meshes.count("E") == 1);
-    BOOST_TEST(iteration_100.meshes.count("rho") == 1);
+        BOOST_TEST(iteration_100.meshes.size() == 2);
+        BOOST_TEST(iteration_100.meshes.count("E") == 1);
+        BOOST_TEST(iteration_100.meshes.count("rho") == 1);
 
-    std::vector< std::string > al{"x", "y", "z"};
-    std::vector< double > gs{8.0000000000000007e-07,
-                             8.0000000000000007e-07,
-                             1.0000000000000001e-07};
-    std::vector< double > ggo{-1.0000000000000001e-05,
-                              -1.0000000000000001e-05,
-                              -5.1999999999999993e-06};
-    std::array< double, 7 > ud{{1.,  1., -3., -1.,  0.,  0.,  0.}};
-    Mesh& E = iteration_100.meshes["E"];
-    BOOST_TEST(E.geometry() == Mesh::Geometry::cartesian);
-    BOOST_TEST(E.dataOrder() == Mesh::DataOrder::C);
-    BOOST_TEST(E.axisLabels() == al);
-    BOOST_TEST(E.gridSpacing< double >() == gs);
-    BOOST_TEST(E.gridGlobalOffset() == ggo);
-    BOOST_TEST(E.gridUnitSI() == 1.0);
-    BOOST_TEST(E.unitDimension() == ud);
-    BOOST_TEST(E.timeOffset< double >() == 0.0);
+        std::vector< std::string > al{"x", "y", "z"};
+        std::vector< double > gs{8.0000000000000007e-07,
+                                 8.0000000000000007e-07,
+                                 1.0000000000000001e-07};
+        std::vector< double > ggo{-1.0000000000000001e-05,
+                                  -1.0000000000000001e-05,
+                                  -5.1999999999999993e-06};
+        std::array< double, 7 > ud{{1.,  1., -3., -1.,  0.,  0.,  0.}};
+        Mesh& E = iteration_100.meshes["E"];
+        BOOST_TEST(E.geometry() == Mesh::Geometry::cartesian);
+        BOOST_TEST(E.dataOrder() == Mesh::DataOrder::C);
+        BOOST_TEST(E.axisLabels() == al);
+        BOOST_TEST(E.gridSpacing< double >() == gs);
+        BOOST_TEST(E.gridGlobalOffset() == ggo);
+        BOOST_TEST(E.gridUnitSI() == 1.0);
+        BOOST_TEST(E.unitDimension() == ud);
+        BOOST_TEST(E.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(E.size() == 3);
-    BOOST_TEST(E.count("x") == 1);
-    BOOST_TEST(E.count("y") == 1);
-    BOOST_TEST(E.count("z") == 1);
+        BOOST_TEST(E.size() == 3);
+        BOOST_TEST(E.count("x") == 1);
+        BOOST_TEST(E.count("y") == 1);
+        BOOST_TEST(E.count("z") == 1);
 
-    std::vector< double > p{0.5, 0., 0.};
-    Extent e{26, 26, 201};
-    MeshRecordComponent& E_x = E["x"];
-    BOOST_TEST(E_x.unitSI() == 1.0);
-    BOOST_TEST(E_x.position< double >() == p);
-    BOOST_TEST(E_x.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(E_x.getExtent() == e);
-    BOOST_TEST(E_x.getDimensionality() == 3);
+        std::vector< double > p{0.5, 0., 0.};
+        Extent e{26, 26, 201};
+        MeshRecordComponent& E_x = E["x"];
+        BOOST_TEST(E_x.unitSI() == 1.0);
+        BOOST_TEST(E_x.position< double >() == p);
+        BOOST_TEST(E_x.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(E_x.getExtent() == e);
+        BOOST_TEST(E_x.getDimensionality() == 3);
 
-    p = {0., 0.5, 0.};
-    MeshRecordComponent& E_y = E["y"];
-    BOOST_TEST(E_y.unitSI() == 1.0);
-    BOOST_TEST(E_y.position< double >() == p);
-    BOOST_TEST(E_y.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(E_y.getExtent() == e);
-    BOOST_TEST(E_y.getDimensionality() == 3);
+        p = {0., 0.5, 0.};
+        MeshRecordComponent& E_y = E["y"];
+        BOOST_TEST(E_y.unitSI() == 1.0);
+        BOOST_TEST(E_y.position< double >() == p);
+        BOOST_TEST(E_y.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(E_y.getExtent() == e);
+        BOOST_TEST(E_y.getDimensionality() == 3);
 
-    p = {0., 0., 0.5};
-    MeshRecordComponent& E_z = E["z"];
-    BOOST_TEST(E_z.unitSI() == 1.0);
-    BOOST_TEST(E_z.position< double >() == p);
-    BOOST_TEST(E_z.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(E_z.getExtent() == e);
-    BOOST_TEST(E_z.getDimensionality() == 3);
+        p = {0., 0., 0.5};
+        MeshRecordComponent& E_z = E["z"];
+        BOOST_TEST(E_z.unitSI() == 1.0);
+        BOOST_TEST(E_z.position< double >() == p);
+        BOOST_TEST(E_z.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(E_z.getExtent() == e);
+        BOOST_TEST(E_z.getDimensionality() == 3);
 
-    gs = {8.0000000000000007e-07,
-          8.0000000000000007e-07,
-          1.0000000000000001e-07};
-    ggo = {-1.0000000000000001e-05,
-           -1.0000000000000001e-05,
-           -5.1999999999999993e-06};
-    ud = {{-3.,  0.,  1.,  1.,  0.,  0.,  0.}};
-    Mesh& rho = iteration_100.meshes["rho"];
-    BOOST_TEST(rho.geometry() == Mesh::Geometry::cartesian);
-    BOOST_TEST(rho.dataOrder() == Mesh::DataOrder::C);
-    BOOST_TEST(rho.axisLabels() == al);
-    BOOST_TEST(rho.gridSpacing< double >() == gs);
-    BOOST_TEST(rho.gridGlobalOffset() == ggo);
-    BOOST_TEST(rho.gridUnitSI() == 1.0);
-    BOOST_TEST(rho.unitDimension() == ud);
-    BOOST_TEST(rho.timeOffset< double >() == 0.0);
+        gs = {8.0000000000000007e-07,
+              8.0000000000000007e-07,
+              1.0000000000000001e-07};
+        ggo = {-1.0000000000000001e-05,
+               -1.0000000000000001e-05,
+               -5.1999999999999993e-06};
+        ud = {{-3.,  0.,  1.,  1.,  0.,  0.,  0.}};
+        Mesh& rho = iteration_100.meshes["rho"];
+        BOOST_TEST(rho.geometry() == Mesh::Geometry::cartesian);
+        BOOST_TEST(rho.dataOrder() == Mesh::DataOrder::C);
+        BOOST_TEST(rho.axisLabels() == al);
+        BOOST_TEST(rho.gridSpacing< double >() == gs);
+        BOOST_TEST(rho.gridGlobalOffset() == ggo);
+        BOOST_TEST(rho.gridUnitSI() == 1.0);
+        BOOST_TEST(rho.unitDimension() == ud);
+        BOOST_TEST(rho.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(rho.size() == 1);
-    BOOST_TEST(rho.count(MeshRecordComponent::SCALAR) == 1);
+        BOOST_TEST(rho.size() == 1);
+        BOOST_TEST(rho.count(MeshRecordComponent::SCALAR) == 1);
 
-    p = {0., 0., 0.};
-    e = {26, 26, 201};
-    MeshRecordComponent& rho_scalar = rho[MeshRecordComponent::SCALAR];
-    BOOST_TEST(rho_scalar.unitSI() == 1.0);
-    BOOST_TEST(rho_scalar.position< double >() == p);
-    BOOST_TEST(rho_scalar.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(rho_scalar.getExtent() == e);
-    BOOST_TEST(rho_scalar.getDimensionality() == 3);
+        p = {0., 0., 0.};
+        e = {26, 26, 201};
+        MeshRecordComponent& rho_scalar = rho[MeshRecordComponent::SCALAR];
+        BOOST_TEST(rho_scalar.unitSI() == 1.0);
+        BOOST_TEST(rho_scalar.position< double >() == p);
+        BOOST_TEST(rho_scalar.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(rho_scalar.getExtent() == e);
+        BOOST_TEST(rho_scalar.getDimensionality() == 3);
 
-    BOOST_TEST(iteration_100.particles.size() == 1);
-    BOOST_TEST(iteration_100.particles.count("electrons") == 1);
+        BOOST_TEST(iteration_100.particles.size() == 1);
+        BOOST_TEST(iteration_100.particles.count("electrons") == 1);
 
-    ParticleSpecies& electrons = iteration_100.particles["electrons"];
+        ParticleSpecies& electrons = iteration_100.particles["electrons"];
 
-    BOOST_TEST(electrons.size() == 6);
-    BOOST_TEST(electrons.count("charge") == 1);
-    BOOST_TEST(electrons.count("mass") == 1);
-    BOOST_TEST(electrons.count("momentum") == 1);
-    BOOST_TEST(electrons.count("position") == 1);
-    BOOST_TEST(electrons.count("positionOffset") == 1);
-    BOOST_TEST(electrons.count("weighting") == 1);
+        BOOST_TEST(electrons.size() == 6);
+        BOOST_TEST(electrons.count("charge") == 1);
+        BOOST_TEST(electrons.count("mass") == 1);
+        BOOST_TEST(electrons.count("momentum") == 1);
+        BOOST_TEST(electrons.count("position") == 1);
+        BOOST_TEST(electrons.count("positionOffset") == 1);
+        BOOST_TEST(electrons.count("weighting") == 1);
 
-    ud = {{0.,  0.,  1.,  1.,  0.,  0.,  0.}};
-    Record& charge = electrons["charge"];
-    BOOST_TEST(charge.unitDimension() == ud);
-    BOOST_TEST(charge.timeOffset< double >() == 0.0);
+        ud = {{0.,  0.,  1.,  1.,  0.,  0.,  0.}};
+        Record& charge = electrons["charge"];
+        BOOST_TEST(charge.unitDimension() == ud);
+        BOOST_TEST(charge.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(charge.size() == 1);
-    BOOST_TEST(charge.count(RecordComponent::SCALAR) == 1);
+        BOOST_TEST(charge.size() == 1);
+        BOOST_TEST(charge.count(RecordComponent::SCALAR) == 1);
 
-    e = {85000};
-    RecordComponent& charge_scalar = charge[RecordComponent::SCALAR];
-    BOOST_TEST(charge_scalar.unitSI() == 1.0);
-    BOOST_TEST(charge_scalar.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(charge_scalar.getDimensionality() == 1);
-    BOOST_TEST(charge_scalar.getExtent() == e);
+        e = {85000};
+        RecordComponent& charge_scalar = charge[RecordComponent::SCALAR];
+        BOOST_TEST(charge_scalar.unitSI() == 1.0);
+        BOOST_TEST(charge_scalar.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(charge_scalar.getDimensionality() == 1);
+        BOOST_TEST(charge_scalar.getExtent() == e);
 
-    ud = {{1.,  0.,  0.,  0.,  0.,  0.,  0.}};
-    Record& mass = electrons["mass"];
-    BOOST_TEST(mass.unitDimension() == ud);
-    BOOST_TEST(mass.timeOffset< double >() == 0.0);
+        ud = {{1.,  0.,  0.,  0.,  0.,  0.,  0.}};
+        Record& mass = electrons["mass"];
+        BOOST_TEST(mass.unitDimension() == ud);
+        BOOST_TEST(mass.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(mass.size() == 1);
-    BOOST_TEST(mass.count(RecordComponent::SCALAR) == 1);
+        BOOST_TEST(mass.size() == 1);
+        BOOST_TEST(mass.count(RecordComponent::SCALAR) == 1);
 
-    RecordComponent& mass_scalar = mass[RecordComponent::SCALAR];
-    BOOST_TEST(mass_scalar.unitSI() == 1.0);
-    BOOST_TEST(mass_scalar.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(mass_scalar.getDimensionality() == 1);
-    BOOST_TEST(mass_scalar.getExtent() == e);
+        RecordComponent& mass_scalar = mass[RecordComponent::SCALAR];
+        BOOST_TEST(mass_scalar.unitSI() == 1.0);
+        BOOST_TEST(mass_scalar.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(mass_scalar.getDimensionality() == 1);
+        BOOST_TEST(mass_scalar.getExtent() == e);
 
-    ud = {{1.,  1., -1.,  0.,  0.,  0.,  0.}};
-    Record& momentum = electrons["momentum"];
-    BOOST_TEST(momentum.unitDimension() == ud);
-    BOOST_TEST(momentum.timeOffset< double >() == 0.0);
+        ud = {{1.,  1., -1.,  0.,  0.,  0.,  0.}};
+        Record& momentum = electrons["momentum"];
+        BOOST_TEST(momentum.unitDimension() == ud);
+        BOOST_TEST(momentum.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(momentum.size() == 3);
-    BOOST_TEST(momentum.count("x") == 1);
-    BOOST_TEST(momentum.count("y") == 1);
-    BOOST_TEST(momentum.count("z") == 1);
+        BOOST_TEST(momentum.size() == 3);
+        BOOST_TEST(momentum.count("x") == 1);
+        BOOST_TEST(momentum.count("y") == 1);
+        BOOST_TEST(momentum.count("z") == 1);
 
-    RecordComponent& momentum_x = momentum["x"];
-    BOOST_TEST(momentum_x.unitSI() == 1.0);
-    BOOST_TEST(momentum_x.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(momentum_x.getDimensionality() == 1);
-    BOOST_TEST(momentum_x.getExtent() == e);
+        RecordComponent& momentum_x = momentum["x"];
+        BOOST_TEST(momentum_x.unitSI() == 1.0);
+        BOOST_TEST(momentum_x.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(momentum_x.getDimensionality() == 1);
+        BOOST_TEST(momentum_x.getExtent() == e);
 
-    RecordComponent& momentum_y = momentum["y"];
-    BOOST_TEST(momentum_y.unitSI() == 1.0);
-    BOOST_TEST(momentum_y.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(momentum_y.getDimensionality() == 1);
-    BOOST_TEST(momentum_y.getExtent() == e);
+        RecordComponent& momentum_y = momentum["y"];
+        BOOST_TEST(momentum_y.unitSI() == 1.0);
+        BOOST_TEST(momentum_y.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(momentum_y.getDimensionality() == 1);
+        BOOST_TEST(momentum_y.getExtent() == e);
 
-    RecordComponent& momentum_z = momentum["z"];
-    BOOST_TEST(momentum_z.unitSI() == 1.0);
-    BOOST_TEST(momentum_z.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(momentum_z.getDimensionality() == 1);
-    BOOST_TEST(momentum_z.getExtent() == e);
+        RecordComponent& momentum_z = momentum["z"];
+        BOOST_TEST(momentum_z.unitSI() == 1.0);
+        BOOST_TEST(momentum_z.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(momentum_z.getDimensionality() == 1);
+        BOOST_TEST(momentum_z.getExtent() == e);
 
-    ud = {{1.,  0.,  0.,  0.,  0.,  0.,  0.}};
-    Record& position = electrons["position"];
-    BOOST_TEST(position.unitDimension() == ud);
-    BOOST_TEST(position.timeOffset< double >() == 0.0);
+        ud = {{1.,  0.,  0.,  0.,  0.,  0.,  0.}};
+        Record& position = electrons["position"];
+        BOOST_TEST(position.unitDimension() == ud);
+        BOOST_TEST(position.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(position.size() == 3);
-    BOOST_TEST(position.count("x") == 1);
-    BOOST_TEST(position.count("y") == 1);
-    BOOST_TEST(position.count("z") == 1);
+        BOOST_TEST(position.size() == 3);
+        BOOST_TEST(position.count("x") == 1);
+        BOOST_TEST(position.count("y") == 1);
+        BOOST_TEST(position.count("z") == 1);
 
-    RecordComponent& position_x = position["x"];
-    BOOST_TEST(position_x.unitSI() == 1.0);
-    BOOST_TEST(position_x.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(position_x.getDimensionality() == 1);
-    BOOST_TEST(position_x.getExtent() == e);
+        RecordComponent& position_x = position["x"];
+        BOOST_TEST(position_x.unitSI() == 1.0);
+        BOOST_TEST(position_x.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(position_x.getDimensionality() == 1);
+        BOOST_TEST(position_x.getExtent() == e);
 
-    RecordComponent& position_y = position["y"];
-    BOOST_TEST(position_y.unitSI() == 1.0);
-    BOOST_TEST(position_y.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(position_y.getDimensionality() == 1);
-    BOOST_TEST(position_y.getExtent() == e);
+        RecordComponent& position_y = position["y"];
+        BOOST_TEST(position_y.unitSI() == 1.0);
+        BOOST_TEST(position_y.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(position_y.getDimensionality() == 1);
+        BOOST_TEST(position_y.getExtent() == e);
 
-    RecordComponent& position_z = position["z"];
-    BOOST_TEST(position_z.unitSI() == 1.0);
-    BOOST_TEST(position_z.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(position_z.getDimensionality() == 1);
-    BOOST_TEST(position_z.getExtent() == e);
+        RecordComponent& position_z = position["z"];
+        BOOST_TEST(position_z.unitSI() == 1.0);
+        BOOST_TEST(position_z.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(position_z.getDimensionality() == 1);
+        BOOST_TEST(position_z.getExtent() == e);
 
-    Record& positionOffset = electrons["positionOffset"];
-    BOOST_TEST(positionOffset.unitDimension() == ud);
-    BOOST_TEST(positionOffset.timeOffset< double >() == 0.0);
+        Record& positionOffset = electrons["positionOffset"];
+        BOOST_TEST(positionOffset.unitDimension() == ud);
+        BOOST_TEST(positionOffset.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(positionOffset.size() == 3);
-    BOOST_TEST(positionOffset.count("x") == 1);
-    BOOST_TEST(positionOffset.count("y") == 1);
-    BOOST_TEST(positionOffset.count("z") == 1);
+        BOOST_TEST(positionOffset.size() == 3);
+        BOOST_TEST(positionOffset.count("x") == 1);
+        BOOST_TEST(positionOffset.count("y") == 1);
+        BOOST_TEST(positionOffset.count("z") == 1);
 
-    RecordComponent& positionOffset_x = positionOffset["x"];
-    BOOST_TEST(positionOffset_x.unitSI() == 1.0);
-    BOOST_TEST(positionOffset_x.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(positionOffset_x.getDimensionality() == 1);
-    BOOST_TEST(positionOffset_x.getExtent() == e);
+        RecordComponent& positionOffset_x = positionOffset["x"];
+        BOOST_TEST(positionOffset_x.unitSI() == 1.0);
+        BOOST_TEST(positionOffset_x.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(positionOffset_x.getDimensionality() == 1);
+        BOOST_TEST(positionOffset_x.getExtent() == e);
 
-    RecordComponent& positionOffset_y = positionOffset["y"];
-    BOOST_TEST(positionOffset_y.unitSI() == 1.0);
-    BOOST_TEST(positionOffset_y.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(positionOffset_y.getDimensionality() == 1);
-    BOOST_TEST(positionOffset_y.getExtent() == e);
+        RecordComponent& positionOffset_y = positionOffset["y"];
+        BOOST_TEST(positionOffset_y.unitSI() == 1.0);
+        BOOST_TEST(positionOffset_y.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(positionOffset_y.getDimensionality() == 1);
+        BOOST_TEST(positionOffset_y.getExtent() == e);
 
-    RecordComponent& positionOffset_z = positionOffset["z"];
-    BOOST_TEST(positionOffset_z.unitSI() == 1.0);
-    BOOST_TEST(positionOffset_z.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(positionOffset_z.getDimensionality() == 1);
-    BOOST_TEST(positionOffset_z.getExtent() == e);
+        RecordComponent& positionOffset_z = positionOffset["z"];
+        BOOST_TEST(positionOffset_z.unitSI() == 1.0);
+        BOOST_TEST(positionOffset_z.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(positionOffset_z.getDimensionality() == 1);
+        BOOST_TEST(positionOffset_z.getExtent() == e);
 
-    ud = {{0.,  0.,  0.,  0.,  0.,  0.,  0.}};
-    Record& weighting = electrons["weighting"];
-    BOOST_TEST(weighting.unitDimension() == ud);
-    BOOST_TEST(weighting.timeOffset< double >() == 0.0);
+        ud = {{0.,  0.,  0.,  0.,  0.,  0.,  0.}};
+        Record& weighting = electrons["weighting"];
+        BOOST_TEST(weighting.unitDimension() == ud);
+        BOOST_TEST(weighting.timeOffset< double >() == 0.0);
 
-    BOOST_TEST(weighting.size() == 1);
-    BOOST_TEST(weighting.count(RecordComponent::SCALAR) == 1);
+        BOOST_TEST(weighting.size() == 1);
+        BOOST_TEST(weighting.count(RecordComponent::SCALAR) == 1);
 
-    RecordComponent& weighting_scalar = weighting[RecordComponent::SCALAR];
-    BOOST_TEST(weighting_scalar.unitSI() == 1.0);
-    BOOST_TEST(weighting_scalar.getDatatype() == Datatype::DOUBLE);
-    BOOST_TEST(weighting_scalar.getDimensionality() == 1);
-    BOOST_TEST(weighting_scalar.getExtent() == e);
+        RecordComponent& weighting_scalar = weighting[RecordComponent::SCALAR];
+        BOOST_TEST(weighting_scalar.unitSI() == 1.0);
+        BOOST_TEST(weighting_scalar.getDatatype() == Datatype::DOUBLE);
+        BOOST_TEST(weighting_scalar.getDimensionality() == 1);
+        BOOST_TEST(weighting_scalar.getExtent() == e);
+    } catch (no_such_file_error& e)
+    {
+        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+        return;
+    }
 }
 
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_content_test)
 {
-    Series o = Series::read("../samples/git-sample/data00000100.h5");
-
+    try
     {
-        double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
-                                   {-1.9979540244463578e-09, -2.5512036927466397e-10, 1.0402234629225404e-09},
-                                   {-1.7353589676361025e-09, -8.0899198451334087e-10, -1.6443779671249104e-10}},
+        Series o = Series::read("../samples/git-sample/data00000100.h5");
 
-                                  {{-2.0029988778702545e-09, -1.9543477947081556e-10, 1.0916454407094989e-09},
-                                   {-2.3890367462087170e-09, -4.7158010829662089e-10, 9.0026075483251589e-10},
-                                   {-1.9033881137886510e-09, -7.5192119197708962e-10, 5.0038861942880430e-10}},
+        {
+            double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
+                                       {-1.9979540244463578e-09, -2.5512036927466397e-10, 1.0402234629225404e-09},
+                                       {-1.7353589676361025e-09, -8.0899198451334087e-10, -1.6443779671249104e-10}},
 
-                                  {{-1.3271805876513554e-09, -5.9243276950837753e-10, -2.2445734160214670e-10},
-                                   {-7.4578609954301101e-10, -1.1995737736469891e-10, 2.5611823772919706e-10},
-                                   {-9.4806251738077663e-10, -1.5472800818372434e-10, -3.6461900165818406e-10}}};
-        MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
-        Offset offset{20, 20, 190};
-        Extent extent{3, 3, 3};
-        std::unique_ptr< double[] > data;
-        rho.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
-        double* raw_ptr = data.get();
+                                      {{-2.0029988778702545e-09, -1.9543477947081556e-10, 1.0916454407094989e-09},
+                                       {-2.3890367462087170e-09, -4.7158010829662089e-10, 9.0026075483251589e-10},
+                                       {-1.9033881137886510e-09, -7.5192119197708962e-10, 5.0038861942880430e-10}},
 
-        for( int i = 0; i < 3; ++i )
-            for( int j = 0; j < 3; ++j )
-                for( int k = 0; k < 3; ++k )
-                    BOOST_TEST(raw_ptr[((i*3) + j)*3 + k] == actual[i][j][k]);
-    }
+                                      {{-1.3271805876513554e-09, -5.9243276950837753e-10, -2.2445734160214670e-10},
+                                       {-7.4578609954301101e-10, -1.1995737736469891e-10, 2.5611823772919706e-10},
+                                       {-9.4806251738077663e-10, -1.5472800818372434e-10, -3.6461900165818406e-10}}};
+            MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
+            Offset offset{20, 20, 190};
+            Extent extent{3, 3, 3};
+            std::unique_ptr< double[] > data;
+            rho.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+            double* raw_ptr = data.get();
 
+            for( int i = 0; i < 3; ++i )
+                for( int j = 0; j < 3; ++j )
+                    for( int k = 0; k < 3; ++k )
+                        BOOST_TEST(raw_ptr[((i*3) + j)*3 + k] == actual[i][j][k]);
+        }
+
+        {
+            double constant_value = 9.1093829099999999e-31;
+            RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
+            Offset offset{15};
+            Extent extent{3};
+            std::unique_ptr< double[] > data;
+            electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+            double* raw_ptr = data.get();
+
+            for( int i = 0; i < 3; ++i )
+                BOOST_TEST(raw_ptr[i] == constant_value);
+        }
+    } catch (no_such_file_error& e)
     {
-        double constant_value = 9.1093829099999999e-31;
-        RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
-        Offset offset{15};
-        Extent extent{3};
-        std::unique_ptr< double[] > data;
-        electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
-        double* raw_ptr = data.get();
-
-        for( int i = 0; i < 3; ++i )
-            BOOST_TEST(raw_ptr[i] == constant_value);
+        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+        return;
     }
 }
 
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_fileBased_read_test)
 {
-    Series o = Series::read("../samples/git-sample/data%T.h5");
+    try
+    {
+        Series o = Series::read("../samples/git-sample/data%T.h5");
 
-    BOOST_TEST(o.iterations.size() == 5);
-    BOOST_TEST(o.iterations.count(100) == 1);
-    BOOST_TEST(o.iterations.count(200) == 1);
-    BOOST_TEST(o.iterations.count(300) == 1);
-    BOOST_TEST(o.iterations.count(400) == 1);
-    BOOST_TEST(o.iterations.count(500) == 1);
+        BOOST_TEST(o.iterations.size() == 5);
+        BOOST_TEST(o.iterations.count(100) == 1);
+        BOOST_TEST(o.iterations.count(200) == 1);
+        BOOST_TEST(o.iterations.count(300) == 1);
+        BOOST_TEST(o.iterations.count(400) == 1);
+        BOOST_TEST(o.iterations.count(500) == 1);
+    } catch (no_such_file_error& e)
+    {
+        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+        return;
+    }
 }
 
 BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -7,7 +7,7 @@
 #define protected public
 #include "Series.hpp"
 
-#ifdef LIBOPENPMD_WITH_HDF5
+#if defined(openPMD_HAVE_HDF5)
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_structure_test)
 {
     Series o = Series::read("../samples/git-sample/data00000100.h5");
@@ -918,14 +918,20 @@ BOOST_AUTO_TEST_CASE(hdf5_deletion_test)
     e.erase("deletion_scalar_constant");
     o.flush();
 }
+#else
+BOOST_AUTO_TEST_CASE(no_serial_hdf5)
+{
+    BOOST_TEST(true);
+}
 #endif
-#ifdef LIBOPENPMD_WITH_ADIOS1
+#if defined(openPMD_HAVE_ADIOS1)
 BOOST_AUTO_TEST_CASE(adios_write_test)
 {
-    Output o = Output("samples",
-                      "serial_write",
-                      IterationEncoding::fileBased,
-                      Format::ADIOS,
-                      AccessType::CREATE);
+    Output o = Output("../samples/serial_write.bp");
+}
+#else
+BOOST_AUTO_TEST_CASE(no_serial_adios1)
+{
+    BOOST_TEST(true);
 }
 #endif


### PR DESCRIPTION
Building and using a built version of libopenPMD now only offers either serial or parallel backends.