### PR TITLE
Travis: Allow Fail Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ matrix:
     - env:
         - openPMD_USE_MPI=OFF openPMD_USE_HDF5=ON openPMD_USE_ADIOS1=OFF openPMD_USE_ADIOS2=OFF
       compiler: gcc
+  allow_failures:
+    - compiler: clang
 
 install:
   - SPACK_FOUND=$(which spack >/dev/null && { echo 0; } || { echo 1; })


### PR DESCRIPTION
As long as it does not build in CI, allow clang 5.0.0 to fail.

GCC will probably need a 4.8 to 4.9 update for the new C++11 std regex lib