### PR TITLE
Constants: Suffixes

### DIFF
--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -394,8 +394,8 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(o.iterations.count(0) == 1);
 
         Iteration& i = o.iterations[0];
-        BOOST_TEST(i.time< float >() == static_cast< float >(0.0));
-        BOOST_TEST(i.dt< float >() == static_cast< float >(1.0));
+        BOOST_TEST(i.time< float >() == static_cast< float >(0.0f));
+        BOOST_TEST(i.dt< float >() == static_cast< float >(1.0f));
         BOOST_TEST(i.timeUnitSI() == 1.3899999999999999e-16);
 
         BOOST_TEST(i.meshes.size() == 4);
@@ -405,9 +405,9 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(i.meshes.count("e_energyDensity") == 1);
 
         std::vector< std::string > al{"z", "y", "x"};
-        std::vector< float > gs{static_cast< float >(6.2393283843994141),
-                                static_cast< float >(1.0630855560302734),
-                                static_cast< float >(6.2393283843994141)};
+        std::vector< float > gs{static_cast< float >(6.2393283843994141f),
+                                static_cast< float >(1.0630855560302734f),
+                                static_cast< float >(6.2393283843994141f)};
         std::vector< double > ggo{0., 0., 0.};
         std::array< double, 7 > ud{{0.,  1., -2., -1.,  0.,  0.,  0.}};
         Mesh& B = i.meshes["B"];
@@ -418,16 +418,16 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(B.gridGlobalOffset() == ggo);
         BOOST_TEST(B.gridUnitSI() == 4.1671151661999998e-08);
         BOOST_TEST(B.unitDimension() == ud);
-        BOOST_TEST(B.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(B.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(B.size() == 3);
         BOOST_TEST(B.count("x") == 1);
         BOOST_TEST(B.count("y") == 1);
         BOOST_TEST(B.count("z") == 1);
 
-        std::vector< float > p{static_cast< float >(0.),
-                               static_cast< float >(0.5),
-                               static_cast< float >(0.5)};
+        std::vector< float > p{static_cast< float >(0.0f),
+                               static_cast< float >(0.5f),
+                               static_cast< float >(0.5f)};
         Extent e{80, 384, 80};
         MeshRecordComponent& B_x = B["x"];
         BOOST_TEST(B_x.unitSI() == 40903.822240601701);
@@ -436,9 +436,9 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(B_x.getExtent() == e);
         BOOST_TEST(B_x.getDimensionality() == 3);
 
-        p = {static_cast< float >(0.5),
-             static_cast< float >(0.),
-             static_cast< float >(0.5)};
+        p = {static_cast< float >(0.5f),
+             static_cast< float >(0.0f),
+             static_cast< float >(0.5f)};
         MeshRecordComponent& B_y = B["y"];
         BOOST_TEST(B_y.unitSI() == 40903.822240601701);
         BOOST_TEST(B_y.position< float >() == p);
@@ -446,9 +446,9 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(B_y.getExtent() == e);
         BOOST_TEST(B_y.getDimensionality() == 3);
 
-        p = {static_cast< float >(0.5),
-             static_cast< float >(0.5),
-             static_cast< float >(0.)};
+        p = {static_cast< float >(0.5f),
+             static_cast< float >(0.5f),
+             static_cast< float >(0.0f)};
         MeshRecordComponent& B_z = B["z"];
         BOOST_TEST(B_z.unitSI() == 40903.822240601701);
         BOOST_TEST(B_z.position< float >() == p);
@@ -465,16 +465,16 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(E.gridGlobalOffset() == ggo);
         BOOST_TEST(E.gridUnitSI() == 4.1671151661999998e-08);
         BOOST_TEST(E.unitDimension() == ud);
-        BOOST_TEST(E.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(E.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(E.size() == 3);
         BOOST_TEST(E.count("x") == 1);
         BOOST_TEST(E.count("y") == 1);
         BOOST_TEST(E.count("z") == 1);
 
-        p = {static_cast< float >(0.5),
-             static_cast< float >(0.),
-             static_cast< float >(0.)};
+        p = {static_cast< float >(0.5f),
+             static_cast< float >(0.0f),
+             static_cast< float >(0.0f)};
         e = {80, 384, 80};
         MeshRecordComponent& E_x = E["x"];
         BOOST_TEST(E_x.unitSI() == 12262657411105.049);
@@ -483,9 +483,9 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(E_x.getExtent() == e);
         BOOST_TEST(E_x.getDimensionality() == 3);
 
-        p = {static_cast< float >(0.),
-             static_cast< float >(0.5),
-             static_cast< float >(0.)};
+        p = {static_cast< float >(0.0f),
+             static_cast< float >(0.5f),
+             static_cast< float >(0.0f)};
         MeshRecordComponent& E_y = E["y"];
         BOOST_TEST(E_y.unitSI() == 12262657411105.049);
         BOOST_TEST(E_y.position< float >() == p);
@@ -493,9 +493,9 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(E_y.getExtent() == e);
         BOOST_TEST(E_y.getDimensionality() == 3);
 
-        p = {static_cast< float >(0.),
-             static_cast< float >(0.),
-             static_cast< float >(0.5)};
+        p = {static_cast< float >(0.0f),
+             static_cast< float >(0.0f),
+             static_cast< float >(0.5f)};
         MeshRecordComponent& E_z = E["z"];
         BOOST_TEST(E_z.unitSI() == 12262657411105.049);
         BOOST_TEST(E_z.position< float >() == p);
@@ -512,14 +512,14 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(e_chargeDensity.gridGlobalOffset() == ggo);
         BOOST_TEST(e_chargeDensity.gridUnitSI() == 4.1671151661999998e-08);
         BOOST_TEST(e_chargeDensity.unitDimension() == ud);
-        BOOST_TEST(e_chargeDensity.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_chargeDensity.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_chargeDensity.size() == 1);
         BOOST_TEST(e_chargeDensity.count(MeshRecordComponent::SCALAR) == 1);
 
-        p = {static_cast< float >(0.),
-             static_cast< float >(0.),
-             static_cast< float >(0.)};
+        p = {static_cast< float >(0.f),
+             static_cast< float >(0.f),
+             static_cast< float >(0.f)};
         MeshRecordComponent& e_chargeDensity_scalar = e_chargeDensity[MeshRecordComponent::SCALAR];
         BOOST_TEST(e_chargeDensity_scalar.unitSI() == 66306201.002331272);
         BOOST_TEST(e_chargeDensity_scalar.position< float >() == p);
@@ -536,7 +536,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         BOOST_TEST(e_energyDensity.gridGlobalOffset() == ggo);
         BOOST_TEST(e_energyDensity.gridUnitSI() == 4.1671151661999998e-08);
         BOOST_TEST(e_energyDensity.unitDimension() == ud);
-        BOOST_TEST(e_energyDensity.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_energyDensity.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_energyDensity.size() == 1);
         BOOST_TEST(e_energyDensity.count(MeshRecordComponent::SCALAR) == 1);
@@ -570,7 +570,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         ud = {{0.,  0.,  1.,  1.,  0.,  0.,  0.}};
         Record& e_charge = species_e["charge"];
         BOOST_TEST(e_charge.unitDimension() == ud);
-        BOOST_TEST(e_charge.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_charge.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_charge.size() == 1);
         BOOST_TEST(e_charge.count(RecordComponent::SCALAR) == 1);
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         ud = {{0.,  1.,  0.,  0.,  0.,  0.,  0.}};
         Record& e_mass = species_e["mass"];
         BOOST_TEST(e_mass.unitDimension() == ud);
-        BOOST_TEST(e_mass.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_mass.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_mass.size() == 1);
         BOOST_TEST(e_mass.count(RecordComponent::SCALAR) == 1);
@@ -599,7 +599,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         ud = {{1.,  1., -1.,  0.,  0.,  0.,  0.}};
         Record& e_momentum = species_e["momentum"];
         BOOST_TEST(e_momentum.unitDimension() == ud);
-        BOOST_TEST(e_momentum.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_momentum.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_momentum.size() == 3);
         BOOST_TEST(e_momentum.count("x") == 1);
@@ -627,7 +627,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         ud = {{1.,  0.,  0.,  0.,  0.,  0.,  0.}};
         Record& e_position = species_e["position"];
         BOOST_TEST(e_position.unitDimension() == ud);
-        BOOST_TEST(e_position.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_position.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_position.size() == 3);
         BOOST_TEST(e_position.count("x") == 1);
@@ -655,7 +655,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         ud = {{1.,  0.,  0.,  0.,  0.,  0.,  0.}};
         Record& e_positionOffset = species_e["positionOffset"];
         BOOST_TEST(e_positionOffset.unitDimension() == ud);
-        BOOST_TEST(e_positionOffset.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_positionOffset.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_positionOffset.size() == 3);
         BOOST_TEST(e_positionOffset.count("x") == 1);
@@ -683,7 +683,7 @@ BOOST_AUTO_TEST_CASE(hzdr_hdf5_sample_content_test)
         ud = {{0.,  0.,  0.,  0.,  0.,  0.,  0.}};
         Record& e_weighting = species_e["weighting"];
         BOOST_TEST(e_weighting.unitDimension() == ud);
-        BOOST_TEST(e_weighting.timeOffset< float >() == static_cast< float >(0.0));
+        BOOST_TEST(e_weighting.timeOffset< float >() == static_cast< float >(0.0f));
 
         BOOST_TEST(e_weighting.size() == 1);
         BOOST_TEST(e_weighting.count(RecordComponent::SCALAR) == 1);
@@ -715,17 +715,17 @@ BOOST_AUTO_TEST_CASE(hdf5_dtype_test)
         s.setAttribute("int32", i32);
         int64_t i64 = 64;
         s.setAttribute("int64", i64);
-        uint16_t u16 = 16;
+        uint16_t u16 = 16u;
         s.setAttribute("uint16", u16);
-        uint32_t u32 = 32;
+        uint32_t u32 = 32u;
         s.setAttribute("uint32", u32);
-        uint64_t u64 = 64;
+        uint64_t u64 = 64u;
         s.setAttribute("uint64", u64);
-        float f = 16e10;
+        float f = 16.e10f;
         s.setAttribute("float", f);
-        double d = 1e64;
+        double d = 1.e64;
         s.setAttribute("double", d);
-        long double l = 1e80;
+        long double l = 1.e80L;
         s.setAttribute("longdouble", l);
         std::string str = "string";
         s.setAttribute("string", str);
@@ -734,12 +734,12 @@ BOOST_AUTO_TEST_CASE(hdf5_dtype_test)
         s.setAttribute("vecInt32", std::vector< int32_t >({2147483646, 2147483647}));
         s.setAttribute("vecInt64", std::vector< int64_t >({9223372036854775806, 9223372036854775807}));
         s.setAttribute("vecUchar", std::vector< char >({'u', 'c', 'h', 'a', 'r'}));
-        s.setAttribute("vecUint16", std::vector< uint16_t >({65534, 65535}));
-        s.setAttribute("vecUint32", std::vector< uint32_t >({4294967294, 4294967295}));
-        s.setAttribute("vecUint64", std::vector< uint64_t >({18446744073709551614, 18446744073709551615}));
-        s.setAttribute("vecFloat", std::vector< float >({0, 3.40282e+38}));
-        s.setAttribute("vecDouble", std::vector< double >({0, 1.79769e+308}));
-        s.setAttribute("vecLongdouble", std::vector< long double >({0, 1.18973e+4932}));
+        s.setAttribute("vecUint16", std::vector< uint16_t >({65534u, 65535u}));
+        s.setAttribute("vecUint32", std::vector< uint32_t >({4294967294u, 4294967295u}));
+        s.setAttribute("vecUint64", std::vector< uint64_t >({18446744073709551614u, 18446744073709551615u}));
+        s.setAttribute("vecFloat", std::vector< float >({0.f, 3.40282e+38f}));
+        s.setAttribute("vecDouble", std::vector< double >({0., 1.79769e+308}));
+        s.setAttribute("vecLongdouble", std::vector< long double >({0.L, 1.18973e+4932L}));
         s.setAttribute("vecString", std::vector< std::string >({"vector", "of", "strings"}));
     }
     
@@ -750,24 +750,24 @@ BOOST_AUTO_TEST_CASE(hdf5_dtype_test)
     BOOST_TEST(s.getAttribute("int16").get< int16_t >() == 16);
     BOOST_TEST(s.getAttribute("int32").get< int32_t >() == 32);
     BOOST_TEST(s.getAttribute("int64").get< int64_t >() == 64);
-    BOOST_TEST(s.getAttribute("uint16").get< uint16_t >() == 16);
-    BOOST_TEST(s.getAttribute("uint32").get< uint32_t >() == 32);
-    BOOST_TEST(s.getAttribute("uint64").get< uint64_t >() == 64);
-    BOOST_TEST(s.getAttribute("float").get< float >() == 16e10);
-    BOOST_TEST(s.getAttribute("double").get< double >() == 1e64);
-    BOOST_TEST(s.getAttribute("longdouble").get< long double >() == 1e80);
+    BOOST_TEST(s.getAttribute("uint16").get< uint16_t >() == 16u);
+    BOOST_TEST(s.getAttribute("uint32").get< uint32_t >() == 32u);
+    BOOST_TEST(s.getAttribute("uint64").get< uint64_t >() == 64u);
+    BOOST_TEST(s.getAttribute("float").get< float >() == 16.e10f);
+    BOOST_TEST(s.getAttribute("double").get< double >() == 1.e64);
+    BOOST_TEST(s.getAttribute("longdouble").get< long double >() == 1.e80L);
     BOOST_TEST(s.getAttribute("string").get< std::string >() == "string");
     BOOST_TEST(s.getAttribute("vecChar").get< std::vector< char > >() == std::vector< char >({'c', 'h', 'a', 'r'}));
     BOOST_TEST(s.getAttribute("vecInt16").get< std::vector< int16_t > >() == std::vector< int16_t >({32766, 32767}));
     BOOST_TEST(s.getAttribute("vecInt32").get< std::vector< int32_t > >() == std::vector< int32_t >({2147483646, 2147483647}));
     BOOST_TEST(s.getAttribute("vecInt64").get< std::vector< int64_t > >() == std::vector< int64_t >({9223372036854775806, 9223372036854775807}));
     BOOST_TEST(s.getAttribute("vecUchar").get< std::vector< char > >() == std::vector< char >({'u', 'c', 'h', 'a', 'r'}));
-    BOOST_TEST(s.getAttribute("vecUint16").get< std::vector< uint16_t > >() == std::vector< uint16_t >({65534, 65535}));
-    BOOST_TEST(s.getAttribute("vecUint32").get< std::vector< uint32_t > >() == std::vector< uint32_t >({4294967294, 4294967295}));
-    BOOST_TEST(s.getAttribute("vecUint64").get< std::vector< uint64_t > >() == std::vector< uint64_t >({18446744073709551614, 18446744073709551615}));
-    BOOST_TEST(s.getAttribute("vecFloat").get< std::vector< float > >() == std::vector< float >({0, 3.40282e+38}));
-    BOOST_TEST(s.getAttribute("vecDouble").get< std::vector< double > >() == std::vector< double >({0, 1.79769e+308}));
-    BOOST_TEST(s.getAttribute("vecLongdouble").get< std::vector< long double > >() == std::vector< long double >({0, 1.18973e+4932}));
+    BOOST_TEST(s.getAttribute("vecUint16").get< std::vector< uint16_t > >() == std::vector< uint16_t >({65534u, 65535u}));
+    BOOST_TEST(s.getAttribute("vecUint32").get< std::vector< uint32_t > >() == std::vector< uint32_t >({4294967294u, 4294967295u}));
+    BOOST_TEST(s.getAttribute("vecUint64").get< std::vector< uint64_t > >() == std::vector< uint64_t >({18446744073709551614u, 18446744073709551615u}));
+    BOOST_TEST(s.getAttribute("vecFloat").get< std::vector< float > >() == std::vector< float >({0.f, 3.40282e+38f}));
+    BOOST_TEST(s.getAttribute("vecDouble").get< std::vector< double > >() == std::vector< double >({0., 1.79769e+308}));
+    BOOST_TEST(s.getAttribute("vecLongdouble").get< std::vector< long double > >() == std::vector< long double >({0.L, 1.18973e+4932L}));
     BOOST_TEST(s.getAttribute("vecString").get< std::vector< std::string > >() == std::vector< std::string >({"vector", "of", "strings"}));
 }
 


### PR DESCRIPTION
Add suffixes to remove warnings on constants in tests. Especially unsigned and long double throw warnings during compile.