### PR TITLE
MPI Info: Default to NULL

### DIFF
--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -57,7 +57,7 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(AbstractIOHandler* handler,
                                                      MPI_Comm comm)
         : HDF5IOHandlerImpl{handler},
           m_mpiComm{comm},
-          m_mpiInfo{MPI_INFO_ENV}
+          m_mpiInfo{MPI_INFO_NULL} /* MPI 3.0+: MPI_INFO_ENV */
 {
     m_datasetTransferProperty = H5Pcreate(H5P_DATASET_XFER);
     m_fileAccessProperty = H5Pcreate(H5P_FILE_ACCESS);


### PR DESCRIPTION
Replace the MPI 3.0 `MPI_INFO_ENV` key with no-info for now.

If you want to enable it again in the future, see discussion in #44