### PR TITLE
Download Samples Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,12 +127,7 @@ script:
   - mkdir -p $HOME/build 
   - cd $HOME/build
   - if [ ! -d samples/git-sample/ ]; then
-       mkdir -p samples/git-sample/ &&
-       wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz &&
-       tar -xf example-3d.tar.gz &&
-       cp example-3d/hdf5/* samples/git-sample/ &&
-       chmod 777 samples/ &&
-       rm -rf example-3d.* example-3d;
+       $TRAVIS_BUILD_DIR/.travis/download_samples.sh;
     fi
   - CXXFLAGS=$CXXFLAGS CXX=$CXX CC=$CC
     cmake

--- a/.travis/download_samples.sh
+++ b/.travis/download_samples.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+
+mkdir -p samples/git-sample/
+wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz
+tar -xf example-3d.tar.gz
+mv example-3d/hdf5/* samples/git-sample/
+chmod 777 samples/
+rm -rf example-3d.* example-3d;


### PR DESCRIPTION
Refactor the download process of samples out of travis into a script.
This allows to re-use it, e.g. while setting up a local development machine.