### PR TITLE
Single header for all user-exposure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Initial backends will include ADIOS and HDF5.
 
 // ...
 
-auto s = openPMD::Series::read("output_files/data00000%T.h5");
+auto s = openPMD::Series::read("output_files/data%T.h5");
 
 std::cout << "Read iterations...";
 for( auto const& i : s.iterations )

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Initial backends will include ADIOS and HDF5.
 
 // ...
 
-auto s = openPMD::Series("output_files/");
+auto s = openPMD::Series::read("output_files/data00000%T.h5");
 
 std::cout << "Read iterations...";
 for( auto const& i : s.iterations )

--- a/include/openPMD.hpp
+++ b/include/openPMD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017 Fabian Koller
+/* Copyright 2017-2018 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD.hpp
+++ b/include/openPMD.hpp
@@ -1,0 +1,31 @@
+/* Copyright 2017 Fabian Koller
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#define OPENPMDAPI_VERSION_MAJOR 0
+#define OPENPMDAPI_VERSION_MINOR 1
+#define OPENPMDAPI_VERSION_PATCH 0
+
+#define OPENPMD_STANDARD_MAJOR 1
+#define OPENPMD_STANDARD_MINOR 0
+#define OPENPMD_STANDARD_PATCH 1
+
+#include "Series.hpp"


### PR DESCRIPTION
To simplify the user experience, a single header with an expressive name is needed for all user-exposed functionality. This header also includes version ```#define```s for the API and the openPMD standard.