### PR TITLE
Mesh: Add Missing template spec.

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -118,6 +118,16 @@ Mesh::setGridSpacing(std::vector< T > gs)
     return *this;
 }
 
+template
+Mesh&
+Mesh::setGridSpacing(std::vector< float > gs);
+template
+Mesh&
+Mesh::setGridSpacing(std::vector< double > gs);
+template
+Mesh&
+Mesh::setGridSpacing(std::vector< long double > gs);
+
 std::vector< double >
 Mesh::gridGlobalOffset() const
 {

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -45,3 +45,13 @@ MeshRecordComponent::setPosition(std::vector< T > pos)
     setAttribute("position", pos);
     return *this;
 }
+
+template
+MeshRecordComponent&
+MeshRecordComponent::setPosition(std::vector< float > pos);
+template
+MeshRecordComponent&
+MeshRecordComponent::setPosition(std::vector< double > pos);
+template
+MeshRecordComponent&
+MeshRecordComponent::setPosition(std::vector< long double > pos);


### PR DESCRIPTION
Add missing template specializations to `Mesh` and `MeshRecordComponent` member functions. Seen as compile error with gcc 6.3.0