### PR TITLE
Python Bindings: Initial Structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -202,6 +202,12 @@ install:
   # spack setup
   - cp $TRAVIS_BUILD_DIR/.travis/spack/*.yaml
        $SPACK_ROOT/etc/spack/
+  # manually fix SF via mirrors
+  - SPACK_CACHE=$SPACK_ROOT/var/spack/cache/
+  - curl https://sourceforge.mirrorservice.org/t/tc/tcl/Tcl/8.6.6/tcl8.6.6-src.tar.gz --create-dirs -o $SPACK_CACHE/tcl/tcl-8.6.6.tar.gz
+  - curl https://sourceforge.mirrorservice.org/m/mo/modules/Modules/modules-3.2.10/modules-3.2.10.tar.gz --create-dirs -o $SPACK_CACHE/environment-modules/environment-modules-3.2.10.tar.gz
+  - curl https://sourceforge.mirrorservice.org/b/bo/boost/boost/1.62.0/boost_1_62_0.tar.bz2 --create-dirs -o $SPACK_CACHE/boost/boost-1.62.0.tar.bz2
+  # manually fix SF mirrors end
   - spack bootstrap
   - source /etc/profile &&
     source $SPACK_ROOT/share/spack/setup-env.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,8 +160,25 @@ jobs:
             - openmpi-bin
       before_install: *gcc63_init
       script: *script-cpp-unit
-    # GCC 6.3.0 + Python 2/3
+    # GCC 6.3.0 + Python 2.7
     - <<: *test-cpp-unit
+      language: python
+      python: "2.7"
+      env:
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+      compiler: gcc
+      addons:
+        apt:
+          <<: *apt_common_sources
+          packages:
+            - *gcc63_deps
+      before_install: *gcc63_init
+      script: *script-cpp-unit
+    # GCC 6.3.0 + Python 3.6
+    # GCC 6.3.0 + Python 2.7
+    - <<: *test-cpp-unit
+      language: python
+      python: "3.6"
       env:
         - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
       compiler: gcc
@@ -214,9 +231,9 @@ install:
     fi
   - if [ $USE_PYTHON == "ON" ]; then
       travis_wait spack install
-        py-pybind11@2.2.1
+        py-pybind11@2.2.1 ^python@$TRAVIS_PYTHON_VERSION
         $COMPILERSPEC &&
-      spack load --dependencies py-pybind11@2.2.1 $COMPILERSPEC;
+      spack load --dependencies py-pybind11@2.2.1 ^python@$TRAVIS_PYTHON_VERSION $COMPILERSPEC;
     fi
   - if [ $USE_HDF5 == "ON" ]; then
       travis_wait spack install

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       stage: 'C++ Unit Tests'
       language: cpp
       env:
-        - USE_MPI=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
       compiler: clang
       addons:
         apt:
@@ -82,6 +82,8 @@ jobs:
             -DopenPMD_USE_HDF5=$USE_HDF5
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
+            -DopenPMD_USE_PYTHON=$USE_PYTHON
+            -DPYTHON_EXECUTABLE:FILEPATH=$(which python)
             -DCMAKE_INSTALL_PREFIX=$HOME/openPMD-test-install
             $TRAVIS_BUILD_DIR
         - make -j 2
@@ -91,7 +93,7 @@ jobs:
         # - dpkg -i openPMD*.deb
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
       compiler: clang
       addons:
         apt:
@@ -105,7 +107,7 @@ jobs:
     # GCC 4.9.4
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
       compiler: gcc
       addons:
         apt:
@@ -119,7 +121,7 @@ jobs:
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
       compiler: gcc
       addons:
         apt:
@@ -133,7 +135,7 @@ jobs:
     # GCC 6.3.0
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
       compiler: gcc
       addons:
         apt:
@@ -147,7 +149,7 @@ jobs:
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
       compiler: gcc
       addons:
         apt:
@@ -156,6 +158,18 @@ jobs:
             - *gcc63_deps
             - libopenmpi-dev
             - openmpi-bin
+      before_install: *gcc63_init
+      script: *script-cpp-unit
+    # GCC 6.3.0 + Python 2/3
+    - <<: *test-cpp-unit
+      env:
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+      compiler: gcc
+      addons:
+        apt:
+          <<: *apt_common_sources
+          packages:
+            - *gcc63_deps
       before_install: *gcc63_init
       script: *script-cpp-unit
   allow_failures:
@@ -185,10 +199,11 @@ install:
       cmake@3.10.0
       $COMPILERSPEC
   - spack load cmake@3.10.0 $COMPILERSPEC
+  - SPACK_BOOST_VAR="~atomic~chrono~date_time~graph~iostreams~locale~math~program_options~random~regex~serialization~signals+filesystem+system+test~timer~wave"
   - travis_wait spack install
-      boost@1.62.0
+      boost@1.62.0$SPACK_BOOST_VAR
       $COMPILERSPEC
-  - spack load boost@1.62.0 $COMPILERSPEC
+  - spack load boost@1.62.0$SPACK_BOOST_VAR $COMPILERSPEC
   # optional dependencies - MPI, HDF5, ADIOS1, ADIOS2
   - if [ $USE_MPI == "ON" ]; then
       travis_wait spack install
@@ -196,6 +211,12 @@ install:
         $COMPILERSPEC &&
       spack load openmpi@1.6.5 $COMPILERSPEC;
       SPACK_VAR_MPI="+mpi";
+    fi
+  - if [ $USE_PYTHON == "ON" ]; then
+      travis_wait spack install
+        py-pybind11@2.2.1
+        $COMPILERSPEC &&
+      spack load --dependencies py-pybind11@2.2.1 $COMPILERSPEC;
     fi
   - if [ $USE_HDF5 == "ON" ]; then
       travis_wait spack install

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -13,6 +13,12 @@ packages:
       openmpi@1.6.5%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%clang@5.0.0 arch=linux-ubuntu14-x86_64: /usr
     buildable: False
+  python:
+    version: [2.7.14, 3.6.3]
+    paths:
+      python@2.7.14%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
+      python@3.6.3%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
+    buildable: False
   all:
     providers:
       mpi: [openmpi]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,7 @@ endif()
 if(openPMD_HAVE_PYTHON)
     pybind11_add_module(openPMD.py MODULE
         src/binding/python/openPMD.cpp
+        src/binding/python/AccessType.cpp
         src/binding/python/Dataset.cpp
         src/binding/python/Datatype.cpp
         src/binding/python/Iteration.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,9 @@ set(openPMD_EXAMPLE_NAMES
     6_dump_filebased_series
     7_extended_write_serial
 )
+set(openPMD_PYTHON_EXAMPLE_NAMES
+    2_read_serial
+)
 foreach(testname ${openPMD_TEST_NAMES})
     add_executable(${testname}Tests test/${testname}Test.cpp)
     if(openPMD_HAVE_MPI)
@@ -432,6 +435,7 @@ set(MPI_TEST_EXE
     ${MPIEXEC_NUMPROC_FLAG} 2
 )
 
+# C++ Unit tests
 foreach(testname ${openPMD_TEST_NAMES})
     if(${testname} MATCHES "^Parallel.*$")
         if(openPMD_HAVE_MPI)
@@ -448,9 +452,55 @@ foreach(testname ${openPMD_TEST_NAMES})
     endif()
 endforeach()
 
-#foreach(examplename ${openPMD_EXAMPLE_NAMES})
-#    add_test(${examplename} ${examplename})
-#endforeach()
+# TODO: C++ Examples
+#if(EXISTS "${openPMD_BINARY_DIR}/samples/git-sample/")
+#    foreach(examplename ${openPMD_EXAMPLE_NAMES})
+#        add_test(NAME Example.py.${examplename}
+#            COMMAND ${examplename}
+#            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+#        )
+#    endforeach()
+#else()
+#    message(STATUS "Missing samples/git-sample/ directory! "
+#                   "Skipping C++ example test!\n\n"
+#                   "Note: run\n"
+#                   "    . ${openPMD_SOURCE_DIR}/.travis/download_samples.sh\n"
+#                   "to add example files!")
+#endif()
+
+# TODO: Python Unit tests
+#if(openPMD_HAVE_PYTHON)
+#    # ...
+#endif()
+
+# Python Examples
+if(openPMD_HAVE_PYTHON)
+    if(EXISTS "${openPMD_BINARY_DIR}/samples/git-sample/")
+        foreach(examplename ${openPMD_PYTHON_EXAMPLE_NAMES})
+            add_custom_command(TARGET openPMD.py POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy
+                        ${openPMD_SOURCE_DIR}/examples/${examplename}.py
+                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
+            )
+            add_test(NAME Example.py.${examplename}
+                COMMAND ${PYTHON_EXECUTABLE}
+                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
+                WORKING_DIRECTORY
+                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            )
+            set_tests_properties(Example.py.${examplename}
+                PROPERTIES ENVIRONMENT
+                    "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+            )
+        endforeach()
+    else()
+        message(STATUS "Missing samples/git-sample/ directory! "
+                       "Skipping Python example test!\n\n"
+                       "Note: run\n"
+                       "    . ${openPMD_SOURCE_DIR}/.travis/download_samples.sh\n"
+                       "to add example files!")
+    endif()
+endif()
 
 
 # Status Message for Build Options ############################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Iteration.cpp
         src/binding/python/IterationEncoding.cpp
         src/binding/python/Mesh.cpp
+        src/binding/python/Record.cpp
         src/binding/python/RecordComponent.cpp
         src/binding/python/Series.cpp
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Datatype.cpp
         src/binding/python/Iteration.cpp
         src/binding/python/IterationEncoding.cpp
+        src/binding/python/RecordComponent.cpp
         src/binding/python/Series.cpp
     )
     target_link_libraries(openPMD.py PRIVATE openPMD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,7 @@ if(openPMD_HAVE_PYTHON)
         message(STATUS "Missing samples/git-sample/ directory! "
                        "Skipping Python example test!\n\n"
                        "Note: run\n"
-                       "    . ${openPMD_SOURCE_DIR}/.travis/download_samples.sh\n"
+                       "    ${openPMD_SOURCE_DIR}/.travis/download_samples.sh\n"
                        "to add example files!")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ openpmd_option(HDF5   "Enable HDF5 support"    AUTO)
 openpmd_option(ADIOS1 "Enable ADIOS1 support"  OFF)
 openpmd_option(ADIOS2 "Enable ADIOS2 support"  OFF)
 # openpmd_option(JSON "Enable JSON support" AUTO)
-# openpmd_option(PYTHON "Enable Python bindings" OFF)
+openpmd_option(PYTHON "Enable Python bindings" AUTO)
 
 option(openPMD_USE_INTERNAL_VARIANT "Use internally shipped MPark.Variant" ON)
 
@@ -176,6 +176,21 @@ endif()
 
 # TODO: Check if ADIOS2 is parallel when openPMD_HAVE_MPI is ON
 
+# external library: pybind11 (optional)
+if(openPMD_USE_PYTHON STREQUAL AUTO)
+    find_package(pybind11 2.2.1 CONFIG)  # 2.3.0
+    if(pybind11_FOUND)
+        set(openPMD_HAVE_PYTHON TRUE)
+    else()
+        set(openPMD_HAVE_PYTHON FALSE)
+    endif()
+elseif(openPMD_USE_PYTHON)
+    find_package(pybind11 2.2.1 CONFIG REQUIRED)  # 2.3.0
+    set(openPMD_HAVE_PYTHON TRUE)
+else()
+    set(openPMD_HAVE_PYTHON FALSE)
+endif()
+
 
 # Targets #####################################################################
 #
@@ -264,6 +279,35 @@ if(openPMD_HAVE_ADIOS2)
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS2=1")
 endif()
 
+# python bindings
+if(openPMD_HAVE_PYTHON)
+    pybind11_add_module(openPMD.py MODULE
+        src/binding/python/openPMD.cpp
+        src/binding/python/Dataset.cpp
+        src/binding/python/Datatype.cpp
+        src/binding/python/Iteration.cpp
+        src/binding/python/IterationEncoding.cpp
+        src/binding/python/Series.cpp
+    )
+    target_link_libraries(openPMD.py PRIVATE openPMD)
+
+    set(CMAKE_INSTALL_PYTHONDIR
+        "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages"
+    )
+    set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_PYTHONDIR}"
+        CACHE INTERNAL "" FORCE
+    )
+    set_target_properties(openPMD.py PROPERTIES
+        OUTPUT_NAME openPMD
+        LIBRARY_OUTPUT_DIRECTORY ${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}
+        RUNTIME_OUTPUT_DIRECTORY ${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}
+    )
+
+    #if(openPMD_HAVE_MPI)
+    #    target_link_libraries(openPMD.py PRIVATE PythonModule::mpi4py)
+    #endif()
+endif()
+
 # tests
 set(openPMD_TEST_NAMES
     Core
@@ -343,6 +387,11 @@ install(TARGETS openPMD EXPORT openPMDTargets
     RUNTIME DESTINATION bin
     INCLUDES DESTINATION include
 )
+if(openPMD_HAVE_PYTHON)
+    install(TARGETS openPMD.py
+        DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
+    )
+endif()
 install(DIRECTORY "${openPMD_SOURCE_DIR}/include/."
   DESTINATION include
   PATTERN ".svn" EXCLUDE
@@ -414,6 +463,9 @@ message("        bin: ${CMAKE_INSTALL_BINDIR}")
 message("        lib: ${CMAKE_INSTALL_LIBDIR}")
 message("    include: ${CMAKE_INSTALL_INCLUDEDIR}")
 message("      cmake: ${CMAKE_INSTALL_CMAKEDIR}")
+if(openPMD_HAVE_PYTHON)
+    message("     python: ${CMAKE_INSTALL_PYTHONDIR}")
+endif()
 message("")
 message("  Build Type: ${CMAKE_BUILD_TYPE}")
 message("  Build Options:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Iteration.cpp
         src/binding/python/IterationEncoding.cpp
         src/binding/python/Mesh.cpp
+        src/binding/python/ParticleSpecies.cpp
         src/binding/python/Record.cpp
         src/binding/python/RecordComponent.cpp
         src/binding/python/Series.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Iteration.cpp
         src/binding/python/IterationEncoding.cpp
         src/binding/python/Mesh.cpp
+        src/binding/python/ParticlePatches.cpp
         src/binding/python/ParticleSpecies.cpp
         src/binding/python/Record.cpp
         src/binding/python/RecordComponent.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Datatype.cpp
         src/binding/python/Iteration.cpp
         src/binding/python/IterationEncoding.cpp
+        src/binding/python/Mesh.cpp
         src/binding/python/RecordComponent.cpp
         src/binding/python/Series.cpp
     )

--- a/README.md
+++ b/README.md
@@ -58,7 +58,29 @@ for( auto const& i : s.iterations )
 
 ### Python
 
-*not yet implemented*
+```python
+from openPMD import Series
+
+
+# ...
+
+series = Series.read("output_files/data%T.h5")
+
+print("Read iterations...")
+for k, i in series.iterations.items():
+    # mesh records
+    print("Iteration {0} contains {1} meshes:".format(k, len(i.meshes)))
+    for m in i.meshes:
+        print("\t {0}".format(m))
+
+    # particle records
+    print("Iteration {0} contains {1} particle species:".format(
+        k, len(i.particles)))
+    for ps in i.particles:
+        print("\t {0}".format(ps))
+
+# ...
+```
 
 ### More!
 
@@ -119,6 +141,9 @@ git clone https://github.com/openPMD/openPMD-api.git
 
 mkdir -p openPMD-api-build
 cd openPMD-api-build
+
+# optional for some tests
+.travis/download_samples.sh
 
 # for own install prefix append:
 #   -DCMAKE_INSTALL_PREFIX=$HOME/somepath

--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ while those can be build either with or without:
 * MPI 2.3+, e.g. OpenMPI or MPICH2
 
 Optional language bindings:
-* Python: (*not yet implemented*)
+* Python:
+  * Python 3.X+
   * pybind11 2.3.0+
+  * mpi4py?
+  * numpy-dev?
   * xtensor-python 0.17.0+
 
 ## Installation
@@ -141,7 +144,8 @@ CMake controls options with prefixed `-D`, e.g. `-DopenPMD_USE_MPI=OFF`:
 | `openPMD_USE_HDF5`   | **AUTO**/ON/OFF  | Enable support for HDF5                |
 | `openPMD_USE_ADIOS1` | **AUTO**/ON/OFF  | Enable support for ADIOS1 <sup>1</sup> |
 | `openPMD_USE_ADIOS2` | AUTO/ON/**OFF**  | Enable support for ADIOS2 <sup>1</sup> |
-| `openPMD_USE_PYTHON` | AUTO/ON/**OFF**  | Enable Python bindings <sup>1</sup>    |
+| `openPMD_USE_PYTHON` | **AUTO**/ON/OFF  | Enable Python bindings                 |
+| `PYTHON_EXECUTABLE`  | (first found)    | Path to Python executable              |
 
 <sup>1</sup> *not yet implemented*
 

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -15,7 +15,8 @@ CMake Option           Values          Description
 ``openPMD_USE_HDF5``   **AUTO**/ON/OFF Enable support for HDF5
 ``openPMD_USE_ADIOS1`` **AUTO**/ON/OFF Enable support for ADIOS1 :sup:`1`
 ``openPMD_USE_ADIOS2`` AUTO/ON/**OFF** Enable support for ADIOS2 :sup:`1`
-``openPMD_USE_PYTHON`` AUTO/ON/**OFF** Enable Python bindings :sup:`1`
+``openPMD_USE_PYTHON`` **AUTO**/ON/OFF Enable Python bindings
+``PYTHON_EXECUTABLE``  (first found)   Path to Python executable
 ====================== =============== ==================================
 
 :sup:`1` *not yet implemented*

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -35,8 +35,11 @@ while those can be build either with or without:
 Optional: language bindings
 ---------------------------
 
-* Python: (*not yet implemented*)
+* Python:
 
+  * Python 3.X+
   * pybind11 2.3.0+
+  * mpi4py?
+  * numpy-dev?
   * xtensor-python 0.17.0+
 

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -68,6 +68,9 @@ On Linux platforms:
    mkdir -p openPMD-api-build
    cd openPMD-api-build
 
+   # optional for some tests
+   .travis/download_samples.sh
+
    # for own install prefix append:
    #   -DCMAKE_INSTALL_PREFIX=$HOME/somepath
    # for options append:

--- a/docs/source/usage/2_read_serial.py
+++ b/docs/source/usage/2_read_serial.py
@@ -1,0 +1,1 @@
+../../../examples/2_read_serial.py

--- a/docs/source/usage/serial.rst
+++ b/docs/source/usage/serial.rst
@@ -8,17 +8,35 @@ Serial API
 Reading
 -------
 
+C++
+^^^
+
 .. literalinclude:: 2_read_serial.cpp
    :language: cpp
    :lines: 21-
 
 An extended example can be found in ``examples/6_dump_filebased_series.cpp``.
 
+Python
+^^^^^^
+
+.. literalinclude:: 2_read_serial.py
+   :language: py
+   :lines: 9-
+
 Writing
 -------
+
+C++
+^^^
 
 .. literalinclude:: 3_write_serial.cpp
    :language: cpp
    :lines: 21-
 
 An extended example can be found in ``examples/7_extended_write_serial.cpp``.
+
+Python
+^^^^^^
+
+*TBD*

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""
+This file is part of the openPMD-api.
+
+Copyright 2018 openPMD contributors
+Authors: Axel Huebl
+License: LGPLv3+
+"""
+from openPMD import Series
+
+
+if __name__ == "__main__":
+    series = Series.read("../samples/git-sample/data%T.h5")
+    print("Read a Series with openPMD standard version %s" %
+          series.openPMD)
+
+    print("The Series contains {0} iterations:".format(len(series.iterations)))
+    for i in series.iterations:
+        print("\t {0}".format(i))
+    print("")
+
+    i = series.iterations[100]
+    print("Iteration 100 contains {0} meshes:".format(len(i.meshes)))
+    for m in i.meshes:
+        print("\t {0}".format(m))
+    print("")
+    print("Iteration 100 contains {0} particle species:".format(
+        len(i.particles)))
+    for ps in i.particles:
+        print("\t {0}".format(ps))
+    print("")
+
+    E = i.meshes["E"]
+    # TODO: add __getitem__ to openPMD.Mesh and openPMD.Particle object for
+    #       non-scalar records: return a record component
+    # E_x = i.meshes["E"]["x"]
+    # TODO: add extent and dtype property to record components
+    # Extent extent = E_x.get_extent  # or as property: E_x.extent
+    # print("Field E.x has shape ({0}) and has datatype {1}".format(
+    #     extent, E_x.dtype));
+
+    # TODO buffer protocol / numpy bindings
+    # chunk_data = E_x[1:3, 1:3, 1:2]
+    # print("Queued the loading of a single chunk from disk, "
+    #       "ready to execute")
+    # series.flush()
+    # print("Chunk has been read from disk\n"
+    #       "Read chunk contains:")
+    # for row in range(2):
+    #     for col in range(2):
+    #         print("\t({0}|{1}|{2})\t{3}".format(
+    #            row + 1, col + 1, 1, chunk_data[row*chunk_extent[1]+col])
+    #         )
+    #     print("")

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -17,6 +17,12 @@ public:
     mapped_type& operator[](key_type const&) override;
     mapped_type& operator[](key_type&&) override;
 
+    size_t
+    numPatches() const
+    {
+        return m_patchPositions.size();
+    }
+
 private:
     void read();
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -40,8 +40,8 @@ public:
 
     RecordComponent& resetDataset(Dataset);
 
-    uint8_t getDimensionality();
-    Extent getExtent();
+    uint8_t getDimensionality() const;
+    Extent getExtent() const;
 
     template< typename T >
     RecordComponent& makeConstant(T);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -31,13 +31,13 @@ RecordComponent::resetDataset(Dataset d)
 }
 
 uint8_t
-RecordComponent::getDimensionality()
+RecordComponent::getDimensionality() const
 {
     return m_dataset.rank;
 }
 
 Extent
-RecordComponent::getExtent()
+RecordComponent::getExtent() const
 {
     return m_dataset.extent;
 }

--- a/src/binding/python/AccessType.cpp
+++ b/src/binding/python/AccessType.cpp
@@ -1,0 +1,15 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/IO/AccessType.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_AccessType(py::module &m) {
+    py::enum_<AccessType>(m, "Access_Type")
+        .value("read_only", AccessType::READ_ONLY)
+        .value("read_write", AccessType::READ_WRITE)
+        .value("create", AccessType::CREATE)
+    ;
+}

--- a/src/binding/python/AccessType.cpp
+++ b/src/binding/python/AccessType.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/IO/AccessType.hpp"
 

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -11,7 +11,8 @@ using namespace openPMD;
 
 
 // Extent & Offset are of std::vector< std::uint64_t >
-PYBIND11_MAKE_OPAQUE(Extent)
+// those are already specialized in <pybind11/stl.h>
+// PYBIND11_MAKE_OPAQUE(Extent)
 
 void init_Dataset(py::module &m) {
     py::bind_vector< Extent >(m, "Extent");

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -1,0 +1,42 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+#include "openPMD/Dataset.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+// Extent & Offset are of std::vector< std::uint64_t >
+PYBIND11_MAKE_OPAQUE(Extent)
+
+void init_Dataset(py::module &m) {
+    py::bind_vector< Extent >(m, "Extent");
+    // TODO expose "Offset" as own type as well?
+
+    py::class_<Dataset>(m, "Dataset")
+
+        .def(py::init<Datatype, Offset>())
+
+        .def("__repr__",
+            [](const Dataset &d) {
+                return "<openPMD.Dataset of rank '" + std::to_string(d.rank) + "'>";
+            }
+        )
+
+        .def_readonly("extent", &Dataset::extent)
+        .def("extend", &Dataset::extend)
+        .def_readonly("chunkSize", &Dataset::chunkSize)
+        .def("set_chunk_size", &Dataset::setChunkSize)
+        .def_readonly("compression", &Dataset::compression)
+        .def("set_compression", &Dataset::setCompression)
+        .def_readonly("transform", &Dataset::transform)
+        .def("setCustomTransform", &Dataset::setCustomTransform)
+        .def_readonly("rank", &Dataset::rank)
+        .def_readonly("dtype", &Dataset::dtype)
+    ;
+}
+

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Datatype.hpp"
 

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -1,0 +1,44 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/Datatype.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_Datatype(py::module &m) {
+    py::enum_<Datatype>(m, "Datatype", py::arithmetic())
+        .value("CHAR", Datatype::CHAR)
+        .value("UCHAR", Datatype::UCHAR)
+        .value("INT16", Datatype::INT16)
+        .value("INT32", Datatype::INT32)
+        .value("INT64", Datatype::INT64)
+        .value("UINT16", Datatype::UINT16)
+        .value("UINT32", Datatype::UINT32)
+        .value("UINT64", Datatype::UINT64)
+        .value("FLOAT", Datatype::FLOAT)
+        .value("DOUBLE", Datatype::DOUBLE)
+        .value("LONG_DOUBLE", Datatype::LONG_DOUBLE)
+        .value("STRING", Datatype::STRING)
+        .value("VEC_CHAR", Datatype::VEC_CHAR)
+        .value("VEC_INT16", Datatype::VEC_INT16)
+        .value("VEC_INT32", Datatype::VEC_INT32)
+        .value("VEC_INT64", Datatype::VEC_INT64)
+        .value("VEC_UCHAR", Datatype::VEC_UCHAR)
+        .value("VEC_UINT16", Datatype::VEC_UINT16)
+        .value("VEC_UINT32", Datatype::VEC_UINT32)
+        .value("VEC_UINT64", Datatype::VEC_UINT64)
+        .value("VEC_FLOAT", Datatype::VEC_FLOAT)
+        .value("VEC_DOUBLE", Datatype::VEC_DOUBLE)
+        .value("VEC_LONG_DOUBLE", Datatype::VEC_LONG_DOUBLE)
+        .value("VEC_STRING", Datatype::VEC_STRING)
+        .value("ARR_DBL_7", Datatype::ARR_DBL_7)
+        .value("BOOL", Datatype::BOOL)
+        .value("DATATYPE", Datatype::DATATYPE)
+        .value("UNDEFINED", Datatype::UNDEFINED)
+    ;
+
+    // 2x: determineDatatype
+    // equivalence check: decay_equiv
+    // m.def("add", [](int a, int b) { return a + b; });
+}

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
 #include "openPMD/Iteration.hpp"

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -1,0 +1,47 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+
+#include "openPMD/Iteration.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+using PyMeshContainer = Container< Mesh >;
+using PyPartContainer = Container< ParticleSpecies >;
+PYBIND11_MAKE_OPAQUE(PyMeshContainer)
+PYBIND11_MAKE_OPAQUE(PyPartContainer)
+
+void init_Iteration(py::module &m) {
+    py::bind_map< PyMeshContainer >(m, "Mesh_Container");
+    py::bind_map< PyPartContainer >(m, "Particle_Container");
+
+    py::class_<Iteration>(m, "Iteration")
+        .def(py::init<Iteration const &>())
+
+        .def("__repr__",
+            [](Iteration const & it) {
+                return "<openPMD.Iteration of at t = '" + std::to_string(it.template time<double>() * it.timeUnitSI()) + " s'>";
+            }
+        )
+
+        .def("time", &Iteration::time<float>)
+        .def("time", &Iteration::time<double>)
+        .def("time", &Iteration::time<long double>)
+        .def("set_time", &Iteration::setTime<float>)
+        .def("set_time", &Iteration::setTime<double>)
+        .def("set_time", &Iteration::setTime<long double>)
+        .def("dt", &Iteration::dt<float>)
+        .def("dt", &Iteration::dt<double>)
+        .def("dt", &Iteration::dt<long double>)
+        .def("set_dt", &Iteration::setDt<float>)
+        .def("set_dt", &Iteration::setDt<double>)
+        .def("set_dt", &Iteration::setDt<long double>)
+        .def("time_unit_SI", &Iteration::timeUnitSI)
+        .def("set_time_unit_SI", &Iteration::setTimeUnitSI)
+
+        .def_readwrite("meshes", &Iteration::meshes)
+        .def_readwrite("particles", &Iteration::particles)
+    ;
+}

--- a/src/binding/python/IterationEncoding.cpp
+++ b/src/binding/python/IterationEncoding.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/IterationEncoding.hpp"
 

--- a/src/binding/python/IterationEncoding.cpp
+++ b/src/binding/python/IterationEncoding.cpp
@@ -1,0 +1,14 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/IterationEncoding.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_IterationEncoding(py::module &m) {
+    py::enum_<IterationEncoding>(m, "Iteration_Encoding")
+        .value("file_based", IterationEncoding::fileBased)
+        .value("group_based", IterationEncoding::groupBased)
+    ;
+}

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -40,9 +40,10 @@ void init_Mesh(py::module &m) {
         .def_property_readonly("time_offset", &Mesh::timeOffset<float>)
         .def_property_readonly("time_offset", &Mesh::timeOffset<double>)
         .def_property_readonly("time_offset", &Mesh::timeOffset<long double>)
-        .def("set_time_offset", &Mesh::setTimeOffset<float>)
-        .def("set_time_offset", &Mesh::setTimeOffset<double>)
-        .def("set_time_offset", &Mesh::setTimeOffset<long double>)
+        //! @todo missing specializations
+        // .def("set_time_offset", &Mesh::setTimeOffset<float>)
+        // .def("set_time_offset", &Mesh::setTimeOffset<double>)
+        // .def("set_time_offset", &Mesh::setTimeOffset<long double>)
     ;
 
     py::enum_<Mesh::Geometry>(m, "Geometry")

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -1,0 +1,59 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/Mesh.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_Mesh(py::module &m) {
+    py::class_<Mesh>(m, "Mesh")
+        .def(py::init<Mesh const &>())
+
+        .def("__repr__",
+            [](Mesh const &) {
+                return "<openPMD.Mesh>";
+            }
+        )
+
+        .def_property_readonly("geometry", &Mesh::geometry)
+        .def("set_geometry", &Mesh::setGeometry)
+        .def_property_readonly("geometry_parameters", &Mesh::geometryParameters)
+        .def("set_geometry_parameters", &Mesh::setGeometryParameters)
+        .def_property_readonly("data_order", &Mesh::dataOrder)
+        .def("set_data_order", &Mesh::setDataOrder)
+        .def_property_readonly("axis_labels", &Mesh::axisLabels)
+        .def("set_axis_labels", &Mesh::setAxisLabels)
+        .def_property_readonly("grid_spacing", &Mesh::gridSpacing<float>)
+        .def_property_readonly("grid_spacing", &Mesh::gridSpacing<double>)
+        .def_property_readonly("grid_spacing", &Mesh::gridSpacing<long double>)
+        .def("set_grid_spacing", &Mesh::setGridSpacing<float>)
+        .def("set_grid_spacing", &Mesh::setGridSpacing<double>)
+        .def("set_grid_spacing", &Mesh::setGridSpacing<long double>)
+        .def_property_readonly("grid_global_offset", &Mesh::gridGlobalOffset)
+        .def("set_grid_global_offset", &Mesh::setGridGlobalOffset)
+        .def_property_readonly("grid_unit_SI", &Mesh::gridUnitSI)
+        .def("set_grid_unit_SI", &Mesh::setGridUnitSI)
+        .def("set_unit_dimension", &Mesh::setUnitDimension)
+        .def_property_readonly("time_offset", &Mesh::timeOffset<float>)
+        .def_property_readonly("time_offset", &Mesh::timeOffset<double>)
+        .def_property_readonly("time_offset", &Mesh::timeOffset<long double>)
+        .def("set_time_offset", &Mesh::setTimeOffset<float>)
+        .def("set_time_offset", &Mesh::setTimeOffset<double>)
+        .def("set_time_offset", &Mesh::setTimeOffset<long double>)
+    ;
+
+    py::enum_<Mesh::Geometry>(m, "Geometry")
+        .value("cartesian", Mesh::Geometry::cartesian)
+        .value("thetaMode", Mesh::Geometry::thetaMode)
+        .value("cylindrical", Mesh::Geometry::cylindrical)
+        .value("spherical", Mesh::Geometry::spherical)
+    ;
+
+    py::enum_<Mesh::DataOrder>(m, "Data_Order")
+        .value("C", Mesh::DataOrder::C)
+        .value("F", Mesh::DataOrder::F)
+    ;
+}

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Mesh.hpp"
 

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -1,0 +1,23 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/ParticlePatches.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_ParticlePatches(py::module &m) {
+    py::class_<ParticlePatches>(m, "ParticlePatches")
+        .def("__repr__",
+            [](ParticlePatches const & pp) {
+                return "<openPMD.ParticlePatches of size '" + std::to_string(pp.numPatches()) + "'>";
+            }
+        )
+
+        .def_property_readonly("num_patches", &ParticlePatches::numPatches)
+
+        // expose index / slice operator
+    ;
+}

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/ParticlePatches.hpp"
 

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -1,0 +1,19 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/ParticleSpecies.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_ParticleSpecies(py::module &m) {
+    py::class_<ParticleSpecies>(m, "ParticleSpecies")
+        .def("__repr__",
+            [](ParticleSpecies const &) {
+                return "<openPMD.ParticleSpecies>";
+            }
+        )
+
+        .def_readwrite("particle_patches", &ParticleSpecies::particlePatches)
+    ;
+}

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/ParticleSpecies.hpp"
 

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -1,0 +1,27 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/Record.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_Record(py::module &m) {
+    py::class_<Record>(m, "Record")
+        .def(py::init<Record const &>())
+
+        .def("__repr__",
+            [](Record const &) {
+                return "<openPMD.Record>";
+            }
+        )
+
+        .def("set_unit_dimension", &Record::setUnitDimension)
+        .def_property_readonly("time_offset", &Record::timeOffset<float>)
+        .def_property_readonly("time_offset", &Record::timeOffset<double>)
+        .def_property_readonly("time_offset", &Record::timeOffset<long double>)
+        .def("set_time_offset", &Record::setTimeOffset<float>)
+        .def("set_time_offset", &Record::setTimeOffset<double>)
+        .def("set_time_offset", &Record::setTimeOffset<long double>)
+    ;
+}

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Record.hpp"
 

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1,0 +1,49 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/RecordComponent.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_RecordComponent(py::module &m) {
+    py::class_<RecordComponent>(m, "Record_Component")
+        .def("__repr__",
+            [](RecordComponent const & rc) {
+                return "<openPMD.Record_Component of dimensionality '" + std::to_string(rc.getDimensionality()) + "'>";
+            }
+        )
+
+        .def("set_unit_SI", &RecordComponent::setUnitSI)
+        .def("reset_dataset", &RecordComponent::resetDataset)
+
+        .def("get_dimensionality", &RecordComponent::getDimensionality)
+        .def("get_extent", &RecordComponent::getExtent)
+
+        .def("make_constant", &RecordComponent::makeConstant<float>)
+        .def("make_constant", &RecordComponent::makeConstant<double>)
+        .def("make_constant", &RecordComponent::makeConstant<long double>)
+        .def("make_constant", &RecordComponent::makeConstant<int16_t>)
+        .def("make_constant", &RecordComponent::makeConstant<int32_t>)
+        .def("make_constant", &RecordComponent::makeConstant<int64_t>)
+        .def("make_constant", &RecordComponent::makeConstant<uint16_t>)
+        .def("make_constant", &RecordComponent::makeConstant<uint32_t>)
+        .def("make_constant", &RecordComponent::makeConstant<uint64_t>)
+        .def("make_constant", &RecordComponent::makeConstant<char>)
+        .def("make_constant", &RecordComponent::makeConstant<unsigned char>)
+        .def("make_constant", &RecordComponent::makeConstant<bool>)
+
+        //.def("load_chunk", &RecordComponent::loadChunk)
+        //.def("store_chunk", &RecordComponent::storeChunk)
+
+        .def_property_readonly_static("SCALAR", [](py::object){ return RecordComponent::SCALAR; })
+    ;
+
+    py::enum_<RecordComponent::Allocation>(m, "Allocation")
+        .value("USER", RecordComponent::Allocation::USER)
+        .value("API", RecordComponent::Allocation::API)
+        .value("AUTO", RecordComponent::Allocation::AUTO)
+    ;
+}

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/RecordComponent.hpp"
 

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
 #include "openPMD/Series.hpp"

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -1,0 +1,55 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+
+#include "openPMD/Series.hpp"
+#include "openPMD/Iteration.hpp"
+#include "openPMD/backend/Container.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+using PyIterationContainer = Container< Iteration, uint64_t >;
+PYBIND11_MAKE_OPAQUE(PyIterationContainer)
+
+void init_Series(py::module &m) {
+    py::bind_map< PyIterationContainer >(m, "Iteration_Container");
+
+    py::class_<Series>(m, "Series")
+
+        // private
+        //.def(py::init<std::string const &, AccessType>())
+
+        .def_static("create", [](std::string const & filepath){ return Series::create(filepath); })
+        .def_static("read", [](std::string const & filepath){ return Series::read(filepath); })
+
+        .def_property_readonly("openPMD", &Series::openPMD)
+        .def("set_openPMD", &Series::setOpenPMD)
+        .def_property_readonly("openPMD_extension", &Series::openPMDextension)
+        .def("set_openPMD_extension", &Series::setOpenPMDextension)
+        .def_property_readonly("base_ath", &Series::basePath)
+        .def("set_base_path", &Series::setBasePath)
+        .def_property_readonly("meshes_path", &Series::meshesPath)
+        .def("set_meshes_path", &Series::setMeshesPath)
+        .def_property_readonly("particles_path", &Series::particlesPath)
+        .def("set_particles_path", &Series::setParticlesPath)
+        .def_property_readonly("author", &Series::author)
+        .def("set_author", &Series::setAuthor)
+        .def_property_readonly("software", &Series::software)
+        .def("set_software", &Series::setSoftware)
+        .def_property_readonly("software_version", &Series::softwareVersion)
+        .def("set_software_version", &Series::setSoftwareVersion)
+        // softwareDependencies
+        // machine
+        .def_property_readonly("date", &Series::date)
+        .def("set_date", &Series::setDate)
+        .def_property_readonly("iteration_encoding", &Series::iterationEncoding)
+        .def("set_iteration_encoding", &Series::setIterationEncoding)
+        .def_property_readonly("iteration_format", &Series::iterationFormat)
+        .def("set_iteration_format", &Series::setIterationFormat)
+        .def_property_readonly("name", &Series::name)
+        .def("set_name", &Series::setName)
+        .def("flush", &Series::flush)
+
+        .def_readwrite("iterations", &Series::iterations)
+    ;
+}

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -16,8 +16,8 @@ void init_Mesh(py::module &);
 /*
 void init_ParticlePatches(py::module &);
 void init_ParticleSpecies(py::module &);
-void init_Record(py::module &);
 */
+void init_Record(py::module &);
 void init_RecordComponent(py::module &);
 void init_Series(py::module &);
 
@@ -33,8 +33,8 @@ PYBIND11_MODULE(openPMD, m) {
     /*
     init_ParticlePatches(m);
     init_ParticleSpecies(m);
-    init_Record(m);
     */
+    init_Record(m);
     init_RecordComponent(m);
     init_Series(m);
 

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -6,10 +6,10 @@ namespace py = pybind11;
 // forward declarations of exposed classes
 void init_Series(py::module &);
 void init_Dataset(py::module &);
-/*
 void init_Datatype(py::module &);
 void init_Iteration(py::module &);
 void init_IterationEncoding(py::module &);
+/*
 void init_Mesh(py::module &);
 void init_ParticlePatches(py::module &);
 void init_ParticleSpecies(py::module &);
@@ -21,18 +21,18 @@ void init_RecordComponent(py::module &);
 PYBIND11_MODULE(openPMD, m) {
     // m.doc() = ...;
 
-    init_Series(m);
     init_Dataset(m);
-    /*
     init_Datatype(m);
     init_Iteration(m);
     init_IterationEncoding(m);
+    /*
     init_Mesh(m);
     init_ParticlePatches(m);
     init_ParticleSpecies(m);
     init_Record(m);
     init_RecordComponent(m);
     */
+    init_Series(m);
 
     // m.attr("__version__") = "1.2.3-dev";
 }

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -1,0 +1,39 @@
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+
+// forward declarations of exposed classes
+void init_Series(py::module &);
+void init_Dataset(py::module &);
+/*
+void init_Datatype(py::module &);
+void init_Iteration(py::module &);
+void init_IterationEncoding(py::module &);
+void init_Mesh(py::module &);
+void init_ParticlePatches(py::module &);
+void init_ParticleSpecies(py::module &);
+void init_Record(py::module &);
+void init_RecordComponent(py::module &);
+*/
+
+
+PYBIND11_MODULE(openPMD, m) {
+    // m.doc() = ...;
+
+    init_Series(m);
+    init_Dataset(m);
+    /*
+    init_Datatype(m);
+    init_Iteration(m);
+    init_IterationEncoding(m);
+    init_Mesh(m);
+    init_ParticlePatches(m);
+    init_ParticleSpecies(m);
+    init_Record(m);
+    init_RecordComponent(m);
+    */
+
+    // m.attr("__version__") = "1.2.3-dev";
+}
+

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -8,8 +8,8 @@ void init_Dataset(py::module &);
 void init_Datatype(py::module &);
 void init_Iteration(py::module &);
 void init_IterationEncoding(py::module &);
-/*
 void init_Mesh(py::module &);
+/*
 void init_ParticlePatches(py::module &);
 void init_ParticleSpecies(py::module &);
 void init_Record(py::module &);
@@ -25,8 +25,8 @@ PYBIND11_MODULE(openPMD, m) {
     init_Datatype(m);
     init_Iteration(m);
     init_IterationEncoding(m);
-    /*
     init_Mesh(m);
+    /*
     init_ParticlePatches(m);
     init_ParticleSpecies(m);
     init_Record(m);

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -1,5 +1,9 @@
 #include <pybind11/pybind11.h>
 
+#include "openPMD/version.hpp"
+
+#include <sstream>
+
 namespace py = pybind11;
 
 
@@ -34,6 +38,13 @@ PYBIND11_MODULE(openPMD, m) {
     init_RecordComponent(m);
     init_Series(m);
 
-    // m.attr("__version__") = "1.2.3-dev";
+    // build version
+    std::stringstream openPMDapi;
+    openPMDapi << OPENPMDAPI_VERSION_MAJOR << "."
+               << OPENPMDAPI_VERSION_MINOR << "."
+               << OPENPMDAPI_VERSION_PATCH;
+    if( std::string( OPENPMDAPI_VERSION_LABEL ).size() > 0 )
+        openPMDapi << "-" << OPENPMDAPI_VERSION_LABEL;
+    m.attr("__version__") = openPMDapi.str();
 }
 

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/version.hpp"
 

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -13,9 +13,7 @@ void init_Datatype(py::module &);
 void init_Iteration(py::module &);
 void init_IterationEncoding(py::module &);
 void init_Mesh(py::module &);
-/*
 void init_ParticlePatches(py::module &);
-*/
 void init_ParticleSpecies(py::module &);
 void init_Record(py::module &);
 void init_RecordComponent(py::module &);
@@ -30,9 +28,7 @@ PYBIND11_MODULE(openPMD, m) {
     init_Iteration(m);
     init_IterationEncoding(m);
     init_Mesh(m);
-    /*
     init_ParticlePatches(m);    
-    */
     init_ParticleSpecies(m);
     init_Record(m);
     init_RecordComponent(m);

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -15,8 +15,8 @@ void init_IterationEncoding(py::module &);
 void init_Mesh(py::module &);
 /*
 void init_ParticlePatches(py::module &);
-void init_ParticleSpecies(py::module &);
 */
+void init_ParticleSpecies(py::module &);
 void init_Record(py::module &);
 void init_RecordComponent(py::module &);
 void init_Series(py::module &);
@@ -31,9 +31,9 @@ PYBIND11_MODULE(openPMD, m) {
     init_IterationEncoding(m);
     init_Mesh(m);
     /*
-    init_ParticlePatches(m);
-    init_ParticleSpecies(m);
+    init_ParticlePatches(m);    
     */
+    init_ParticleSpecies(m);
     init_Record(m);
     init_RecordComponent(m);
     init_Series(m);

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -4,7 +4,6 @@ namespace py = pybind11;
 
 
 // forward declarations of exposed classes
-void init_Series(py::module &);
 void init_Dataset(py::module &);
 void init_Datatype(py::module &);
 void init_Iteration(py::module &);
@@ -14,8 +13,9 @@ void init_Mesh(py::module &);
 void init_ParticlePatches(py::module &);
 void init_ParticleSpecies(py::module &);
 void init_Record(py::module &);
-void init_RecordComponent(py::module &);
 */
+void init_RecordComponent(py::module &);
+void init_Series(py::module &);
 
 
 PYBIND11_MODULE(openPMD, m) {
@@ -30,8 +30,8 @@ PYBIND11_MODULE(openPMD, m) {
     init_ParticlePatches(m);
     init_ParticleSpecies(m);
     init_Record(m);
-    init_RecordComponent(m);
     */
+    init_RecordComponent(m);
     init_Series(m);
 
     // m.attr("__version__") = "1.2.3-dev";


### PR DESCRIPTION
Draft for Python bindings #32

## Initial To Do

- CI:
  - [x] add to compile matrix
  - [x] add first example
- [x] finish [install](https://github.com/ornladios/ADIOS2/blob/master/bindings/python/CMakeLists.txt) with pure CMake
- [x] add more classes: `Dataset`, `IterationEncoding`, `ParticlePatches`, `Record`, `Datatype`, `Mesh`, `ParticleSpecies`, `Iteration`, `RecordComponent`

## Future:
- add [`setup.py`](https://github.com/pybind/cmake_example/blob/master/setup.py)? (source wheel, binary wheel): this is actually just a CMake wrapper and can be really hard for users to understand/control, especially with the transitive C dependencies (HDF5, ADIOS)
- add actual data reading into ndarrays
- add unit tests