### PR TITLE
Doxygen: Mainpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Initial backends will include ADIOS and HDF5.
 
 *Syntax not yet implemented as shown below*
 
-```C++
+```cpp
 #include <openPMD/openPMD.hpp>
 #include <iostream>
 

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -10,6 +10,7 @@ GENERATE_XML      = YES
 RECURSIVE         = YES
 #QUIET             = YES
 JAVADOC_AUTOBRIEF = YES
+USE_MDFILE_AS_MAINPAGE = README.md
 
 # ideally, you want to warn on missing doc coverage!
 WARN_IF_UNDOCUMENTED = NO


### PR DESCRIPTION
Define the README as mainpage on Doxygen HTML output (`gh-pages`).
Fix the detection of syntax highlighting for C++.