### PR TITLE
openPMD:: namespace

### DIFF
--- a/examples/1_structure.cpp
+++ b/examples/1_structure.cpp
@@ -21,6 +21,8 @@
 #include <openPMD/openPMD.hpp>
 
 
+using namespace openPMD;
+
 int main(int argc, char *argv[])
 {
     /* The root of any openPMD output spans across all data for all iterations is a 'Series'.

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -25,6 +25,7 @@
 
 
 using std::cout;
+using namespace openPMD;
 
 int main()
 {

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -25,6 +25,7 @@
 
 
 using std::cout;
+using namespace openPMD;
 
 int main(int argc, char *argv[])
 {

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -27,6 +27,7 @@
 
 
 using std::cout;
+using namespace openPMD;
 
 int main(int argc, char *argv[])
 {

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -27,6 +27,7 @@
 
 
 using std::cout;
+using namespace openPMD;
 
 int main(int argc, char *argv[])
 {

--- a/examples/6_dump_filebased_series.cpp
+++ b/examples/6_dump_filebased_series.cpp
@@ -4,6 +4,8 @@
 #include <numeric>
 
 
+using namespace openPMD;
+
 int main()
 {
     Series o = Series::read("../samples/git-sample/data%T.h5");

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -4,6 +4,8 @@
 #include <boost/filesystem.hpp>
 
 
+using namespace openPMD;
+
 void
 write()
 {

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -8,6 +8,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 using Extent = std::vector< std::uint64_t >;
 using Offset = std::vector< std::uint64_t >;
 
@@ -30,4 +32,4 @@ public:
     std::string compression;
     std::string transform;
 };
-
+} // openPMD

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -8,6 +8,8 @@
 #include <vector>
 
 
+namespace openPMD
+{
 /** Concrete datatype of an object available at runtime.
  */
 enum class Datatype : int
@@ -36,7 +38,7 @@ enum class Datatype : int
     DATATYPE = 1000,
 
     UNDEFINED
-};  //Datatype
+}; // Datatype
 
 /** @brief Fundamental equivalence check for two given types T and U.
  *
@@ -155,6 +157,10 @@ determineDatatype(std::shared_ptr< T >)
 
     return DT::UNDEFINED;
 }
+} // openPMD
 
-std::ostream&
-operator<<(std::ostream&, Datatype);
+namespace std
+{
+    ostream&
+    operator<<(ostream&, openPMD::Datatype);
+} // std

--- a/include/openPMD/IO/ADIOS/ADIOS1FilePosition.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1FilePosition.hpp
@@ -3,9 +3,12 @@
 #include <IO/AbstractFilePosition.hpp>
 
 
+namespace openPMD
+{
 struct ADIOS1FilePosition : public AbstractFilePosition
 {
     ADIOS1FilePosition()
     { }
 
 };  //ADIOS2FilePosition
+} // openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -27,6 +27,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 #if defined(openPMD_HAVE_ADIOS1)
 class ADIOS1IOHandler;
 
@@ -78,3 +80,4 @@ public:
 private:
     std::unique_ptr< ADIOS1IOHandlerImpl > m_impl;
 };  //ADIOS1IOHandler
+} // openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS2FilePosition.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2FilePosition.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include <IO/AbstractFilePosition.hpp>
+#include "openPMDIO/AbstractFilePosition.hpp"
 
 
+namespace openPMD
+{
 struct ADIOS2FilePosition : public AbstractFilePosition
 {
     ADIOS2FilePosition()
     { }
 
 };  //ADIOS2FilePosition
+} // openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -27,9 +27,9 @@
 #include <string>
 
 
+namespace openPMD
+{
 #if defined(openPMD_HAVE_ADIOS2)
-
-
 class ADIOS2IOHandler;
 
 class ADIOS2IOHandlerImpl
@@ -80,3 +80,4 @@ public:
 private:
     std::unique_ptr< ADIOS2IOHandlerImpl > m_impl;
 };  //ADIOS2IOHandler
+} // openPMD

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -31,8 +31,9 @@
 #include <memory>
 
 
+namespace openPMD
+{
 #if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
-
 class ParallelADIOS1IOHandler;
 
 class ParallelADIOS1IOHandlerImpl : public ADIOS1IOHandlerImpl
@@ -64,3 +65,4 @@ public:
 private:
     std::unique_ptr< ParallelADIOS1IOHandlerImpl > m_impl;
 };  //ParallelADIOS1IOHandler
+} // openPMD

--- a/include/openPMD/IO/AbstractFilePosition.hpp
+++ b/include/openPMD/IO/AbstractFilePosition.hpp
@@ -21,9 +21,12 @@
 #pragma once
 
 
+namespace openPMD
+{
 class AbstractFilePosition
 {
 public:
     virtual ~AbstractFilePosition() { }
 
 };  //AbstractFilePosition
+} // openPMD

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -35,6 +35,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 class no_such_file_error : public std::runtime_error
 {
 public:
@@ -134,3 +136,4 @@ public:
      */
     std::future< void > flush();
 };  //DummyIOHandler
+} // openPMD

--- a/include/openPMD/IO/AccessType.hpp
+++ b/include/openPMD/IO/AccessType.hpp
@@ -21,6 +21,8 @@
 #pragma once
 
 
+namespace openPMD
+{
 /** File access permissions to use during IO.
  */
 enum class AccessType
@@ -29,3 +31,4 @@ enum class AccessType
     READ_WRITE,
     CREATE
 };  //AccessType
+} // openPMD

--- a/include/openPMD/IO/Format.hpp
+++ b/include/openPMD/IO/Format.hpp
@@ -21,6 +21,8 @@
 #pragma once
 
 
+namespace openPMD
+{
 /** File format to use during IO.
  */
 enum class Format
@@ -30,3 +32,4 @@ enum class Format
     ADIOS2,
     DUMMY
 };  //Format
+} // openPMD

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -30,6 +30,8 @@
 #include <stack>
 
 
+namespace openPMD
+{
 inline hid_t
 getH5DataType(Attribute const& att)
 {
@@ -235,3 +237,4 @@ concrete_h5_file_position(Writable* w)
 
     return replace_all(pos, "//", "/");
 }
+} // openPMD

--- a/include/openPMD/IO/HDF5/HDF5FilePosition.hpp
+++ b/include/openPMD/IO/HDF5/HDF5FilePosition.hpp
@@ -23,6 +23,8 @@
 #include "openPMD/IO/AbstractFilePosition.hpp"
 
 
+namespace openPMD
+{
 struct HDF5FilePosition : public AbstractFilePosition
 {
     HDF5FilePosition(std::string const& s)
@@ -31,3 +33,4 @@ struct HDF5FilePosition : public AbstractFilePosition
 
     std::string location;
 };  //HDF5FilePosition
+} // openPMD

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -33,8 +33,9 @@
 #include <string>
 
 
+namespace openPMD
+{
 #if defined(openPMD_HAVE_HDF5)
-
 class HDF5IOHandler;
 
 class HDF5IOHandlerImpl
@@ -91,3 +92,4 @@ public:
 private:
     std::unique_ptr< HDF5IOHandlerImpl > m_impl;
 };  //HDF5IOHandler
+} // openPMD

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -32,8 +32,9 @@
 #include <string>
 
 
+namespace openPMD
+{
 #if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
-
 class ParallelHDF5IOHandler;
 
 class ParallelHDF5IOHandlerImpl : public HDF5IOHandlerImpl
@@ -65,3 +66,4 @@ public:
 private:
     std::unique_ptr< ParallelHDF5IOHandlerImpl > m_impl;
 };  //ParallelHDF5IOHandler
+} // openPMD

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -11,6 +11,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 /** Concrete datatype of an object available at runtime.
  */
 enum class ArgumentDatatype : int
@@ -247,3 +249,4 @@ public:
     Operation operation;
     std::map< std::string, ParameterArgument > parameter;
 };  //IOTask
+} // openPMD

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -20,13 +20,14 @@
  */
 #pragma once
 
-
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/Mesh.hpp"
 #include "openPMD/ParticleSpecies.hpp"
 
 
+namespace openPMD
+{
 /** @brief  Logical compilation of data from one snapshot (e.g. a single simulation cycle).
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#required-attributes-for-the-basepath
@@ -131,3 +132,4 @@ template< typename T >
 inline T
 Iteration::dt() const
 { return Attributable::readFloatingpoint< T >("dt"); }
+} // openPMD

--- a/include/openPMD/IterationEncoding.hpp
+++ b/include/openPMD/IterationEncoding.hpp
@@ -20,10 +20,11 @@
  */
 #pragma once
 
-
 #include <iosfwd>
 
 
+namespace openPMD
+{
 /** Encoding scheme of an Iterations Series'.
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
@@ -31,7 +32,11 @@
 enum class IterationEncoding
 {
     fileBased, groupBased
-};  //IterationEncoding
+};
+} // openPMD
 
-std::ostream&
-operator<<(std::ostream&, IterationEncoding);
+namespace std
+{
+    ostream&
+    operator<<(ostream&, openPMD::IterationEncoding);
+} // std

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -9,6 +9,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 /** @brief Container for N-dimensional, homogenous Records.
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#mesh-based-records
@@ -157,7 +159,7 @@ private:
 
     void flush(std::string const&) override;
     void read() override;
-};  //Mesh
+}; // Mesh
 
 template< typename T >
 inline std::vector< T >
@@ -168,9 +170,13 @@ template< typename T >
 inline T
 Mesh::timeOffset() const
 { return readFloatingpoint< T >("timeOffset"); }
+} // openPMD
 
-std::ostream&
-operator<<(std::ostream&, Mesh::Geometry);
+namespace std
+{
+    ostream&
+    operator<<(ostream&, openPMD::Mesh::Geometry);
 
-std::ostream&
-operator<<(std::ostream&, Mesh::DataOrder);
+    std::ostream&
+    operator<<(ostream&, openPMD::Mesh::DataOrder);
+} // std

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -7,6 +7,8 @@
 #include <vector>
 
 
+namespace openPMD
+{
 class ParticlePatches : public Container< PatchRecord >
 {
     friend class ParticleSpecies;
@@ -20,3 +22,4 @@ private:
 
     std::vector< PatchPosition > m_patchPositions;
 };  //ParticlePatches
+} // openPMD

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -8,6 +8,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 class ParticleSpecies : public Container< Record >
 {
     friend class Container< ParticleSpecies >;
@@ -31,3 +33,4 @@ Container< ParticleSpecies >::operator[](Container< ParticleSpecies >::key_type 
 template<>
 Container< ParticleSpecies >::mapped_type&
 Container< ParticleSpecies >::operator[](Container< ParticleSpecies >::key_type && key);
+} // openPMD

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -8,6 +8,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 class Record : public BaseRecord< RecordComponent >
 {
     friend class Container< Record >;
@@ -47,4 +49,4 @@ Record::setTimeOffset(T to)
     setAttribute("timeOffset", to);
     return *this;
 }
-
+} // openPMD

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -11,6 +11,8 @@
 #include <stdexcept>
 
 
+namespace openPMD
+{
 class RecordComponent : public BaseRecordComponent
 {
     template<
@@ -214,3 +216,4 @@ RecordComponent::storeChunk(Offset o, Extent e, std::shared_ptr<T> data)
     dWrite.data = std::static_pointer_cast< void >(data);
     m_chunks.push(IOTask(this, dWrite));
 }
+} // openPMD

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -35,6 +35,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 /** @brief  Root level of the openPMD hierarchy.
  *
  * Entry point and common link between all iterations of particle and mesh data.
@@ -263,3 +265,4 @@ private:
     IterationEncoding m_iterationEncoding;
     std::string m_name;
 };  //Series
+} // openPMD

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -8,6 +8,8 @@
 #include <utility>
 
 
+namespace openPMD
+{
 std::unique_ptr< void, std::function< void(void*) > >
 allocatePtr(Datatype dtype, Extent const& e);
 
@@ -86,3 +88,4 @@ allocatePtr(Datatype dtype, size_t numPoints)
 
     return std::move(std::unique_ptr< void, std::function< void(void*) > >(data, del));
 }
+} // openPMD

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 
+namespace openPMD
+{
 inline bool
 contains(std::string const &s,
          std::string const &infix)
@@ -107,3 +109,4 @@ strip(std::string s, std::vector< char > to_remove)
 
     return s;
 }
+} // openPMD

--- a/include/openPMD/auxiliary/Variadic.hpp
+++ b/include/openPMD/auxiliary/Variadic.hpp
@@ -31,6 +31,8 @@ namespace variadicSrc = mpark;
 #include <type_traits>
 
 
+namespace openPMD
+{
 /** Generic object to store a set of datatypes in without losing type safety.
  *
  * @tparam T_DTYPES Enumeration of datatypes to be stored and identified.
@@ -81,3 +83,4 @@ public:
 private:
     resource m_data;
 };
+} // openPMD

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -31,6 +31,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 class no_such_attribute_error : public std::runtime_error
 {
 public:
@@ -278,3 +280,4 @@ Attributable::readVectorFloatingpoint(std::string const& key) const
     }
     return vt;
 }
+} // openPMD

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -29,6 +29,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 //TODO This might have to be a Writable
 //Reasoning - Flushes are expeted to be done often.
 //Attributes should not be written unless dirty.
@@ -59,3 +61,4 @@ using Attribute = Variadic< Datatype,
                             std::vector< std::string >,
                             std::array< double, 7 >,
                             bool >;
+} // openPMD

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -8,6 +8,8 @@
 #include <stdexcept>
 
 
+namespace openPMD
+{
 enum class UnitDimension : uint8_t
 {
     L = 0, M, T, I, theta, N, J
@@ -177,3 +179,4 @@ BaseRecord< T_elem >::readBase()
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'timeOffset'");
 }
+} // openPMD

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -4,6 +4,8 @@
 #include "openPMD/Dataset.hpp"
 
 
+namespace openPMD
+{
 class BaseRecordComponent : public Attributable
 {
     template< typename T_elem >
@@ -26,3 +28,4 @@ protected:
     Dataset m_dataset;
     bool m_isConstant;
 };  //BaseRecordComponent
+} // openPMD

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -29,6 +29,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 /** @brief Map-like container that enforces openPMD requirements and handles IO.
  *
  * @see http://en.cppreference.com/w/cpp/container/map
@@ -196,3 +198,4 @@ protected:
         flushAttributes();
     }
 };
+} // openPMD

--- a/include/openPMD/backend/GenericPatchData.hpp
+++ b/include/openPMD/backend/GenericPatchData.hpp
@@ -7,6 +7,8 @@
 #include <type_traits>
 
 
+namespace openPMD
+{
 class GenericPatchData
 {
 public:
@@ -51,3 +53,4 @@ GenericPatchData::operator T()
 {
     return m_data.get< T >();
 }
+} // openPMD

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 
+namespace openPMD
+{
 class MeshRecordComponent : public RecordComponent
 {
     template<
@@ -44,3 +46,4 @@ MeshRecordComponent::makeConstant(T value)
     RecordComponent::makeConstant(value);
     return *this;
 }
+} // openPMD

--- a/include/openPMD/backend/PatchPosition.hpp
+++ b/include/openPMD/backend/PatchPosition.hpp
@@ -4,6 +4,8 @@
 #include <functional>
 
 
+namespace openPMD
+{
 struct PatchPosition
 {
     PatchPosition()
@@ -15,28 +17,32 @@ struct PatchPosition
               numParticlesOffset{numParticlesOffset}
     { }
 
+    bool
+    operator==(openPMD::PatchPosition const & other) const
+    {
+        return (this->numParticles == other.numParticles)
+               && (this->numParticlesOffset == other.numParticlesOffset);
+    }
+
     uint64_t numParticles;
     uint64_t numParticlesOffset;
-};  //PatchPosition
-
-inline bool
-operator==(PatchPosition const& pp1, PatchPosition const& pp2)
-{
-    return (pp1.numParticles == pp2.numParticles)
-           && (pp1.numParticlesOffset == pp2.numParticlesOffset);
-}
+};
+} // openPMD
 
 namespace std
 {
     template<>
-    struct hash< PatchPosition >
+    struct hash< openPMD::PatchPosition >
     {
-        std::size_t operator()(const PatchPosition& k) const
+        std::size_t
+        operator()(openPMD::PatchPosition const & k) const
         {
             using std::hash;
 
+            //! @todo add comment about this hash
             return hash< uint64_t >()(k.numParticles)
-                   ^ (hash< uint64_t >()(k.numParticlesOffset)<<1);
+                   ^ (hash< uint64_t >()(k.numParticlesOffset) << 1);
         }
     };
 }
+

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -7,6 +7,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 class PatchRecord : public BaseRecord< PatchRecordComponent >
 {
     friend class Container< PatchRecord >;
@@ -22,3 +24,4 @@ private:
     void flush(std::string const&) override;
     void read() override;
 };  //PatchRecord
+} // openPMD

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -8,6 +8,8 @@
 #include <string>
 
 
+namespace openPMD
+{
 class PatchRecordComponent : public BaseRecordComponent
 {
     template<
@@ -33,3 +35,4 @@ private:
 
     std::unordered_map< PatchPosition, GenericPatchData > m_data;
 };  //PatchRecordComponent
+} // openPMD

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 
 
+namespace openPMD
+{
 class AbstractFilePosition;
 class AbstractIOHandler;
 
@@ -62,3 +64,4 @@ protected:
     bool dirty;
     bool written;
 };
+} // openPMD

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 
 
+namespace openPMD
+{
 Dataset::Dataset(Datatype d, Extent e)
         : extent{e},
           dtype{d},
@@ -57,3 +59,4 @@ Dataset::setCustomTransform(std::string const& parameter)
     transform = parameter;
     return *this;
 }
+} // openPMD

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -4,9 +4,9 @@
 
 
 std::ostream&
-operator<<(std::ostream& os, Datatype d)
+std::operator<<(std::ostream& os, openPMD::Datatype d)
 {
-    using DT = Datatype;
+    using DT = openPMD::Datatype;
     switch( d )
     {
         case DT::CHAR:

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -21,6 +21,8 @@
 #include "openPMD/IO/ADIOS/ADIOS1IOHandler.hpp"
 
 
+namespace openPMD
+{
 #if openPMD_HAVE_ADIOS1
 ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
@@ -71,3 +73,4 @@ ADIOS1IOHandler::flush()
     return std::future< void >();
 }
 #endif
+} // openPMD

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -21,8 +21,9 @@
 #include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
 
 
+namespace openPMD
+{
 #if openPMD_HAVE_ADIOS2
-
 ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
           m_impl{new ADIOS2IOHandlerImpl(this)}
@@ -73,3 +74,4 @@ ADIOS2IOHandler::flush()
     return std::future< void >();
 }
 #endif
+} // openPMD

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -21,6 +21,8 @@
 #include "openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp"
 
 
+namespace openPMD
+{
 #if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
                                              AccessType at,
@@ -58,3 +60,4 @@ ParallelADIOS1IOHandler::flush()
     return std::future< void >();
 }
 #endif
+} // openPMD

--- a/src/IO/AbstractIOHandler.cpp
+++ b/src/IO/AbstractIOHandler.cpp
@@ -25,6 +25,8 @@
 #include <iostream>
 
 
+namespace openPMD
+{
 #if openPMD_HAVE_MPI
 std::shared_ptr< AbstractIOHandler >
 AbstractIOHandler::createIOHandler(std::string const& path,
@@ -110,3 +112,4 @@ void DummyIOHandler::enqueue(IOTask const&)
 std::future< void >
 DummyIOHandler::flush()
 { return std::future< void >(); }
+} // openPMD

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -27,20 +27,23 @@
 #   include "openPMD/IO/IOTask.hpp"
 #   include "openPMD/IO/HDF5/HDF5Auxiliary.hpp"
 #   include "openPMD/IO/HDF5/HDF5FilePosition.hpp"
+#endif
 
-#   include <boost/filesystem.hpp>
+#include <boost/filesystem.hpp>
 
-#   include <future>
-#   include <iostream>
-#   include <string>
-#   include <vector>
+#include <future>
+#include <iostream>
+#include <string>
+#include <vector>
 
+namespace openPMD
+{
+#if defined(openPMD_HAVE_HDF5)
 #   ifdef DEBUG
 #       define ASSERT(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error(std::string((TEXT))); }
 #   else
 #       define ASSERT(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif
-
 
 HDF5IOHandlerImpl::HDF5IOHandlerImpl(AbstractIOHandler* handler)
         : m_datasetTransferProperty{H5P_DEFAULT},
@@ -1525,3 +1528,4 @@ HDF5IOHandler::flush()
     return std::future< void >();
 }
 #endif
+} // openPMD

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -29,6 +29,8 @@
 #include <iostream>
 
 
+namespace openPMD
+{
 #if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   ifdef DEBUG
@@ -36,7 +38,6 @@
 #   else
 #       define ASSERT(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif
-
 
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
                                              AccessType at,
@@ -98,3 +99,4 @@ ParallelHDF5IOHandler::flush()
     return std::future< void >();
 }
 #endif
+} // openPMD

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -1,6 +1,8 @@
 #include "openPMD/IO/IOTask.hpp"
 
 
+namespace openPMD
+{
 template<>
 std::map< std::string, ParameterArgument > structToMap(Parameter< Operation::CREATE_FILE > const& p)
 {
@@ -162,4 +164,5 @@ std::map< std::string, ParameterArgument > structToMap(Parameter< Operation::LIS
     ret.insert({"attributes", ParameterArgument(p.attributes)});
     return ret;
 }
+} // openPMD
 

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -24,6 +24,8 @@
 #include "openPMD/Series.hpp"
 
 
+namespace openPMD
+{
 Iteration::Iteration()
         : meshes{Container< Mesh >()},
           particles{Container< ParticleSpecies >()}
@@ -362,3 +364,4 @@ template
 Iteration& Iteration::setDt< double >(double dt);
 template
 Iteration& Iteration::setDt< long double >(long double dt);
+} // openPMD

--- a/src/IterationEncoding.cpp
+++ b/src/IterationEncoding.cpp
@@ -24,14 +24,14 @@
 
 
 std::ostream&
-operator<<(std::ostream& os, IterationEncoding ie)
+std::operator<<(std::ostream& os, openPMD::IterationEncoding ie)
 {
     switch( ie )
     {
-        case IterationEncoding::fileBased:
+        case openPMD::IterationEncoding::fileBased:
             os << "fileBased";
             break;
-        case IterationEncoding::groupBased:
+        case openPMD::IterationEncoding::groupBased:
             os << "groupBased";
             break;
     }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -24,6 +24,8 @@
 #include <iostream>
 
 
+namespace openPMD
+{
 Mesh::Mesh()
 {
     setTimeOffset(0.f);
@@ -341,22 +343,23 @@ Mesh::read()
     /* this file need not be flushed */
     written = true;
 }
+} // openPMD
 
 std::ostream&
-operator<<(std::ostream& os, Mesh::Geometry go)
+std::operator<<(std::ostream& os, openPMD::Mesh::Geometry go)
 {
     switch( go )
     {
-        case Mesh::Geometry::cartesian:
+        case openPMD::Mesh::Geometry::cartesian:
             os<<"cartesian";
             break;
-        case Mesh::Geometry::thetaMode:
+        case openPMD::Mesh::Geometry::thetaMode:
             os<<"thetaMode";
             break;
-        case Mesh::Geometry::cylindrical:
+        case openPMD::Mesh::Geometry::cylindrical:
             os<<"cylindrical";
             break;
-        case Mesh::Geometry::spherical:
+        case openPMD::Mesh::Geometry::spherical:
             os<<"spherical";
             break;
     }
@@ -364,14 +367,14 @@ operator<<(std::ostream& os, Mesh::Geometry go)
 }
 
 std::ostream&
-operator<<(std::ostream& os, Mesh::DataOrder dor)
+std::operator<<(std::ostream& os, openPMD::Mesh::DataOrder dor)
 {
     switch( dor )
     {
-        case Mesh::DataOrder::C:
+        case openPMD::Mesh::DataOrder::C:
             os<<'C';
             break;
-        case Mesh::DataOrder::F:
+        case openPMD::Mesh::DataOrder::F:
             os<<'F';
             break;
     }

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -1,6 +1,8 @@
 #include "openPMD/ParticlePatches.hpp"
 
 
+namespace openPMD
+{
 ParticlePatches::mapped_type&
 ParticlePatches::operator[](ParticlePatches::key_type const& key)
 {
@@ -90,3 +92,4 @@ ParticlePatches::read()
     for( size_t i = 0; i < numParticles.size(); ++i )
         m_patchPositions.emplace_back(PatchPosition(numParticles[i], numParticlesOffset[i]));
 }
+} // openPMD

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -2,6 +2,8 @@
 #include "openPMD/ParticleSpecies.hpp"
 
 
+namespace openPMD
+{
 ParticleSpecies::ParticleSpecies() = default;
 
 void
@@ -134,3 +136,4 @@ Container< ParticleSpecies >::operator[](Container< ParticleSpecies >::key_type 
         return ret;
     }
 }
+} // openPMD

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 
 
+namespace openPMD
+{
 Record::Record()
 {
     setTimeOffset(0.f);
@@ -106,3 +108,4 @@ Record::read()
     /* this file need not be flushed */
     written = true;
 }
+} // openPMD

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 
 
+namespace openPMD
+{
 RecordComponent::RecordComponent()
         : m_constantValue{-1}
 {
@@ -186,4 +188,5 @@ RecordComponent::readBase()
 
     readAttributes();
 }
+} // openPMD
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -28,6 +28,8 @@
 #include <regex>
 
 
+namespace openPMD
+{
 void
 check_extension(std::string const& filepath)
 {
@@ -808,3 +810,4 @@ Series::cleanFilename(std::string s, Format f)
 
     return s;
 }
+} // openPMD

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -25,6 +25,8 @@
 #include <set>
 
 
+namespace openPMD
+{
 Attributable::Attributable()
         : m_attributes{std::make_shared< A_MAP >()}
 { }
@@ -303,3 +305,4 @@ Attributable::readVectorFloatingpoint(std::string const& key) const;
 template
 std::vector< long double >
 Attributable::readVectorFloatingpoint(std::string const& key) const;
+} // openPMD

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -1,6 +1,8 @@
 #include "openPMD/backend/BaseRecordComponent.hpp"
 
 
+namespace openPMD
+{
 double
 BaseRecordComponent::unitSI() const
 {
@@ -27,3 +29,4 @@ BaseRecordComponent::getDatatype()
 {
     return m_dataset.dtype;
 }
+} // openPMD

--- a/src/backend/GenericPatchData.cpp
+++ b/src/backend/GenericPatchData.cpp
@@ -1,9 +1,11 @@
 #include "openPMD/backend/GenericPatchData.hpp"
 
-
+namespace openPMD
+{
 GenericPatchData::GenericPatchData()
         : m_data(0)
 {
     m_data.dtype = Dtype::UNDEFINED;
 }
+} // openPMD
 

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -1,6 +1,8 @@
 #include "openPMD/backend/MeshRecordComponent.hpp"
 
 
+namespace openPMD
+{
 MeshRecordComponent::MeshRecordComponent()
         : RecordComponent()
 {
@@ -55,3 +57,4 @@ MeshRecordComponent::setPosition(std::vector< double > pos);
 template
 MeshRecordComponent&
 MeshRecordComponent::setPosition(std::vector< long double > pos);
+} // openPMD

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -2,6 +2,8 @@
 #include "openPMD/backend/PatchRecord.hpp"
 
 
+namespace openPMD
+{
 PatchRecord&
 PatchRecord::setUnitDimension(std::map< UnitDimension, double > const& udim)
 {
@@ -54,3 +56,4 @@ PatchRecord::read()
         IOHandler->flush();
     }
 }
+} // openPMD

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -1,6 +1,8 @@
 #include "openPMD/backend/PatchRecordComponent.hpp"
 
 
+namespace openPMD
+{
 GenericPatchData&
 PatchRecordComponent::operator[](PatchPosition const& pos)
 {
@@ -35,3 +37,4 @@ PatchRecordComponent::flush(std::string const& name)
     }
     IOHandler->flush();
 }
+} // openPMD

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -2,6 +2,8 @@
 #include <openPMD/backend/Writable.hpp>
 
 
+namespace openPMD
+{
 Writable::Writable()
         : abstractFilePosition{nullptr},
           parent{nullptr},
@@ -12,4 +14,4 @@ Writable::Writable()
 
 Writable::~Writable()
 { }
-
+} // openPMD

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -9,6 +9,7 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/Dataset.hpp"
 #undef protected
+using namespace openPMD;
 
 #include <boost/test/included/unit_test.hpp>
 

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -4,6 +4,7 @@
 #define protected public
 #include "openPMD/openPMD.hpp"
 #undef protected
+using namespace openPMD;
 
 #include <boost/test/included/unit_test.hpp>
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -5,6 +5,7 @@
 #define BOOST_TEST_MODULE libopenpmd_parallel_io_test
 
 #include "openPMD/openPMD.hpp"
+using namespace openPMD;
 
 #include <boost/test/included/unit_test.hpp>
 #if openPMD_HAVE_MPI

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4,6 +4,7 @@
 #define protected public
 #include "openPMD/openPMD.hpp"
 #undef protected
+using namespace openPMD;
 
 #include <boost/test/included/unit_test.hpp>
 


### PR DESCRIPTION
Add a `openPMD::` namespace to all things.
Avoids collisions in dependent project on included classes, functions, ...

Closes #16