### PR TITLE
auxiliary:: namespace

### DIFF
--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -235,6 +235,6 @@ concrete_h5_file_position(Writable* w)
         hierarchy.pop();
     }
 
-    return replace_all(pos, "//", "/");
+    return auxiliary::replace_all(pos, "//", "/");
 }
 } // openPMD

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -30,7 +30,7 @@ enum class ArgumentDatatype : int
 
     UNDEFINED
 };
-using ParameterArgument = Variadic< ArgumentDatatype,
+using ParameterArgument = auxiliary::Variadic< ArgumentDatatype,
                                     std::string,
                                     std::vector< uint64_t >,
                                     void*,

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -10,6 +10,8 @@
 
 namespace openPMD
 {
+namespace auxiliary
+{
 std::unique_ptr< void, std::function< void(void*) > >
 allocatePtr(Datatype dtype, Extent const& e);
 
@@ -88,4 +90,5 @@ allocatePtr(Datatype dtype, size_t numPoints)
 
     return std::move(std::unique_ptr< void, std::function< void(void*) > >(data, del));
 }
+} // auxiliary
 } // openPMD

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -7,6 +7,8 @@
 
 namespace openPMD
 {
+namespace auxiliary
+{
 inline bool
 contains(std::string const &s,
          std::string const &infix)
@@ -109,4 +111,5 @@ strip(std::string s, std::vector< char > to_remove)
 
     return s;
 }
+} // auxiliary
 } // openPMD

--- a/include/openPMD/auxiliary/Variadic.hpp
+++ b/include/openPMD/auxiliary/Variadic.hpp
@@ -33,6 +33,8 @@ namespace variadicSrc = mpark;
 
 namespace openPMD
 {
+namespace auxiliary
+{
 /** Generic object to store a set of datatypes in without losing type safety.
  *
  * @tparam T_DTYPES Enumeration of datatypes to be stored and identified.
@@ -83,4 +85,5 @@ public:
 private:
     resource m_data;
 };
+} // auxiliary
 } // openPMD

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -41,7 +41,7 @@ namespace openPMD
  * @note Extending and/or modifying the available formats requires identical
  *       modifications to Datatype.
  */
-using Attribute = Variadic< Datatype,
+using Attribute = auxiliary::Variadic< Datatype,
                             char, unsigned char,
                             int16_t, int32_t, int64_t,
                             uint16_t, uint32_t, uint64_t,

--- a/include/openPMD/backend/GenericPatchData.hpp
+++ b/include/openPMD/backend/GenericPatchData.hpp
@@ -27,13 +27,13 @@ private:
         INT8, INT16, INT32, INT64,
         BOOL,
         UNDEFINED };
-    using variadic_t = Variadic< Dtype,
+    using variadic_t = auxiliary::Variadic< Dtype,
                                  float, double,
                                  uint8_t, uint16_t, uint32_t, uint64_t,
                                  int8_t, int16_t, int32_t, int64_t,
                                  bool >;
     variadic_t m_data;
-};  //GenericPatchData
+}; // GenericPatchData
 
 
 template< typename T >

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -180,7 +180,7 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
 
         /* Create a new file using current properties. */
         std::string name = m_handler->directory + parameters.at("name").get< std::string >();
-        if( !ends_with(name, ".h5") )
+        if( !auxiliary::ends_with(name, ".h5") )
             name += ".h5";
         hid_t id = H5Fcreate(name.c_str(),
                              H5F_ACC_TRUNC,
@@ -204,9 +204,9 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
     {
         /* Sanitize path */
         std::string path = parameters.at("path").get< std::string >();
-        if( starts_with(path, "/") )
-            path = replace_first(path, "/", "");
-        if( !ends_with(path, "/") )
+        if( auxiliary::starts_with(path, "/") )
+            path = auxiliary::replace_first(path, "/", "");
+        if( !auxiliary::ends_with(path, "/") )
             path += '/';
 
         /* Open H5Object to write into */
@@ -224,7 +224,7 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         /* Create the path in the file */
         std::stack< hid_t > groups;
         groups.push(node_id);
-        for( std::string const& folder : split(path, "/", false) )
+        for( std::string const& folder : auxiliary::split(path, "/", false) )
         {
             hid_t group_id = H5Gcreate(groups.top(),
                                        folder.c_str(),
@@ -258,10 +258,10 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
     if( !writable->written )
     {
         std::string name = parameters.at("name").get< std::string >();
-        if( starts_with(name, "/") )
-            name = replace_first(name, "/", "");
-        if( ends_with(name, "/") )
-            name = replace_first(name, "/", "");
+        if( auxiliary::starts_with(name, "/") )
+            name = auxiliary::replace_first(name, "/", "");
+        if( auxiliary::ends_with(name, "/") )
+            name = auxiliary::replace_first(name, "/", "");
 
 
         /* Open H5Object to write into */
@@ -305,7 +305,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         std::string const& compression = parameters.at("compression").get< std::string >();
         if( !compression.empty() )
         {
-            std::vector< std::string > args = split(compression, ":");
+            std::vector< std::string > args = auxiliary::split(compression, ":");
             std::string const& format = args[0];
             if( (format == "zlib" || format == "gzip" || format == "deflate")
                 && args.size() == 2 )
@@ -372,9 +372,9 @@ HDF5IOHandlerImpl::extendDataset(Writable* writable,
 
     /* Sanitize name */
     std::string name = parameters.at("name").get< std::string >();
-    if( starts_with(name, "/") )
-        name = replace_first(name, "/", "");
-    if( !ends_with(name, "/") )
+    if( auxiliary::starts_with(name, "/") )
+        name = auxiliary::replace_first(name, "/", "");
+    if( !auxiliary::ends_with(name, "/") )
         name += '/';
 
     dataset_id = H5Dopen(node_id,
@@ -409,7 +409,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
         throw no_such_file_error("Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.at("name").get< std::string >();
-    if( !ends_with(name, ".h5") )
+    if( !auxiliary::ends_with(name, ".h5") )
         name += ".h5";
 
     unsigned flags;
@@ -448,9 +448,9 @@ HDF5IOHandlerImpl::openPath(Writable* writable,
 
     /* Sanitize path */
     std::string path = parameters.at("path").get< std::string >();
-    if( starts_with(path, "/") )
-        path = replace_first(path, "/", "");
-    if( !ends_with(path, "/") )
+    if( auxiliary::starts_with(path, "/") )
+        path = auxiliary::replace_first(path, "/", "");
+    if( !auxiliary::ends_with(path, "/") )
         path += '/';
 
     path_id = H5Gopen(node_id,
@@ -484,9 +484,9 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
 
     /* Sanitize name */
     std::string name = parameters.at("name").get< std::string >();
-    if( starts_with(name, "/") )
-        name = replace_first(name, "/", "");
-    if( !ends_with(name, "/") )
+    if( auxiliary::starts_with(name, "/") )
+        name = auxiliary::replace_first(name, "/", "");
+    if( !auxiliary::ends_with(name, "/") )
         name += '/';
 
     dataset_id = H5Dopen(node_id,
@@ -577,7 +577,7 @@ HDF5IOHandlerImpl::deleteFile(Writable* writable,
         ASSERT(status == 0, "Internal error: Failed to close HDF5 file during file deletion");
 
         std::string name = m_handler->directory + parameters.at("name").get< std::string >();
-        if( !ends_with(name, ".h5") )
+        if( !auxiliary::ends_with(name, ".h5") )
             name += ".h5";
 
         using namespace boost::filesystem;
@@ -606,9 +606,9 @@ HDF5IOHandlerImpl::deletePath(Writable* writable,
     {
         /* Sanitize path */
         std::string path = parameters.at("path").get< std::string >();
-        if( starts_with(path, "/") )
-            path = replace_first(path, "/", "");
-        if( !ends_with(path, "/") )
+        if( auxiliary::starts_with(path, "/") )
+            path = auxiliary::replace_first(path, "/", "");
+        if( !auxiliary::ends_with(path, "/") )
             path += '/';
 
         /* Open H5Object to delete in
@@ -650,9 +650,9 @@ HDF5IOHandlerImpl::deleteDataset(Writable* writable,
     {
         /* Sanitize name */
         std::string name = parameters.at("name").get< std::string >();
-        if( starts_with(name, "/") )
-            name = replace_first(name, "/", "");
-        if( !ends_with(name, "/") )
+        if( auxiliary::starts_with(name, "/") )
+            name = auxiliary::replace_first(name, "/", "");
+        if( !auxiliary::ends_with(name, "/") )
             name += '/';
 
         /* Open H5Object to delete in
@@ -1209,7 +1209,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                 status = H5Aread(attr_id,
                                  attr_type,
                                  c);
-                a = Attribute(strip(std::string(c), {'\0'}));
+                a = Attribute(auxiliary::strip(std::string(c), {'\0'}));
                 status = H5Dvlen_reclaim(attr_type,
                                          attr_space,
                                          H5P_DEFAULT,
@@ -1221,7 +1221,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                 status = H5Aread(attr_id,
                                  attr_type,
                                  vc.data());
-                a = Attribute(strip(std::string(vc.data(), size), {'\0'}));
+                a = Attribute(auxiliary::strip(std::string(vc.data(), size), {'\0'}));
             }
         } else if( H5Tget_class(attr_type) == H5T_ENUM )
         {
@@ -1351,7 +1351,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                                  attr_type,
                                  vc.data());
                 for( auto const& val : vc )
-                    vs.push_back(strip(std::string(val), {'\0'}));
+                    vs.push_back(auxiliary::strip(std::string(val), {'\0'}));
                 status = H5Dvlen_reclaim(attr_type,
                                          attr_space,
                                          H5P_DEFAULT,
@@ -1364,7 +1364,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                                  attr_type,
                                  c.data());
                 for( hsize_t i = 0; i < dims[0]; ++i )
-                    vs.push_back(strip(std::string(c.data() + i*length, length), {'\0'}));
+                    vs.push_back(auxiliary::strip(std::string(c.data() + i*length, length), {'\0'}));
             }
             a = Attribute(vs);
         } else

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -89,13 +89,13 @@ Iteration::flushFileBased(uint64_t i)
         /* create file */
         Series* s = dynamic_cast<Series *>(parent->parent);
         Parameter< Operation::CREATE_FILE > fCreate;
-        fCreate.name = replace_first(s->iterationFormat(), "%T", std::to_string(i));
+        fCreate.name = auxiliary::replace_first(s->iterationFormat(), "%T", std::to_string(i));
         IOHandler->enqueue(IOTask(s, fCreate));
         IOHandler->flush();
 
         /* create basePath */
         Parameter< Operation::CREATE_PATH > pCreate;
-        pCreate.path = replace_first(s->basePath(), "%T/", "");
+        pCreate.path = auxiliary::replace_first(s->basePath(), "%T/", "");
         IOHandler->enqueue(IOTask(&s->iterations, pCreate));
         IOHandler->flush();
 
@@ -108,13 +108,13 @@ Iteration::flushFileBased(uint64_t i)
         /* open file */
         Series* s = dynamic_cast<Series *>(parent->parent);
         Parameter< Operation::OPEN_FILE > fOpen;
-        fOpen.name = replace_last(s->iterationFormat(), "%T", std::to_string(i));
+        fOpen.name = auxiliary::replace_last(s->iterationFormat(), "%T", std::to_string(i));
         IOHandler->enqueue(IOTask(s, fOpen));
         IOHandler->flush();
 
         /* open basePath */
         Parameter< Operation::OPEN_PATH > pOpen;
-        pOpen.path = replace_first(s->basePath(), "%T/", "");
+        pOpen.path = auxiliary::replace_first(s->basePath(), "%T/", "");
         IOHandler->enqueue(IOTask(&s->iterations, pOpen));
         IOHandler->flush();
 
@@ -229,12 +229,16 @@ Iteration::read()
     {
         IOHandler->enqueue(IOTask(&meshes, pList));
         IOHandler->flush();
-        hasMeshes = (std::count(pList.paths->begin(),
-                                pList.paths->end(),
-                                replace_last(s->meshesPath(), "/", "")) == 1);
-        hasParticles = (std::count(pList.paths->begin(),
-                                   pList.paths->end(),
-                                   replace_last(s->particlesPath(), "/", "")) == 1);
+        hasMeshes = std::count(
+            pList.paths->begin(),
+            pList.paths->end(),
+            auxiliary::replace_last(s->meshesPath(), "/", "")
+        ) == 1;
+        hasParticles = std::count(
+            pList.paths->begin(),
+            pList.paths->end(),
+            auxiliary::replace_last(s->particlesPath(), "/", "")
+        ) == 1;
         pList.paths->clear();
     } else
     {

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -33,9 +33,9 @@ namespace openPMD
 void
 check_extension(std::string const& filepath)
 {
-    if( !ends_with(filepath, ".h5") &&
-        !ends_with(filepath, ".bp") &&
-        !ends_with(filepath, ".dummy") )
+    if( !auxiliary::ends_with(filepath, ".h5") &&
+        !auxiliary::ends_with(filepath, ".bp") &&
+        !auxiliary::ends_with(filepath, ".dummy") )
         throw std::runtime_error("File format not recognized. "
                                  "Did you append a correct filename extension?");
 }
@@ -122,13 +122,13 @@ Series::Series(std::string const& filepath,
         ie = IterationEncoding::groupBased;
 
     Format f;
-    if( ends_with(name, ".h5") )
+    if( auxiliary::ends_with(name, ".h5") )
         f = Format::HDF5;
-    else if( ends_with(name, ".bp") )
+    else if( auxiliary::ends_with(name, ".bp") )
         f = Format::ADIOS1;
     else
     {
-        if( !ends_with(name, ".dummy") )
+        if( !auxiliary::ends_with(name, ".dummy") )
             std::cerr << "Unknown filename extension. "
                          "Falling back to DUMMY format."
                       << std::endl;
@@ -148,7 +148,7 @@ Series::Series(std::string const& filepath,
             setOpenPMD(OPENPMD);
             setOpenPMDextension(0);
             setAttribute("basePath", std::string(BASEPATH));
-            if( ie == IterationEncoding::fileBased && !contains(m_name, "%T") )
+            if( ie == IterationEncoding::fileBased && !auxiliary::contains(m_name, "%T") )
                 throw std::runtime_error("For fileBased formats the iteration regex %T must be included in the file name");
             setIterationEncoding(ie);
             break;
@@ -156,7 +156,7 @@ Series::Series(std::string const& filepath,
         case AccessType::READ_ONLY:
         case AccessType::READ_WRITE:
         {
-            if( contains(m_name, "%T") )
+            if( auxiliary::contains(m_name, "%T") )
                 readFileBased();
             else
                 readGroupBased();
@@ -191,13 +191,13 @@ Series::Series(std::string const& filepath,
         ie = IterationEncoding::groupBased;
 
     Format f;
-    if( ends_with(name, ".h5") )
+    if( auxiliary::ends_with(name, ".h5") )
         f = Format::HDF5;
-    else if( ends_with(name, ".bp") )
+    else if( auxiliary::ends_with(name, ".bp") )
         f = Format::ADIOS1;
     else
     {
-        if( !ends_with(name, ".dummy") )
+        if( !auxiliary::ends_with(name, ".dummy") )
             std::cerr << "Unknown filename extension. "
                          "Falling back to DUMMY format."
                       << std::endl;
@@ -217,7 +217,7 @@ Series::Series(std::string const& filepath,
             setOpenPMD(OPENPMD);
             setOpenPMDextension(0);
             setAttribute("basePath", std::string(BASEPATH));
-            if( ie == IterationEncoding::fileBased && !contains(m_name, "%T") )
+            if( ie == IterationEncoding::fileBased && !auxiliary::contains(m_name, "%T") )
                 throw std::runtime_error("For fileBased formats the iteration regex %T must be included in the file name");
             setIterationEncoding(ie);
             break;
@@ -225,7 +225,7 @@ Series::Series(std::string const& filepath,
         case AccessType::READ_ONLY:
         case AccessType::READ_WRITE:
         {
-            if( contains(m_name, "%T") )
+            if( auxiliary::contains(m_name, "%T") )
                 readFileBased();
             else
                 readGroupBased();
@@ -296,7 +296,7 @@ Series::setMeshesPath(std::string const& mp)
                     [](Container< Iteration, uint64_t >::value_type const& i){ return i.second.meshes.written; }) )
         throw std::runtime_error("A files meshesPath can not (yet) be changed after it has been written.");
 
-    if( ends_with(mp, "/") )
+    if( auxiliary::ends_with(mp, "/") )
         setAttribute("meshesPath", mp);
     else
         setAttribute("meshesPath", mp + "/");
@@ -317,7 +317,7 @@ Series::setParticlesPath(std::string const& pp)
                     [](Container< Iteration, uint64_t >::value_type const& i){ return i.second.particles.written; }) )
         throw std::runtime_error("A files particlesPath can not (yet) be changed after it has been written.");
 
-    if( ends_with(pp, "/") )
+    if( auxiliary::ends_with(pp, "/") )
         setAttribute("particlesPath", pp);
     else
         setAttribute("particlesPath", pp + "/");
@@ -464,7 +464,7 @@ Series::setName(std::string const& n)
     if( written )
         throw std::runtime_error("A files name can not (yet) be changed after it has been written.");
 
-    if( m_iterationEncoding == IterationEncoding::fileBased && !contains(m_name, "%T") )
+    if( m_iterationEncoding == IterationEncoding::fileBased && !auxiliary::contains(m_name, "%T") )
             throw std::runtime_error("For fileBased formats the iteration regex %T must be included in the file name");
 
     m_name = n;
@@ -506,7 +506,7 @@ Series::flushFileBased()
 
         i.second.flushFileBased(i.first);
 
-        iterations.flush(replace_first(basePath(), "%T/", ""));
+        iterations.flush(auxiliary::replace_first(basePath(), "%T/", ""));
 
         if( dirty )
         {
@@ -532,7 +532,7 @@ Series::flushGroupBased()
 
     if( !iterations.written )
         iterations.parent = this;
-    iterations.flush(replace_first(basePath(), "%T/", ""));
+    iterations.flush(auxiliary::replace_first(basePath(), "%T/", ""));
 
     for( auto& i : iterations )
     {
@@ -573,7 +573,7 @@ Series::flushParticlesPath()
 void
 Series::readFileBased()
 {
-    std::regex pattern(replace_first(m_name, "%T", "[[:digit:]]+"));
+    std::regex pattern(auxiliary::replace_first(m_name, "%T", "[[:digit:]]+"));
 
     Parameter< Operation::OPEN_FILE > fOpen;
     Parameter< Operation::READ_ATT > aRead;
@@ -764,7 +764,7 @@ Series::read()
     Parameter< Operation::OPEN_PATH > pOpen;
     std::string version = openPMD();
     if( version == "1.0.0" || version == "1.0.1" || version == "1.1.0" )
-        pOpen.path = replace_first(basePath(), "/%T/", "");
+        pOpen.path = auxiliary::replace_first(basePath(), "/%T/", "");
     else
         throw std::runtime_error("Unknown openPMD version - " + version);
     IOHandler->enqueue(IOTask(&iterations, pOpen));
@@ -795,14 +795,14 @@ Series::cleanFilename(std::string s, Format f)
     switch( f )
     {
         case Format::HDF5:
-            s = replace_last(s, ".h5", "");
+            s = auxiliary::replace_last(s, ".h5", "");
             break;
         case Format::ADIOS1:
         case Format::ADIOS2:
-            s = replace_last(s, ".bp", "");
+            s = auxiliary::replace_last(s, ".bp", "");
             break;
         case Format::DUMMY:
-            s = replace_last(s, ".dummy", "");
+            s = auxiliary::replace_last(s, ".dummy", "");
             break;
         default:
             break;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -168,7 +168,7 @@ Attributable::readAttributes()
     for( auto const& att_name : attributes )
     {
         aRead.name = att_name;
-        std::string att = strip(att_name, {'\0'});
+        std::string att = auxiliary::strip(att_name, {'\0'});
         IOHandler->enqueue(IOTask(this, aRead));
         try
         {

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -50,7 +50,7 @@ PatchRecord::read()
         dRead.offset = {0};
 
         size_t numPoints = dRead.extent[0];
-        auto data = allocatePtr(dRead.dtype, numPoints);
+        auto data = auxiliary::allocatePtr(dRead.dtype, numPoints);
         dRead.data = data.get();
         IOHandler->enqueue(IOTask(&prc, dRead));
         IOHandler->flush();

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -16,16 +16,18 @@ using namespace openPMD;
 
 BOOST_AUTO_TEST_CASE(string_test)
 {
+    using namespace auxiliary;
+
     std::string s = "Man muss noch Chaos in sich haben, "
-                    "um einen tanzenden Stern gebären zu können.";
+                    "um einen tanzenden Stern gebaeren zu koennen.";
     BOOST_TEST(starts_with(s, "M"));
     BOOST_TEST(starts_with(s, "Man"));
     BOOST_TEST(starts_with(s, "Man muss noch"));
     BOOST_TEST(!starts_with(s, " "));
 
     BOOST_TEST(ends_with(s, "."));
-    BOOST_TEST(ends_with(s, "können."));
-    BOOST_TEST(ends_with(s, "gebären zu können."));
+    BOOST_TEST(ends_with(s, "koennen."));
+    BOOST_TEST(ends_with(s, "gebaeren zu koennen."));
 
     BOOST_TEST(contains(s, "M"));
     BOOST_TEST(contains(s, "."));


### PR DESCRIPTION
Add an `auxiliary::` namespace to all things.
Each directory should be accompanied by an according namespace.

Follow-up PRs should add the same for:
- `backend/`
- `IO/`
  - `ADIOS/`
  - `HDF5/`