### PR TITLE
Add `version.hpp`

### DIFF
--- a/include/openPMD/version.hpp
+++ b/include/openPMD/version.hpp
@@ -20,5 +20,18 @@
  */
 #pragma once
 
-#include "openPMD/Series.hpp"
-#include "openPMD/version.hpp"
+// version of the openPMD-api library
+#define OPENPMDAPI_VERSION_MAJOR 0
+#define OPENPMDAPI_VERSION_MINOR 1
+#define OPENPMDAPI_VERSION_PATCH 0
+#define OPENPMDAPI_VERSION_LABEL "dev"
+
+// maximum supported version of the openPMD standard (read & write)
+#define OPENPMD_STANDARD_MAJOR 1
+#define OPENPMD_STANDARD_MINOR 1
+#define OPENPMD_STANDARD_PATCH 0
+
+// minimum supported version of the openPMD standard (read)
+#define OPENPMD_STANDARD_MIN_MAJOR 1
+#define OPENPMD_STANDARD_MIN_MINOR 0
+#define OPENPMD_STANDARD_MIN_PATCH 0


### PR DESCRIPTION
Add a separate `openPMD/version.hpp` for easier parsing.

Allows separate include without dependencies and defines now:
- library version and label, e.g. `-rc1` or `-dev`
- supported version of the openPMD standard:
  - read & write maximum
  - read minimum