### PR TITLE
Travis: CMake Binary Download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   apt: true
   directories:
     - $HOME/.cache/spack
+    - $HOME/.cache/cmake-3.10.0
   pip: true
 
 env:
@@ -175,8 +176,13 @@ install:
     source $SPACK_ROOT/share/spack/setup-env.sh
   - SPACK_VAR_MPI="~mpi";
   # required dependencies - CMake 3.10.0 & Boost 1.62.0
+  - if [ ! -f $HOME/.cache/cmake-3.10.0/bin/cmake ]; then
+      wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.sh &&
+      sh cmake.sh --skip-license --exclude-subdir --prefix=$HOME/.cache/cmake-3.10.0 &&
+      rm cmake.sh;
+    fi
   - travis_wait spack install
-      cmake@3.10.0~openssl~ncurses
+      cmake@3.10.0
       $COMPILERSPEC
   - spack load cmake@3.10.0 $COMPILERSPEC
   - travis_wait spack install

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -1,6 +1,11 @@
 packages:
   cmake:
     version: [3.10.0]
+    paths:
+      cmake@3.10.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
+      cmake@3.10.0%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
+      cmake@3.10.0%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
+    buildable: False
   openmpi:
     version: [1.6.5]
     paths:


### PR DESCRIPTION
Use a pre-compiled CMake binary to save install time with spack.
Before, the build of CMake took up about 10min and travis usually shuts down after ~45min.

We need this time for e.g. compiling
- boost (always)
- MPI (half of the matrix)
- pybind11 (a little)
- the project itself (also ~5min)