### PR TITLE
Travis: Skip Spack Bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ jobs:
         apt:
           <<: *apt_common_sources
           packages: &clang50_deps
+            - environment-modules
             - gfortran-4.9
             - g++-4.9  # CMake build
       before_install: &clang50_init
@@ -113,6 +114,7 @@ jobs:
         apt:
           <<: *apt_common_sources
           packages: &gcc49_deps
+            - environment-modules
             - gfortran-4.9
             - gcc-4.9
             - g++-4.9
@@ -141,6 +143,7 @@ jobs:
         apt:
           <<: *apt_common_sources
           packages: &gcc63_deps
+            - environment-modules
             - gfortran-6
             - gcc-6
             - g++-6
@@ -175,7 +178,6 @@ jobs:
       before_install: *gcc63_init
       script: *script-cpp-unit
     # GCC 6.3.0 + Python 3.6
-    # GCC 6.3.0 + Python 2.7
     - <<: *test-cpp-unit
       language: python
       python: "3.6"
@@ -204,11 +206,8 @@ install:
        $SPACK_ROOT/etc/spack/
   # manually fix SF via mirrors
   - SPACK_CACHE=$SPACK_ROOT/var/spack/cache/
-  - curl https://sourceforge.mirrorservice.org/t/tc/tcl/Tcl/8.6.6/tcl8.6.6-src.tar.gz --create-dirs -o $SPACK_CACHE/tcl/tcl-8.6.6.tar.gz
-  - curl https://sourceforge.mirrorservice.org/m/mo/modules/Modules/modules-3.2.10/modules-3.2.10.tar.gz --create-dirs -o $SPACK_CACHE/environment-modules/environment-modules-3.2.10.tar.gz
-  - curl https://sourceforge.mirrorservice.org/b/bo/boost/boost/1.62.0/boost_1_62_0.tar.bz2 --create-dirs -o $SPACK_CACHE/boost/boost-1.62.0.tar.bz2
+  - curl http://ftp.pbone.net/mirror/ftp.sourceforge.net/pub/sourceforge/b/bo/boost/boost/1.62.0/boost_1_62_0.tar.bz2 --create-dirs -o $SPACK_CACHE/boost/boost-1.62.0.tar.bz2
   # manually fix SF mirrors end
-  - spack bootstrap
   - source /etc/profile &&
     source $SPACK_ROOT/share/spack/setup-env.sh
   - SPACK_VAR_MPI="~mpi";


### PR DESCRIPTION
since we have default tools such as curl, spack bootstrap solely bootstraps the missing `environment-modules` for the builds. We just pre-install them now to save build time and source dependencies.

References on spack dependencies:
  https://spack.readthedocs.io/en/latest/getting_started.html#core-spack-utilities