### PR TITLE
fix type conflict between Extent and std::vector< size_t >

### DIFF
--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -21,7 +21,7 @@ public:
     Dataset(Datatype, Extent);
 
     Dataset& extend(Extent newExtent);
-    Dataset& setChunkSize(std::vector< size_t > const&);
+    Dataset& setChunkSize(Extent const&);
     Dataset& setCompression(std::string const&, uint8_t const);
     Dataset& setCustomTransform(std::string const&);
 

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -26,7 +26,7 @@ Dataset::extend(Extent newExtents)
 }
 
 Dataset&
-Dataset::setChunkSize(std::vector< size_t > const& cs)
+Dataset::setChunkSize(Extent const& cs)
 {
     if( extent.size() != rank )
         throw std::runtime_error("Dimensionality of extended Dataset must match the original dimensionality");


### PR DESCRIPTION
This patch is needed in order to get the code to compile with GCC 7 or Clang 5. (It is not needed for GCC 4.8.) Without this change, both newer compilers give errors like

```
 /Users/amundson/src/libopenPMD/src/Dataset.cpp:37:15: error: no viable overloaded '='
    chunkSize = cs;
 17 {
    ~~~~~~~~~ ^ ~~
/Library/Developer/CommandLineTools/usr/include/c++/v1/vector:545:13: note: candidate function not
      viable: no known conversion from 'const vector<size_t, allocator<unsigned long>>' to 'const
      vector<unsigned long long, allocator<unsigned long long>>' for 1st argument
    vector& operator=(const vector& __x);

```