### PR TITLE
Travis: GCC 7.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,8 +191,6 @@ jobs:
             - *gcc63_deps
       before_install: *gcc63_init
       script: *script-cpp-unit
-  allow_failures:
-    - compiler: clang
 
 install:
   # spack install

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,7 @@ jobs:
             - openmpi-bin
       before_install: *gcc49_init
       script: *script-cpp-unit
-    # GCC 6.3.0
+    # GCC 7.2.0
     - <<: *test-cpp-unit
       env:
         - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
@@ -142,13 +142,13 @@ jobs:
       addons:
         apt:
           <<: *apt_common_sources
-          packages: &gcc63_deps
+          packages: &gcc72_deps
             - environment-modules
-            - gfortran-6
-            - gcc-6
-            - g++-6
-      before_install: &gcc63_init
-         - CXX=g++-6 && CC=gcc-6 && COMPILERSPEC="%gcc@6.3.0"
+            - gfortran-7
+            - gcc-7
+            - g++-7
+      before_install: &gcc72_init
+         - CXX=g++-7 && CC=gcc-7 && COMPILERSPEC="%gcc@7.2.0"
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       env:
@@ -158,10 +158,10 @@ jobs:
         apt:
           <<: *apt_common_sources
           packages:
-            - *gcc63_deps
+            - *gcc72_deps
             - libopenmpi-dev
             - openmpi-bin
-      before_install: *gcc63_init
+      before_install: *gcc72_init
       script: *script-cpp-unit
     # GCC 6.3.0 + Python 2.7
     - <<: *test-cpp-unit
@@ -173,9 +173,13 @@ jobs:
       addons:
         apt:
           <<: *apt_common_sources
-          packages:
-            - *gcc63_deps
-      before_install: *gcc63_init
+          packages: &gcc63_deps
+            - environment-modules
+            - gfortran-6
+            - gcc-6
+            - g++-6
+      before_install: &gcc63_init
+         - CXX=g++-6 && CC=gcc-6 && COMPILERSPEC="%gcc@6.3.0"
       script: *script-cpp-unit
     # GCC 6.3.0 + Python 3.6
     - <<: *test-cpp-unit

--- a/.travis/spack/compilers.yaml
+++ b/.travis/spack/compilers.yaml
@@ -38,3 +38,16 @@ compilers:
       fc: /usr/bin/gfortran-6
     spec: gcc@6.3.0
     target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu14.04
+    paths:
+      cc: /usr/bin/gcc-7
+      cxx: /usr/bin/g++-7
+      f77: /usr/bin/gfortran-7
+      fc: /usr/bin/gfortran-7
+    spec: gcc@7.2.0
+    target: x86_64

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -4,6 +4,7 @@ packages:
     paths:
       cmake@3.10.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
+      cmake@3.10.0%gcc@7.2.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
     buildable: False
   openmpi:
@@ -11,6 +12,7 @@ packages:
     paths:
       openmpi@1.6.5%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /usr
+      openmpi@1.6.5%gcc@7.2.0 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%clang@5.0.0 arch=linux-ubuntu14-x86_64: /usr
     buildable: False
   python:
@@ -22,4 +24,4 @@ packages:
   all:
     providers:
       mpi: [openmpi]
-    compiler: [clang@5.0.0, gcc@4.9.4, gcc@6.3.0]
+    compiler: [clang@5.0.0, gcc@4.9.4, gcc@6.3.0, gcc@7.2.0]


### PR DESCRIPTION
Add gcc/g++ 7.2.0 to the travis build matrix.

Clang 5.0 is compiling since the last fixes, removes "allow failures" for it.