### PR TITLE
[WIP] Travis: OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - $HOME/.cache/spack
     - $HOME/.cache/cmake-3.10.0
+    - $HOME/Library/Caches/Homebrew
   pip: true
 
 env:
@@ -104,6 +105,16 @@ jobs:
             - libopenmpi-dev
             - openmpi-bin
       before_install: *clang50_init
+      script: *script-cpp-unit
+    # Clang 8.1.0-apple + Python 2.7.10 @ OSX
+    - <<: *test-cpp-unit
+      os: osx
+      language: generic
+      env:
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+      compiler: clang
+      before_install:
+         - COMPILERSPEC="%clang@8.1.0"
       script: *script-cpp-unit
     # GCC 4.9.4
     - <<: *test-cpp-unit
@@ -204,16 +215,33 @@ install:
       git clone --depth 50 https://github.com/spack/spack.git $SPACK_ROOT;
     fi
   # spack setup
+  - source /etc/profile
   - cp $TRAVIS_BUILD_DIR/.travis/spack/*.yaml
        $SPACK_ROOT/etc/spack/
-  - source /etc/profile &&
-    source $SPACK_ROOT/share/spack/setup-env.sh
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      travis_wait brew install modules &&
+      brew info modules &&
+      ls /usr/local/Cellar/modules/4.1.1/ &&
+      source /usr/local/opt/modules/init/bash &&
+      export TRAVIS_PYTHON_VERSION=2.7.10;
+    fi
+  - source $SPACK_ROOT/share/spack/setup-env.sh
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      export MODULEPATH=$SPACK_ROOT/share/spack/modules/$(spack arch):$MODULEPATH;
+    fi
   - SPACK_VAR_MPI="~mpi";
   # required dependencies - CMake 3.10.0 & Boost 1.62.0
   - if [ ! -f $HOME/.cache/cmake-3.10.0/bin/cmake ]; then
-      wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.sh &&
-      sh cmake.sh --skip-license --exclude-subdir --prefix=$HOME/.cache/cmake-3.10.0 &&
-      rm cmake.sh;
+      if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+        wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.sh &&
+        sh cmake.sh --skip-license --exclude-subdir --prefix=$HOME/.cache/cmake-3.10.0 &&
+        rm cmake.sh;
+      else
+        curl -L -s -o cmake.dmg https://cmake.org/files/v3.10/cmake-3.10.0-Darwin-x86_64.dmg &&
+        yes | hdiutil mount cmake.dmg &&
+        sudo cp -R "/Volumes/cmake-3.10.0-Darwin-x86_64/CMake.app" /Applications &&
+        rm cmake.dmg;
+      fi;
     fi
   - travis_wait spack install
       cmake@3.10.0

--- a/.travis/spack/compilers.yaml
+++ b/.travis/spack/compilers.yaml
@@ -4,6 +4,19 @@ compilers:
     extra_rpaths: []
     flags: {}
     modules: []
+    operating_system: sierra
+    paths:
+      cc: /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: null
+      fc: null
+    spec: clang@8.1.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
     operating_system: ubuntu14.04
     paths:
       cc: /usr/local/clang-5.0.0/bin/clang

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -6,6 +6,7 @@ packages:
       cmake@3.10.0%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@7.2.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
+      cmake@3.10.0%clang@8.1.0 arch=darwin-sierra-x86_64: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
     version: [1.6.5]
@@ -16,10 +17,11 @@ packages:
       openmpi@1.6.5%clang@5.0.0 arch=linux-ubuntu14-x86_64: /usr
     buildable: False
   python:
-    version: [2.7.14, 3.6.3]
+    version: [2.7.14, 2.7.10, 3.6.3]
     paths:
       python@2.7.14%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@3.6.3%gcc@6.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
+      python@2.7.10%clang@8.1.0 arch=darwin-sierra-x86_64: /usr
     buildable: False
   all:
     providers:


### PR DESCRIPTION
Try to add OSX testing (no-MPI): #86 

### To Do

Boost [RT bug](https://travis-ci.org/openPMD/openPMD-api/jobs/353383748):
- [ ] Probably a Boost.Test bug:
```
unknown location:0: fatal error: in "Test setup": boost::runtime::access_to_missing_argument: There is no argument provided for parameter color_output
```
Tried to debug with debug flags in boost but hard to grasp. Tried to run through with `lldb` but looks like the check (`breakpoint set --file /Users/Axel/lib/boost-1.66.0/include/boost/test/utils/runtime/argument.hpp --line 97`) is somehow triggert with a different param... as if something is writing in the stack... Valgrind is complaining about an invalid free from it. clang address sanitizier as well. Seen up to Boost 1.66.0. Also reproducible (besides travis' AppleClang 8) with AppleClang 7.0 on an older local mac.

See also: https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/issues/10#issuecomment-330061796

Maybe we just move to [Catch2](https://github.com/catchorg/Catch2) asap and get rid of it.

- [ ] linker warnings: @bstaletic recommends to hide and explicitly expose in the base lib as well; also positive for binary size and performance. https://gist.github.com/ax3l/ba17f4bb1edb5885a6bd01f58de4d542
issue:
```
ld: warning: direct access in function 'pybind11::detail::erase_all(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)' from file 'CMakeFiles/openPMD.py.dir/src/binding/python/openPMD.cpp.o' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'lib/libopenPMD.a(Series.cpp.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings
```
