### PR TITLE
Add missing override

### DIFF
--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -127,7 +127,7 @@ class DummyIOHandler : public AbstractIOHandler
 {
 public:
     DummyIOHandler(std::string const&, AccessType);
-    virtual ~DummyIOHandler();
+    virtual ~DummyIOHandler() override;
 
     /** No-op consistent with the IOHandler interface to enable library use without IO.
      */

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -134,6 +134,6 @@ public:
     void enqueue(IOTask const&) override;
     /** No-op consistent with the IOHandler interface to enable library use without IO.
      */
-    std::future< void > flush();
+    std::future< void > flush() override;
 };  //DummyIOHandler
 } // openPMD

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -18,7 +18,7 @@ class Record : public BaseRecord< RecordComponent >
 
 public:
     Record(Record const&);
-    virtual ~Record();
+    virtual ~Record() override;
 
     Record& setUnitDimension(std::map< UnitDimension, double > const&);
 

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -33,7 +33,7 @@ public:
     using const_iterator = typename Container< T_elem >::const_iterator;
 
     BaseRecord(BaseRecord const& b);
-    virtual ~BaseRecord() { }
+    virtual ~BaseRecord() override { }
 
     mapped_type& operator[](key_type const& key) override;
     mapped_type& operator[](key_type&& key) override;

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -49,7 +49,7 @@ protected:
     bool m_containsScalar;
 
 private:
-    virtual void flush(std::string const&) = 0;
+    virtual void flush(std::string const&) override = 0;
     virtual void read() = 0;
 };  //BaseRecord
 


### PR DESCRIPTION
Add missing C++11 `override` specifier to derived classes on `flush()`.

Fixes warnings in clang.