### PR TITLE
Feature Defines: 0(False) or 1(True)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,8 @@ if(openPMD_HAVE_MPI)
     target_link_libraries(openPMD PUBLIC MPI::MPI_C MPI::MPI_CXX)
 
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_MPI=1")
+else()
+    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_MPI=0")
 endif()
 
 if(openPMD_HAVE_HDF5)
@@ -267,17 +269,23 @@ if(openPMD_HAVE_HDF5)
     target_include_directories(openPMD SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
     target_compile_definitions(openPMD PUBLIC ${HDF5_DEFINITIONS})
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_HDF5=1")
+else()
+    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_HDF5=0")
 endif()
 
 if(openPMD_HAVE_ADIOS1)
     target_link_libraries(openPMD PUBLIC ${ADIOS_LIBRARIES})
     target_include_directories(openPMD SYSTEM PUBLIC ${ADIOS_INCLUDE_DIRS})
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS1=1")
+else()
+    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS1=0")
 endif()
 
 if(openPMD_HAVE_ADIOS2)
     target_link_libraries(openPMD PUBLIC ADIOS2::ADIOS2)
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS2=1")
+else()
+    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS2=0")
 endif()
 
 # python bindings

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -29,7 +29,7 @@
 
 namespace openPMD
 {
-#if defined(openPMD_HAVE_ADIOS1)
+#if openPMD_HAVE_ADIOS1
 class ADIOS1IOHandler;
 
 class ADIOS1IOHandlerImpl

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -29,7 +29,7 @@
 
 namespace openPMD
 {
-#if defined(openPMD_HAVE_ADIOS2)
+#if openPMD_HAVE_ADIOS2
 class ADIOS2IOHandler;
 
 class ADIOS2IOHandlerImpl

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -22,7 +22,7 @@
 
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
-#if defined(openPMD_HAVE_HDF5)
+#if openPMD_HAVE_HDF5
 #   include <hdf5.h>
 #endif
 
@@ -35,7 +35,7 @@
 
 namespace openPMD
 {
-#if defined(openPMD_HAVE_HDF5)
+#if openPMD_HAVE_HDF5
 class HDF5IOHandler;
 
 class HDF5IOHandlerImpl

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -21,7 +21,7 @@
 #include "openPMD/IO/HDF5/HDF5IOHandler.hpp"
 
 
-#if defined(openPMD_HAVE_HDF5)
+#if openPMD_HAVE_HDF5
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/backend/Attribute.hpp"
 #   include "openPMD/IO/IOTask.hpp"
@@ -38,7 +38,7 @@
 
 namespace openPMD
 {
-#if defined(openPMD_HAVE_HDF5)
+#if openPMD_HAVE_HDF5
 #   ifdef DEBUG
 #       define ASSERT(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error(std::string((TEXT))); }
 #   else
@@ -1498,7 +1498,7 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
 }
 #endif
 
-#if defined(openPMD_HAVE_HDF5)
+#if openPMD_HAVE_HDF5
 HDF5IOHandler::HDF5IOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at),
           m_impl{new HDF5IOHandlerImpl(this)}

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -8,7 +8,7 @@ using namespace openPMD;
 
 #include <boost/test/included/unit_test.hpp>
 
-#if defined(openPMD_HAVE_HDF5)
+#if openPMD_HAVE_HDF5
 BOOST_AUTO_TEST_CASE(git_hdf5_sample_structure_test)
 {
     try
@@ -1020,7 +1020,7 @@ BOOST_AUTO_TEST_CASE(no_serial_hdf5)
     BOOST_TEST(true);
 }
 #endif
-#if defined(openPMD_HAVE_ADIOS1)
+#if openPMD_HAVE_ADIOS1
 BOOST_AUTO_TEST_CASE(adios_write_test)
 {
     Output o = Output("../samples/serial_write.bp");


### PR DESCRIPTION
Remove implicit defines to 0(False) for undefined pre-compiler vars. This means, switching on `defined(...)` is not possible anymore.

Every value "not 0" is True (as always).

Fixes warnings in clang, is more explicit and allows easier control of pre-compiler vars in IDEs.