### PR TITLE
Example Download: curl

### DIFF
--- a/.travis/download_samples.sh
+++ b/.travis/download_samples.sh
@@ -2,7 +2,7 @@
 #
 
 mkdir -p samples/git-sample/
-wget -nv https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz
 tar -xf example-3d.tar.gz
 mv example-3d/hdf5/* samples/git-sample/
 chmod 777 samples/
@@ -10,10 +10,10 @@ rm -rf example-3d.* example-3d;
 
 #https://github.com/yt-project/yt/pull/1645
 mkdir -p samples/issue-sample/
-wget -nv https://github.com/yt-project/yt/files/1542668/no_fields.zip
+curl -sOL https://github.com/yt-project/yt/files/1542668/no_fields.zip
 unzip no_fields.zip
 mv no_fields samples/issue-sample/
-wget -nv https://github.com/yt-project/yt/files/1542670/no_particles.zip
+curl -sOL https://github.com/yt-project/yt/files/1542670/no_particles.zip
 unzip no_particles.zip
 mv no_particles samples/issue-sample/
 rm -rf no_fields.zip no_particles.zip;


### PR DESCRIPTION
Use curl instead of wget for sample downloads.
curl is available on more systems, e.g. OSX, by default.