### PR TITLE
Fix: MPI but no HDF5

### DIFF
--- a/src/IO/AbstractIOHandler.cpp
+++ b/src/IO/AbstractIOHandler.cpp
@@ -38,11 +38,18 @@ AbstractIOHandler::createIOHandler(std::string const& path,
     switch( f )
     {
         case Format::HDF5:
+#   if openPMD_HAVE_HDF5
             ret = std::make_shared< ParallelHDF5IOHandler >(path, at, comm);
+#   else
+            std::cerr << "Parallel HDF5 backend not found. "
+                      << "Your IO operations will be NOOPS!" << std::endl;
+            ret = std::make_shared< DummyIOHandler >(path, at);
+#   endif
             break;
         case Format::ADIOS1:
         case Format::ADIOS2:
-            std::cerr << "Backend not yet working. Your IO operations will be NOOPS!" << std::endl;
+            std::cerr << "Parallel ADIOS2 backend not yet working. "
+                      << "Your IO operations will be NOOPS!" << std::endl;
             ret = std::make_shared< DummyIOHandler >(path, at);
             break;
         default:


### PR DESCRIPTION
Fixes the build if *MPI is found* but *HDF5 is not*.

There are in principle several ways to react on that in the code, either by calling the alternative constructor, returning a dummy and writing an error, throwing or by re-designing the `#if` in the HDF5 parallel backend.

@C0nsultant feel free to revise the strategy as it suits you :-)