### PR TITLE
CMake: Std C++11 Only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,8 @@ target_compile_features(openPMD
     PUBLIC cxx_std_11
 )
 set_target_properties(openPMD PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
 )
 


### PR DESCRIPTION
Keep the default `-std=c++11` and avoid extensions, e.g. gnu ones.

Follow-up to #119 which accidentally removed it.