### PR TITLE
Handle noHDF5+MPI gracefully

### DIFF
--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -22,9 +22,11 @@
 
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
-#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
-#   include "openPMD/IO/HDF5/HDF5IOHandler.hpp"
+#if openPMD_HAVE_MPI
 #   include <mpi.h>
+#   if openPMD_HAVE_HDF5
+#       include "openPMD/IO/HDF5/HDF5IOHandler.hpp"
+#   endif
 #endif
 
 #include <future>
@@ -54,7 +56,7 @@ class ParallelHDF5IOHandlerImpl
 class ParallelHDF5IOHandler : public AbstractIOHandler
 {
 public:
-#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
+#if openPMD_HAVE_MPI
     ParallelHDF5IOHandler(std::string const& path, AccessType, MPI_Comm);
 #else
     ParallelHDF5IOHandler(std::string const& path, AccessType);

--- a/src/IO/AbstractIOHandler.cpp
+++ b/src/IO/AbstractIOHandler.cpp
@@ -37,17 +37,10 @@ AbstractIOHandler::createIOHandler(std::string const& path,
     switch( f )
     {
         case Format::HDF5:
-#   if openPMD_HAVE_HDF5
             return std::make_shared< ParallelHDF5IOHandler >(path, at, comm);
-#   else
-            std::cerr << "Parallel HDF5 backend not found. "
-                      << "Your IO operations will be NOOPS!" << std::endl;
-            return std::make_shared< DummyIOHandler >(path, at);
-#   endif
         case Format::ADIOS1:
         case Format::ADIOS2:
-            std::cerr << "Parallel ADIOS2 backend not yet working. "
-                      << "Your IO operations will be NOOPS!" << std::endl;
+            std::cerr << "Backend not yet working. Your IO operations will be NOOPS!" << std::endl;
             return std::make_shared< DummyIOHandler >(path, at);
         default:
             return std::make_shared< DummyIOHandler >(path, at);

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -20,10 +20,12 @@
  */
 #include "openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp"
 
-#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
-#   include "openPMD/auxiliary/StringManip.hpp"
+#if openPMD_HAVE_MPI
 #   include <mpi.h>
-#   include <boost/filesystem.hpp>
+#   if openPMD_HAVE_HDF5
+#       include "openPMD/auxiliary/StringManip.hpp"
+#       include <boost/filesystem.hpp>
+#   endif
 #endif
 
 #include <iostream>
@@ -83,12 +85,22 @@ ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
     }
 }
 #else
+#   if openPMD_HAVE_MPI
+ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
+                                             AccessType at,
+                                             MPI_Comm comm)
+        : AbstractIOHandler(path, at, comm)
+{
+    throw std::runtime_error("openPMD-api built without HDF5 support");
+}
+#   else
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
                                              AccessType at)
         : AbstractIOHandler(path, at)
 {
-    throw std::runtime_error("openPMD-api built without parallel HDF5 support");
+    throw std::runtime_error("openPMD-api built without parallel support and without HDF5 support");
 }
+#   endif
 
 ParallelHDF5IOHandler::~ParallelHDF5IOHandler()
 { }


### PR DESCRIPTION
Offer MPI-aware interface if HDF5 is not available to avoid compilation
errors.
Closes #113.