### PR TITLE
Doxygen: Python Highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ for( auto const& i : s.iterations )
 
 ### Python
 
-```python
+```py
 from openPMD import Series
 
 


### PR DESCRIPTION
Doxygen syntax highlighting in markdown ([start "main" page](http://www.openpmd.org/openPMD-api) / README) does only recognize `py` and not `python` for code blocks. Follow-up to #75

Github & Sphinx know more aliases.

Since they are [not officially supported Doxygen languages](https://github.com/doxygen/doxygen/blob/7e2fcd305c8c9377aa958a3d812cc31bc81c0e32/doc/markdown.doc#L396-L397), Bash/Shell and CMake snippets are unfortunately not (yet) supported in the official Doxygen code-block syntax highlighter... [Community Bash plugin](https://github.com/Anvil/bash-doxygen), [Community CMake plugin](https://github.com/saschazelzer/CMakeDoxygenFilter)