### PR TITLE
Enclose all exposed classes in namespaces

### DIFF
--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -56,7 +56,7 @@ TEST_CASE( "string_test", "[auxiliary]" )
 
 namespace openPMD
 {
-namespace Test
+namespace test
 {
 struct S : public Writable
 {
@@ -77,7 +77,7 @@ TEST_CASE( "container_default_test", "[auxiliary]")
 
 namespace openPMD
 {
-namespace Test
+namespace test
 {
 class structure : public Attributable
 {
@@ -147,7 +147,7 @@ TEST_CASE( "container_retrieve_test", "[auxiliary]" )
 
 namespace openPMD
 {
-namespace Test
+namespace test
 {
 struct Widget : public Writable
 {
@@ -191,7 +191,7 @@ TEST_CASE( "attributable_default_test", "[auxiliary]" )
 
 namespace openPMD
 {
-namespace Test
+namespace test
 {
 class AttributedWidget : public Attributable
 {
@@ -240,7 +240,7 @@ TEST_CASE( "attributable_access_test", "[auxiliary]" )
 
 namespace openPMD
 {
-namespace Test
+namespace test
 {
 class Dotty : public Attributable
 {

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -63,7 +63,7 @@ struct S : public Writable
     int val;
     bool written;
 };
-} // Test
+} // test
 } // openPMD
 
 TEST_CASE( "container_default_test", "[auxiliary]")
@@ -89,7 +89,7 @@ public:
     std::string text() const { return variantSrc::get< std::string >(getAttribute("text").getResource()); }
     structure& setText(std::string text) { setAttribute("text", text); return *this; }
 };
-} // Test
+} // test
 } // openPMD
 
 TEST_CASE( "container_retrieve_test", "[auxiliary]" )
@@ -157,7 +157,7 @@ struct Widget : public Writable
     Widget(int)
     { }
 };
-} // Test
+} // test
 } // openPMD
 
 TEST_CASE( "container_access_test", "[auxiliary]" )
@@ -205,7 +205,7 @@ public:
         return getAttribute(key).getResource();
     }
 };
-} // Test
+} // test
 } // openPMD
 
 TEST_CASE( "attributable_access_test", "[auxiliary]" )
@@ -259,7 +259,7 @@ public:
     Dotty& setAtt2(double d) { setAttribute("att2", d); return *this; }
     Dotty& setAtt3(std::string s) { setAttribute("att3", s); return *this; }
 };
-} // Test
+} // test
 } // openPMD
 
 TEST_CASE( "dot_test", "[auxiliary]" )

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -68,7 +68,7 @@ struct S : public Writable
 
 TEST_CASE( "container_default_test", "[auxiliary]")
 {
-    Container< openPMD::Test::S > c = Container< openPMD::Test::S >();
+    Container< openPMD::test::S > c = Container< openPMD::test::S >();
     c.IOHandler = AbstractIOHandler::createIOHandler("", AccessType::CREATE, Format::DUMMY);
 
     REQUIRE(c.size() == 0);
@@ -94,7 +94,7 @@ public:
 
 TEST_CASE( "container_retrieve_test", "[auxiliary]" )
 {
-    using structure = openPMD::Test::structure;
+    using structure = openPMD::test::structure;
     Container< structure > c = Container< structure >();
     c.IOHandler = AbstractIOHandler::createIOHandler("", AccessType::CREATE, Format::DUMMY);
 
@@ -162,7 +162,7 @@ struct Widget : public Writable
 
 TEST_CASE( "container_access_test", "[auxiliary]" )
 {
-    using Widget = openPMD::Test::Widget;
+    using Widget = openPMD::test::Widget;
     Container< Widget > c = Container< Widget >();
     c.IOHandler = AbstractIOHandler::createIOHandler("", AccessType::CREATE, Format::DUMMY);
 
@@ -210,7 +210,7 @@ public:
 
 TEST_CASE( "attributable_access_test", "[auxiliary]" )
 {
-    using AttributedWidget = openPMD::Test::AttributedWidget;
+    using AttributedWidget = openPMD::test::AttributedWidget;
     AttributedWidget a = AttributedWidget();
 
     a.setAttribute("key", std::string("value"));
@@ -264,7 +264,7 @@ public:
 
 TEST_CASE( "dot_test", "[auxiliary]" )
 {
-    openPMD::Test::Dotty d;
+    openPMD::test::Dotty d;
     REQUIRE(d.att1() == 1);
     REQUIRE(d.att2() == static_cast<double>(2));
     REQUIRE(d.att3() == "3");

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -54,20 +54,31 @@ TEST_CASE( "string_test", "[auxiliary]" )
     REQUIRE(expected3 == split("/path/to/relevant/data/", "/"));
 }
 
+namespace openPMD
+{
+namespace Test
+{
+struct S : public Writable
+{
+    int val;
+    bool written;
+};
+} // Test
+} // openPMD
+
 TEST_CASE( "container_default_test", "[auxiliary]")
 {
-    struct S : public Writable
-    {
-        int val;
-        bool written;
-    };
-    Container< S > c = Container< S >();
+    Container< openPMD::Test::S > c = Container< openPMD::Test::S >();
     c.IOHandler = AbstractIOHandler::createIOHandler("", AccessType::CREATE, Format::DUMMY);
 
     REQUIRE(c.size() == 0);
     REQUIRE(c.erase("nonExistentKey") == false);
 }
 
+namespace openPMD
+{
+namespace Test
+{
 class structure : public Attributable
 {
 public:
@@ -78,9 +89,12 @@ public:
     std::string text() const { return variantSrc::get< std::string >(getAttribute("text").getResource()); }
     structure& setText(std::string text) { setAttribute("text", text); return *this; }
 };
+} // Test
+} // openPMD
 
 TEST_CASE( "container_retrieve_test", "[auxiliary]" )
 {
+    using structure = openPMD::Test::structure;
     Container< structure > c = Container< structure >();
     c.IOHandler = AbstractIOHandler::createIOHandler("", AccessType::CREATE, Format::DUMMY);
 
@@ -131,6 +145,10 @@ TEST_CASE( "container_retrieve_test", "[auxiliary]" )
     REQUIRE(c["entry"].text() == "Different text");
 }
 
+namespace openPMD
+{
+namespace Test
+{
 struct Widget : public Writable
 {
     Widget()
@@ -139,9 +157,12 @@ struct Widget : public Writable
     Widget(int)
     { }
 };
+} // Test
+} // openPMD
 
 TEST_CASE( "container_access_test", "[auxiliary]" )
 {
+    using Widget = openPMD::Test::Widget;
     Container< Widget > c = Container< Widget >();
     c.IOHandler = AbstractIOHandler::createIOHandler("", AccessType::CREATE, Format::DUMMY);
 
@@ -168,6 +189,10 @@ TEST_CASE( "attributable_default_test", "[auxiliary]" )
     REQUIRE(a.numAttributes() == 0);
 }
 
+namespace openPMD
+{
+namespace Test
+{
 class AttributedWidget : public Attributable
 {
 public:
@@ -180,9 +205,12 @@ public:
         return getAttribute(key).getResource();
     }
 };
+} // Test
+} // openPMD
 
 TEST_CASE( "attributable_access_test", "[auxiliary]" )
 {
+    using AttributedWidget = openPMD::Test::AttributedWidget;
     AttributedWidget a = AttributedWidget();
 
     a.setAttribute("key", std::string("value"));
@@ -210,6 +238,10 @@ TEST_CASE( "attributable_access_test", "[auxiliary]" )
     REQUIRE(a.numAttributes() == 1);
 }
 
+namespace openPMD
+{
+namespace Test
+{
 class Dotty : public Attributable
 {
 public:
@@ -227,10 +259,12 @@ public:
     Dotty& setAtt2(double d) { setAttribute("att2", d); return *this; }
     Dotty& setAtt3(std::string s) { setAttribute("att3", s); return *this; }
 };
+} // Test
+} // openPMD
 
 TEST_CASE( "dot_test", "[auxiliary]" )
 {
-    Dotty d;
+    openPMD::Test::Dotty d;
     REQUIRE(d.att1() == 1);
     REQUIRE(d.att2() == static_cast<double>(2));
     REQUIRE(d.att3() == "3");


### PR DESCRIPTION
Put the classes inside test cases into namespaces as they are exposed
to the public.

Closes #130.