### PR TITLE
Spack Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,12 @@ Optional language bindings:
 
 Choose *one* of the install methods below to get started:
 
-### Spack
-
-*not yet implemented*
+### [Spack](http://spack.io)
 
 ```bash
+# optional: append +python
 spack install openpmd-api
-spack load openpmd-api
+spack load --dependencies openpmd-api
 ```
 
 ### Conda

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -34,10 +34,6 @@ A package for openPMD-api is available on the Spack package manager.
    spack install openpmd-api  # optional: +python
    spack load --dependencies openpmd-api
 
-.. attention::
-
-   Not yet published.
-
 .. _install-conda:
 
 .. only:: html


### PR DESCRIPTION
Moved the spack package to mainline: https://github.com/spack/spack/pull/7765
Currently, it will always install the current `dev` branch as version `develop` until we reach `1.0.0`.

Close #7