### PR TITLE
Python: Containers & MeshRecordComponent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,8 @@ if(openPMD_HAVE_PYTHON)
     pybind11_add_module(openPMD.py MODULE
         src/binding/python/openPMD.cpp
         src/binding/python/AccessType.cpp
+        src/binding/python/BaseRecord.cpp
+        src/binding/python/Container.cpp
         src/binding/python/Dataset.cpp
         src/binding/python/Datatype.cpp
         src/binding/python/Iteration.cpp
@@ -327,6 +329,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/ParticleSpecies.cpp
         src/binding/python/Record.cpp
         src/binding/python/RecordComponent.cpp
+        src/binding/python/MeshRecordComponent.cpp
         src/binding/python/Series.cpp
     )
     target_link_libraries(openPMD.py PRIVATE openPMD)

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -30,10 +30,8 @@ if __name__ == "__main__":
         print("\t {0}".format(ps))
     print("")
 
-    E = i.meshes["E"]
-    # TODO: add __getitem__ to openPMD.Mesh and openPMD.Particle object for
-    #       non-scalar records: return a record component
-    # E_x = i.meshes["E"]["x"]
+    E_x = i.meshes["E"]["x"]
+
     # TODO: add extent and dtype property to record components
     # Extent extent = E_x.get_extent  # or as property: E_x.extent
     # print("Field E.x has shape ({0}) and has datatype {1}".format(

--- a/src/binding/python/AccessType.cpp
+++ b/src/binding/python/AccessType.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/IO/AccessType.hpp"
 

--- a/src/binding/python/BaseRecord.cpp
+++ b/src/binding/python/BaseRecord.cpp
@@ -1,0 +1,25 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/MeshRecordComponent.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_BaseRecord(py::module &m) {
+    py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Mesh_Base_Record");
+
+    py::enum_<UnitDimension>(m, "Unit_Dimension")
+        .value("L", UnitDimension::L)
+        .value("M", UnitDimension::M)
+        .value("T", UnitDimension::T)
+        .value("I", UnitDimension::I)
+        .value("theta", UnitDimension::theta)
+        .value("N", UnitDimension::N)
+        .value("J", UnitDimension::J)
+    ;
+}

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -1,0 +1,32 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+
+#include "openPMD/backend/Container.hpp"
+//include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/Iteration.hpp"
+#include "openPMD/Mesh.hpp"
+#include "openPMD/ParticleSpecies.hpp"
+#include "openPMD/backend/MeshRecordComponent.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+using PyIterationContainer = Container< Iteration, uint64_t >;
+using PyMeshContainer = Container< Mesh >;
+using PyPartContainer = Container< ParticleSpecies >;
+using PyMeshRecordComponentContainer = Container< MeshRecordComponent >;
+PYBIND11_MAKE_OPAQUE(PyIterationContainer)
+PYBIND11_MAKE_OPAQUE(PyMeshContainer)
+PYBIND11_MAKE_OPAQUE(PyPartContainer)
+PYBIND11_MAKE_OPAQUE(PyMeshRecordComponentContainer)
+
+
+void init_Container(py::module &m) {
+    py::bind_map< PyIterationContainer >(m, "Iteration_Container");
+    py::bind_map< PyMeshContainer >(m, "Mesh_Container");
+    py::bind_map< PyPartContainer >(m, "Particle_Container");
+    py::bind_map< PyMeshRecordComponentContainer >(m, "Mesh_Record_Component_Container");
+
+}

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
 #include "openPMD/Dataset.hpp"

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/Datatype.hpp"
 

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -1,6 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 
 #include "openPMD/Iteration.hpp"
 
@@ -9,15 +7,8 @@
 namespace py = pybind11;
 using namespace openPMD;
 
-using PyMeshContainer = Container< Mesh >;
-using PyPartContainer = Container< ParticleSpecies >;
-PYBIND11_MAKE_OPAQUE(PyMeshContainer)
-PYBIND11_MAKE_OPAQUE(PyPartContainer)
 
 void init_Iteration(py::module &m) {
-    py::bind_map< PyMeshContainer >(m, "Mesh_Container");
-    py::bind_map< PyPartContainer >(m, "Particle_Container");
-
     py::class_<Iteration>(m, "Iteration")
         .def(py::init<Iteration const &>())
 

--- a/src/binding/python/IterationEncoding.cpp
+++ b/src/binding/python/IterationEncoding.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/IterationEncoding.hpp"
 

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -1,7 +1,8 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/Mesh.hpp"
+#include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/backend/MeshRecordComponent.hpp"
 
 #include <string>
 
@@ -10,7 +11,7 @@ using namespace openPMD;
 
 
 void init_Mesh(py::module &m) {
-    py::class_<Mesh>(m, "Mesh")
+    py::class_<Mesh, BaseRecord<MeshRecordComponent> >(m, "Mesh")
         .def(py::init<Mesh const &>())
 
         .def("__repr__",
@@ -41,6 +42,7 @@ void init_Mesh(py::module &m) {
         .def_property_readonly("time_offset", &Mesh::timeOffset<float>)
         .def_property_readonly("time_offset", &Mesh::timeOffset<double>)
         .def_property_readonly("time_offset", &Mesh::timeOffset<long double>)
+
         //! @todo missing specializations
         // .def("set_time_offset", &Mesh::setTimeOffset<float>)
         // .def("set_time_offset", &Mesh::setTimeOffset<double>)

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -1,0 +1,23 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/backend/MeshRecordComponent.hpp"
+#include "openPMD/RecordComponent.hpp"
+
+#include <string>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_MeshRecordComponent(py::module &m) {
+    py::class_<MeshRecordComponent, RecordComponent>(m, "Mesh_Record_Component")
+        .def("__repr__",
+            [](MeshRecordComponent const & rc) {
+                return "<openPMD.Mesh_Record_Component of dimensionality '"
+                + std::to_string(rc.getDimensionality()) + "'>";
+            }
+        )
+        
+        // @todo add position
+    ;
+}

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/ParticlePatches.hpp"
 

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/ParticleSpecies.hpp"
 

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/Record.hpp"
 

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "openPMD/RecordComponent.hpp"
 

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -1,20 +1,12 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 
 #include "openPMD/Series.hpp"
-#include "openPMD/Iteration.hpp"
-#include "openPMD/backend/Container.hpp"
 
 namespace py = pybind11;
 using namespace openPMD;
 
-using PyIterationContainer = Container< Iteration, uint64_t >;
-PYBIND11_MAKE_OPAQUE(PyIterationContainer)
 
 void init_Series(py::module &m) {
-    py::bind_map< PyIterationContainer >(m, "Iteration_Container");
-
     py::class_<Series>(m, "Series")
 
         // private

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -1,5 +1,5 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+//include <pybind11/stl.h>
 
 #include "openPMD/version.hpp"
 
@@ -9,11 +9,14 @@ namespace py = pybind11;
 
 
 // forward declarations of exposed classes
+void init_BaseRecord(py::module &);
+void init_Container(py::module &);
 void init_Dataset(py::module &);
 void init_Datatype(py::module &);
 void init_Iteration(py::module &);
 void init_IterationEncoding(py::module &);
 void init_Mesh(py::module &);
+void init_MeshRecordComponent(py::module &);
 void init_ParticlePatches(py::module &);
 void init_ParticleSpecies(py::module &);
 void init_Record(py::module &);
@@ -24,15 +27,19 @@ void init_Series(py::module &);
 PYBIND11_MODULE(openPMD, m) {
     // m.doc() = ...;
 
+    // note: order from parent to child classes
+    init_Container(m);
+    init_BaseRecord(m);
     init_Dataset(m);
     init_Datatype(m);
     init_Iteration(m);
     init_IterationEncoding(m);
     init_Mesh(m);
+    init_RecordComponent(m);
+    init_MeshRecordComponent(m);
     init_ParticlePatches(m);    
     init_ParticleSpecies(m);
     init_Record(m);
-    init_RecordComponent(m);
     init_Series(m);
 
     // build version


### PR DESCRIPTION
Expose the mesh record component and container (std::map) bindings properly.

cc @CFGrote: I implemented the access to record components in meshes :)
Now one can go further and add the access to the python protocol buffers (methods `loadChunk`, convenience slice operator, etc.)