### PR TITLE
Python: Extend (Shape) & Datatype (dtype)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/openPMD.cpp
         src/binding/python/AccessType.cpp
         src/binding/python/BaseRecord.cpp
+        src/binding/python/BaseRecordComponent.cpp
         src/binding/python/Container.cpp
         src/binding/python/Dataset.cpp
         src/binding/python/Datatype.cpp

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -31,11 +31,10 @@ if __name__ == "__main__":
     print("")
 
     E_x = i.meshes["E"]["x"]
+    shape = E_x.shape
 
-    # TODO: add extent and dtype property to record components
-    # Extent extent = E_x.get_extent  # or as property: E_x.extent
-    # print("Field E.x has shape ({0}) and has datatype {1}".format(
-    #     extent, E_x.dtype));
+    print("Field E.x has shape {0} and datatype {1}".format(
+          shape, E_x.dtype))
 
     # TODO buffer protocol / numpy bindings
     # chunk_data = E_x[1:3, 1:3, 1:2]

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -20,7 +20,7 @@ public:
 
     BaseRecordComponent& resetDatatype(Datatype);
 
-    Datatype getDatatype();
+    Datatype getDatatype() const;
 
 protected:
     BaseRecordComponent();

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -25,7 +25,7 @@ BaseRecordComponent::BaseRecordComponent()
 { }
 
 Datatype
-BaseRecordComponent::getDatatype()
+BaseRecordComponent::getDatatype() const
 {
     return m_dataset.dtype;
 }

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -1,0 +1,29 @@
+#include <pybind11/pybind11.h>
+
+#include "openPMD/backend/BaseRecordComponent.hpp"
+//include "openPMD/backend/Attributable.hpp"
+
+#include <sstream>
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_BaseRecordComponent(py::module &m) {
+    //                            , Attributable
+    py::class_<BaseRecordComponent>(m, "Base_Record_Component")
+        .def("__repr__",
+            [](BaseRecordComponent const & brc) {
+                std::stringstream ss;
+                ss << "<openPMD.Base_Record_Component of '";
+                ss << brc.getDatatype() << "'>";
+                return ss.str();
+            }
+        )
+
+        .def("reset_datatype", &BaseRecordComponent::resetDatatype)
+
+        .def_property_readonly("unit_SI", &BaseRecordComponent::unitSI)
+        .def_property_readonly("dtype", &BaseRecordComponent::getDatatype)
+    ;
+}

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/backend/BaseRecordComponent.hpp"
 
 #include <string>
 
@@ -9,7 +10,7 @@ using namespace openPMD;
 
 
 void init_RecordComponent(py::module &m) {
-    py::class_<RecordComponent>(m, "Record_Component")
+    py::class_<RecordComponent, BaseRecordComponent>(m, "Record_Component")
         .def("__repr__",
             [](RecordComponent const & rc) {
                 return "<openPMD.Record_Component of dimensionality '" + std::to_string(rc.getDimensionality()) + "'>";
@@ -19,8 +20,8 @@ void init_RecordComponent(py::module &m) {
         .def("set_unit_SI", &RecordComponent::setUnitSI)
         .def("reset_dataset", &RecordComponent::resetDataset)
 
-        .def("get_dimensionality", &RecordComponent::getDimensionality)
-        .def("get_extent", &RecordComponent::getExtent)
+        .def_property_readonly("ndim", &RecordComponent::getDimensionality)
+        .def_property_readonly("shape", &RecordComponent::getExtent)
 
         .def("make_constant", &RecordComponent::makeConstant<float>)
         .def("make_constant", &RecordComponent::makeConstant<double>)

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -10,6 +10,7 @@ namespace py = pybind11;
 
 // forward declarations of exposed classes
 void init_BaseRecord(py::module &);
+void init_BaseRecordComponent(py::module &);
 void init_Container(py::module &);
 void init_Dataset(py::module &);
 void init_Datatype(py::module &);
@@ -35,6 +36,7 @@ PYBIND11_MODULE(openPMD, m) {
     init_Iteration(m);
     init_IterationEncoding(m);
     init_Mesh(m);
+    init_BaseRecordComponent(m);
     init_RecordComponent(m);
     init_MeshRecordComponent(m);
     init_ParticlePatches(m);    


### PR DESCRIPTION
Add more interfaces for extend (shape) and datatype (dtype)

Currently output `Extent[26, 26, 201]` and `Datatype.DOUBLE`... needs to be made more numpy-ish later