### PR TITLE
Write Example: Simplify

### DIFF
--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Fabian Koller
+/* Copyright 2017-2018 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <memory>
+#include <numeric>
 
 
 using std::cout;
@@ -29,17 +30,18 @@ using namespace openPMD;
 
 int main(int argc, char *argv[])
 {
-    // allocate a data set to write
+    // user input: size of matrix to write, default 3x3
     size_t size = (argc == 2 ? atoi(argv[1]) : 3);
+
+    // matrix dataset to write with values 0...size*size-1
     std::shared_ptr< double > global_data{
         new double[size*size],
-        [](double *p){ delete[] p; p = nullptr; }
+        std::default_delete< double[] >()
     };
-    for( size_t i = 0; i < size*size; ++i )
-        *(global_data.get() + i) = static_cast< double >(i);
+    std::iota(global_data.get(), global_data.get() + size*size, 0.);
 
     cout << "Set up a 2D square array (" << size << 'x' << size
-         << ") that will be written to disk\n";
+         << ") that will be written\n";
 
     // open file for writing
     Series series = Series::create(
@@ -61,18 +63,18 @@ int main(int argc, char *argv[])
          << " and Datatype " << dataset.dtype << '\n';
 
     E.resetDataset(dataset);
-    cout << "Set the on-disk Dataset properties for the scalar field E in iteration 1\n";
+    cout << "Set the dataset properties for the scalar field E in iteration 1\n";
 
     series.flush();
-    cout << "File structure has been written to disk\n";
+    cout << "File structure has been written\n";
 
     Offset offset = {0, 0};
     E.storeChunk(offset, extent, global_data);
     cout << "Stored the whole Dataset contents as a single chunk, "
-            "ready to write content to disk\n";
+            "ready to write content\n";
 
     series.flush();
-    cout << "Dataset content has been fully written to disk\n";
+    cout << "Dataset content has been fully written\n";
 
     return 0;
 }


### PR DESCRIPTION
Simplify the serial write example a little. Use more standard functionality, remove pointer magic and add comments. Remove "disk" speak.