### PR TITLE
RTD Build Pygments

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ recommonmark
 sphinx
 breathe>=4.5
 sphinxcontrib.programoutput
+pygments
 # generate plots
 matplotlib
 scipy

--- a/docs/source/usage/firststeps.rst
+++ b/docs/source/usage/firststeps.rst
@@ -17,6 +17,6 @@ C++11
 Python
 ------
 
-.. code-block:: python
+.. code-block:: python3
 
    import openPMD

--- a/docs/source/usage/serial.rst
+++ b/docs/source/usage/serial.rst
@@ -21,7 +21,7 @@ Python
 ^^^^^^
 
 .. literalinclude:: 2_read_serial.py
-   :language: py
+   :language: python3
    :lines: 9-
 
 Writing


### PR DESCRIPTION
Syntax highlighting with pygments in online docs missing.
Looks like pygments is outdated. Add it to requirements.