### PR TITLE
Syntax Highlighting: Fix RTD Theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx_rtd_theme
+sphinx_rtd_theme>=0.3.1
 recommonmark
 sphinx
 breathe>=4.5


### PR DESCRIPTION
The syntax highlighting with pygments was broken in the readthedocs theme.

Fixed in sphinx_rtd_theme 0.3.0+, so we just install a newer version of it in the rtd instance: https://github.com/rtfd/sphinx_rtd_theme/pull/448

Second try of #154