### PR TITLE
Python: Serial Write Example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ set(openPMD_EXAMPLE_NAMES
 )
 set(openPMD_PYTHON_EXAMPLE_NAMES
     2_read_serial
+    3_write_serial
 )
 
 if(BUILD_TESTING)

--- a/docs/source/usage/3_write_serial.py
+++ b/docs/source/usage/3_write_serial.py
@@ -1,0 +1,1 @@
+../../../examples/3_write_serial.py

--- a/docs/source/usage/serial.rst
+++ b/docs/source/usage/serial.rst
@@ -39,4 +39,6 @@ An extended example can be found in ``examples/7_extended_write_serial.cpp``.
 Python
 ^^^^^^
 
-*TBD*
+.. literalinclude:: 3_write_serial.py
+   :language: python3
+   :lines: 9-

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""
+This file is part of the openPMD-api.
+
+Copyright 2018 openPMD contributors
+Authors: Axel Huebl
+License: LGPLv3+
+"""
+import openPMD
+# import numpy as np
+
+
+if __name__ == "__main__":
+    # user input: size of matrix to write, default 3x3
+    size = 3
+
+    # matrix dataset to write with values 0...size*size-1
+    # global_data = np.range(size*size, dtype=np.double)
+
+    print("Set up a 2D square array ({0}x{1}) that will be written".format(
+        size, size))
+
+    # open file for writing
+    series = openPMD.Series(
+        "../samples/3_write_serial.h5",
+        openPMD.Access_Type.create
+    )
+
+    print("Created an empty {0} Series".format(series.iteration_encoding))
+
+    print(len(series.iterations))
+    E = series.iterations[1].meshes["E"][openPMD.Mesh_Record_Component.SCALAR]
+
+    datatype = openPMD.Datatype.DOUBLE
+    # datatype = openPMD.determineDatatype(global_data)
+    extent = openPMD.Extent([size, size])
+    dataset = openPMD.Dataset(datatype, extent)
+
+    print("Created a Dataset of size {0}x{1} and Datatype {2}".format(
+        dataset.extent[0], dataset.extent[1], dataset.dtype))
+
+    E.reset_dataset(dataset)
+    print("Set the dataset properties for the scalar field E in iteration 1")
+
+    # writing fails on already open file error
+    series.flush()
+    print("File structure has been written")
+
+    # offset = openPMD.Offset([0, 0])
+    offset = openPMD.Extent([0, 0])
+    # TODO implement binding
+    # E.storeChunk(offset, extent, global_data)
+    print("Stored the whole Dataset contents as a single chunk, " +
+          "ready to write content")
+
+    series.flush()
+    print("Dataset content has been fully written")


### PR DESCRIPTION
Add a serial write example for python.

Adds all but the final buffer-protocol / numpy bindings. Related to #32.

Depends on (needs rebase after):

- [x] #156
- [x] #158