### PR TITLE
Fix Warnings: Unused, Cast

### DIFF
--- a/src/IO/AbstractIOHandlerImpl.cpp
+++ b/src/IO/AbstractIOHandlerImpl.cpp
@@ -97,7 +97,7 @@ AbstractIOHandlerImpl::flush()
           listAttributes(i.writable, *dynamic_cast< Parameter< O::LIST_ATTS >* >(i.parameter.get()));
           break;
       }
-    } catch (unsupported_data_error& e)
+    } catch (unsupported_data_error&)
     {
       (*m_handler).m_work.pop();
       throw;

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -222,7 +222,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         for( auto const& val : parameters.extent )
             dims.push_back(static_cast< hsize_t >(val));
 
-        hid_t space = H5Screate_simple(dims.size(), dims.data(), dims.data());
+        hid_t space = H5Screate_simple(static_cast< int >(dims.size()), dims.data(), dims.data());
         ASSERT(space >= 0, "Internal error: Failed to create dataspace during dataset creation");
 
         std::vector< hsize_t > chunkDims;
@@ -678,7 +678,7 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
     std::vector< hsize_t > block;
     for( auto const& val : parameters.extent )
         block.push_back(static_cast< hsize_t >(val));
-    memspace = H5Screate_simple(block.size(), block.data(), nullptr);
+    memspace = H5Screate_simple(static_cast< int >(block.size()), block.data(), nullptr);
     filespace = H5Dget_space(dataset_id);
     status = H5Sselect_hyperslab(filespace,
                                  H5S_SELECT_SET,
@@ -978,7 +978,7 @@ HDF5IOHandlerImpl::readDataset(Writable* writable,
     std::vector< hsize_t > block;
     for( auto const& val : parameters.extent )
         block.push_back(static_cast< hsize_t >(val));
-    memspace = H5Screate_simple(block.size(), block.data(), nullptr);
+    memspace = H5Screate_simple(static_cast< int >(block.size()), block.data(), nullptr);
     filespace = H5Dget_space(dataset_id);
     status = H5Sselect_hyperslab(filespace,
                                  H5S_SELECT_SET,


### PR DESCRIPTION
Fix warnings about an unused parameter (error var).
Fix other warnings about implicit `size_t` to `int` conversion in HDF5 APIs.