### PR TITLE
ADIOS filesystem: path shadowed by var

### DIFF
--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -622,12 +622,12 @@ ADIOS1IOHandlerImpl::deleteFile(Writable* writable,
         if( !auxiliary::ends_with(name, ".bp") )
             name += ".bp";
 
-        using namespace boost::filesystem;
-        path file(name);
-        if( !exists(file) )
+        namespace bf = boost::filesystem;
+        bf::path file(name);
+        if( !bf::exists(file) )
             throw std::runtime_error("File does not exist: " + name);
 
-        remove(file);
+        bf::remove(file);
 
         writable->written = false;
         writable->abstractFilePosition.reset();


### PR DESCRIPTION
I sporadically get compile errors on Linux because the `path` type from boost filesystem is shadowed by a locally defined variable `path` (line 609) in one of the methods of the ADIOS1 backend.

This fixes it.