### PR TITLE
[WIP] Symbol Visibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
     - BUILD: ~/buildTmp
     - CXXFLAGS: "-std=c++11 -Wall -Wextra -Woverloaded-virtual -Wshadow"
+    - USE_SHARED=OFF
     - SPACK_ROOT: $HOME/.cache/spack
     - PATH: $PATH:$HOME/.cache/spack/bin
 
@@ -80,6 +81,7 @@ jobs:
         - CXXFLAGS=$CXXFLAGS CXX=$CXX CC=$CC
           cmake
             -DCMAKE_BUILD_TYPE=Debug
+            -DBUILD_SHARED_LIBS=$USE_SHARED
             -DopenPMD_USE_MPI=$USE_MPI
             -DopenPMD_USE_HDF5=$USE_HDF5
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
@@ -134,7 +136,7 @@ jobs:
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SHARED=ON
       compiler: gcc
       addons:
         apt:
@@ -179,7 +181,7 @@ jobs:
       language: python
       python: "2.7"
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SHARED=ON
       compiler: gcc
       addons:
         apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ openpmd_option(ADIOS1 "Enable ADIOS1 support"  AUTO)
 openpmd_option(ADIOS2 "Enable ADIOS2 support"  OFF)
 # openpmd_option(JSON "Enable JSON support" AUTO)
 openpmd_option(PYTHON "Enable Python bindings" AUTO)
+openpmd_option(SYMBOLHIDING "Enable symbol hiding in libraries" AUTO)
 
 option(openPMD_USE_INTERNAL_VARIANT "Use internally shipped MPark.Variant" ON)
 option(openPMD_USE_INTERNAL_CATCH   "Use internally shipped Catch2" ON)
@@ -84,6 +85,34 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # silence BOOST filesystem
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cpp")
 endif ()
+
+
+# Compiler Features ###########################################################
+#
+include(CheckCXXSourceCompiles)
+
+check_cxx_source_compiles(
+    "
+        #include <cstdlib>
+        __attribute__((visibility(\"default\"))) static void f(void);
+        int main(void){ return 0; }
+    "
+    HAVE_ATTRIBUTE_VISIBILITY_DEFAULT
+)
+if(HAVE_ATTRIBUTE_VISIBILITY_DEFAULT OR
+   "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    if(openPMD_USE_SYMBOLHIDING STREQUAL "AUTO" OR
+       openPMD_USE_SYMBOLHIDING)
+        set(openPMD_HAVE_SYMBOLHIDING ON)
+    else()
+        set(openPMD_HAVE_SYMBOLHIDING OFF)
+    endif()
+else()
+    set(openPMD_HAVE_SYMBOLHIDING OFF)
+    if(openPMD_USE_SYMBOLHIDING)
+        message(FATAL_ERROR "Compiler does not support symbol hiding.")
+    endif()
+endif()
 
 
 # Dependencies ################################################################
@@ -228,7 +257,7 @@ set(IO_SOURCE
         src/IO/HDF5/ParallelHDF5IOHandler.cpp)
 
 # library
-add_Library(openPMD ${CORE_SOURCE} ${IO_SOURCE})
+add_library(openPMD ${CORE_SOURCE} ${IO_SOURCE})
 
 # properties
 target_compile_features(openPMD
@@ -239,6 +268,17 @@ set_target_properties(openPMD PROPERTIES
     CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
 )
+target_compile_definitions(openPMD PUBLIC
+    $<BUILD_INTERFACE:OPENPMD_BUILDPHASE=1>)
+
+# symbol hiding
+if(openPMD_HAVE_SYMBOLHIDING)
+    set_target_properties(openPMD PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+    target_compile_definitions(openPMD PUBLIC openPMD_HAVE_SYMBOLHIDING=1)
+endif()
 
 # own headers
 target_include_directories(openPMD PUBLIC

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "openPMD/Datatype.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <memory>
 #include <type_traits>
@@ -13,7 +14,7 @@ namespace openPMD
 using Extent = std::vector< std::uint64_t >;
 using Offset = std::vector< std::uint64_t >;
 
-class Dataset
+class OPENPMD_PUBLIC Dataset
 {
     friend class RecordComponent;
 

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "openPMD/auxiliary/Visibility.hpp"
+
 #include <array>
 #include <cstdint>
 #include <iosfwd>
@@ -81,6 +83,7 @@ constexpr bool decay_equiv_v = decay_equiv< T, U >::value;
 #endif
 
 template< typename T >
+OPENPMD_PUBLIC
 inline
 #if __cplusplus >= 201402L
 constexpr
@@ -120,6 +123,7 @@ determineDatatype()
 }
 
 template< typename T >
+OPENPMD_PUBLIC
 inline
 #if __cplusplus >= 201402L
 constexpr
@@ -161,6 +165,7 @@ determineDatatype(std::shared_ptr< T >)
 
 namespace std
 {
+    OPENPMD_PUBLIC
     ostream&
     operator<<(ostream&, openPMD::Datatype);
 } // std

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -23,6 +23,7 @@
 #include "openPMD/IO/AccessType.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/IO/IOTask.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #if openPMD_HAVE_MPI
 #   include <mpi.h>
@@ -37,7 +38,7 @@
 
 namespace openPMD
 {
-class no_such_file_error : public std::runtime_error
+class OPENPMD_PUBLIC no_such_file_error : public std::runtime_error
 {
 public:
     no_such_file_error(char const* what_arg)
@@ -49,7 +50,7 @@ public:
     virtual ~no_such_file_error() { }
 };
 
-class unsupported_data_error : public std::runtime_error
+class OPENPMD_PUBLIC unsupported_data_error : public std::runtime_error
 {
 public:
     unsupported_data_error(char const* what_arg)
@@ -70,7 +71,7 @@ public:
  * scenarios it is therefore necessary to manually execute all operations
  * by calling AbstractIOHanlder::flush().
  */
-class AbstractIOHandler
+class OPENPMD_PUBLIC AbstractIOHandler
 {
 public:
 #if openPMD_HAVE_MPI

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -24,6 +24,7 @@
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/Mesh.hpp"
 #include "openPMD/ParticleSpecies.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 
 namespace openPMD
@@ -32,7 +33,7 @@ namespace openPMD
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#required-attributes-for-the-basepath
  */
-class Iteration : public Attributable
+class OPENPMD_PUBLIC Iteration : public Attributable
 {
     template<
             typename T,

--- a/include/openPMD/IterationEncoding.hpp
+++ b/include/openPMD/IterationEncoding.hpp
@@ -20,6 +20,8 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/Visibility.hpp"
+
 #include <iosfwd>
 
 
@@ -29,7 +31,7 @@ namespace openPMD
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
  */
-enum class IterationEncoding
+enum class OPENPMD_PUBLIC IterationEncoding
 {
     fileBased, groupBased
 };
@@ -37,6 +39,7 @@ enum class IterationEncoding
 
 namespace std
 {
+    OPENPMD_PUBLIC
     ostream&
     operator<<(ostream&, openPMD::IterationEncoding);
 } // std

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -3,6 +3,7 @@
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <array>
 #include <vector>
@@ -15,7 +16,7 @@ namespace openPMD
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#mesh-based-records
  */
-class Mesh : public BaseRecord< MeshRecordComponent >
+class OPENPMD_PUBLIC Mesh : public BaseRecord< MeshRecordComponent >
 {
     friend class Container< Mesh >;
     friend class Iteration;
@@ -174,9 +175,11 @@ Mesh::timeOffset() const
 
 namespace std
 {
+    OPENPMD_PUBLIC
     ostream&
     operator<<(ostream&, openPMD::Mesh::Geometry);
 
+    OPENPMD_PUBLIC
     std::ostream&
     operator<<(ostream&, openPMD::Mesh::DataOrder);
 } // std

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -22,13 +22,14 @@
 
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/backend/PatchRecord.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <vector>
 
 
 namespace openPMD
 {
-class ParticlePatches : public Container< PatchRecord >
+class OPENPMD_PUBLIC ParticlePatches : public Container< PatchRecord >
 {
     friend class ParticleSpecies;
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -4,13 +4,14 @@
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/ParticlePatches.hpp"
 #include "openPMD/Record.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <string>
 
 
 namespace openPMD
 {
-class ParticleSpecies : public Container< Record >
+class OPENPMD_PUBLIC ParticleSpecies : public Container< Record >
 {
     friend class Container< ParticleSpecies >;
     friend class Container< Record >;

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -2,6 +2,7 @@
 
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <map>
 #include <type_traits>
@@ -10,7 +11,7 @@
 
 namespace openPMD
 {
-class Record : public BaseRecord< RecordComponent >
+class OPENPMD_PUBLIC Record : public BaseRecord< RecordComponent >
 {
     friend class Container< Record >;
     friend class Iteration;

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -2,6 +2,7 @@
 
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/Dataset.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <cmath>
 #include <memory>
@@ -13,7 +14,7 @@
 
 namespace openPMD
 {
-class RecordComponent : public BaseRecordComponent
+class OPENPMD_PUBLIC RecordComponent : public BaseRecordComponent
 {
     template<
             typename T,

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -27,6 +27,7 @@
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/IterationEncoding.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #if openPMD_HAVE_MPI
 #   include <mpi.h>
@@ -44,7 +45,7 @@ namespace openPMD
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
  */
-class Series : public Attributable
+class OPENPMD_PUBLIC Series : public Attributable
 {
     friend class Iteration;
 
@@ -271,6 +272,7 @@ private:
  * @param   filename    tring containing the filename.
  * @return  Format that best fits the filename extension.
  */
+OPENPMD_PUBLIC
 Format determineFormat(std::string const& filename);
 
 /** Remove the filename extension of a given storage format.
@@ -279,6 +281,7 @@ Format determineFormat(std::string const& filename);
  * @param   f           File format to remove filename extension for.
  * @return  String containing the filename without filename extension.
  */
+OPENPMD_PUBLIC
 std::string cleanFilename(std::string const& filename, Format f);
 
 /** Create a functor to determine if a file can be of a format given the filename on disk.
@@ -287,5 +290,6 @@ std::string cleanFilename(std::string const& filename, Format f);
  * @param   f           File format to check backend applicability for.
  * @return  Functor returning true if file could be of type f. False otherwise.
  */
+OPENPMD_PUBLIC
 std::function< bool(std::string const&) > matcher(std::string const& name, Format f);
 } // openPMD

--- a/include/openPMD/auxiliary/Visibility.hpp
+++ b/include/openPMD/auxiliary/Visibility.hpp
@@ -1,0 +1,84 @@
+/* Copyright 2018 Fabian Koller, Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cinttypes>
+
+
+/** @{
+ * Define the compiler-specific attribute for symbol visibility.
+ *
+ * Added to the symbols of the public API.
+ * Needs to be used as qualifier for all publicly exposed, compiled
+ * functionality.
+ */
+#if defined(openPMD_HAVE_SYMBOLHIDING)
+#   if defined(_MSC_VER)
+#       if defined(OPENPMD_BUILDPHASE)
+#           define OPENPMD_PUBLIC __declspec(dllexport)
+#       else
+#           define OPENPMD_PUBLIC __declspec(dllimport)
+#       endif
+#   else
+#       define OPENPMD_PUBLIC __attribute__((visibility("default")))
+#   endif
+#else
+#   define OPENPMD_PUBLIC
+#endif
+//! @}
+
+/** @{
+ * Pre-defines for externally defined declarations that will be visible in our
+ * public API, e.g. from STL containers.
+ */
+#if defined(OPENPMD_BUILDPHASE)
+#   define OPENPMD_EXTERN
+#else
+#   define OPENPMD_EXTERN extern
+#endif
+//! @}
+
+
+// C++ std-lib used in public APIs
+//   note: this means one needs to run with the same stdlib
+//         as one compiled with
+#if defined(_MSC_VER)
+    // std::string
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::allocator< char > ;
+    OPENPMD_EXTERN template struct OPENPMD_PUBLIC std::char_traits< char >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLICstd::basic_string< char >;
+
+    // std::vector< T >
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::allocator< std::uint64_t >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::allocator< float >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::allocator< double >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::allocator< long double >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::allocator< std::string >;
+
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::vector< std::uint64_t >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::vector< float >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::vector< double >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::vector< long double >;
+    OPENPMD_EXTERN template class OPENPMD_PUBLIC std::vector< std::string >;
+#endif

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -23,6 +23,7 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/Writable.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <exception>
 #include <map>
@@ -33,7 +34,7 @@
 
 namespace openPMD
 {
-class no_such_attribute_error : public std::runtime_error
+class OPENPMD_PUBLIC no_such_attribute_error : public std::runtime_error
 {
 public:
     no_such_attribute_error(char const* what_arg)
@@ -51,7 +52,7 @@ public:
  * Mandatory and user-defined Attributes and their data for every object in the
  * openPMD hierarchy are stored and managed through this class.
  */
-class Attributable : public Writable
+class OPENPMD_PUBLIC Attributable : public Writable
 {
     using A_MAP = std::map< std::string, Attribute >;
 

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -2,11 +2,12 @@
 
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/Dataset.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 
 namespace openPMD
 {
-class BaseRecordComponent : public Attributable
+class OPENPMD_PUBLIC BaseRecordComponent : public Attributable
 {
     template< typename T_elem >
     friend

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/backend/Attributable.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <initializer_list>
 #include <type_traits>
@@ -44,7 +45,7 @@ template<
         typename T_key = std::string,
         typename T_container = std::map< T_key, T >
 >
-class Container : public Attributable
+class OPENPMD_PUBLIC Container : public Attributable
 {
     static_assert(std::is_base_of< Writable, T >::value, "Type of container element must be derived from Writable");
     using InternalContainer = T_container;

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <vector>
 
 
 namespace openPMD
 {
-class MeshRecordComponent : public RecordComponent
+class OPENPMD_PUBLIC MeshRecordComponent : public RecordComponent
 {
     template<
             typename T,

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -22,6 +22,7 @@
 
 #include "openPMD/backend/PatchRecordComponent.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <unordered_map>
 #include <string>
@@ -29,7 +30,7 @@
 
 namespace openPMD
 {
-class PatchRecord : public BaseRecord< PatchRecordComponent >
+class OPENPMD_PUBLIC PatchRecord : public BaseRecord< PatchRecordComponent >
 {
     friend class Container< PatchRecord >;
     friend class ParticleSpecies;

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/auxiliary/Visibility.hpp"
 
 #include <unordered_map>
 #include <string>
@@ -28,7 +29,7 @@
 
 namespace openPMD
 {
-class PatchRecordComponent : public BaseRecordComponent
+class OPENPMD_PUBLIC PatchRecordComponent : public BaseRecordComponent
 {
     template<
         typename T,

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -20,6 +20,8 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/Visibility.hpp"
+
 #include <memory>
 
 
@@ -37,7 +39,7 @@ class AbstractIOHandler;
  *                      - whether the logical object has been modified compared
  *                        to last persistent state
  */
-class Writable
+class OPENPMD_PUBLIC Writable
 {
     template<
             typename T,

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -4,6 +4,8 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Boost)
 
+set(openPMD_HAVE_SYMBOLHIDING @openPMD_HAVE_SYMBOLHIDING@)
+
 set(openPMD_HAVE_MPI @openPMD_HAVE_MPI@)
 if(openPMD_HAVE_MPI)
     find_dependency(MPI)


### PR DESCRIPTION
For supported compilers, hide all non-public API symbols by default.

Defines `OPENPMD_PUBLIC` as a macro for all public classes, functions, etc. See details in [this gist](https://gist.github.com/ax3l/ba17f4bb1edb5885a6bd01f58de4d542).

This is a requirement for Windows support, which hides symbols by default in its dlls unless explicitly exposed.

Size of `libopenPMD.so`:
- before hiding: 2,2 MB
- after hiding: 2,1 MB

## To Do

- [x] maybe rename macro to shorter `OPENPMD_PUBLIC`
- [ ] Surprisingly, this does not yet remote the [linker warnings](https://travis-ci.org/openPMD/openPMD-api/jobs/376415481) we see on OSX. I probably have to set the same properties on the created executables.
- [x] lol, on windows we have to switch the headers from export to import as soon as we use the dlls: https://msdn.microsoft.com/en-us/library/8fskxacy.aspx
- [x] lol, publicly passing stl objects, e.g. in `Dataset` as `std::string` members or our usage of `std::vector< uint64_t >` need to be dllimported as well: https://social.msdn.microsoft.com/Forums/vstudio/en-US/df99b712-c00b-4af0-82fd-3764c8b6cbec/exporting-stdstring-from-a-dll-does-not-export-stdstringnpos?forum=vcgeneral - on the other hand, exposing STL objects seems to be considered a very bad idea in this thread and they are big time into C-objects.