### PR TITLE
Container: Read Only Throw Missing

### DIFF
--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -75,6 +75,21 @@ class Attributable
     friend class Iteration;
     friend class Series;
 
+    template< typename T_Key >
+    auto out_of_range_msg(T_Key const& key) -> decltype(std::to_string(key))
+    {
+        return std::string("Attribute '") + std::to_string(key) + std::string("' does not exist (read-only).");
+    }
+    template< typename T_Key >
+    auto out_of_range_msg(T_Key const& key) -> decltype(std::string(key))
+    {
+        return std::string("Attribute '") + std::string(key) + std::string("' does not exist (read-only).");
+    }
+    std::string out_of_range_msg(...)
+    {
+        return std::string("Attribute does not exist (read-only).");
+    }
+
 public:
     Attributable();
     Attributable(Attributable const&);
@@ -205,6 +220,9 @@ template< typename T >
 inline bool
 Attributable::setAttribute(std::string const& key, T&& value)
 {
+    if( IOHandler && AccessType::READ_ONLY == IOHandler->accessType )
+        throw no_such_attribute_error(out_of_range_msg(key));
+
     dirty = true;
     auto it = m_attributes->lower_bound(key);
     if( it != m_attributes->end() && !m_attributes->key_comp()(key, it->first) )

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -103,10 +103,17 @@ Series::Series(std::string const& filepath,
         case AccessType::READ_ONLY:
         case AccessType::READ_WRITE:
         {
+            /* Allow creation of values in Containers and setting of Attributes
+             * Would throw for AccessType::READ_ONLY */
+            auto newType = const_cast< AccessType* >(&m_writable->IOHandler->accessType);
+            *newType = AccessType::READ_WRITE;
+
             if( auxiliary::contains(*m_name, "%T") )
                 readFileBased();
             else
                 readGroupBased();
+
+            *newType = at;
             break;
         }
     }
@@ -161,10 +168,17 @@ Series::Series(std::string const& filepath,
         case AccessType::READ_ONLY:
         case AccessType::READ_WRITE:
         {
+            /* Allow creation of values in Containers and setting of Attributes
+             * Would throw for AccessType::READ_ONLY */
+            auto newType = const_cast< AccessType* >(&m_writable->IOHandler->accessType);
+            *newType = AccessType::READ_WRITE;
+
             if( auxiliary::contains(*m_name, "%T") )
                 readFileBased();
             else
                 readGroupBased();
+
+            *newType = at;
             break;
         }
     }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -25,6 +25,7 @@ TEST_CASE( "git_hdf5_sample_structure_test", "[serial][hdf5]" )
 
         REQUIRE(!o.parent);
         REQUIRE(o.iterations.parent == getWritable(&o));
+        REQUIRE_THROWS_AS(o.iterations[42], std::out_of_range);
         REQUIRE(o.iterations[100].parent == getWritable(&o.iterations));
         REQUIRE(o.iterations[100].meshes.parent == getWritable(&o.iterations[100]));
         REQUIRE(o.iterations[100].meshes["E"].parent == getWritable(&o.iterations[100].meshes));
@@ -735,7 +736,7 @@ TEST_CASE( "hzdr_hdf5_sample_content_test", "[serial][hdf5]" )
         PatchRecord& e_numParticles = e_patches["numParticles"];
         REQUIRE(e_numParticles.size() == 1);
         REQUIRE(e_numParticles.count(RecordComponent::SCALAR) == 1);
-        
+
         PatchRecordComponent& e_numParticles_scalar = e_numParticles[RecordComponent::SCALAR];
         REQUIRE(e_numParticles_scalar.getDatatype() == Datatype::UINT64);
 
@@ -819,7 +820,7 @@ TEST_CASE( "hdf5_dtype_test", "[serial][hdf5]" )
         s.setAttribute("vecString", std::vector< std::string >({"vector", "of", "strings"}));
         s.setAttribute("bool", true);
     }
-    
+
     Series s = Series("../samples/dtype_test.h5", AccessType::READ_ONLY);
 
     REQUIRE(s.getAttribute("char").get< char >() == 'c');

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -34,6 +34,7 @@ TEST_CASE( "git_hdf5_sample_structure_test", "[serial][hdf5]" )
         REQUIRE(o.iterations[100].meshes["E"]["z"].parent == getWritable(&o.iterations[100].meshes["E"]));
         REQUIRE(o.iterations[100].meshes["rho"].parent == getWritable(&o.iterations[100].meshes));
         REQUIRE(o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR].parent == getWritable(&o.iterations[100].meshes));
+        REQUIRE_THROWS_AS(o.iterations[100].meshes["cherries"], std::out_of_range);
         REQUIRE(o.iterations[100].particles.parent == getWritable(&o.iterations[100]));
         REQUIRE(o.iterations[100].particles["electrons"].parent == getWritable(&o.iterations[100].particles));
         REQUIRE(o.iterations[100].particles["electrons"]["charge"].parent == getWritable(&o.iterations[100].particles["electrons"]));
@@ -54,6 +55,12 @@ TEST_CASE( "git_hdf5_sample_structure_test", "[serial][hdf5]" )
         REQUIRE(o.iterations[100].particles["electrons"]["positionOffset"]["z"].parent == getWritable(&o.iterations[100].particles["electrons"]["positionOffset"]));
         REQUIRE(o.iterations[100].particles["electrons"]["weighting"].parent == getWritable(&o.iterations[100].particles["electrons"]));
         REQUIRE(o.iterations[100].particles["electrons"]["weighting"][RecordComponent::SCALAR].parent == getWritable(&o.iterations[100].particles["electrons"]));
+        REQUIRE_THROWS_AS(o.iterations[100].particles["electrons"]["numberOfLegs"], std::out_of_range);
+        REQUIRE_THROWS_AS(o.iterations[100].particles["apples"], std::out_of_range);
+
+        int32_t i32 = 32;
+        REQUIRE_THROWS(o.setAttribute("setAttributeFail", i32));
+
     } catch (no_such_file_error& e)
     {
         std::cerr << "git sample not accessible. (" << e.what() << ")\n";


### PR DESCRIPTION
Missing keys in read-only containers should throw.

## To Do

- [x] fix existing tests ~@C0nsultant feel free to go on, I am a bit stuck why some throw~
- [x] add: C++ tests that throw
- [x] Py: throws a clean `IndexError` that can be catched :)