### PR TITLE
Warnings: Class then Struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ openpmd_option(PYTHON           "Enable Python bindings"                    AUTO
 option(openPMD_USE_INTERNAL_VARIANT "Use internally shipped MPark.Variant" ON)
 option(openPMD_USE_INTERNAL_CATCH   "Use internally shipped Catch2" ON)
 
-
 set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -28,7 +28,7 @@ namespace openPMD
 {
 namespace test
 {
-class TestHelper;
+struct TestHelper;
 } // test
 class AbstractFilePosition;
 class AbstractIOHandler;
@@ -62,7 +62,7 @@ class Writable
     friend class ADIOS2IOHandlerImpl;
     friend class HDF5IOHandlerImpl;
     friend class ParallelHDF5IOHandlerImpl;
-    friend class test::TestHelper;
+    friend struct test::TestHelper;
     friend std::string concrete_h5_file_position(Writable*);
     friend std::string concrete_bp1_file_position(Writable*);
 

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -122,9 +122,8 @@ namespace openPMD
 {
 namespace test
 {
-class structure : public TestHelper
+struct structure : public TestHelper
 {
-public:
     structure()
         : TestHelper()
     { }
@@ -254,9 +253,8 @@ namespace openPMD
 {
 namespace test
 {
-class AttributedWidget : public TestHelper
+struct AttributedWidget : public TestHelper
 {
-public:
     AttributedWidget()
         : TestHelper()
     { }
@@ -303,9 +301,8 @@ namespace openPMD
 {
 namespace test
 {
-class Dotty : public TestHelper
+struct Dotty : public TestHelper
 {
-public:
     Dotty()
         : TestHelper()
     {


### PR DESCRIPTION
Remove little warnings and leftovers from #176.

But all in all - MSVC compiles now! That was it! :)