### PR TITLE
Python: Module.have_variant

### DIFF
--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -41,7 +41,7 @@ PYBIND11_MODULE(openPMD, m) {
     init_BaseRecordComponent(m);
     init_RecordComponent(m);
     init_MeshRecordComponent(m);
-    init_ParticlePatches(m);    
+    init_ParticlePatches(m);
     init_ParticleSpecies(m);
     init_Record(m);
     init_Series(m);
@@ -54,5 +54,12 @@ PYBIND11_MODULE(openPMD, m) {
     if( std::string( OPENPMDAPI_VERSION_LABEL ).size() > 0 )
         openPMDapi << "-" << OPENPMDAPI_VERSION_LABEL;
     m.attr("__version__") = openPMDapi.str();
+
+    // variants
+    m.attr("have_mpi") = bool(openPMD_HAVE_MPI);
+    m.attr("have_hdf5") = bool(openPMD_HAVE_HDF5);
+    m.attr("have_adios1") = bool(openPMD_HAVE_ADIOS1);
+    m.attr("have_adios2") = bool(openPMD_HAVE_ADIOS2);
+    // m.attr("have_json") = bool(openPMD_HAVE_JSON);
 }
 


### PR DESCRIPTION
Add `openPMD.have_[mpi,hdf5,adios1,adios2]` to Python module. Allows to query enabled (compiled) variants.

```python
In [1]: import openPMD

In [2]: openPMD.have_mpi
Out[2]: True

In [3]: openPMD.have_hdf5
Out[3]: True

In [4]: openPMD.have_adios1
Out[4]: False

In [5]: openPMD.have_adios2
Out[5]: False
```