### PR TITLE
MSVC: decltype function Work-Around

### DIFF
--- a/include/openPMD/auxiliary/HasToString.hpp
+++ b/include/openPMD/auxiliary/HasToString.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <type_traits>
+
+
+namespace openPMD
+{
+namespace auxiliary
+{
+    /** checks if std::to_string() is defined for a type
+     */
+    class HasToString
+    {
+        template< typename T_Key >
+        [[noreturn]] auto static ok( T_Key key ) ->
+            std::pair< std::true_type, decltype( std::to_string( key ) ) > {}
+
+        template< typename T_Key >
+        [[noreturn]] auto static ok( T_Key ) ->
+            std::pair< std::false_type, bool > {}
+
+        template< typename T_Key >
+        using type_proto = decltype( ok< T_Key > );
+
+    public:
+        template< typename T_Key >
+        using type = typename type_proto< T_Key >::first_type;
+    };
+
+    /** Access to ::type member of HasToString< T_Key >
+     */
+    template< typename T_Key >
+    using HasToString_t = typename HasToString::type< T_Key >;
+
+} // auxiliary
+} // openPMD

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -23,8 +23,10 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/Writable.hpp"
+#include "openPMD/auxiliary/HasToString.hpp"
 
 #include <exception>
+#include <type_traits>
 #include <map>
 #include <memory>
 #include <vector>
@@ -76,12 +78,14 @@ class Attributable
     friend class Series;
 
     template< typename T_Key >
-    auto out_of_range_msg(T_Key const& key) -> decltype(std::to_string(key))
+    auto out_of_range_msg(T_Key const& key) ->
+        typename std::enable_if< auxiliary::HasToString_t<T_Key>::value, std::string >::type
     {
         return std::string("Attribute '") + std::to_string(key) + std::string("' does not exist (read-only).");
     }
     template< typename T_Key >
-    auto out_of_range_msg(T_Key const& key) -> decltype(std::string(key))
+    auto out_of_range_msg(T_Key const& key) ->
+        decltype(std::string(key))
     {
         return std::string("Attribute '") + std::string(key) + std::string("' does not exist (read-only).");
     }

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/backend/Attributable.hpp"
+#include "openPMD/auxiliary/HasToString.hpp"
 
 #include <initializer_list>
 #include <type_traits>
@@ -72,12 +73,14 @@ class Container : public Attributable
     friend class Series;
 
     template< typename T_Key >
-    auto out_of_range_msg(T_Key const& key) -> decltype(std::to_string(key))
+    auto out_of_range_msg(T_Key const& key) ->
+        typename std::enable_if< auxiliary::HasToString_t<T_Key>::value, std::string >::type
     {
         return std::string("Key '") + std::to_string(key) + std::string("' does not exist (read-only).");
     }
     template< typename T_Key >
-    auto out_of_range_msg(T_Key const& key) -> decltype(std::string(key))
+    auto out_of_range_msg(T_Key const& key) ->
+        decltype(std::string(key))
     {
         return std::string("Key '") + std::string(key) + std::string("' does not exist (read-only).");
     }


### PR DESCRIPTION
Adds a work-around for MSVC looking up `decltype(function(var))`. Due to missing two-phase lookup, MSVC always determines a type (instead of no-type) which prevents our SFINAE.

So of course, we implement a SFINAE for trait `HasToString` to allow using this still in a SFINAE.

Introduced in #172