### PR TITLE
Key Error on Read-Only

### DIFF
--- a/include/openPMD/auxiliary/OutOfRangeMsg.hpp
+++ b/include/openPMD/auxiliary/OutOfRangeMsg.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+
+namespace openPMD
+{
+namespace auxiliary
+{
+
+    /** Return an error string for read-only access
+     *
+     * Build an error string for write-access of keys into containers that
+     * are read-only.
+     */
+    class OutOfRangeMsg
+    {
+        std::string m_name;
+
+    public:
+        OutOfRangeMsg() : m_name("Key") {}
+        OutOfRangeMsg( std::string const name ) : m_name(name) {}
+
+        template<
+            typename T_Key,
+            typename = typename std::enable_if<
+                std::is_integral< T_Key >::value ||
+                std::is_floating_point< T_Key >::value
+            >::type
+        >
+        std::string operator()( T_Key const key ) const
+        {
+            return m_name + std::string(" '") + std::to_string( key ) +
+                   std::string( "' does not exist (read-only)." );
+        }
+
+        std::string operator()( std::string const key ) const
+        {
+            return m_name + std::string(" '") + std::string( key ) +
+                   std::string( "' does not exist (read-only)." );
+        }
+
+        std::string operator()( ... ) const
+        {
+            return m_name + std::string( " does not exist (read-only)." );
+        }
+    };
+
+} // auxiliary
+} // openPMD

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -71,25 +71,6 @@ class Container : public Attributable
     friend class ParticleSpecies;
     friend class Series;
 
-#if !defined(_MSC_VER)
-    template< typename T_Key >
-    auto out_of_range_msg(T_Key const& key) ->
-        decltype(std::to_string(key))
-    {
-        return std::string("Key '") + std::to_string(key) + std::string("' does not exist (read-only).");
-    }
-#endif
-    template< typename T_Key >
-    auto out_of_range_msg(T_Key const& key) ->
-        decltype(std::string(key))
-    {
-        return std::string("Key '") + std::string(key) + std::string("' does not exist (read-only).");
-    }
-    std::string out_of_range_msg(...)
-    {
-        return std::string("Key does not exist (read-only).");
-    }
-
 public:
     using key_type = typename InternalContainer::key_type;
     using mapped_type = typename InternalContainer::mapped_type;
@@ -164,7 +145,10 @@ public:
         else
         {
             if( AccessType::READ_ONLY == IOHandler->accessType )
+            {
+                auxiliary::OutOfRangeMsg const out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
+            }
 
             T t = T();
             t.linkHierarchy(m_writable);
@@ -188,7 +172,10 @@ public:
         else
         {
             if( AccessType::READ_ONLY == IOHandler->accessType )
+            {
+                auxiliary::OutOfRangeMsg out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
+            }
 
             T t = T();
             t.linkHierarchy(m_writable);


### PR DESCRIPTION
Refactor the key error message for read-only containers.

Implement the non-MSVC SFINAE from #172 properly again. `std::to_string` is only defined for ints and floats. Also factor out duplicate code.