### PR TITLE
Travis-CI: ADIOS1 Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       stage: 'C++ Unit Tests'
       language: cpp
       env:
-        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:
@@ -97,6 +97,8 @@ jobs:
         # - dpkg -i openPMD*.deb
         - ls -R $HOME/openPMD-test-install | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//--/g' -e 's/^/   /' -e 's/-/|/'
     - <<: *test-cpp-unit
+      language: python
+      python: "2.7"
       env:
         - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
@@ -121,6 +123,8 @@ jobs:
       script: *script-cpp-unit
     # GCC 4.9.4
     - <<: *test-cpp-unit
+      language: python
+      python: "2.7"
       env:
         - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=OFF
       compiler: gcc
@@ -136,6 +140,8 @@ jobs:
          - CXX=g++-4.9 && CC=gcc-4.9 && COMPILERSPEC="%gcc@4.9.4"
       script: *script-cpp-unit
     - <<: *test-cpp-unit
+      language: python
+      python: "2.7"
       env:
         - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
@@ -150,6 +156,8 @@ jobs:
       script: *script-cpp-unit
     # GCC 7.3.0
     - <<: *test-cpp-unit
+      language: python
+      python: "2.7"
       env:
         - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
@@ -165,6 +173,8 @@ jobs:
          - CXX=g++-7 && CC=gcc-7 && COMPILERSPEC="%gcc@7.3.0"
       script: *script-cpp-unit
     - <<: *test-cpp-unit
+      language: python
+      python: "2.7"
       env:
         - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
@@ -182,7 +192,7 @@ jobs:
       language: python
       python: "2.7"
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON ADIOS1_VERSION=@1.13.1 USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -200,7 +210,7 @@ jobs:
       language: python
       python: "3.6"
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON HDF5_VERSION=@1.8.13 USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON HDF5_VERSION=@1.8.13 USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -245,6 +255,11 @@ install:
       brew info modules &&
       source /usr/local/opt/modules/init/bash &&
       export TRAVIS_PYTHON_VERSION=2.7.10;
+    fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then
+        export TRAVIS_PYTHON_VERSION=2.7.14;
+      fi;
     fi
   - source $SPACK_ROOT/share/spack/setup-env.sh
   # fresh (cache-cleaned) travis runs seem to not properly init environment-modules
@@ -300,9 +315,9 @@ install:
   - if [ $USE_ADIOS1 == "ON" ]; then
       travis_wait spack install
         adios$ADIOS1_VERSION
-        $SPACK_VAR_MPI
+        $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION
         $COMPILERSPEC &&
-      spack load adios$ADIOS1_VERSION $SPACK_VAR_MPI $COMPILERSPEC;
+      spack load adios$ADIOS1_VERSION $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION $COMPILERSPEC;
     fi
   - if [ $USE_ADIOS2 == "ON" ]; then
       travis_wait spack install

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
       os: osx
       language: generic
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       before_install:
          - COMPILERSPEC="%clang@8.1.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       stage: 'C++ Unit Tests'
       language: cpp
       env:
-        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:
@@ -98,7 +98,7 @@ jobs:
         - ls -R $HOME/openPMD-test-install | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//--/g' -e 's/^/   /' -e 's/-/|/'
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:
@@ -114,7 +114,7 @@ jobs:
       os: osx
       language: generic
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       before_install:
          - COMPILERSPEC="%clang@8.1.0"
@@ -122,7 +122,7 @@ jobs:
     # GCC 4.9.4
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=OFF
+        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=OFF
       compiler: gcc
       addons:
         apt:
@@ -137,7 +137,7 @@ jobs:
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -151,7 +151,7 @@ jobs:
     # GCC 7.3.0
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -166,7 +166,7 @@ jobs:
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       env:
-        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -182,7 +182,7 @@ jobs:
       language: python
       python: "2.7"
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -200,7 +200,7 @@ jobs:
       language: python
       python: "3.6"
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON HDF5_VERSION=@1.8.13 USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON HDF5_VERSION=@1.8.13 USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -299,10 +299,10 @@ install:
     fi
   - if [ $USE_ADIOS1 == "ON" ]; then
       travis_wait spack install
-        adios
+        adios$ADIOS1_VERSION
         $SPACK_VAR_MPI
         $COMPILERSPEC &&
-      spack load adios $SPACK_VAR_MPI $COMPILERSPEC;
+      spack load adios$ADIOS1_VERSION $SPACK_VAR_MPI $COMPILERSPEC;
     fi
   - if [ $USE_ADIOS2 == "ON" ]; then
       travis_wait spack install

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -25,7 +25,10 @@ packages:
   python:
     version: [2.7.14, 2.7.10, 3.5.5, 3.6.3]
     paths:
+      python@2.7.14%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
+      python@2.7.14%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@2.7.14%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
+      python@2.7.14%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
       python@2.7.10%clang@8.1.0 arch=darwin-sierra-x86_64: /usr

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -20,6 +20,8 @@ packages:
     buildable: False
   hdf5:
     version: [1.10.1, 1.8.13]
+  adios:
+    variants: ~zfp ~sz ~lz4 ~blosc
   python:
     version: [2.7.14, 2.7.10, 3.5.5, 3.6.3]
     paths:


### PR DESCRIPTION
Try to test the ADIOS1 backend on Travis-CI.
Builds in the matrix one entry with the oldes supported ADIOS1 release and in others the latest stable release.

Don't be confused, ADIOS weirdly has a python build dependency. And up to 1.13.1 this needs to be python 2.7... https://github.com/ornladios/ADIOS/pull/178

Update: seems to trigger https://github.com/spack/spack/issues/8082