### PR TITLE
Container: ipython completions

### DIFF
--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -178,6 +178,16 @@ namespace detail
             &Map::size
         );
 
+        cl.def(
+            "_ipython_key_completions_",
+            []( Map & m ) {
+                auto l = py::list();
+                for( const auto &myPair : m )
+                    l.append( myPair.first );
+                return l;
+            }
+        );
+
         return cl;
     }
 } // namespace detail


### PR DESCRIPTION
Add ipython completions for the `__getitem__` method in the `Container` class.

Mainly helps with all string-keys since ints seem not really to be completed, even in regular `dict`s.

### Example

```python
In [1]: import openPMD

In [2]: s = openPMD.Series("openPMD-example-datasets/example-2d/hdf5/data00000100.h5", openPMD.Access_Type.read_only)
Series constructor called with explicit iteration suggests loading a single file with groupBased iteration encoding. Loaded file is fileBased.

In [3]: it = s.iterations[100]

In [4]: list(it.particles)
Out[4]: ['Hydrogen1+', 'electrons']

In [5]: it.particles['Hy<TAB>
In [5]: it.particles['Hydrogen+
```

### Reference

https://ipython.readthedocs.io/en/5.x/config/integrating.html