### PR TITLE
Fix standard consistency

### DIFF
--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -55,8 +55,9 @@ class Writable
     >
     friend class Container;
     friend class Iteration;
-    friend class Series;
     friend class ParticleSpecies;
+    friend class Series;
+    friend class Record;
     friend class ADIOS1IOHandlerImpl;
     friend class ParallelADIOS1IOHandlerImpl;
     friend class ADIOS2IOHandlerImpl;

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -55,6 +55,7 @@ class Writable
     >
     friend class Container;
     friend class Iteration;
+    friend class Mesh;
     friend class ParticleSpecies;
     friend class Series;
     friend class Record;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -187,8 +187,10 @@ Mesh::flush(std::string const& name)
         if( *m_containsScalar )
         {
             MeshRecordComponent& r = at(RecordComponent::SCALAR);
+            r.m_writable->parent = parent;
             r.parent = parent;
             r.flush(name);
+            m_writable->abstractFilePosition = r.m_writable->abstractFilePosition;
             abstractFilePosition = r.abstractFilePosition;
             written = true;
         } else

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -54,8 +54,10 @@ Record::flush(std::string const& name)
         if( *m_containsScalar )
         {
             RecordComponent& r = at(RecordComponent::SCALAR);
+            r.m_writable->parent = parent;
             r.parent = parent;
             r.flush(name);
+            m_writable->abstractFilePosition = r.m_writable->abstractFilePosition;
             abstractFilePosition = r.abstractFilePosition;
             written = true;
         } else


### PR DESCRIPTION
With the adoption of handles to resources (in #156), the filepositions of scalar records were not adjusted accordingly. This resulted in the Attributes of the Record (e.g. timeOffset) to be written to the next-higher Writable.

Closes #187.