### PR TITLE
CMake: ADIOS1 Static Lib Suffix

### DIFF
--- a/cmake/FindADIOS.cmake
+++ b/cmake/FindADIOS.cmake
@@ -164,9 +164,9 @@ endif(ADIOS_FOUND)
 
 # option: use only static libs ################################################
 if(ADIOS_USE_STATIC_LIBS)
-    # carfully: we have to restore the original path in the end
+    # careful, we have to restore the original path in the end
     set(_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
 endif()
 
 


### PR DESCRIPTION
More general static library suffix via [`CMAKE_STATIC_LIBRARY_SUFFIX`](https://cmake.org/cmake/help/v3.0/variable/CMAKE_STATIC_LIBRARY_SUFFIX.html) in `FindADIOS.cmake` (ADIOS1).

CMake default is both shared and static ([in that order](https://stackoverflow.com/questions/28194215/default-values-for-cmake-find-library-prefixes-cmake-find-library-suffixes?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa)).

Rather cosmetic change, since both OSX and Linux use `.a` as suffix and ADIOS1 does not build on Windows (which would then be `.lib` files for static archives).