### PR TITLE
Docs: All Static Builds

### DIFF
--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -5,6 +5,9 @@ Build Options
 
 .. sectionauthor:: Axel Huebl
 
+Variants
+--------
+
 The following options can be added to the ``cmake`` call to control features.
 CMake controls options with prefixed ``-D``, e.g. ``-DopenPMD_USE_MPI=OFF``:
 
@@ -21,7 +24,41 @@ CMake Option                   Values          Description
 ============================== =============== ==================================================
 
 :sup:`1` *not yet implemented*
-:sup:`2` e.g. C++ keywords, currently disabled only for MSVC*
+
+:sup:`2` e.g. C++ keywords, currently disabled only for MSVC
+
+
+Shared or Static
+----------------
+
+By default, we will build as a static library and install also its headers.
+You can only build a static (``libopenPMD.a`` or ``openPMD.lib``) or a shared library (``libopenPMD.so`` or ``openPMD.dll``) at a time.
+
+The following options can be tried to switch between static and shared builds and control if dependencies are linked dynamically or statically:
+
+============================== =============== ==================================================
+CMake Option                   Values          Description
+============================== =============== ==================================================
+``BUILD_SHARED_LIBS``          ON/**OFF**      Build the C++ API as shared library
+``Boost_USE_STATIC_LIBS``      ON/**OFF**      Require static Boost library
+``HDF5_USE_STATIC_LIBRARIES``  ON/**OFF**      Require static HDF5 library
+``ADIOS_USE_STATIC_LIBRARIES`` ON/**OFF**      Require static ADIOS1 library
+============================== =============== ==================================================
+
+Note that python modules (``openPMD.cpython.[...].so`` or ``openPMD.pyd``) are always dynamic libraries.
+Therefore, if you want to build the python module and prefer static dependencies, make sure to provide all of dependencies build with position independent code (``-fPIC``).
+The same requirement is true if you want to build a *shared* C++ API library with *static* dependencies.
+
+
+Debug
+-----
+
+By default, the ``Release`` version is built.
+In order to build with debug symbols, pass ``-DCMAKE_BUILD_TYPE=Debug`` to your ``cmake`` command.
+
+
+Shipped Dependencies
+--------------------
 
 Additionally, the following libraries are shipped internally for convenience.
 These might get installed in your :ref:`CMAKE_INSTALL_PREFIX <install-cmake>` if the option is ``ON``.
@@ -35,12 +72,9 @@ CMake Option                     Values      Installs Library       Version
 ``openPMD_USE_INTERNAL_CATCH``   **ON**/OFF  No       Catch2          2.2.1+
 ================================ =========== ======== ============= ========
 
-By default, this will build as a static library (``libopenPMD.a``) and installs also its headers.
-In order to build a shared library, append ``-DBUILD_SHARED_LIBS=ON`` to the ``cmake`` command.
-You can only build a static or a shared library at a time.
 
-By default, the ``Release`` version is built.
-In order to build with debug symbols, pass ``-DCMAKE_BUILD_TYPE=Debug`` to your ``cmake`` command.
+Tests
+-----
 
 By default, tests are built.
 In order to skip building tests, pass ``-DBUILD_TESTING=OFF`` to your ``cmake`` command.


### PR DESCRIPTION
Restructure the build options and give hints on all-static builds.