### PR TITLE
Helper: Raw Pointer store/load

### DIFF
--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -60,8 +60,7 @@ int main()
 
     Offset chunk_offset = {1, 1, 1};
     Extent chunk_extent = {2, 2, 1};
-    std::shared_ptr< double > chunk_data;
-    E_x.loadChunk(chunk_offset, chunk_extent, chunk_data);
+    auto chunk_data = E_x.loadChunk<double>(chunk_offset, chunk_extent);
     cout << "Queued the loading of a single chunk from disk, "
             "ready to execute\n";
     series.flush();

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -60,7 +60,7 @@ int main()
 
     Offset chunk_offset = {1, 1, 1};
     Extent chunk_extent = {2, 2, 1};
-    std::unique_ptr< double[] > chunk_data;
+    std::shared_ptr< double > chunk_data;
     E_x.loadChunk(chunk_offset, chunk_extent, chunk_data);
     cout << "Queued the loading of a single chunk from disk, "
             "ready to execute\n";
@@ -72,7 +72,7 @@ int main()
         for( size_t col = 0; col < chunk_extent[1]; ++col )
             cout << "\t"
                  << '(' << row + chunk_offset[0] << '|' << col + chunk_offset[1] << '|' << 1 << ")\t"
-                 << chunk_data[row*chunk_extent[1]+col];
+                 << chunk_data.get()[row*chunk_extent[1]+col];
         cout << '\n';
     }
 

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
           .meshes["E"][MeshRecordComponent::SCALAR];
     cout << "Created a scalar mesh Record with all required openPMD attributes\n";
 
-    Datatype datatype = determineDatatype(storeRaw(global_data));
+    Datatype datatype = determineDatatype(shareRaw(global_data));
     Extent extent = {size, size};
     Dataset dataset = Dataset(datatype, extent);
     cout << "Created a Dataset of size " << dataset.extent[0] << 'x' << dataset.extent[1]
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
     cout << "File structure and required attributes have been written\n";
 
     Offset offset = {0, 0};
-    E.storeChunk(offset, extent, storeRaw(global_data));
+    E.storeChunk(offset, extent, shareRaw(global_data));
     cout << "Stored the whole Dataset contents as a single chunk, "
             "ready to write content\n";
 

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -34,11 +34,9 @@ int main(int argc, char *argv[])
     size_t size = (argc == 2 ? atoi(argv[1]) : 3);
 
     // matrix dataset to write with values 0...size*size-1
-    std::shared_ptr< double > global_data{
-        new double[size*size],
-        std::default_delete< double[] >()
-    };
-    std::iota(global_data.get(), global_data.get() + size*size, 0.);
+    std::vector<double> global_data;
+    global_data.reserve(size*size);
+    std::iota(global_data.begin(), global_data.end(), 0.);
 
     cout << "Set up a 2D square array (" << size << 'x' << size
          << ") that will be written\n";
@@ -56,7 +54,7 @@ int main(int argc, char *argv[])
           .meshes["E"][MeshRecordComponent::SCALAR];
     cout << "Created a scalar mesh Record with all required openPMD attributes\n";
 
-    Datatype datatype = determineDatatype(global_data);
+    Datatype datatype = determineDatatype(storeRaw(global_data));
     Extent extent = {size, size};
     Dataset dataset = Dataset(datatype, extent);
     cout << "Created a Dataset of size " << dataset.extent[0] << 'x' << dataset.extent[1]
@@ -69,7 +67,7 @@ int main(int argc, char *argv[])
     cout << "File structure and required attributes have been written\n";
 
     Offset offset = {0, 0};
-    E.storeChunk(offset, extent, global_data);
+    E.storeChunk(offset, extent, storeRaw(global_data));
     cout << "Stored the whole Dataset contents as a single chunk, "
             "ready to write content\n";
 

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -34,8 +34,7 @@ int main(int argc, char *argv[])
     size_t size = (argc == 2 ? atoi(argv[1]) : 3);
 
     // matrix dataset to write with values 0...size*size-1
-    std::vector<double> global_data;
-    global_data.reserve(size*size);
+    std::vector<double> global_data(size*size);
     std::iota(global_data.begin(), global_data.end(), 0.);
 
     cout << "Set up a 2D square array (" << size << 'x' << size

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -61,8 +61,7 @@ int main(int argc, char *argv[])
         };
         Extent chunk_extent = {2, 2, 1};
 
-        std::shared_ptr< double > chunk_data;
-        E_x.loadChunk(chunk_offset, chunk_extent, chunk_data);
+        auto chunk_data = E_x.loadChunk<double>(chunk_offset, chunk_extent);
 
         if( 0 == mpi_rank )
             cout << "Queued the loading of a single chunk per MPI rank from disk, "

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
         };
         Extent chunk_extent = {2, 2, 1};
 
-        std::unique_ptr< double[] > chunk_data;
+        std::shared_ptr< double > chunk_data;
         E_x.loadChunk(chunk_offset, chunk_extent, chunk_data);
 
         if( 0 == mpi_rank )
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
                     for( size_t col = 0; col < chunk_extent[1]; ++col )
                         cout << "\t"
                              << '(' << row + chunk_offset[0] << '|' << col + chunk_offset[1] << '|' << 1 << ")\t"
-                             << chunk_data[row*chunk_extent[1]+col];
+                             << chunk_data.get()[row*chunk_extent[1]+col];
                     cout << std::endl;
                 }
             }

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
      */
     {
         // allocate a data set to write
-        std::shared_ptr< double > global_data{new double[mpi_size]};
+        std::shared_ptr< double > global_data(new double[mpi_size], [](double *p) { delete[] p; });
         for( int i = 0; i < mpi_size; ++i )
             global_data.get()[i] = i;
         if( 0 == mpi_rank )

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -44,15 +44,15 @@ int main(int argc, char *argv[])
      */
     {
         // allocate a data set to write
-        std::unique_ptr< double[] > global_data{new double[mpi_size]};
+        std::shared_ptr< double > global_data{new double[mpi_size]};
         for( int i = 0; i < mpi_size; ++i )
-            global_data[i] = i;
+            global_data.get()[i] = i;
         if( 0 == mpi_rank )
             cout << "Set up a 1D array with one element per MPI rank (" << mpi_size
                  << ") that will be written to disk\n";
 
         std::shared_ptr< double > local_data{new double};
-        *local_data = global_data[mpi_rank];
+        *local_data = global_data.get()[mpi_rank];
         if( 0 == mpi_rank )
             cout << "Set up a 1D array with one element, representing the view of the MPI rank\n";
 

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -174,7 +174,7 @@ struct Parameter< Operation::READ_DATASET > : public AbstractParameter
     Extent extent;
     Offset offset;
     Datatype dtype;
-    void* data = nullptr;
+    std::shared_ptr< void > data;
 };
 
 template<>

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -165,7 +165,7 @@ struct Parameter< Operation::WRITE_DATASET > : public AbstractParameter
     Extent extent;
     Offset offset;
     Datatype dtype;
-    std::shared_ptr< void > data;
+    std::shared_ptr< void const > data;
 };
 
 template<>

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -103,10 +103,10 @@ public:
     template< typename T >
     RecordComponent& makeConstant(T);
 
-    template< typename T >
+    template< typename T, typename D >
     void loadChunk(Offset const&,
                    Extent const&,
-                   std::unique_ptr< T[] >&,
+                   std::unique_ptr< T[], D >&,
                    Allocation = Allocation::AUTO,
                    double targetUnitSI = std::numeric_limits< double >::quiet_NaN() );
     template< typename T >
@@ -140,9 +140,9 @@ RecordComponent::makeConstant(T value)
     return *this;
 }
 
-template< typename T >
+template< typename T, typename D >
 inline void
-RecordComponent::loadChunk(Offset const& o, Extent const& e, std::unique_ptr< T[] >& data, Allocation alloc, double targetUnitSI)
+RecordComponent::loadChunk(Offset const& o, Extent const& e, std::unique_ptr< T[], D >& data, Allocation alloc, double targetUnitSI)
 {
     if( !std::isnan(targetUnitSI) )
         throw std::runtime_error("unitSI scaling during chunk loading not yet implemented");
@@ -170,7 +170,7 @@ RecordComponent::loadChunk(Offset const& o, Extent const& e, std::unique_ptr< T[
         numPoints *= dimensionSize;
 
     if( (Allocation::AUTO == alloc && !data) || Allocation::API == alloc )
-        data = std::unique_ptr< T[] >(new T[numPoints]);
+        data = std::unique_ptr< T[], D >(new T[numPoints]);
     T* raw_ptr = data.get();
 
     if( *m_isConstant )

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "openPMD/backend/BaseRecordComponent.hpp"
-#include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/Dataset.hpp"
 
 #include <cmath>
@@ -68,10 +67,14 @@ public:
     RecordComponent& makeConstant(T);
 
     template< typename T >
+    std::shared_ptr< T > loadChunk(Offset const&,
+                   Extent const&,
+                   double targetUnitSI = std::numeric_limits< double >::quiet_NaN() );
+
+    template< typename T >
     void loadChunk(Offset const&,
                    Extent const&,
                    std::shared_ptr< T >,
-                   Allocation = Allocation::AUTO,
                    double targetUnitSI = std::numeric_limits< double >::quiet_NaN() );
     template< typename T >
     void storeChunk(Offset, Extent, std::shared_ptr< T >);
@@ -105,8 +108,21 @@ RecordComponent::makeConstant(T value)
 }
 
 template< typename T >
+inline std::shared_ptr< T >
+RecordComponent::loadChunk(Offset const& o, Extent const& e, double targetUnitSI)
+{
+    uint64_t numPoints = 1u;
+    for( auto const& dimensionSize : e )
+        numPoints *= dimensionSize;
+
+    auto newData = std::shared_ptr<T>(new T[numPoints], []( T *p ){ delete [] p; });
+    loadChunk(o, e, newData, targetUnitSI);
+    return newData;
+}
+
+template< typename T >
 inline void
-RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T > data, Allocation alloc, double targetUnitSI)
+RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T > data, double targetUnitSI)
 {
     if( !std::isnan(targetUnitSI) )
         throw std::runtime_error("unitSI scaling during chunk loading not yet implemented");
@@ -124,31 +140,17 @@ RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T 
                                      + " - DS: " + std::to_string(dse[i])
                                      + " - Chunk: " + std::to_string(o[i] + e[i])
                                      + ")");
-    if( Allocation::API == alloc && data )
-        throw std::runtime_error("Preallocated pointer passed with signaled API-allocation during chunk loading.");
-    else if( Allocation::USER == alloc && !data )
-        throw std::runtime_error("Unallocated pointer passed with signaled user-allocation during chunk loading.");
+    if( !data )
+        throw std::runtime_error("Unallocated pointer passed during chunk loading.");
 
-    uint64_t numPoints = 1u;
-    for( auto const& dimensionSize : e )
-        numPoints *= dimensionSize;
-
-    if( (Allocation::AUTO == alloc && !data) || Allocation::API == alloc )
-    {
-        auto newData = std::shared_ptr<T>( new T[numPoints], []( T *p ){ delete [] p; } );
-        data.swap(newData);
-    }
     T* raw_ptr = data.get();
 
     if( *m_isConstant )
     {
-        /*
-        Parameter< Operation::READ_ATT > aRead;
-        aRead.name = "value";
-        IOHandler->enqueue(IOTask(this, aRead));
-        IOHandler->flush();
-        T value = Attribute(*aRead.resource).get< T >();
-         */
+        uint64_t numPoints = 1u;
+        for( auto const& dimensionSize : e )
+            numPoints *= dimensionSize;
+
         T value = m_constantValue->get< T >();
         std::fill(raw_ptr, raw_ptr + numPoints, value);
     } else
@@ -162,58 +164,6 @@ RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T 
         IOHandler->flush();
     }
 }
-
-//template< typename T >
-//inline std::unique_ptr< T, std::function< void(T*) > >
-//RecordComponent::loadChunk(Offset o, Extent e, double targetUnitSI)
-//{
-//    if( targetUnitSI != 0. )
-//        throw std::runtime_error("unitSI scaling during chunk loading not yet implemented");
-//    Datatype dtype = determineDatatype(std::shared_ptr< T >());
-//    if( dtype != getDatatype() )
-//        throw std::runtime_error("Type conversion during chunk loading not implemented yet");
-//    uint8_t dim = getDimensionality();
-//    if( e.size() != dim || o.size() != dim )
-//        throw std::runtime_error("Dimensionality of chunk and dataset do not match.");
-//    Extent dse = getExtent();
-//    for( uint8_t i = 0; i < dim; ++i )
-//        if( dse[i] < o[i] + e[i] )
-//            throw std::runtime_error("Chunk does not reside inside dataset (Dimension on index " + std::to_string(i)
-//                                     + " - DS: " + std::to_string(dse[i])
-//                                     + " - Chunk: " + std::to_string(o[i] + e[i])
-//                                     + ")");
-//
-//    uint64_t numPoints = 1u;
-//    for( auto const& dimensionSize : e )
-//        numPoints *= dimensionSize;
-//
-//    auto data = std::move(allocatePtr(getDatatype(), numPoints));
-//    void *ptr = data.get();
-//
-//    if( *m_isConstant )
-//    {
-//        Parameter< Operation::READ_ATT > attribute_parameter;
-//        attribute_parameter.name = "value";
-//        IOHandler->enqueue(IOTask(this, attribute_parameter));
-//        IOHandler->flush();
-//        T* ptr = static_cast< T* >(data);
-//        T value = Attribute(*attribute_parameter.resource).get< T >();
-//        std::fill(ptr, ptr + numPoints, value);
-//    } else
-//    {
-//        Parameter< Operation::READ_DATASET > chunk_parameter;
-//        chunk_parameter.offset = o;
-//        chunk_parameter.extent = e;
-//        chunk_parameter.dtype = getDatatype();
-//        chunk_parameter.data = data;
-//        IOHandler->enqueue(IOTask(this, chunk_parameter));
-//        IOHandler->flush();
-//    }
-//
-//    T* ptr = static_cast< T* >(data);
-//    auto deleter = [](T* p){ delete[] p; p = nullptr; };
-//    return std::unique_ptr< T, decltype(deleter) >(ptr, deleter);
-//}
 
 template< typename T >
 inline void
@@ -240,7 +190,7 @@ RecordComponent::storeChunk(Offset o, Extent e, std::shared_ptr<T> data)
     dWrite.extent = e;
     dWrite.dtype = dtype;
     /* std::static_pointer_cast correctly reference-counts the pointer */
-    dWrite.data = std::static_pointer_cast< void >(data);
+    dWrite.data = std::static_pointer_cast< void const >(data);
     m_chunks->push(IOTask(this, dWrite));
 }
 } // openPMD

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -143,8 +143,6 @@ RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T 
     if( !data )
         throw std::runtime_error("Unallocated pointer passed during chunk loading.");
 
-    T* raw_ptr = data.get();
-
     if( *m_isConstant )
     {
         uint64_t numPoints = 1u;
@@ -152,6 +150,8 @@ RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T 
             numPoints *= dimensionSize;
 
         T value = m_constantValue->get< T >();
+
+        T* raw_ptr = data.get();
         std::fill(raw_ptr, raw_ptr + numPoints, value);
     } else
     {
@@ -159,7 +159,7 @@ RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T 
         dRead.offset = o;
         dRead.extent = e;
         dRead.dtype = getDatatype();
-        dRead.data = raw_ptr;
+        dRead.data = std::static_pointer_cast< void >(data);
         IOHandler->enqueue(IOTask(this, dRead));
         IOHandler->flush();
     }

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -29,10 +29,47 @@
 #include <queue>
 #include <string>
 #include <stdexcept>
+#include <vector>
+#include <array>
 
 
 namespace openPMD
 {
+//! @{
+/** Share ownership with a raw pointer
+ *
+ * Helper function to share write ownership
+ * unprotected and without reference counting with a
+ * raw pointer or stdlib container.
+ *
+ * @warning this is a helper function to bypass the shared-pointer
+ *          API for storing data behind raw pointers. Using it puts
+ *          the resposibility of buffer-consistency between stores
+ *          and flushes to the users side without an indication via
+ *          reference counting.
+ */
+template< typename T >
+std::shared_ptr< T >
+storeRaw( T* x )
+{
+    return std::shared_ptr< T >( x, [](T*){} );
+}
+
+template< typename T >
+std::shared_ptr< T >
+storeRaw( std::vector< T > & v )
+{
+    return std::shared_ptr< T >( v.data(), [](T*){} );
+}
+
+template< typename T, std::size_t T_size >
+std::shared_ptr< T >
+storeRaw( std::array< T, T_size > & a )
+{
+    return std::shared_ptr< T >( a.data(), [](T*){} );
+}
+//! @}
+
 class RecordComponent : public BaseRecordComponent
 {
     template<

--- a/include/openPMD/auxiliary/ShareRaw.hpp
+++ b/include/openPMD/auxiliary/ShareRaw.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2018 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <array>
+
+
+namespace openPMD
+{
+    //! @{
+    /** Share ownership with a raw pointer
+     *
+     * Helper function to share load/store data ownership
+     * unprotected and without reference counting with a
+     * raw pointer or stdlib container (that implements a
+     * contiguous data storage).
+     *
+     * @warning this is a helper function to bypass the shared-pointer
+     *          API for storing data behind raw pointers. Using it puts
+     *          the resposibility of buffer-consistency between stores
+     *          and flushes to the users side without an indication via
+     *          reference counting.
+     */
+    template< typename T >
+    std::shared_ptr< T >
+    shareRaw( T* x )
+    {
+        return std::shared_ptr< T >( x, [](T*){} );
+    }
+
+    template< typename T >
+    std::shared_ptr< T >
+    shareRaw( std::vector< T > & v )
+    {
+        return std::shared_ptr< T >( v.data(), [](T*){} );
+    }
+
+    template< typename T, std::size_t T_size >
+    std::shared_ptr< T >
+    shareRaw( std::array< T, T_size > & a )
+    {
+        return std::shared_ptr< T >( a.data(), [](T*){} );
+    }
+    //! @}
+} // openPMD

--- a/include/openPMD/auxiliary/ShareRaw.hpp
+++ b/include/openPMD/auxiliary/ShareRaw.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <vector>
 #include <array>
+#include <type_traits>
 
 
 namespace openPMD
@@ -43,23 +44,32 @@ namespace openPMD
      */
     template< typename T >
     std::shared_ptr< T >
-    shareRaw( T* x )
+    shareRaw( T * x )
     {
-        return std::shared_ptr< T >( x, [](T*){} );
+        return std::shared_ptr< T >( x, [](T *){} );
     }
 
     template< typename T >
-    std::shared_ptr< T >
-    shareRaw( std::vector< T > & v )
+    std::shared_ptr< T const >
+    shareRaw( T const * x )
     {
-        return std::shared_ptr< T >( v.data(), [](T*){} );
+        return std::shared_ptr< T const >( x, [](T const *){} );
     }
 
-    template< typename T, std::size_t T_size >
-    std::shared_ptr< T >
-    shareRaw( std::array< T, T_size > & a )
+    template< typename T >
+    auto
+    shareRaw( T & c ) -> std::shared_ptr< typename std::remove_pointer< decltype( c.data() ) >::type >
     {
-        return std::shared_ptr< T >( a.data(), [](T*){} );
+        using value_type = typename std::remove_pointer< decltype( c.data() ) >::type;
+        return std::shared_ptr< value_type >( c.data(), [](value_type *){} );
+    }
+
+    template< typename T >
+    auto
+    shareRaw( T const & c ) -> std::shared_ptr< typename std::remove_pointer< decltype( c.data() ) >::type >
+    {
+        using value_type = typename std::remove_pointer< decltype( c.data() ) >::type;
+        return std::shared_ptr< value_type >( c.data(), [](value_type *){} );
     }
     //! @}
 } // openPMD

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -21,4 +21,5 @@
 #pragma once
 
 #include "openPMD/Series.hpp"
+#include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/version.hpp"

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -1016,7 +1016,7 @@ ADIOS1IOHandlerImpl::readDataset(Writable* writable,
     ASSERT(adios_errno == err_no_error, "Internal error: Failed to select ADIOS bounding box during dataset reading");
 
     std::string varname = concrete_bp1_file_position(writable);
-    void* data = parameters.data;
+    void* data = parameters.data.get();
 
     int status;
     status = adios_schedule_read(f,

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -688,7 +688,7 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
                                  block.data());
     ASSERT(status == 0, "Internal error: Failed to select hyperslab during dataset write");
 
-    std::shared_ptr< void > data = parameters.data;
+    std::shared_ptr< void const > data = parameters.data;
 
     //TODO Check if parameter dtype and dataset dtype match
     Attribute a(0);

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -988,7 +988,7 @@ HDF5IOHandlerImpl::readDataset(Writable* writable,
                                  block.data());
     ASSERT(status == 0, "Internal error: Failed to select hyperslab during dataset read");
 
-    void* data = parameters.data;
+    void* data = parameters.data.get();
 
     Attribute a(0);
     a.dtype = parameters.dtype;

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -499,10 +499,10 @@ TEST_CASE( "wrapper_test", "[core]" )
 #if openPMD_HAVE_INVASIVE_TESTS
     REQUIRE(*mrc2.m_isConstant);
 #endif
-    auto loadData = std::shared_ptr< double >(new double[1]);
-    mrc2.loadChunk({0}, {1}, loadData);
+    double loadData;
+    mrc2.loadChunk({0}, {1}, shareRaw(&loadData));
     o.flush();
-    REQUIRE(loadData.get()[0] == value);
+    REQUIRE(loadData == value);
     value = 43.;
     mrc2.makeConstant(value);
     std::array< double, 1 > moreData = {{ 112233. }};

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -503,7 +503,7 @@ TEST_CASE( "wrapper_test", "[core]" )
     mrc2.loadChunk({0}, {1}, loadData);
     o.flush();
     REQUIRE(loadData[0] == value);
-    value = 43;
+    value = 43.;
     mrc2.makeConstant(value);
     o.iterations[4].meshes["E"]["y"].loadChunk({0}, {1}, loadData);
     o.flush();

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -79,7 +79,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[parallel][hdf5]" )
             MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
             Offset offset{20 + rank, 20, 190};
             Extent extent{1, 3, 3};
-            std::unique_ptr< double[] > data;
+            std::shared_ptr< double > data;
             rho.loadChunk(offset, extent, data);
             double* raw_ptr = data.get();
 
@@ -93,7 +93,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[parallel][hdf5]" )
             RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
             Offset offset{(rank+1) * 5};
             Extent extent{3};
-            std::unique_ptr< double[] > data;
+            std::shared_ptr< double > data;
             electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
             double* raw_ptr = data.get();
 
@@ -209,13 +209,13 @@ TEST_CASE( "hzdr_adios_sample_content_test", "[parallel][adios1]" )
 
             Offset offset{20 + rank, 20, 150};
             Extent extent{1, 3, 3};
-            std::unique_ptr< float[] > data;
+            std::shared_ptr< float > data;
             B_z.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
             float* raw_ptr = data.get();
 
             for( int j = 0; j < 3; ++j )
                 for( int k = 0; k < 3; ++k )
-                    REQUIRE(raw_ptr[j*3 + k] == actual[rank][j][k]);
+                    REQUIRE(raw_ptr.get()[j*3 + k] == actual[rank][j][k]);
         }
     } catch (no_such_file_error& e)
     {

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -79,8 +79,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[parallel][hdf5]" )
             MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
             Offset offset{20 + rank, 20, 190};
             Extent extent{1, 3, 3};
-            std::shared_ptr< double > data;
-            rho.loadChunk(offset, extent, data);
+            auto data = rho.loadChunk<double>(offset, extent);
             double* raw_ptr = data.get();
 
             for( int j = 0; j < 3; ++j )
@@ -93,8 +92,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[parallel][hdf5]" )
             RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
             Offset offset{(rank+1) * 5};
             Extent extent{3};
-            std::shared_ptr< double > data;
-            electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+            auto data = electrons_mass.loadChunk<double>(offset, extent);
             double* raw_ptr = data.get();
 
             for( int i = 0; i < 3; ++i )
@@ -209,13 +207,12 @@ TEST_CASE( "hzdr_adios_sample_content_test", "[parallel][adios1]" )
 
             Offset offset{20 + rank, 20, 150};
             Extent extent{1, 3, 3};
-            std::shared_ptr< float > data;
-            B_z.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+            auto data = B_z.loadChunk<float>(offset, extent);
             float* raw_ptr = data.get();
 
             for( int j = 0; j < 3; ++j )
                 for( int k = 0; k < 3; ++k )
-                    REQUIRE(raw_ptr.get()[j*3 + k] == actual[rank][j][k]);
+                    REQUIRE(raw_ptr[j*3 + k] == actual[rank][j][k]);
         }
     } catch (no_such_file_error& e)
     {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -351,7 +351,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[serial][hdf5]" )
             MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
             Offset offset{20, 20, 190};
             Extent extent{3, 3, 3};
-            std::unique_ptr< double[] > data;
+            std::shared_ptr< double > data;
             rho.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
             double* raw_ptr = data.get();
 
@@ -366,7 +366,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[serial][hdf5]" )
             RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
             Offset offset{15};
             Extent extent{3};
-            std::unique_ptr< double[] > data;
+            std::shared_ptr< double > data;
             electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
             double* raw_ptr = data.get();
 
@@ -890,7 +890,7 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     for( uint64_t i = 0; i < 4; ++i )
     {
         position_local.at(0) = position_global[i];
-        e["position"]["x"].storeChunk({i}, {1}, storeRaw(position_local));
+        e["position"]["x"].storeChunk({i}, {1}, shareRaw(position_local));
         o.flush();
     }
 
@@ -903,7 +903,7 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     for( uint64_t i = 0; i < 4; ++i )
     {
         positionOffset_local[0] = positionOffset_global[i];
-        e["positionOffset"]["x"].storeChunk({i}, {1}, storeRaw(positionOffset_local));
+        e["positionOffset"]["x"].storeChunk({i}, {1}, shareRaw(positionOffset_local));
         o.flush();
     }
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -884,26 +884,26 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     std::vector< double > position_global(4);
     double pos{0.};
     std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local(new double);
-    e["position"]["x"].resetDataset(Dataset(determineDatatype(position_local), {4}));
+    std::vector< double > position_local = {0.};
+    e["position"]["x"].resetDataset(Dataset(determineDatatype<double>(), {4}));
 
     for( uint64_t i = 0; i < 4; ++i )
     {
-        *position_local = position_global[i];
-        e["position"]["x"].storeChunk({i}, {1}, position_local);
+        position_local.at(0) = position_global[i];
+        e["position"]["x"].storeChunk({i}, {1}, storeRaw(position_local));
         o.flush();
     }
 
     std::vector< uint64_t > positionOffset_global(4);
     uint64_t posOff{0};
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
-    std::shared_ptr< uint64_t > positionOffset_local(new uint64_t);
-    e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local), {4}));
+    std::array< uint64_t, 1 > positionOffset_local = {{ 0u }};
+    e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype<uint64_t>(), {4}));
 
     for( uint64_t i = 0; i < 4; ++i )
     {
-        *positionOffset_local = positionOffset_global[i];
-        e["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local);
+        positionOffset_local[0] = positionOffset_global[i];
+        e["positionOffset"]["x"].storeChunk({i}, {1}, storeRaw(positionOffset_local));
         o.flush();
     }
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -351,8 +351,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[serial][hdf5]" )
             MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
             Offset offset{20, 20, 190};
             Extent extent{3, 3, 3};
-            std::shared_ptr< double > data;
-            rho.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+            auto data = rho.loadChunk<double>(offset, extent);
             double* raw_ptr = data.get();
 
             for( int i = 0; i < 3; ++i )
@@ -366,8 +365,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[serial][hdf5]" )
             RecordComponent& electrons_mass = o.iterations[100].particles["electrons"]["mass"][RecordComponent::SCALAR];
             Offset offset{15};
             Extent extent{3};
-            std::shared_ptr< double > data;
-            electrons_mass.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+            auto data = electrons_mass.loadChunk<double>(offset, extent);
             double* raw_ptr = data.get();
 
             for( int i = 0; i < 3; ++i )
@@ -947,13 +945,12 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
     ParticleSpecies& e_2 = o.iterations[2].particles["e"];
 
     std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local_2(new double);
-    e_2["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_2), {4}));
+    e_2["position"]["x"].resetDataset(Dataset(determineDatatype<double>(), {4}));
 
     for( uint64_t i = 0; i < 4; ++i )
     {
-        *position_local_2 = position_global[i];
-        e_2["position"]["x"].storeChunk({i}, {1}, position_local_2);
+        double const position_local_2 = position_global.at(i);
+        e_2["position"]["x"].storeChunk({i}, {1}, shareRaw(&position_local_2));
         o.flush();
     }
 
@@ -1515,8 +1512,7 @@ TEST_CASE( "hzdr_adios1_sample_content_test", "[serial][adios1]" )
                                      {7.3689453e-06f, 7.3689453e-06f, 7.3689453e-06f}}};
         Offset offset{20, 20, 150};
         Extent extent{3, 3, 3};
-        std::unique_ptr< float[] > data;
-        B_z.loadChunk(offset, extent, data, RecordComponent::Allocation::API);
+        auto data = B_z.loadChunk(offset, extent);
         float* raw_ptr = data.get();
 
         for( int i = 0; i < 3; ++i )

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -746,7 +746,7 @@ TEST_CASE( "hzdr_hdf5_sample_content_test", "[serial][hdf5]" )
         REQUIRE(e_extent_z.unitSI() == 2.599999993753294e-07);
         REQUIRE(e_extent_z.getDatatype() == Datatype::UINT64);
 
-        std::unique_ptr< uint64_t > data;
+        std::shared_ptr< uint64_t > data;
         e_extent_z.load(0, data);
         o.flush();
         REQUIRE(*data == static_cast< uint64_t >(80));


### PR DESCRIPTION
Quick & dirty draft to share raw pointers for read & write.

Related to #140

### To Do

- [x] add docstrings
- [x] add tests
- [x] loadChunk: also a `shared_ptr` data interface, separate out allocation API
- [x] move helpers into own header
- [x] ~unit tests for reference counts of `shared_ptr`s~ deferred to #211