### PR TITLE
Replace boost.filesystem

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -111,7 +111,7 @@ install:
   - cmd: conda config --add channels conda-forge
 
   # Configure the VM.
-  - cmd: conda install -n root --quiet --yes cmake boost-cpp pybind11 hdf5
+  - cmd: conda install -n root --quiet --yes cmake pybind11 hdf5
 
 before_build:
   - cmd: cd C:\projects\openpmd-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -232,7 +232,7 @@ install:
       export MODULEPATH=$SPACK_ROOT/share/spack/modules/$(spack arch):$MODULEPATH;
     fi
   - SPACK_VAR_MPI="~mpi";
-  # required dependencies - CMake 3.10.0 & Boost 1.62.0
+  # required dependencies - CMake 3.10.0
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       if [ ! -f $HOME/.cache/cmake-3.10.0/bin/cmake ]; then
         wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.sh &&
@@ -255,11 +255,6 @@ install:
   # diagnostics: modules created and visible?
   - module av
   - module li
-  - SPACK_BOOST_VAR="~atomic~chrono~date_time~graph~iostreams~locale~math~program_options~random~regex~serialization~signals+filesystem+system~test~timer~wave"
-  - travis_wait spack install
-      boost@1.65.0$SPACK_BOOST_VAR
-      $COMPILERSPEC
-  - spack load boost@1.65.0$SPACK_BOOST_VAR $COMPILERSPEC
   # optional dependencies - MPI, HDF5, ADIOS1, ADIOS2
   - if [ $USE_MPI == "ON" ]; then
       travis_wait spack install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,6 @@ include(CTest)
 
 # Dependencies ################################################################
 #
-# external library: Boost (mandatory)
-find_package(Boost 1.62.0 REQUIRED
-    COMPONENTS system filesystem)
-
 # external library: MPI (optional)
 if(openPMD_USE_MPI STREQUAL AUTO)
     find_package(MPI)
@@ -256,15 +252,6 @@ if(BUILD_TESTING)
         find_package(Catch2 2.2.1 CONFIG REQUIRED)
         message(STATUS "Catch2: Found version ${Catch2_VERSION}")
     endif()
-endif()
-
-if(TARGET Boost::filesystem)
-    target_link_libraries(openPMD PUBLIC
-        Boost::boost Boost::system Boost::filesystem)
-else()
-    target_link_libraries(openPMD PUBLIC
-        ${Boost_LIBRARIES})
-    target_include_directories(openPMD SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 endif()
 
 if(openPMD_HAVE_MPI)
@@ -457,8 +444,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     endif()
     string(CONCAT CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} "
             "-Wno-unknown-pragmas")
-    # silence BOOST filesystem
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cpp")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Warning C4503: "decorated name length exceeded, name was truncated"
     # Symbols longer than 4096 chars are truncated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,24 +210,6 @@ set(IO_SOURCE
         src/IO/HDF5/HDF5IOHandler.cpp
         src/IO/HDF5/ParallelHDF5IOHandler.cpp)
 
-if(WIN32)
-    set(TARGET_PLATFORM "WIN32")
-    set_property(
-            SOURCE src/auxiliary/Filesystem.cpp
-            APPEND
-            PROPERTY COMPILE_DEFINITIONS
-            WIN32=1
-    )
-else()
-    set(TARGET_PLATFORM "UNIX")
-    set_property(
-            SOURCE src/auxiliary/Filesystem.cpp
-            APPEND
-            PROPERTY COMPILE_DEFINITIONS
-            UNIX=1
-    )
-endif()
-
 # library
 add_library(openPMD ${CORE_SOURCE} ${IO_SOURCE})
 
@@ -406,8 +388,6 @@ endif()
 if(BUILD_TESTING)
     foreach(testname ${openPMD_TEST_NAMES})
         add_executable(${testname}Tests test/${testname}Test.cpp)
-
-        target_compile_definitions(${testname}Tests PUBLIC "-D${TARGET_PLATFORM}=1")
 
         if(openPMD_HAVE_INVASIVE_TESTS)
             target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_INVASIVE_TESTS=1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ set(CORE_SOURCE
         src/Record.cpp
         src/RecordComponent.cpp
         src/Series.cpp
+        src/auxiliary/Filesystem.cpp
         src/backend/Attributable.cpp
         src/backend/BaseRecordComponent.cpp
         src/backend/MeshRecordComponent.cpp
@@ -208,6 +209,24 @@ set(IO_SOURCE
         src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
         src/IO/HDF5/HDF5IOHandler.cpp
         src/IO/HDF5/ParallelHDF5IOHandler.cpp)
+
+if(WIN32)
+    set(TARGET_PLATFORM "WIN32")
+    set_property(
+            SOURCE src/auxiliary/Filesystem.cpp
+            APPEND
+            PROPERTY COMPILE_DEFINITIONS
+            WIN32=1
+    )
+else()
+    set(TARGET_PLATFORM "UNIX")
+    set_property(
+            SOURCE src/auxiliary/Filesystem.cpp
+            APPEND
+            PROPERTY COMPILE_DEFINITIONS
+            UNIX=1
+    )
+endif()
 
 # library
 add_library(openPMD ${CORE_SOURCE} ${IO_SOURCE})
@@ -387,9 +406,13 @@ endif()
 if(BUILD_TESTING)
     foreach(testname ${openPMD_TEST_NAMES})
         add_executable(${testname}Tests test/${testname}Test.cpp)
+
+        target_compile_definitions(${testname}Tests PUBLIC "-D${TARGET_PLATFORM}=1")
+
         if(openPMD_HAVE_INVASIVE_TESTS)
             target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_INVASIVE_TESTS=1")
         endif()
+
         if(openPMD_HAVE_MPI)
             target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_MPI=1")
         else()

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Our manual shows full [read & write examples](https://openpmd-api.readthedocs.io
 
 Required:
 * CMake 3.10.0+
-* Boost 1.62.0+: `filesystem`, `system`
 * C++11 capable compiler, e.g. g++ 4.9+, clang 3.9+
 
 Shipped internally:

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -40,7 +40,6 @@ The following options can be tried to switch between static and shared builds an
 CMake Option                   Values          Description
 ============================== =============== ==================================================
 ``BUILD_SHARED_LIBS``          ON/**OFF**      Build the C++ API as shared library
-``Boost_USE_STATIC_LIBS``      ON/**OFF**      Require static Boost library
 ``HDF5_USE_STATIC_LIBRARIES``  ON/**OFF**      Require static HDF5 library
 ``ADIOS_USE_STATIC_LIBRARIES`` ON/**OFF**      Require static ADIOS1 library
 ============================== =============== ==================================================

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -12,7 +12,6 @@ Required
 --------
 
 * CMake 3.10.0+
-* Boost 1.62.0+: ``filesystem``, ``system``
 * C++11 capable compiler, e.g. g++ 4.9+, clang 3.9+
 
 Shipped internally

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -1,7 +1,7 @@
 #include <openPMD/openPMD.hpp>
 
+#include <algorithm>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 
 using namespace openPMD;

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -28,10 +28,10 @@
 #   include <mpi.h>
 #endif
 
-#include <stdexcept>
-#include <memory>
 #include <future>
+#include <memory>
 #include <queue>
+#include <stdexcept>
 #include <string>
 
 

--- a/include/openPMD/auxiliary/Filesystem.hpp
+++ b/include/openPMD/auxiliary/Filesystem.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2018 Fabian Koller
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace openPMD
+{
+namespace auxiliary
+{
+bool
+path_exists( std::string const& path );
+
+bool
+file_exists( std::string const& path );
+
+std::vector< std::string >
+list_directory(std::string const& path );
+
+void
+create_directories( std::string const& path );
+
+void
+remove_file( std::string const& path );
+} // auxiliary
+} // openPMD

--- a/include/openPMD/auxiliary/Filesystem.hpp
+++ b/include/openPMD/auxiliary/Filesystem.hpp
@@ -27,19 +27,59 @@ namespace openPMD
 {
 namespace auxiliary
 {
+/** Check if a directory exists at a give absolute or relative path.
+ *
+ * @param   path    Absolute or relative path to examine.
+ * @return  true if the given path or file status corresponds to an existing directory, false otherwise.
+ */
 bool
-path_exists( std::string const& path );
+directory_exists(std::string const& path);
 
+/** Check if a file exists at a given absolute or relative path.
+ *
+ * @param   path    Absolute or relative path to examine.
+ * @return  true if the given path or file status corresponds to an existing file, false otherwise.
+ */
 bool
-file_exists( std::string const& path );
+file_exists(std::string const& path);
 
+/** List all contents of a directory at a given absolute or relative path.
+ *
+ * @note    The equivalent of `ls path`
+ * @note    Both contained files and directories are listed.
+ *          `.` and `..` are not returned.
+ * @throw   std::system_error when the given path is not a valid directory.
+ * @param   path    Absolute or relative path of directory to examine.
+ * @return  Vector of all contained files and directories.
+ */
 std::vector< std::string >
 list_directory(std::string const& path );
 
-void
-create_directories( std::string const& path );
+/** Create all required directories to have a reachable given absolute or relative path.
+ *
+ * @note    The equivalent of `mkdir -p path`
+ * @param   path    Absolute or relative path to the new directory to create.
+ * @return  true if a directory was created for the directory p resolves to, false otherwise.
+ */
+bool
+create_directories(std::string const& path);
 
-void
-remove_file( std::string const& path );
+/** Remove the directory identified by the given path.
+ *
+ * @note    The equivalent of `rm -r path`.
+ * @param   path    Absolute or relative path to the directory to delete.
+ * @return  true if the directory was deleted, false otherwise and if it did not exist.
+ */
+bool
+remove_directory(std::string const& path);
+
+/** Remove the file identified by the given path.
+ *
+ * @note    The equivalent of `rm path`.
+ * @param   path    Absolute or relative path to the file to delete.
+ * @return  true if the file was deleted, false otherwise and if it did not exist.
+ */
+bool
+remove_file(std::string const& path);
 } // auxiliary
 } // openPMD

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -39,23 +39,41 @@ contains(std::string const &s,
 }
 
 inline bool
+contains(std::string const &s,
+         char const infix)
+{
+    return s.find(infix) != std::string::npos;
+}
+
+inline bool
 starts_with(std::string const &s,
             std::string const &prefix)
 {
-    if( s.size() >= prefix.size() )
-        return (0 == s.compare(0, prefix.size(), prefix));
-    else
-        return false;
+    return (s.size() >= prefix.size()) &&
+           (0 == s.compare(0, prefix.size(), prefix));
+}
+
+inline bool
+starts_with(std::string const &s,
+            char const prefix)
+{
+    return !s.empty() &&
+           s[0] == prefix;
 }
 
 inline bool
 ends_with(std::string const &s,
           std::string const &suffix)
 {
-    if( s.size() >= suffix.size() )
-        return (0 == s.compare(s.size() - suffix.size(), suffix.size(), suffix));
-    else
-        return false;
+    return (s.size() >= suffix.size()) &&
+           (0 == s.compare(s.size() - suffix.size(), suffix.size(), suffix));
+}
+
+inline bool
+ends_with(std::string const &s,
+          char const suffix)
+{
+    return !s.empty() && s.back() == suffix;
 }
 
 inline std::string

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -2,8 +2,6 @@
 #   https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-a-package-configuration-file
 include(CMakeFindDependencyMacro)
 
-find_dependency(Boost)
-
 set(openPMD_HAVE_MPI @openPMD_HAVE_MPI@)
 if(openPMD_HAVE_MPI)
     find_dependency(MPI)

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -349,9 +349,9 @@ ADIOS1IOHandlerImpl::createPath(Writable* writable,
     {
         /* Sanitize path */
         std::string path = parameters.path;
-        if( auxiliary::starts_with(path, "/") )
+        if( auxiliary::starts_with(path, '/') )
             path = auxiliary::replace_first(path, "/", "");
-        if( !auxiliary::ends_with(path, "/") )
+        if( !auxiliary::ends_with(path, '/') )
             path += '/';
 
         /* ADIOS has no concept for explicitly creating paths.
@@ -393,9 +393,9 @@ ADIOS1IOHandlerImpl::createDataset(Writable* writable,
 
         /* Sanitize name */
         std::string name = parameters.name;
-        if( auxiliary::starts_with(name, "/") )
+        if( auxiliary::starts_with(name, '/') )
             name = auxiliary::replace_first(name, "/", "");
-        if( auxiliary::ends_with(name, "/") )
+        if( auxiliary::ends_with(name, '/') )
             name = auxiliary::replace_first(name, "/", "");
 
         std::string path = concrete_bp1_file_position(writable) + name;
@@ -496,9 +496,9 @@ ADIOS1IOHandlerImpl::openPath(Writable* writable,
 {
     /* Sanitize path */
     std::string path = parameters.path;
-    if( auxiliary::starts_with(path, "/") )
+    if( auxiliary::starts_with(path, '/') )
         path = auxiliary::replace_first(path, "/", "");
-    if( !auxiliary::ends_with(path, "/") )
+    if( !auxiliary::ends_with(path, '/') )
         path += '/';
 
     writable->written = true;
@@ -523,7 +523,7 @@ ADIOS1IOHandlerImpl::openDataset(Writable* writable,
 
     /* Sanitize name */
     std::string name = parameters.name;
-    if( auxiliary::starts_with(name, "/") )
+    if( auxiliary::starts_with(name, '/') )
         name = auxiliary::replace_first(name, "/", "");
 
     std::string datasetname = concrete_bp1_file_position(writable) + name;
@@ -952,7 +952,7 @@ ADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
     }
 
     std::string name = concrete_bp1_file_position(writable);
-    if( !auxiliary::ends_with(name, "/") )
+    if( !auxiliary::ends_with(name, '/') )
         name += '/';
     name += parameters.name;
 
@@ -1034,7 +1034,7 @@ ADIOS1IOHandlerImpl::readAttribute(Writable* writable,
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
 
     std::string attrname = concrete_bp1_file_position(writable);
-    if( !auxiliary::ends_with(attrname, "/") )
+    if( !auxiliary::ends_with(attrname, '/') )
         attrname += "/";
     attrname += parameters.name;
 
@@ -1412,7 +1412,7 @@ ADIOS1IOHandlerImpl::listAttributes(Writable* writable,
 
     std::string name = concrete_bp1_file_position(writable);
 
-    if( !auxiliary::ends_with(name, "/") )
+    if( !auxiliary::ends_with(name, '/') )
     {
         /* writable is a dataset and corresponds to an ADIOS variable */
         ADIOS_VARINFO* info;

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -21,11 +21,12 @@
 #include "openPMD/IO/ADIOS/ADIOS1IOHandler.hpp"
 
 #if openPMD_HAVE_ADIOS1
+#   include "openPMD/auxiliary/Filesystem.hpp"
 #   include "openPMD/auxiliary/Memory.hpp"
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
-#   include <boost/filesystem.hpp>
+#   include <cstring>
 #   include <iostream>
 #   include <memory>
 #endif
@@ -320,10 +321,8 @@ ADIOS1IOHandlerImpl::createFile(Writable* writable,
 
     if( !writable->written )
     {
-        using namespace boost::filesystem;
-        path dir(m_handler->directory);
-        if( !exists(dir) )
-            create_directories(dir);
+        if( !auxiliary::directory_exists(m_handler->directory) )
+            auxiliary::create_directories(m_handler->directory);
 
         std::string name = m_handler->directory + parameters.name;
         if( !auxiliary::ends_with(name, ".bp") )
@@ -457,9 +456,7 @@ void
 ADIOS1IOHandlerImpl::openFile(Writable* writable,
                               Parameter< Operation::OPEN_FILE > const& parameters)
 {
-    using namespace boost::filesystem;
-    path dir(m_handler->directory);
-    if( !exists(dir) )
+    if( !auxiliary::directory_exists(m_handler->directory) )
         throw no_such_file_error("Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.name;
@@ -622,12 +619,10 @@ ADIOS1IOHandlerImpl::deleteFile(Writable* writable,
         if( !auxiliary::ends_with(name, ".bp") )
             name += ".bp";
 
-        namespace bf = boost::filesystem;
-        bf::path file(name);
-        if( !bf::exists(file) )
+        if( !auxiliary::file_exists(name) )
             throw std::runtime_error("File does not exist: " + name);
 
-        bf::remove(file);
+        auxiliary::remove_file(name);
 
         writable->written = false;
         writable->abstractFilePosition.reset();

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -24,8 +24,7 @@
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
-#   include <boost/filesystem.hpp>
-#   include <cstdlib>
+#   include <cstring>
 #endif
 
 namespace openPMD

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -22,12 +22,12 @@
 
 
 #if openPMD_HAVE_HDF5
+#   include "openPMD/auxiliary/Filesystem.hpp"
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/backend/Attribute.hpp"
 #   include "openPMD/IO/IOTask.hpp"
 #   include "openPMD/IO/HDF5/HDF5Auxiliary.hpp"
 #   include "openPMD/IO/HDF5/HDF5FilePosition.hpp"
-#   include <boost/filesystem.hpp>
 #endif
 
 #include <future>
@@ -99,10 +99,8 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
 
     if( !writable->written )
     {
-        using namespace boost::filesystem;
-        path dir(m_handler->directory);
-        if( !exists(dir) )
-            create_directories(dir);
+        if( !auxiliary::path_exists(m_handler->directory) )
+            auxiliary::create_directories(m_handler->directory);
 
         std::string name = m_handler->directory + parameters.name;
         if( !auxiliary::ends_with(name, ".h5") )
@@ -343,9 +341,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     //TODO check if file already open
     //not possible with current implementation
     //quick idea - map with filenames as key
-    using namespace boost::filesystem;
-    path dir(m_handler->directory);
-    if( !exists(dir) )
+    if( !auxiliary::path_exists(m_handler->directory) )
         throw no_such_file_error("Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.name;
@@ -520,12 +516,10 @@ HDF5IOHandlerImpl::deleteFile(Writable* writable,
         if( !auxiliary::ends_with(name, ".h5") )
             name += ".h5";
 
-        using namespace boost::filesystem;
-        path file(name);
-        if( !exists(file) )
+        if( !auxiliary::file_exists(name) )
             throw std::runtime_error("File does not exist: " + name);
 
-        remove(file);
+        auxiliary::remove_file(name);
 
         writable->written = false;
         writable->abstractFilePosition.reset();

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -136,9 +136,9 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
     {
         /* Sanitize path */
         std::string path = parameters.path;
-        if( auxiliary::starts_with(path, "/") )
+        if( auxiliary::starts_with(path, '/') )
             path = auxiliary::replace_first(path, "/", "");
-        if( !auxiliary::ends_with(path, "/") )
+        if( !auxiliary::ends_with(path, '/') )
             path += '/';
 
         /* Open H5Object to write into */
@@ -194,9 +194,9 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
     {
         /* Sanitize name */
         std::string name = parameters.name;
-        if( auxiliary::starts_with(name, "/") )
+        if( auxiliary::starts_with(name, '/') )
             name = auxiliary::replace_first(name, "/", "");
-        if( auxiliary::ends_with(name, "/") )
+        if( auxiliary::ends_with(name, '/') )
             name = auxiliary::replace_first(name, "/", "");
 
         /* Open H5Object to write into */
@@ -311,9 +311,9 @@ HDF5IOHandlerImpl::extendDataset(Writable* writable,
 
     /* Sanitize name */
     std::string name = parameters.name;
-    if( auxiliary::starts_with(name, "/") )
+    if( auxiliary::starts_with(name, '/') )
         name = auxiliary::replace_first(name, "/", "");
-    if( !auxiliary::ends_with(name, "/") )
+    if( !auxiliary::ends_with(name, '/') )
         name += '/';
 
     dataset_id = H5Dopen(node_id,
@@ -385,9 +385,9 @@ HDF5IOHandlerImpl::openPath(Writable* writable,
 
     /* Sanitize path */
     std::string path = parameters.path;
-    if( auxiliary::starts_with(path, "/") )
+    if( auxiliary::starts_with(path, '/') )
         path = auxiliary::replace_first(path, "/", "");
-    if( !auxiliary::ends_with(path, "/") )
+    if( !auxiliary::ends_with(path, '/') )
         path += '/';
 
     path_id = H5Gopen(node_id,
@@ -421,9 +421,9 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
 
     /* Sanitize name */
     std::string name = parameters.name;
-    if( auxiliary::starts_with(name, "/") )
+    if( auxiliary::starts_with(name, '/') )
         name = auxiliary::replace_first(name, "/", "");
-    if( !auxiliary::ends_with(name, "/") )
+    if( !auxiliary::ends_with(name, '/') )
         name += '/';
 
     dataset_id = H5Dopen(node_id,
@@ -541,9 +541,9 @@ HDF5IOHandlerImpl::deletePath(Writable* writable,
     {
         /* Sanitize path */
         std::string path = parameters.path;
-        if( auxiliary::starts_with(path, "/") )
+        if( auxiliary::starts_with(path, '/') )
             path = auxiliary::replace_first(path, "/", "");
-        if( !auxiliary::ends_with(path, "/") )
+        if( !auxiliary::ends_with(path, '/') )
             path += '/';
 
         /* Open H5Object to delete in
@@ -585,9 +585,9 @@ HDF5IOHandlerImpl::deleteDataset(Writable* writable,
     {
         /* Sanitize name */
         std::string name = parameters.name;
-        if( auxiliary::starts_with(name, "/") )
+        if( auxiliary::starts_with(name, '/') )
             name = auxiliary::replace_first(name, "/", "");
-        if( !auxiliary::ends_with(name, "/") )
+        if( !auxiliary::ends_with(name, '/') )
             name += '/';
 
         /* Open H5Object to delete in

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -99,7 +99,7 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
 
     if( !writable->written )
     {
-        if( !auxiliary::path_exists(m_handler->directory) )
+        if( !auxiliary::directory_exists(m_handler->directory) )
             auxiliary::create_directories(m_handler->directory);
 
         std::string name = m_handler->directory + parameters.name;
@@ -341,7 +341,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     //TODO check if file already open
     //not possible with current implementation
     //quick idea - map with filenames as key
-    if( !auxiliary::path_exists(m_handler->directory) )
+    if( !auxiliary::directory_exists(m_handler->directory) )
         throw no_such_file_error("Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.name;

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -30,6 +30,7 @@
 #   include "openPMD/IO/HDF5/HDF5FilePosition.hpp"
 #endif
 
+#include <cstring>
 #include <future>
 #include <iostream>
 #include <string>
@@ -1171,7 +1172,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
             {
                 char* m0 = H5Tget_member_name(attr_type, 0);
                 char* m1 = H5Tget_member_name(attr_type, 1);
-                if( (strcmp("TRUE" , m0) == 0) && (strcmp("FALSE", m1) == 0) )
+                if( (strncmp("TRUE" , m0, 4) == 0) && (strncmp("FALSE", m1, 5) == 0) )
                     attrIsBool = true;
                 H5free_memory(m1);
                 H5free_memory(m0);

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -22,10 +22,6 @@
 
 #if openPMD_HAVE_MPI
 #   include <mpi.h>
-#   if openPMD_HAVE_HDF5
-#       include "openPMD/auxiliary/StringManip.hpp"
-#       include <boost/filesystem.hpp>
-#   endif
 #endif
 
 #include <iostream>
@@ -34,7 +30,6 @@
 namespace openPMD
 {
 #if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
-#   include "openPMD/auxiliary/StringManip.hpp"
 #   ifdef DEBUG
 #       define ASSERT(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error(std::string((TEXT))); }
 #   else

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -245,7 +245,7 @@ Series::setMeshesPath(std::string const& mp)
                     [](Container< Iteration, uint64_t >::value_type const& i){ return i.second.meshes.written; }) )
         throw std::runtime_error("A files meshesPath can not (yet) be changed after it has been written.");
 
-    if( auxiliary::ends_with(mp, "/") )
+    if( auxiliary::ends_with(mp, '/') )
         setAttribute("meshesPath", mp);
     else
         setAttribute("meshesPath", mp + "/");
@@ -266,7 +266,7 @@ Series::setParticlesPath(std::string const& pp)
                     [](Container< Iteration, uint64_t >::value_type const& i){ return i.second.particles.written; }) )
         throw std::runtime_error("A files particlesPath can not (yet) be changed after it has been written.");
 
-    if( auxiliary::ends_with(pp, "/") )
+    if( auxiliary::ends_with(pp, '/') )
         setAttribute("particlesPath", pp);
     else
         setAttribute("particlesPath", pp + "/");

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -526,7 +526,7 @@ Series::readFileBased()
     Parameter< Operation::OPEN_FILE > fOpen;
     Parameter< Operation::READ_ATT > aRead;
 
-    if( !auxiliary::path_exists(IOHandler->directory) )
+    if( !auxiliary::directory_exists(IOHandler->directory) )
         throw no_such_file_error("Supplied directory is not valid: " + IOHandler->directory);
     auto isPartOfSeries = matcher(*m_name, *m_format);
     for( auto const& entry : auxiliary::list_directory(IOHandler->directory) )

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -18,11 +18,10 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+#include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/Series.hpp"
-
-#include <boost/filesystem.hpp>
 
 #include <iostream>
 #include <regex>
@@ -527,16 +526,14 @@ Series::readFileBased()
     Parameter< Operation::OPEN_FILE > fOpen;
     Parameter< Operation::READ_ATT > aRead;
 
-    using namespace boost::filesystem;
-    path dir = path(IOHandler->directory);
-    if( !exists(dir) )
+    if( !auxiliary::path_exists(IOHandler->directory) )
         throw no_such_file_error("Supplied directory is not valid: " + IOHandler->directory);
     auto isPartOfSeries = matcher(*m_name, *m_format);
-    for( path const& entry : directory_iterator(dir) )
+    for( auto const& entry : auxiliary::list_directory(IOHandler->directory) )
     {
-        if( isPartOfSeries(entry.filename().string()) )
+        if( isPartOfSeries(entry) )
         {
-            fOpen.name = entry.filename().string();
+            fOpen.name = entry;
             IOHandler->enqueue(IOTask(this, fOpen));
             IOHandler->flush();
             iterations.parent = getWritable(this);

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -106,7 +106,9 @@ create_directories( std::string const& path )
     auto mk = [](std::string const& p) -> bool { return CreateDirectory(p.c_str(), nullptr); };
 #else
     char seperator = '/';
-    auto mk = [](std::string const& p) -> bool { return (0 == mkdir(p.c_str(), 0777));};
+    mode_t mask = umask(0);
+    umask(mask);
+    auto mk = [mask](std::string const& p) -> bool { return (0 == mkdir(p.c_str(), 0777 & ~mask));};
 #endif
     std::istringstream ss(path);
     std::string token;

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -20,9 +20,9 @@
  */
 #include "openPMD/auxiliary/Filesystem.hpp"
 
-#if WIN32
+#ifdef _WIN32
 #   include <windows.h>
-#elif UNIX
+#else
 #   include <cstring>
 #   include <sys/stat.h>
 #   include <sys/types.h>
@@ -41,12 +41,12 @@ bool
 directory_exists(std::string const& path)
 {
     bool exists = false;
-#if WIN32
+#ifdef _WIN32
     DWORD attributes = GetFileAttributes(path.c_str());
 
     exists = (attributes != INVALID_FILE_ATTRIBUTES &&
              (attributes & FILE_ATTRIBUTE_DIRECTORY));
-#elif UNIX
+#else
     struct stat s;
     bool success = (stat(path.c_str(), &s) == 0);
     exists = success && S_ISDIR(s.st_mode);
@@ -58,12 +58,12 @@ bool
 file_exists( std::string const& path )
 {
     bool exists = false;
-#if WIN32
+#ifdef _WIN32
     DWORD attributes = GetFileAttributes(path.c_str());
 
     exists = (attributes != INVALID_FILE_ATTRIBUTES &&
              !(attributes & FILE_ATTRIBUTE_DIRECTORY));
-#elif UNIX
+#else
     struct stat s;
     bool success = (stat(path.c_str(), &s) == 0);
     exists = success && S_ISREG(s.st_mode);
@@ -75,7 +75,7 @@ std::vector< std::string >
 list_directory(std::string const& path )
 {
   std::vector< std::string > ret;
-#if WIN32
+#ifdef _WIN32
     std::string pattern(path);
     pattern.append("\\*");
     WIN32_FIND_DATA data;
@@ -86,7 +86,7 @@ list_directory(std::string const& path )
         } while (FindNextFile(hFind, &data) != 0);
         FindClose(hFind);
     }
-#elif UNIX
+#else
     auto directory = opendir(path.c_str());
     if( !directory )
         throw std::system_error(std::error_code(errno, std::system_category()));
@@ -106,9 +106,9 @@ create_directories( std::string const& path )
         return true;
 
     bool success = false;
-#if WIN32
+#ifdef _WIN32
     success = CreateDirectory(path.c_str(), NULL);
-#elif UNIX
+#else
     success = (mkdir(path.c_str(), 0777) == 0);
 #endif
     return success;
@@ -121,9 +121,9 @@ remove_directory( std::string const& path )
         return false;
 
     bool success = false;
-#if WIN32
+#ifdef _WIN32
     success = RemoveDirectory(path.c_str());
-#elif UNIX
+#else
     success = (remove(path.c_str()) == 0);
 #endif
     return success;
@@ -136,9 +136,9 @@ remove_file( std::string const& path )
       return false;
 
     bool success = false;
-#if WIN32
+#ifdef _WIN32
     success = DeleteFile(path.c_str());
-#elif UNIX
+#else
     success = (remove(path.c_str()) == 0);
 #endif
     return success;

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -1,0 +1,110 @@
+/* Copyright 2018 Fabian Koller
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "openPMD/auxiliary/Filesystem.hpp"
+
+#if WIN32
+#   include <windows.h>
+#elif UNIX
+#   include <cstring>
+#   include <sys/stat.h>
+#   include <sys/types.h>
+#   include <dirent.h>
+#endif
+
+#include <stdexcept>
+
+namespace openPMD
+{
+namespace auxiliary
+{
+bool
+path_exists( std::string const& path )
+{
+    bool exists = false;
+#if WIN32
+    DWORD attributes = GetFileAttributes(path.c_str());
+
+    exists = (attributes != INVALID_FILE_ATTRIBUTES &&
+             (attributes & FILE_ATTRIBUTE_DIRECTORY));
+#elif UNIX
+    struct stat s;
+    bool success = (stat(path.c_str(), &s) == 0);
+    exists = success && S_ISDIR(s.st_mode);
+#endif
+    return exists;
+}
+
+bool
+file_exists( std::string const& path )
+{
+    bool exists = false;
+#if WIN32
+    DWORD attributes = GetFileAttributes(path.c_str());
+
+    exists = (attributes != INVALID_FILE_ATTRIBUTES &&
+             !(attributes & FILE_ATTRIBUTE_DIRECTORY));
+#elif UNIX
+    struct stat s;
+    bool success = (stat(path.c_str(), &s) == 0);
+    exists = success && S_ISREG(s.st_mode);
+#endif
+    return exists;
+}
+
+std::vector< std::string >
+list_directory(std::string const& path )
+{
+  std::vector< std::string > ret;
+#if WIN32
+    std::string pattern(path);
+    pattern.append("\\*");
+    WIN32_FIND_DATA data;
+    HANDLE hFind;
+    if ((hFind = FindFirstFile(pattern.c_str(), &data)) != INVALID_HANDLE_VALUE) {
+        do {
+            ret.push_back(data.cFileName);
+        } while (FindNextFile(hFind, &data) != 0);
+        FindClose(hFind);
+    }
+#elif UNIX
+    auto directory = opendir(path.c_str());
+    dirent* entry;
+    while ((entry = readdir(directory)) != nullptr)
+        if( strncmp(entry->d_name, ".", 1) && strncmp(entry->d_name, "..", 2) )
+            ret.emplace_back(entry->d_name);
+    closedir(directory);
+#endif
+    return ret;
+}
+
+void
+create_directories( std::string const& path )
+{
+    throw std::runtime_error("Not yet implemented");
+}
+
+void
+remove_file( std::string const& path )
+{
+    throw std::runtime_error("Not yet implemented");
+}
+} // auxiliary
+} // openPMD

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -377,8 +377,8 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(directory_exists("C:\\Windows"));
     REQUIRE(!directory_exists("C:\\nonexistent_folder_in_C_drive"));
 
-    REQUIRE(file_exists(".\\AuxiliaryTests.exe"));
-    REQUIRE(!file_exists(".\\nonexistent_file_in_cmake_bin_directory.exe"));
+    REQUIRE(file_exists("AuxiliaryTests.exe"));
+    REQUIRE(!file_exists("nonexistent_file_in_cmake_bin_directory.exe"));
 
     auto dir_entries = list_directory("C:\\");
     REQUIRE(!dir_entries.empty());

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -24,10 +24,11 @@ using namespace openPMD;
 
 #include <catch/catch.hpp>
 
-#include <string>
-#include <vector>
 #include <array>
 #include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
 
 
 namespace openPMD
@@ -377,8 +378,11 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(directory_exists("C:\\Windows"));
     REQUIRE(!directory_exists("C:\\nonexistent_folder_in_C_drive"));
 
-    REQUIRE(file_exists("AuxiliaryTests.exe"));
-    REQUIRE(!file_exists("nonexistent_file_in_cmake_bin_directory.exe"));
+    auto entries = list_directory(".");
+    for( auto const& entry : entries )
+        std::cout << entry << std::endl;
+    //REQUIRE(file_exists("AuxiliaryTests.exe"));
+    //REQUIRE(!file_exists("nonexistent_file_in_cmake_bin_directory.exe"));
 
     auto dir_entries = list_directory("C:\\");
     REQUIRE(!dir_entries.empty());

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -375,6 +375,43 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(path_exists("C:\\Program Files"));
     REQUIRE(path_exists("C:\\Windows"));
     REQUIRE(!path_exists("C:\\nonexistent_folder_in_C_drive"));
+
+    REQUIRE(file_exists(".\\AuxiliaryTests.exe"));
+    REQUIRE(!file_exists(".\\nonexistent_file_in_cmake_bin_directory.exe"));
+
+    auto dir_entries = list_directory("C:\\");
+    REQUIRE(!dir_entries.empty());
+    REQUIRE(contains(dir_entries, "Program Files"));
+    REQUIRE(contains(dir_entries, "Windows"));
+    REQUIRE(!contains(dir_entries, "nonexistent_folder_in_C_drive"));
+
+    std::string new_directory = random_string(10);
+    while( directory_exists(new_directory) )
+        new_directory = random_string(10);
+    REQUIRE(create_directories(new_directory));
+    REQUIRE(create_directories(new_directory));
+    REQUIRE(directory_exists(new_directory));
+
+    REQUIRE(remove_directory(new_directory));
+    REQUIRE(!directory_exists(new_directory));
+    REQUIRE(!remove_directory(new_directory));
+
+    REQUIRE(!remove_file(".\\nonexistent_file_in_cmake_bin_directory"));
+    dir_entries = list_directory("..\\CMakeFiles");
+    if( !dir_entries.empty() )
+    {
+        std::string del = "..\\CMakeFiles\\" + *dir_entries.begin();
+        while( !file_exists(del) && directory_exists(del) )
+        {
+            dir_entries = list_directory(del);
+            del += "\\" + *dir_entries.begin();
+        }
+        if( file_exists(del) )
+        {
+            REQUIRE(remove_file(del));
+            REQUIRE(!file_exists(del));
+        }
+    }
 #elif UNIX
     REQUIRE(directory_exists("/"));
     REQUIRE(directory_exists("/boot"));

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -51,17 +51,17 @@ TEST_CASE( "string_test", "[auxiliary]" )
 
     std::string s = "Man muss noch Chaos in sich haben, "
                     "um einen tanzenden Stern gebaeren zu koennen.";
-    REQUIRE(starts_with(s, "M"));
+    REQUIRE(starts_with(s, 'M'));
     REQUIRE(starts_with(s, "Man"));
     REQUIRE(starts_with(s, "Man muss noch"));
-    REQUIRE(!starts_with(s, " "));
+    REQUIRE(!starts_with(s, ' '));
 
-    REQUIRE(ends_with(s, "."));
+    REQUIRE(ends_with(s, '.'));
     REQUIRE(ends_with(s, "koennen."));
     REQUIRE(ends_with(s, "gebaeren zu koennen."));
 
-    REQUIRE(contains(s, "M"));
-    REQUIRE(contains(s, "."));
+    REQUIRE(contains(s, 'M'));
+    REQUIRE(contains(s, '.'));
     REQUIRE(contains(s, "noch Chaos"));
     REQUIRE(!contains(s, "foo"));
 
@@ -371,10 +371,10 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
         };
 
 #ifdef _WIN32
-    REQUIRE(path_exists("C:\\"));
-    REQUIRE(path_exists("C:\\Program Files"));
-    REQUIRE(path_exists("C:\\Windows"));
-    REQUIRE(!path_exists("C:\\nonexistent_folder_in_C_drive"));
+    REQUIRE(directory_exists("C:\\"));
+    REQUIRE(directory_exists("C:\\Program Files"));
+    REQUIRE(directory_exists("C:\\Windows"));
+    REQUIRE(!directory_exists("C:\\nonexistent_folder_in_C_drive"));
 
     REQUIRE(file_exists(".\\AuxiliaryTests.exe"));
     REQUIRE(!file_exists(".\\nonexistent_file_in_cmake_bin_directory.exe"));
@@ -414,9 +414,9 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     }
 #else
     REQUIRE(directory_exists("/"));
-    REQUIRE(directory_exists("/boot"));
-    REQUIRE(directory_exists("/etc"));
-    REQUIRE(directory_exists("/home"));
+    //REQUIRE(directory_exists("/boot"));
+    //REQUIRE(directory_exists("/etc"));
+    //REQUIRE(directory_exists("/home"));
     REQUIRE(!directory_exists("/nonexistent_folder_in_root_directory"));
     REQUIRE(directory_exists("../bin"));
 
@@ -425,22 +425,26 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
 
     auto dir_entries = list_directory("/");
     REQUIRE(!dir_entries.empty());
-    REQUIRE(contains(dir_entries, "boot"));
-    REQUIRE(contains(dir_entries, "etc"));
-    REQUIRE(contains(dir_entries, "home"));
-    REQUIRE(contains(dir_entries, "root"));
+    //REQUIRE(contains(dir_entries, "boot"));
+    //REQUIRE(contains(dir_entries, "etc"));
+    //REQUIRE(contains(dir_entries, "home"));
+    //REQUIRE(contains(dir_entries, "root"));
     REQUIRE(!contains(dir_entries, "nonexistent_folder_in_root_directory"));
 
     std::string new_directory = random_string(10);
     while( directory_exists(new_directory) )
         new_directory = random_string(10);
+    std::string new_sub_directory = new_directory + "/" + random_string(10);
+    REQUIRE(create_directories(new_sub_directory));
     REQUIRE(create_directories(new_directory));
-    REQUIRE(create_directories(new_directory));
+    REQUIRE(directory_exists(new_sub_directory));
     REQUIRE(directory_exists(new_directory));
 
     REQUIRE(remove_directory(new_directory));
     REQUIRE(!directory_exists(new_directory));
+    REQUIRE(!directory_exists(new_sub_directory));
     REQUIRE(!remove_directory(new_directory));
+    REQUIRE(!remove_directory(new_sub_directory));
 
     REQUIRE(!remove_file("./nonexistent_file_in_cmake_bin_directory"));
     dir_entries = list_directory("../CMakeFiles");

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -27,6 +27,7 @@ using namespace openPMD;
 #include <string>
 #include <vector>
 #include <array>
+#include <fstream>
 
 
 namespace openPMD
@@ -392,26 +393,20 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(create_directories(new_directory));
     REQUIRE(directory_exists(new_directory));
 
+    std::string new_file = new_directory + "\\abc.txt";
+    std::fstream fs;
+    fs.open(new_file, std::ios::out);
+    fs.close();
+
+    REQUIRE(file_exists(new_file));
+    REQUIRE(remove_file(new_file));
+    REQUIRE(!file_exists(new_file));
+
     REQUIRE(remove_directory(new_directory));
     REQUIRE(!directory_exists(new_directory));
     REQUIRE(!remove_directory(new_directory));
 
     REQUIRE(!remove_file(".\\nonexistent_file_in_cmake_bin_directory"));
-    dir_entries = list_directory("..\\..\\.travis");
-    if( !dir_entries.empty() )
-    {
-        std::string del = "..\\..\\.travis\\" + *dir_entries.begin();
-        while( !file_exists(del) && directory_exists(del) )
-        {
-            dir_entries = list_directory(del);
-            del += "\\" + *dir_entries.begin();
-        }
-        if( file_exists(del) )
-        {
-            REQUIRE(remove_file(del));
-            REQUIRE(!file_exists(del));
-        }
-    }
 #else
     REQUIRE(directory_exists("/"));
     //REQUIRE(directory_exists("/boot"));
@@ -440,6 +435,15 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(directory_exists(new_sub_directory));
     REQUIRE(directory_exists(new_directory));
 
+    std::string new_file = new_directory + "/abc.txt";
+    std::fstream fs;
+    fs.open(new_file, std::ios::out);
+    fs.close();
+
+    REQUIRE(file_exists(new_file));
+    REQUIRE(remove_file(new_file));
+    REQUIRE(!file_exists(new_file));
+
     REQUIRE(remove_directory(new_directory));
     REQUIRE(!directory_exists(new_directory));
     REQUIRE(!directory_exists(new_sub_directory));
@@ -447,20 +451,5 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(!remove_directory(new_sub_directory));
 
     REQUIRE(!remove_file("./nonexistent_file_in_cmake_bin_directory"));
-    dir_entries = list_directory("../../.travis");
-    if( !dir_entries.empty() )
-    {
-        std::string del = "../../.travis/" + *dir_entries.begin();
-        while( !file_exists(del) && directory_exists(del) )
-        {
-            dir_entries = list_directory(del);
-            del += "/" + *dir_entries.begin();
-        }
-        if( file_exists(del) )
-        {
-            REQUIRE(remove_file(del));
-            REQUIRE(!file_exists(del));
-        }
-    }
 #endif
 }

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -26,7 +26,6 @@ using namespace openPMD;
 
 #include <array>
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -377,12 +376,6 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(directory_exists("C:\\Program Files"));
     REQUIRE(directory_exists("C:\\Windows"));
     REQUIRE(!directory_exists("C:\\nonexistent_folder_in_C_drive"));
-
-    auto entries = list_directory(".");
-    for( auto const& entry : entries )
-        std::cout << entry << std::endl;
-    //REQUIRE(file_exists("AuxiliaryTests.exe"));
-    //REQUIRE(!file_exists("nonexistent_file_in_cmake_bin_directory.exe"));
 
     auto dir_entries = list_directory("C:\\");
     REQUIRE(!dir_entries.empty());

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -397,10 +397,10 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(!remove_directory(new_directory));
 
     REQUIRE(!remove_file(".\\nonexistent_file_in_cmake_bin_directory"));
-    dir_entries = list_directory("..\\CMakeFiles");
+    dir_entries = list_directory("..\\..\\.travis");
     if( !dir_entries.empty() )
     {
-        std::string del = "..\\CMakeFiles\\" + *dir_entries.begin();
+        std::string del = "..\\..\\.travis\\" + *dir_entries.begin();
         while( !file_exists(del) && directory_exists(del) )
         {
             dir_entries = list_directory(del);
@@ -447,10 +447,10 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
     REQUIRE(!remove_directory(new_sub_directory));
 
     REQUIRE(!remove_file("./nonexistent_file_in_cmake_bin_directory"));
-    dir_entries = list_directory("../CMakeFiles");
+    dir_entries = list_directory("../../.travis");
     if( !dir_entries.empty() )
     {
-        std::string del = "../CMakeFiles/" + *dir_entries.begin();
+        std::string del = "../../.travis/" + *dir_entries.begin();
         while( !file_exists(del) && directory_exists(del) )
         {
             dir_entries = list_directory(del);

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -370,7 +370,7 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
             return str;
         };
 
-#if WIN32
+#ifdef _WIN32
     REQUIRE(path_exists("C:\\"));
     REQUIRE(path_exists("C:\\Program Files"));
     REQUIRE(path_exists("C:\\Windows"));
@@ -412,7 +412,7 @@ TEST_CASE( "filesystem_test", "[auxiliary]" )
             REQUIRE(!file_exists(del));
         }
     }
-#elif UNIX
+#else
     REQUIRE(directory_exists("/"));
     REQUIRE(directory_exists("/boot"));
     REQUIRE(directory_exists("/etc"));

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -14,6 +14,7 @@
 #   undef private
 #   undef protected
 #endif
+#include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Container.hpp"
@@ -336,4 +337,35 @@ TEST_CASE( "dot_test", "[auxiliary]" )
     REQUIRE(d.att2() == static_cast<double>(20));
     REQUIRE(d.att3() == "30");
 
+}
+
+TEST_CASE( "filesystem_test", "[auxiliary]" )
+{
+    using auxiliary::list_directory;
+    using auxiliary::path_exists;
+
+    auto contains =
+        [](std::vector< std::string > const & entries, std::string const & path) -> bool
+        { return std::find(entries.cbegin(), entries.cend(), path) != entries.cend(); };
+
+#if WIN32
+    REQUIRE(path_exists("C:\\"));
+    REQUIRE(path_exists("C:\\Program Files"));
+    REQUIRE(path_exists("C:\\Windows"));
+    REQUIRE(path_exists("C:\\nonexistent_folder_in_C_drive"));
+#elif UNIX
+    auto dir_entries = list_directory("/");
+    REQUIRE(!dir_entries.empty());
+    REQUIRE(contains(dir_entries, "boot"));
+    REQUIRE(contains(dir_entries, "etc"));
+    REQUIRE(contains(dir_entries, "home"));
+    REQUIRE(contains(dir_entries, "root"));
+    REQUIRE(!contains(dir_entries, "nonexistent_folder_in_root_directory"));
+
+    REQUIRE(path_exists("/"));
+    REQUIRE(path_exists("/boot"));
+    REQUIRE(path_exists("/etc"));
+    REQUIRE(path_exists("/home"));
+    REQUIRE(!path_exists("/nonexistent_folder_in_root_directory"));
+#endif
 }


### PR DESCRIPTION
Create a minimally slim replacement for boost.filesystem for WIN32 and
POSIX compliant systems.

Closes #70.