### PR TITLE
CI: GCC 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -207,6 +207,25 @@ jobs:
             - *gcc64_deps
       before_install: *gcc64_init
       script: *script-cpp-unit
+    # GCC 4.8.5 + Python 3.5.5
+    - <<: *test-cpp-unit
+      language: python
+      python: "3.5"
+      env:
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF
+      compiler: gcc
+      addons:
+        apt:
+          <<: *apt_common_sources
+          packages:
+            - environment-modules
+            - gfortran
+            - g++
+            - libopenmpi-dev
+            - openmpi-bin
+      before_install: &gcc48_init
+         - CXX=g++-4.8 && CC=gcc-4.8 && COMPILERSPEC="%gcc@4.8.5"
+      script: *script-cpp-unit
 
 install:
   # spack install

--- a/.travis/spack/compilers.yaml
+++ b/.travis/spack/compilers.yaml
@@ -32,6 +32,19 @@ compilers:
     modules: []
     operating_system: ubuntu14.04
     paths:
+      cc: /usr/bin/gcc-4.8
+      cxx: /usr/bin/g++-4.8
+      f77: /usr/bin/gfortran-4.8
+      fc: /usr/bin/gfortran-4.8
+    spec: gcc@4.8.5
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu14.04
+    paths:
       cc: /usr/bin/gcc-4.9
       cxx: /usr/bin/g++-4.9
       f77: /usr/bin/gfortran-4.9

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -2,6 +2,7 @@ packages:
   cmake:
     version: [3.10.0]
     paths:
+      cmake@3.10.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
@@ -11,6 +12,7 @@ packages:
   openmpi:
     version: [1.6.5]
     paths:
+      openmpi@1.6.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /usr
@@ -19,13 +21,14 @@ packages:
   hdf5:
     version: [1.10.1, 1.8.13]
   python:
-    version: [2.7.14, 2.7.10, 3.6.3]
+    version: [2.7.14, 2.7.10, 3.5.5, 3.6.3]
     paths:
       python@2.7.14%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
+      python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
       python@2.7.10%clang@8.1.0 arch=darwin-sierra-x86_64: /usr
     buildable: False
   all:
     providers:
       mpi: [openmpi]
-    compiler: [clang@5.0.0, gcc@4.9.4, gcc@6.4.0, gcc@7.3.0]
+    compiler: [clang@5.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.4.0, gcc@7.3.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,10 +448,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # older clangs: silence unknown warnings
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
     # pybind11 does not fix -Wshadow https://github.com/pybind/pybind11/issues/1267
+    # pybind11 does not fix -Wpedantic https://github.com/pybind/pybind11/issues/1417
     if(NOT openPMD_HAVE_PYTHON)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow -Wpedantic")
     endif()
     string(CONCAT CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} "
             "-Wno-unknown-pragmas")


### PR DESCRIPTION
I wonder if we run well with GCC 4.8.

Add an entry in the test matrix of Travis that compiles: gcc 4.8 + Python 3.5.
Update the GCC 6 minor version.

The reason behind this is the following: unfortunately, Python (binary) package and delivery platforms such as conda-forge and PyPI only support GCC 4.8 as of today. Details are e.g. defined in https://github.com/conda-forge/staged-recipes/issues/872 https://github.com/conda-forge/conda-forge.github.io/issues/460 (conda-forge channel) and [PEP571](https://www.python.org/dev/peps/pep-0571/) (PyPI manylinux binary wheels).

Our dependencies (catch2, mpark.variant, pybind11) do support GCC 4.8+, so that's a good start.

- [x] rebase after #224 is merged
- [x] lower supported version for gcc to 4.8