### PR TITLE
Compiler Docs: VS 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Our manual shows full [read & write examples](https://openpmd-api.readthedocs.io
 
 Required:
 * CMake 3.10.0+
-* C++11 capable compiler, e.g. g++ 4.9+, clang 3.9+
+* C++11 capable compiler, e.g. g++ 4.9+, clang 3.9+, VS 2015+
 
 Shipped internally:
 * [MPark.Variant](https://github.com/mpark/variant) 1.3.0+

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -12,7 +12,7 @@ Required
 --------
 
 * CMake 3.10.0+
-* C++11 capable compiler, e.g. g++ 4.9+, clang 3.9+
+* C++11 capable compiler, e.g. g++ 4.9+, clang 3.9+, VS 2015+
 
 Shipped internally
 ------------------


### PR DESCRIPTION
Document that Visual Studio 2015 (and potentially newer) are supported.

Compiler names [are weird](https://stackoverflow.com/a/31885449/2719194) in VS...