### PR TITLE
 CMake Config: Support NOMPI, Install ADIOS Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(openPMD VERSION 0.1.0) # LANGUAGES CXX
 # the openPMD "markup"/"schema" standard version
 set(openPMD_STANDARD_VERSION 1.1.0)
 
-set(CMAKE_MODULE_PATH "${openPMD_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${openPMD_SOURCE_DIR}/cmake")
 
 
 # Project structure ###########################################################
@@ -502,6 +502,11 @@ install(
         ${openPMD_BINARY_DIR}/openPMDConfig.cmake
         ${openPMD_BINARY_DIR}/openPMDConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
+)
+install(
+    FILES
+        ${openPMD_SOURCE_DIR}/cmake/FindADIOS.cmake
+    DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules
 )
 
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
 
 Use the following lines in your projects `CMakeLists.txt`:
 ```cmake
-# supports:                       COMPONENTS MPI HDF5 ADIOS1 ADIOS2
+# supports:                       COMPONENTS MPI NOMPI HDF5 ADIOS1 ADIOS2
 find_package(openPMD 0.1.0 CONFIG)
 
 if(openPMD_FOUND)

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -5,6 +5,10 @@ include(CMakeFindDependencyMacro)
 set(openPMD_HAVE_MPI @openPMD_HAVE_MPI@)
 if(openPMD_HAVE_MPI)
     find_dependency(MPI)
+    # deselect parallel installs if explicitly a serial install is requested
+    set(openPMD_NOMPI_FOUND FALSE)
+else()
+    set(openPMD_NOMPI_FOUND TRUE)
 endif()
 set(openPMD_MPI_FOUND ${openPMD_HAVE_MPI})
 

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -2,6 +2,8 @@
 #   https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-a-package-configuration-file
 include(CMakeFindDependencyMacro)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
+
 set(openPMD_HAVE_MPI @openPMD_HAVE_MPI@)
 if(openPMD_HAVE_MPI)
     find_dependency(MPI)


### PR DESCRIPTION
Close #61 Add a `NOMPI` component to the CMake components. If several openPMD-api installs are found, the ones with MPI can be skipped with it.

Bugfix: Forgot to install the ADIOS1 Module. Now ADIOS1 can be found *in dependent projects* and the installed CMake openPMD config package be used.