### PR TITLE
SerialIOTest: loadChunk template ADIOS1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,23 @@
 Changelog
 =========
 
+0.1.1-alpha
+-----------
+**Date:** TBD
+
+[Title TBA]
+
+[Short Summary]
+
+Changes to "0.1.0-alpha"
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bug Fixes
+"""""""""
+
+- SerialIOTest: ``loadChunk`` template missing for ADIOS1 #227
+
+
 0.1.0-alpha
 -----------
 **Date:** 2018-06-06

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1512,7 +1512,7 @@ TEST_CASE( "hzdr_adios1_sample_content_test", "[serial][adios1]" )
                                      {7.3689453e-06f, 7.3689453e-06f, 7.3689453e-06f}}};
         Offset offset{20, 20, 150};
         Extent extent{3, 3, 3};
-        auto data = B_z.loadChunk(offset, extent);
+        auto data = B_z.loadChunk<float>(offset, extent);
         float* raw_ptr = data.get();
 
         for( int i = 0; i < 3; ++i )


### PR DESCRIPTION
Forgot to change this access to `loadChunk` in #204.
Seems to cause only problems on GCC 4.8.**2** & ADIOS1