### PR TITLE
Serial ADIOS: Refactor MPI Comm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Bug Fixes
 """""""""
 
 - SerialIOTest: ``loadChunk`` template missing for ADIOS1 #227
+- prepare running serial applications linked against parallel ADIOS1 library #228
 
 
 0.1.0-alpha

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -46,7 +46,7 @@ class ADIOS1IOHandler;
 class ADIOS1IOHandlerImpl : public AbstractIOHandlerImpl
 {
 public:
-    ADIOS1IOHandlerImpl(AbstractIOHandler*, MPI_Comm = MPI_COMM_SELF);
+    ADIOS1IOHandlerImpl(AbstractIOHandler*, MPI_Comm = MPI_COMM_NULL);
     virtual ~ADIOS1IOHandlerImpl();
 
     virtual void init();

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1119,7 +1119,7 @@ TEST_CASE( "no_serial_hdf5", "[serial][hdf5]" )
     REQUIRE(true);
 }
 #endif
-#if !openPMD_HAVE_MPI && openPMD_HAVE_ADIOS1
+#if openPMD_HAVE_ADIOS1
 TEST_CASE( "adios1_dtype_test", "[serial][adios1]" )
 {
     {


### PR DESCRIPTION
Instead of relying on the ADIOS serial MPI moc library, we can also pass `MPI_COMM_NULL` as communicator to avoid triggering MPI functionality and requiring mpi startup.

Needs fix in

  https://github.com/ornladios/ADIOS/pull/182

in order to work without `mpiexec` and linked against a parallel ADIOS library (but will work with any serial ADIOS library as before).