### PR TITLE
Add RODARE Meta Information

### DIFF
--- a/.rodare.json
+++ b/.rodare.json
@@ -1,0 +1,20 @@
+{
+    "creators": [
+        {
+            "name": "Koller, Fabian",
+            "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",
+            "orcid": "0000-0001-8704-1769"
+        },
+        {
+            "name": "Huebl, Axel",
+            "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf, TU Dresden",
+            "orcid": "0000-0003-1943-7141"
+        }
+    ],
+    "title": "openPMD-api - C++ & Python API Scientific I/O with openPMD",
+    "access_right": "open",
+    "upload_type": "software",
+    "license": "LGPL-3.0",
+    "pub_id": "27579",
+    "description": "openPMD is an open metadata format for open data workflows in open science. This library provides a common high-level API for openPMD writing and reading. It provides a common interface to I/O libraries and file formats such as HDF5 and ADIOS. Where supported, openPMD-api implements both serial and MPI parallel I/O capabilities."
+}


### PR DESCRIPTION
Adds HZDR's RODARE meta information.

This repository is then tied to a HZDR publication that collects all releases in ROBIS and is authorized for publishing. RODARE will then create DOIs for us with each release, all tied to a single ROBIS publication database entry.

HZDR Publication Database ROBIS:
  https://www.hzdr.de/db/!Publications

HZDR Data Repository RODARE:
  https://rodare.hzdr.de