### PR TITLE
Singularity: ADIOS

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -1,13 +1,13 @@
-BootStrap: debootstrap
-OSVersion: cosmic
-MirrorURL: http://us.archive.ubuntu.com/ubuntu/
-# Requires on build host: Singularity 2.3+, debootstrap
+Bootstrap: docker
+From: debian:unstable
+#From: debian:testing
+#From: ubuntu:cosmic
 
 %help
 Welcome to the openPMD-api container.
 This container contains a pre-installed openPMD-api library.
-This container supports serial and MPI parallel I/O.
-Supported backends are HDF5.
+This container provides serial I/O.
+Supported backends are HDF5 and ADIOS.
 Supported frontends are C++11 and Python3.
 
 %setup
@@ -23,27 +23,32 @@ Supported frontends are C++11 and Python3.
         make \
         g++ \
         ipython3 \
+        python3-dev \
         pybind11-dev \
-        libopenmpi-dev \
-        libhdf5-openmpi-dev && \
+        libadios-bin libadios-dev \
+        libglib2.0-dev libbz2-dev libibverbs-dev libnetcdf-dev \
+        libhdf5-dev && \
     rm -rf /var/lib/apt/lists/*
 
     # python3-numpy
 
     # missing: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900804
     # libadios-openmpi-dev
-    # libadios-bin libadios-dev
-    # pkg-config libglib2.0-dev libbz2-dev libibverbs-dev
+    # libopenmpi-dev libhdf5-openmpi-dev
 
     cd $(mktemp -d)
     cmake /opt/openpmd-api \
-        -DopenPMD_USE_MPI=ON \
+        -DopenPMD_USE_MPI=OFF \
         -DopenPMD_USE_HDF5=ON \
-        -DopenPMD_USE_ADIOS1=OFF \
+        -DopenPMD_USE_ADIOS1=ON \
         -DopenPMD_USE_ADIOS2=OFF \
         -DopenPMD_USE_PYTHON=ON \
-        -DPYTHON_EXECUTABLE=$(which python)
+        -DPYTHON_EXECUTABLE=$(which python3) \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_INSTALL_PYTHONDIR=lib/python3.6/dist-packages
     make
+    # make test
     make install
 
 #%test
@@ -53,8 +58,8 @@ Supported frontends are C++11 and Python3.
     ipython3
 
 %labels
-    openPMD_HAVE_MPI ON
+    openPMD_HAVE_MPI OFF
     openPMD_HAVE_HDF5 ON
-    openPMD_HAVE_ADIOS1 OFF
+    openPMD_HAVE_ADIOS1 ON
     openPMD_HAVE_ADIOS2 OFF
     openPMD_HAVE_PYTHON ON

--- a/cmake/FindADIOS.cmake
+++ b/cmake/FindADIOS.cmake
@@ -204,7 +204,11 @@ if(ADIOS_FOUND)
         string(REPLACE " -l" "" _LIB ${_LIB})
 
         # find static lib: absolute path in -L then default
-        find_library(_LIB_DIR NAMES ${_LIB} PATHS ${ADIOS_LIBRARY_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
+        if(_LIB MATCHES "^glib")
+            find_library(_LIB_DIR NAMES ${_LIB} PATHS ${ADIOS_LIBRARY_DIRS} NAMES glib-2.0 CMAKE_FIND_ROOT_PATH_BOTH)
+        else()
+            find_library(_LIB_DIR NAMES ${_LIB} PATHS ${ADIOS_LIBRARY_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
+        endif()
 
         if(_LIB MATCHES "^.*nompi.*$")
             set(ADIOS_HAVE_SEQUENTIAL TRUE)


### PR DESCRIPTION
With the ADIOS deployment fixed in Debian's 1.13.1-2 build, we should now be able to build a serial container.

Currently in Debian "unstable", expected in "testing" soon and proposed in Ubuntu "cosmic".

Related reources:
- https://tracker.debian.org/pkg/adios
- https://launchpad.net/ubuntu/+source/adios
- https://bugs.debian.org/900811
- https://bugs.debian.org/894165