### PR TITLE
setup.py for sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.md COPYING COPYING.LESSER
+include requirements.txt
+global-include CMakeLists.txt *.cmake *.cmake.in
+recursive-include include *
+recursive-include src *
+recursive-include share *
+recursive-include test *
+recursive-include examples *

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -1,0 +1,49 @@
+.. _development-release:
+
+Release Channels
+================
+
+.. sectionauthor:: Axel Huebl
+
+Spack
+-----
+
+Our recommended HPC release channel when in need for MPI.
+Also very useful for Linux and OSX desktop releases.
+
+Example workflow for a new release:
+
+https://github.com/spack/spack/pull/9178
+
+[TODO: show how to add a tag; please CC @ax3l on updates]
+
+
+Conda-Forge
+-----------
+
+Our primary release channel for desktops, fully automated binary distribution.
+Supports Windows, OSX and Linux.
+Packages are built without MPI.
+
+Example workflow for a new release:
+
+https://github.com/conda-forge/openpmd-api-feedstock/pull/7
+
+
+PyPI
+----
+
+On PyPI, we only upload a source page with all settings to default / ``AUTO`` and proper ``RPATH`` settings for internal libraries.
+
+PyPI releases are experimental and not highly recommended for the average user.
+They do come handy to test pre-releases quickly with power-users.
+
+.. code-block:: bash
+
+   # prepare source distribution
+   python setup.py sdist
+
+   # GPG sign and upload
+   #   note: have up-to-date tools!
+   #   https://packaging.python.org/guides/making-a-pypi-friendly-readme/
+   twine upload -s dist/*

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,3 +81,4 @@ Development
    dev/buildoptions
    dev/sphinx
    dev/doxygen
+   dev/release

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+cmake>=3.10.0
+pybind11>=2.2.3
+numpy>=1.15.0
+setuptools>=38.6

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,154 @@
+import os
+import re
+import sys
+import platform
+import subprocess
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+from distutils.version import LooseVersion
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError(
+                "CMake 3.10.0+ must be installed to build the following " +
+                "extensions: " +
+                ", ".join(e.name for e in self.extensions))
+
+        cmake_version = LooseVersion(re.search(
+            r'version\s*([\d.]+)',
+            out.decode()
+        ).group(1))
+        if cmake_version < '3.10.0':
+            raise RuntimeError("CMake >= 3.10.0 is required")
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(
+            self.get_ext_fullpath(ext.name)
+        ))
+        # required for auto-detection of auxiliary "native" libs
+        if not extdir.endswith(os.path.sep):
+            extdir += os.path.sep
+
+        cmake_args = [
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+            '-DCMAKE_PYTHON_OUTPUT_DIRECTORY=' + extdir,
+            '-DPYTHON_EXECUTABLE=' + sys.executable,
+            # skip building tests & examples
+            '-DBUILD_TESTING:BOOL=OFF',
+            '-DBUILD_EXAMPLES:BOOL=OFF',
+            # Unix: rpath to current dir when packaged
+            '-DCMAKE_INSTALL_RPATH=$ORIGIN',
+            '-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON',
+            '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF',
+            # Windows: will already have %PATH% in package dir
+        ]
+
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
+        if platform.system() == "Windows":
+            cmake_args += [
+                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(
+                    cfg.upper(),
+                    extdir
+                )
+            ]
+            if sys.maxsize > 2**32:
+                cmake_args += ['-A', 'x64']
+            build_args += ['--', '/m']
+        else:
+            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+            build_args += ['--', '-j2']
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(
+            env.get('CXXFLAGS', ''),
+            self.distribution.get_version()
+        )
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        subprocess.check_call(
+            ['cmake', ext.sourcedir] + cmake_args,
+            cwd=self.build_temp,
+            env=env
+        )
+        subprocess.check_call(
+            ['cmake', '--build', '.'] + build_args,
+            cwd=self.build_temp
+        )
+
+
+with open('./README.md', encoding='utf-8') as f:
+    long_description = f.read()
+
+# Get the package requirements from the requirements.txt file
+with open('./requirements.txt') as f:
+    install_requires = [line.strip('\n') for line in f.readlines()]
+
+# keyword reference:
+#   https://packaging.python.org/guides/distributing-packages-using-setuptools
+setup(
+    name='openPMD-api',
+    # note PEP-440 syntax: x.y.zaN but x.y.z.devN
+    version='0.6.2.dev',
+    author='Fabian Koller, Axel Huebl',
+    author_email='f.koller@hzdr.de, a.huebl@hzdr.de',
+    maintainer='Axel Huebl',
+    maintainer_email='a.huebl@hzdr.de',
+    description='C++ & Python API for Scientific I/O with openPMD',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    keywords=('openpmd openscience hdf5 adios mpi hpc research '
+              'file-format file-handling'),
+    url='https://www.openpmd.org',
+    project_urls={
+        'Documentation': 'https://openpmd-api.readthedocs.io',
+        'Doxygen': 'https://www.openpmd.org/openPMD-api',
+        'Reference': 'https://doi.org/10.14278/rodare.27',
+        'Source': 'https://github.com/openPMD/openPMD-api',
+        'Tracker': 'https://github.com/openPMD/openPMD-api/issues',
+    },
+    ext_modules=[CMakeExtension('openPMD')],
+    cmdclass=dict(build_ext=CMakeBuild),
+    zip_safe=False,
+    python_requires='>=3.5, <3.8',
+    # tests_require=['pytest'],
+    install_requires=install_requires,
+    # extras_require = {
+    #    'GUI':  ["ipywidgets", "matplotlib", "cython"],
+    #    'plot': ["matplotlib", "cython"],
+    #    'tutorials': ["ipywidgets", "matplotlib", "wget", "cython"]
+    # },
+    # cmdclass={'test': PyTest},
+    # platforms='any',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Natural Language :: English',
+        'Environment :: Console',
+        'Intended Audience :: Science/Research',
+        'Operating System :: OS Independent',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Database :: Front-Ends',
+        'Programming Language :: C++',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        ('License :: OSI Approved :: '
+         'GNU Lesser General Public License v3 or later (LGPLv3+)'),
+    ],
+)


### PR DESCRIPTION
Developed a `setup.py` for python-level install *from source* (actually compiling!).

I am not sure it it does more harm than good to expose this to the user or if I should hide a perfectly tailored, `PyPI` distribution building only, `setup.py` deep in the source tree. Or I just keep this not as a documented (aka recommended) install method.

~~I will keep this here for now for documentation purposes.~~

Done:
- `sdist`

Intentionally skipepd:
- `bdist_wheel`: fully static, non-MPI
  - linux: [manylinux2010](https://www.python.org/dev/peps/pep-0571/) PEP571
  - win: ~~mingw~~ (no `std::future` support as of 7.0) -> VC 2015? PEP?
  - osx: apple clang? PEP?