### PR TITLE
Docs: MPI Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Optional I/O backends:
 * [ADIOS2](https://github.com/ornladios/ADIOS2) 2.1+ (*not yet implemented*)
 
 while those can be build either with or without:
-* MPI 2.3+, e.g. OpenMPI or MPICH2
+* MPI 2.1+, e.g. OpenMPI 1.6.5+ or MPICH2
 
 Optional language bindings:
 * Python:

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -31,7 +31,7 @@ Optional: I/O backends
 
 while those can be build either with or without:
 
-* MPI 2.3+, e.g. OpenMPI or MPICH2
+* MPI 2.1+, e.g. OpenMPI 1.6.5+ or MPICH2
 
 Optional: language bindings
 ---------------------------


### PR DESCRIPTION
We currently even test on OpenMPI 1.6.5 which only provides MPI 2.1

(Also, MPI 2.3 was a typo. There is only ... 1.3, 2.0, 2.1, 2.2, 3.0, 3.1. Hm, I initially learned the brand-new 1.3 standard back in the days.)

Of course we can require something more recent anytime we need it. This just means we have to compile it or use the mpich2 libs on trusty (or better: both, in order to continue testing the oldest claimed supported version as well).