### PR TITLE
Write Examples: Scalar Record Name

### DIFF
--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -47,10 +47,10 @@ int main(int argc, char *argv[])
     );
     cout << "Created an empty " << series.iterationEncoding() << " Series\n";
 
-    MeshRecordComponent E =
+    MeshRecordComponent rho =
       series
           .iterations[1]
-          .meshes["E"][MeshRecordComponent::SCALAR];
+          .meshes["rho"][MeshRecordComponent::SCALAR];
     cout << "Created a scalar mesh Record with all required openPMD attributes\n";
 
     Datatype datatype = determineDatatype(shareRaw(global_data));
@@ -59,14 +59,14 @@ int main(int argc, char *argv[])
     cout << "Created a Dataset of size " << dataset.extent[0] << 'x' << dataset.extent[1]
          << " and Datatype " << dataset.dtype << '\n';
 
-    E.resetDataset(dataset);
-    cout << "Set the dataset properties for the scalar field E in iteration 1\n";
+    rho.resetDataset(dataset);
+    cout << "Set the dataset properties for the scalar field rho in iteration 1\n";
 
     series.flush();
     cout << "File structure and required attributes have been written\n";
 
     Offset offset = {0, 0};
-    E.storeChunk(offset, extent, shareRaw(global_data));
+    rho.storeChunk(offset, extent, shareRaw(global_data));
     cout << "Stored the whole Dataset contents as a single chunk, "
             "ready to write content\n";
 

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -29,7 +29,8 @@ if __name__ == "__main__":
     print("Created an empty {0} Series".format(series.iteration_encoding))
 
     print(len(series.iterations))
-    E = series.iterations[1].meshes["E"][openPMD.Mesh_Record_Component.SCALAR]
+    rho = series.iterations[1]. \
+        meshes["rho"][openPMD.Mesh_Record_Component.SCALAR]
 
     datatype = openPMD.Datatype.DOUBLE
     # datatype = openPMD.determineDatatype(global_data)
@@ -39,8 +40,8 @@ if __name__ == "__main__":
     print("Created a Dataset of size {0}x{1} and Datatype {2}".format(
         dataset.extent[0], dataset.extent[1], dataset.dtype))
 
-    E.reset_dataset(dataset)
-    print("Set the dataset properties for the scalar field E in iteration 1")
+    rho.reset_dataset(dataset)
+    print("Set the dataset properties for the scalar field rho in iteration 1")
 
     # writing fails on already open file error
     series.flush()
@@ -50,7 +51,7 @@ if __name__ == "__main__":
     offset = openPMD.Extent([0, 0])
     # TODO implement slicing protocol
     # E[offset[0]:extent[0], offset[1]:extent[1]] = global_data
-    E.store_chunk(offset, extent, global_data)
+    rho.store_chunk(offset, extent, global_data)
     print("Stored the whole Dataset contents as a single chunk, " +
           "ready to write content")
 


### PR DESCRIPTION
Rename the scalar mesh records written in the examples. Use "rho" which is used for scalar observables such as densities instead of "E" which is used for vector fields.