### PR TITLE
Remove MPI from serial ADIOS interface

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -27,7 +27,9 @@
 
 #include <adios_types.h>
 
+#include <cstring>
 #include <iterator>
+#include <iostream>
 #include <sstream>
 #include <stack>
 
@@ -146,5 +148,30 @@ concrete_bp1_file_position(Writable* w)
     }
 
     return auxiliary::replace_all(pos, "//", "/");
+}
+
+inline std::string
+getEnvNum(std::string const& key, std::string const& defaultValue)
+{
+    char const* env = std::getenv(key.c_str());
+    if( env != nullptr )
+    {
+        char const* tmp = env;
+        while( tmp )
+        {
+            if( isdigit(*tmp) )
+                ++tmp;
+            else
+            {
+                std::cerr << key << " is invalid" << std::endl;
+                break;
+            }
+        }
+        if( !tmp )
+            return std::string(env, std::strlen(env));
+        else
+            return defaultValue;
+    } else
+        return defaultValue;
 }
 } // openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -25,7 +25,6 @@
 #if openPMD_HAVE_ADIOS1
 #   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 #   include <adios.h>
-#   include <adios_mpi.h> /* includes a dummy version of mpi if -D_NOMPI */
 #   include <adios_read.h>
 #endif
 
@@ -46,7 +45,7 @@ class ADIOS1IOHandler;
 class ADIOS1IOHandlerImpl : public AbstractIOHandlerImpl
 {
 public:
-    ADIOS1IOHandlerImpl(AbstractIOHandler*, MPI_Comm = MPI_COMM_NULL);
+    ADIOS1IOHandlerImpl(AbstractIOHandler*);
     virtual ~ADIOS1IOHandlerImpl();
 
     virtual void init();
@@ -72,13 +71,12 @@ public:
     virtual void listDatasets(Writable*, Parameter< Operation::LIST_DATASETS > &) override;
     virtual void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
 
-    int64_t open_write(Writable *);
+    virtual int64_t open_write(Writable *);
+    virtual ADIOS_FILE* open_read(std::string const& name);
     void close(int64_t);
     void close(ADIOS_FILE*);
 
 protected:
-    MPI_Comm m_mpiComm; /* dummy provided by ADIOS if -D_NOMPI */
-    MPI_Info m_mpiInfo; /* dummy provided by ADIOS if -D_NOMPI */
     int64_t m_group;
     std::string m_groupName;
     ADIOS_READ_METHOD m_readMethod;

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -24,7 +24,6 @@
 
 #if openPMD_HAVE_ADIOS1
 #   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
-#   include <adios.h>
 #   include <adios_read.h>
 #endif
 

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -45,6 +45,13 @@ public:
     virtual void init() override;
 
     virtual std::future< void > flush() override;
+
+    virtual int64_t open_write(Writable *) override;
+    virtual ADIOS_FILE* open_read(std::string const& name) override;
+
+private:
+    MPI_Comm m_mpiComm;
+    MPI_Info m_mpiInfo;
 };  //ParallelADIOS1IOHandlerImpl
 
 class ParallelADIOS1IOHandler : public AbstractIOHandler

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -26,9 +26,7 @@
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
-#   if  !openPMD_HAVE_MPI
-#       include <mpidummy.h>
-#   endif
+#   include <adios.h>
 #   include <iostream>
 #   include <memory>
 #endif
@@ -51,8 +49,9 @@ ADIOS1IOHandlerImpl::ADIOS1IOHandlerImpl(AbstractIOHandler* handler)
 ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
 {
 #if !openPMD_HAVE_MPI
-    /* create all files where ADIOS file creation has been deferred, but this has never been triggered
-     * this happens when no Operation::WRITE_DATASET is performed */
+  /* create all files where ADIOS file creation has been deferred,
+   * but execution of the deferred operation has never been triggered
+   * (happens when no Operation::WRITE_DATASET is performed) */
     for( auto& f : m_existsOnDisk )
     {
         if( !f.second )

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -26,7 +26,9 @@
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
-#   include <cstring>
+#   if  !openPMD_HAVE_MPI
+#       include <mpidummy.h>
+#   endif
 #   include <iostream>
 #   include <memory>
 #endif
@@ -41,23 +43,14 @@ namespace openPMD
 #       define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif
 
-ADIOS1IOHandlerImpl::ADIOS1IOHandlerImpl(AbstractIOHandler* handler, MPI_Comm comm)
+ADIOS1IOHandlerImpl::ADIOS1IOHandlerImpl(AbstractIOHandler* handler)
         : AbstractIOHandlerImpl(handler),
-          m_mpiInfo{MPI_INFO_NULL},
           m_groupName{"data"}
-{
-    int status = MPI_SUCCESS;
-    if( comm == MPI_COMM_NULL )
-        m_mpiComm = MPI_COMM_NULL;
-    else
-        status = MPI_Comm_dup(comm, &m_mpiComm);
-    VERIFY(status == MPI_SUCCESS, "Internal error: Failed to duplicate MPI communicator");
-    status = adios_init_noxml(m_mpiComm);
-    VERIFY(status == err_no_error, "Internal error: Failed to initialize ADIOS");
-}
+{ }
 
 ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
 {
+#if !openPMD_HAVE_MPI
     /* create all files where ADIOS file creation has been deferred, but this has never been triggered
      * this happens when no Operation::WRITE_DATASET is performed */
     for( auto& f : m_existsOnDisk )
@@ -70,7 +63,7 @@ ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
                                 m_groupName.c_str(),
                                 f.first->c_str(),
                                 "w",
-                                m_mpiComm);
+                                MPI_COMM_NULL);
             if( status != err_no_error )
                 std::cerr << "Internal error: Failed to open_flush ADIOS file\n";
 
@@ -85,23 +78,14 @@ ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
         close(f.second);
 
     int status;
-    if( m_mpiComm != MPI_COMM_NULL )
-        MPI_Barrier(m_mpiComm);
     status = adios_read_finalize_method(m_readMethod);
     if( status != err_no_error )
         std::cerr << "Internal error: Failed to finalize ADIOS reading method (parallel)\n";
 
-    if( m_mpiComm != MPI_COMM_NULL )
-        MPI_Barrier(m_mpiComm);
-    int rank = 0;
-    if( m_mpiComm != MPI_COMM_NULL )
-        MPI_Comm_rank(m_mpiComm, &rank);
-    status = adios_finalize(rank);
+    status = adios_finalize(0);
     if( status != err_no_error )
         std::cerr << "Internal error: Failed to finalize ADIOS (parallel)\n";
-
-    if( m_mpiComm != MPI_COMM_NULL )
-        MPI_Comm_free(&m_mpiComm);
+#endif
 }
 
 std::future< void >
@@ -219,9 +203,13 @@ ADIOS1IOHandlerImpl::flush()
 void
 ADIOS1IOHandlerImpl::init()
 {
+#if !openPMD_HAVE_MPI
     int status;
+    status = adios_init_noxml(MPI_COMM_NULL);
+    VERIFY(status == err_no_error, "Internal error: Failed to initialize ADIOS");
+
     m_readMethod = ADIOS_READ_METHOD_BP;
-    status = adios_read_init_method(m_readMethod, m_mpiComm, "");
+    status = adios_read_init_method(m_readMethod, MPI_COMM_NULL, "");
     VERIFY(status == err_no_error, "Internal error: Failed to initialize ADIOS reading method");
 
     ADIOS_STATISTICS_FLAG noStatistics = adios_stat_no;
@@ -229,6 +217,7 @@ ADIOS1IOHandlerImpl::init()
     VERIFY(status == err_no_error, "Internal error: Failed to declare ADIOS group");
     status = adios_select_method(m_group, "POSIX", "", "");
     VERIFY(status == err_no_error, "Internal error: Failed to select ADIOS method");
+#endif
 }
 #endif
 
@@ -292,15 +281,32 @@ ADIOS1IOHandlerImpl::open_write(Writable* writable)
     }
 
     int64_t fd;
+#if !openPMD_HAVE_MPI
     int status;
     status = adios_open(&fd,
                         m_groupName.c_str(),
                         res->second->c_str(),
                         mode.c_str(),
-                        m_mpiComm);
+                        MPI_COMM_NULL);
     VERIFY(status == err_no_error, "Internal error: Failed to open_write ADIOS file");
+#endif
 
     return fd;
+}
+
+ADIOS_FILE*
+ADIOS1IOHandlerImpl::open_read(std::string const& name)
+{
+    ADIOS_FILE *f;
+#if !openPMD_HAVE_MPI
+    f = adios_read_open_file(name.c_str(),
+                             m_readMethod,
+                             MPI_COMM_NULL);
+    VERIFY(adios_errno != err_file_not_found, "Internal error: ADIOS file not found");
+    VERIFY(f != nullptr, "Internal error: Failed to open_read ADIOS file");
+#endif
+
+    return f;
 }
 
 void
@@ -486,12 +492,7 @@ ADIOS1IOHandlerImpl::openFile(Writable* writable,
         m_openWriteFileHandles.erase(filePath);
     }
 
-    ADIOS_FILE *f;
-    f = adios_read_open_file(name.c_str(),
-                             m_readMethod,
-                             m_mpiComm);
-    VERIFY(adios_errno != err_file_not_found, "Internal error: ADIOS file not found");
-    VERIFY(f != nullptr, "Internal error: Failed to open_read ADIOS file");
+    ADIOS_FILE* f = open_read(name);
 
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< ADIOS1FilePosition >("/");
@@ -1316,7 +1317,7 @@ ADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 for( int i = 0; i < size; ++i )
                 {
                     vs[i] = auxiliary::strip(std::string(c[i], std::strlen(c[i])), {'\0'});
-                    /** @todo pointer should be freed, but this causes memory curruption */
+                    /** @todo pointer should be freed, but this causes memory corruption */
                     //free(c[i]);
                 }
                 a = Attribute(vs);

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -24,7 +24,7 @@
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
-#   include <mpi.h>
+#   include <adios.h>
 #   include <cstring>
 #endif
 
@@ -49,8 +49,9 @@ ParallelADIOS1IOHandlerImpl::ParallelADIOS1IOHandlerImpl(AbstractIOHandler* hand
 
 ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
 {
-    /* create all files where ADIOS file creation has been deferred, but this has never been triggered
-     * this happens when no Operation::WRITE_DATASET is performed */
+    /* create all files where ADIOS file creation has been deferred,
+     * but execution of the deferred operation has never been triggered
+     * (happens when no Operation::WRITE_DATASET is performed) */
     for( auto& f : m_existsOnDisk )
     {
         if( !f.second )

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1121,7 +1121,7 @@ TEST_CASE( "no_serial_hdf5", "[serial][hdf5]" )
     REQUIRE(true);
 }
 #endif
-#if openPMD_HAVE_ADIOS1
+#if openPMD_HAVE_ADIOS1 && !openPMD_HAVE_MPI
 TEST_CASE( "adios1_dtype_test", "[serial][adios1]" )
 {
     {


### PR DESCRIPTION
To be able to compile both serial and parallel ADIOS1 backends, remove
all traces of MPI from the serial interface. MPI_COMM_NULL is used in
the implementation, but not exposed.

Suggested in https://github.com/openPMD/openPMD-api/issues/252#issuecomment-396907630, blocker for #254.