### PR TITLE
Python: Expose Attributes Fully

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Features
 - Python:
 
   - unit tests #249
-  - expose attribute keys #256
+  - expose attributes #256 #266
 - C++:
 
   - ``setAttribute`` signature changed to const ref #268

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Features
 
   - unit tests #249
   - expose attributes #256 #266
+  - use lists for offsets & extents #266
 - C++:
 
   - ``setAttribute`` signature changed to const ref #268

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ if(openPMD_HAVE_PYTHON)
     pybind11_add_module(openPMD.py MODULE
         src/binding/python/openPMD.cpp
         src/binding/python/AccessType.cpp
+        src/binding/python/Attributable.cpp
         src/binding/python/BaseRecord.cpp
         src/binding/python/BaseRecordComponent.cpp
         src/binding/python/Container.cpp

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Where supported, openPMD-api implements both serial and MPI parallel I/O capabil
 
 // ...
 
-auto s = openPMD::Series("output_files/data%T.h5", openPMD::AccessType::READ_ONLY);
+auto s = openPMD::Series("samples/git-sample/data%T.h5", openPMD::AccessType::READ_ONLY);
 
 for( auto const& i : s.iterations ) {
     std::cout << "Iteration: " << i.first << "\n";
@@ -59,7 +59,7 @@ import openPMD
 
 # ...
 
-series = openPMD.Series("output_files/data%T.h5", openPMD.Access_Type.read_only)
+series = openPMD.Series("samples/git-sample/data%T.h5", openPMD.Access_Type.read_only)
 
 for k_i, i in series.iterations.items():
     print("Iteration: {0}".format(k_i))

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
     print("Field E.x has shape {0} and datatype {1}".format(
           shape, E_x.dtype))
 
-    offset = openPMD.Extent([1, 1, 1])
-    extent = openPMD.Extent([2, 2, 1])
+    offset = [1, 1, 1]
+    extent = [2, 2, 1]
     # TODO buffer protocol / numpy bindings
     # chunk_data = E_x[1:3, 1:3, 1:2]
     chunk_data = E_x.load_chunk(offset, extent)

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
 
     datatype = openPMD.Datatype.DOUBLE
     # datatype = openPMD.determineDatatype(global_data)
-    extent = openPMD.Extent([size, size])
+    extent = [size, size]
     dataset = openPMD.Dataset(datatype, extent)
 
     print("Created a Dataset of size {0}x{1} and Datatype {2}".format(
@@ -47,8 +47,7 @@ if __name__ == "__main__":
     series.flush()
     print("File structure has been written")
 
-    # offset = openPMD.Offset([0, 0])
-    offset = openPMD.Extent([0, 0])
+    offset = [0, 0]
     # TODO implement slicing protocol
     # E[offset[0]:extent[0], offset[1]:extent[1]] = global_data
     rho.store_chunk(offset, extent, global_data)

--- a/src/binding/python/AccessType.cpp
+++ b/src/binding/python/AccessType.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/IO/AccessType.hpp"
 

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -1,0 +1,173 @@
+/* Copyright 2018 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
+
+#include "openPMD/backend/Attributable.hpp"
+#include "openPMD/backend/Attribute.hpp"
+#include "openPMD/auxiliary/Variant.hpp"
+
+#include <string>
+#include <vector>
+#include <array>
+
+
+// std::variant
+//   https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
+namespace pybind11 {
+namespace detail {
+    template< typename... Ts >
+    struct type_caster< variantSrc::variant< Ts... > > :
+        variant_caster< variantSrc::variant< Ts... > >
+    {};
+
+} // namespace detail
+} // namespace pybind11
+
+namespace py = pybind11;
+using namespace openPMD;
+
+using PyAttributeKeys = std::vector< std::string >;
+//PYBIND11_MAKE_OPAQUE(PyAttributeKeys)
+
+void init_Attributable(py::module &m) {
+    py::class_<Attributable>(m, "Attributable")
+        .def(py::init<>())
+        .def(py::init<Attributable const &>())
+
+        .def("__repr__",
+            [](Attributable const & attr) {
+                return "<openPMD.Attributable with'" + std::to_string(attr.numAttributes()) + "' attributes>";
+            }
+        )
+
+        .def_property_readonly(
+            "attributes",
+            []( Attributable & attr )
+            {
+                return attr.attributes();
+            },
+            // ref + keepalive
+            py::return_value_policy::reference_internal
+        )
+
+        // C++ pass-through API
+        //   note: since the value is expected as T&& we have to write a lambda here
+        .def("set_attribute", []( Attributable & attr, std::string const& key, char const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, unsigned char const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, int16_t const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, int32_t const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, int64_t const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, uint16_t const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, uint32_t const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, int64_t const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, float const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, double const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, long double const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::string const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<char> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<unsigned char> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int16_t> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int32_t> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int64_t> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<uint16_t> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<uint32_t> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int64_t> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<float> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<double> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<long double> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<std::string> const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, std::array< double, 7 > const& v ) {
+            attr.setAttribute(key, v);
+        })
+        .def("set_attribute", []( Attributable & attr, std::string const& key, bool const& v ) {
+            attr.setAttribute(key, v);
+        })
+
+        .def("get_attribute", []( Attributable & attr, std::string const& key ) {
+            auto v = attr.getAttribute(key);
+            return v.getResource();
+        })
+        .def("delete_attribute", &Attributable::deleteAttribute)
+        .def("contains_attribute", &Attributable::containsAttribute)
+
+        .def("__len__", &Attributable::numAttributes)
+
+        // @todo _ipython_key_completions_ if we find a way to add a [] interface
+
+        .def_property_readonly("comment", &Attributable::comment)
+        .def("set_comment", &Attributable::setComment)
+    ;
+
+    py::bind_vector< PyAttributeKeys >(
+        m,
+        "Attribute_Keys"
+    );
+}

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -71,85 +71,32 @@ void init_Attributable(py::module &m) {
         )
 
         // C++ pass-through API
-        //   note: since the value is expected as T&& we have to write a lambda here
-        .def("set_attribute", []( Attributable & attr, std::string const& key, char const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, unsigned char const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, int16_t const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, int32_t const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, int64_t const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, uint16_t const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, uint32_t const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, int64_t const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, float const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, double const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, long double const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::string const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<char> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<unsigned char> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int16_t> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int32_t> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int64_t> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<uint16_t> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<uint32_t> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<int64_t> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<float> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<double> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<long double> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector<std::string> const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, std::array< double, 7 > const& v ) {
-            attr.setAttribute(key, v);
-        })
-        .def("set_attribute", []( Attributable & attr, std::string const& key, bool const& v ) {
-            attr.setAttribute(key, v);
-        })
+        .def("set_attribute", &Attributable::setAttribute< char >)
+        .def("set_attribute", &Attributable::setAttribute< unsigned char >)
+        .def("set_attribute", &Attributable::setAttribute< int16_t >)
+        .def("set_attribute", &Attributable::setAttribute< int32_t >)
+        .def("set_attribute", &Attributable::setAttribute< int64_t >)
+        .def("set_attribute", &Attributable::setAttribute< uint16_t >)
+        .def("set_attribute", &Attributable::setAttribute< uint32_t >)
+        .def("set_attribute", &Attributable::setAttribute< uint64_t >)
+        .def("set_attribute", &Attributable::setAttribute< float >)
+        .def("set_attribute", &Attributable::setAttribute< double >)
+        .def("set_attribute", &Attributable::setAttribute< long double >)
+        .def("set_attribute", &Attributable::setAttribute< std::string >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< char > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< unsigned char > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< int16_t > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< int32_t > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< int64_t > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< uint16_t > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< uint32_t > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< uint64_t > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< float > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< double > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< long double > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< std::string > >)
+        .def("set_attribute", &Attributable::setAttribute< std::array< double, 7 > >)
+        .def("set_attribute", &Attributable::setAttribute< bool >)
 
         .def("get_attribute", []( Attributable & attr, std::string const& key ) {
             auto v = attr.getAttribute(key);

--- a/src/binding/python/BaseRecord.cpp
+++ b/src/binding/python/BaseRecord.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/Container.hpp"

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -20,6 +20,7 @@
  */
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/Datatype.hpp"

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -32,7 +32,7 @@ using namespace openPMD;
 
 
 void init_BaseRecordComponent(py::module &m) {
-    py::class_<BaseRecordComponent>(m, "Base_Record_Component")
+    py::class_<BaseRecordComponent, Attributable>(m, "Base_Record_Component")
         .def("__repr__",
             [](BaseRecordComponent const & brc) {
                 std::stringstream ss;

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -26,9 +26,9 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/backend/Container.hpp"
-//include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/Mesh.hpp"
 #include "openPMD/ParticleSpecies.hpp"

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -38,7 +38,6 @@
 #include <string>
 #include <memory>
 #include <utility>
-#include <vector>
 
 namespace py = pybind11;
 using namespace openPMD;
@@ -70,7 +69,8 @@ namespace detail
         using MappedType = typename Map::mapped_type;
         using Class_ = py::class_<
             Map,
-            holder_type
+            holder_type,
+            Attributable
         >;
 
         // If either type is a non-module-local bound type then make the map
@@ -143,16 +143,6 @@ namespace detail
             >()
         );
 
-        cl.def_property_readonly(
-            "attributes",
-            []( Map & m )
-            {
-                return m.attributes();
-            },
-            // ref + keepalive
-            py::return_value_policy::reference_internal
-        );
-
         // keep same policy as Container class: missing keys are created
         cl.def(
             "__getitem__",
@@ -213,14 +203,11 @@ using PyMeshContainer = Container< Mesh >;
 using PyPartContainer = Container< ParticleSpecies >;
 using PyRecordContainer = Container< Record >;
 using PyMeshRecordComponentContainer = Container< MeshRecordComponent >;
-using PyAttributeKeys = std::vector< std::string >;
 PYBIND11_MAKE_OPAQUE(PyIterationContainer)
 PYBIND11_MAKE_OPAQUE(PyMeshContainer)
 PYBIND11_MAKE_OPAQUE(PyPartContainer)
 PYBIND11_MAKE_OPAQUE(PyRecordContainer)
 PYBIND11_MAKE_OPAQUE(PyMeshRecordComponentContainer)
-PYBIND11_MAKE_OPAQUE(PyAttributeKeys)
-
 
 void init_Container( py::module & m ) {
     detail::bind_container< PyIterationContainer >(
@@ -242,9 +229,5 @@ void init_Container( py::module & m ) {
     detail::bind_container< PyMeshRecordComponentContainer >(
         m,
         "Mesh_Record_Component_Container"
-    );
-    py::bind_vector< PyAttributeKeys >(
-        m,
-        "Attribute_Keys"
     );
 }

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -20,6 +20,7 @@
  */
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Dataset.hpp"
 

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -19,7 +19,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
-#include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
 
 #include "openPMD/Dataset.hpp"
@@ -30,17 +29,10 @@ namespace py = pybind11;
 using namespace openPMD;
 
 
-// Extent & Offset are of std::vector< std::uint64_t >
-// those are already specialized in <pybind11/stl.h>
-// PYBIND11_MAKE_OPAQUE(Extent)
-
 void init_Dataset(py::module &m) {
-    py::bind_vector< Extent >(m, "Extent");
-    // TODO expose "Offset" as own type as well?
-
     py::class_<Dataset>(m, "Dataset")
 
-        .def(py::init<Datatype, Offset>())
+        .def(py::init<Datatype, Extent>())
 
         .def("__repr__",
             [](const Dataset &d) {

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Datatype.hpp"
 

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -30,7 +30,7 @@ using namespace openPMD;
 
 
 void init_Iteration(py::module &m) {
-    py::class_<Iteration>(m, "Iteration")
+    py::class_<Iteration, Attributable>(m, "Iteration")
         .def(py::init<Iteration const &>())
 
         .def("__repr__",

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Iteration.hpp"
 

--- a/src/binding/python/IterationEncoding.cpp
+++ b/src/binding/python/IterationEncoding.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/IterationEncoding.hpp"
 

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Mesh.hpp"
 #include "openPMD/backend/BaseRecord.hpp"

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/backend/MeshRecordComponent.hpp"
 #include "openPMD/RecordComponent.hpp"

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/ParticlePatches.hpp"
 

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/ParticleSpecies.hpp"
 #include "openPMD/Record.hpp"

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Record.hpp"
 

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -20,6 +20,7 @@
  */
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/RecordComponent.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "openPMD/Series.hpp"
 

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -28,7 +28,7 @@ using namespace openPMD;
 
 
 void init_Series(py::module &m) {
-    py::class_<Series>(m, "Series")
+    py::class_<Series, Attributable>(m, "Series")
 
         .def(py::init<std::string const&, AccessType>())
 
@@ -36,7 +36,7 @@ void init_Series(py::module &m) {
         .def("set_openPMD", &Series::setOpenPMD)
         .def_property_readonly("openPMD_extension", &Series::openPMDextension)
         .def("set_openPMD_extension", &Series::setOpenPMDextension)
-        .def_property_readonly("base_ath", &Series::basePath)
+        .def_property_readonly("base_path", &Series::basePath)
         .def("set_base_path", &Series::setBasePath)
         .def_property_readonly("meshes_path", &Series::meshesPath)
         .def("set_meshes_path", &Series::setMeshesPath)

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -32,6 +32,7 @@ namespace py = pybind11;
 
 // forward declarations of exposed classes
 void init_AccessType(py::module &);
+void init_Attributable(py::module &);
 void init_BaseRecord(py::module &);
 void init_BaseRecordComponent(py::module &);
 void init_Container(py::module &);
@@ -53,6 +54,7 @@ PYBIND11_MODULE(openPMD, m) {
 
     // note: order from parent to child classes
     init_AccessType(m);
+    init_Attributable(m);
     init_Container(m);
     init_BaseRecord(m);
     init_Dataset(m);


### PR DESCRIPTION
Looks still very C++-ish #255 but exposes all needed functionality for now.

Maybe we could read all attributes at once into an intermediate class (`AttributeCollection?` h5py: `AttributeManager`) and return that for read/write access? In both C++ and Python we would need to couple/link this class again safely into the parent so it can not get invalidated and un-flushed without it knowing it.

- [x] rebase after #268