### PR TITLE
Fix ADIOS1 String Attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
       os: osx
       language: generic
       env:
-        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SAMPLES=ON
+        - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       before_install:
          - COMPILERSPEC="%clang@8.1.0"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Bug Fixes
 - recursive directory creation with existing base #261
 - ``FindADIOS.cmake``: reset on multiple calls #263
 - ``SerialIOTest``: remove variable shadowing #262
+- ADIOS1: memory violation in string attribute writes #269
 
 Other
 """""


### PR DESCRIPTION
Fix broken string attribute writes in ADIOS1: Used invalid pointer to string array before and leaked memory as well.

Also enable serial ADIOS1 on OSX for CI testing.

## Background

Valgrind says there are a few memory leaks in `std::string` attribute writing.

Also, there seems to be a `SerialIOTest` crash in ADIOS1 attribute reading, probably some un-init bytes? Before crash it reads:
```
ERROR: Attribute element /iterationFormat has invalid value attribute
ERROR: Attribute element /iterationFormat has invalid value attribute
```

which looks like a string Datatype issue in our backend.

Message origin in ADIOS: https://github.com/ornladios/ADIOS/blob/v1.13.1/src/core/adios_internals.c#L1146-L1161

During valgrind runs, don't get confused by some noise added by https://github.com/ornladios/ADIOS/issues/184