### PR TITLE
Install Docs: Improve from Source

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,10 @@ Bug Fixes
 Other
 """""
 
+- docs:
+
+  - improve "Install from source" section #274
+
 
 0.3.0-alpha
 -----------

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Choose *one* of the install methods below to get started:
 ### [Spack](https://spack.io)
 
 ```bash
-# optional: append +python
+# optional:               +python
 spack install openpmd-api
 spack load --dependencies openpmd-api
 ```
@@ -139,22 +139,24 @@ git clone https://github.com/openPMD/openPMD-api.git
 mkdir -p openPMD-api-build
 cd openPMD-api-build
 
-# optional for some tests
-.travis/download_samples.sh
+# optional: for full tests
+../.travis/download_samples.sh
 
 # for own install prefix append:
 #   -DCMAKE_INSTALL_PREFIX=$HOME/somepath
 # for options append:
 #   -DopenPMD_USE_...=...
+# e.g. for python support add:
+#   -DopenPMD_USE_PYTHON=ON -DPYTHON_EXECUTABLE=$(which python)
 cmake ../openPMD-api
 
-make -j
+cmake --build .
 
 # optional
-make test
+ctest
 
-# sudo is only required for system paths
-sudo make install
+# sudo might be required required for system paths
+cmake --build . --target install
 ```
 
 The following options can be added to the `cmake` call to control features.

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -31,7 +31,8 @@ A package for openPMD-api is available on the Spack package manager.
 
 .. code-block:: bash
 
-   spack install openpmd-api  # optional: +python
+   # optional:               +python
+   spack install openpmd-api
    spack load --dependencies openpmd-api
 
 .. _install-conda:
@@ -62,7 +63,8 @@ You can also install ``openPMD-api`` from source with CMake.
 This requires that you have all :ref:`dependencies <development-dependencies>` installed on your system.
 The developer section on :ref:`build options <development-buildoptions>` provides further details on variants of the build.
 
-On Linux platforms:
+Linux & OSX
+^^^^^^^^^^^
 
 .. code-block:: bash
 
@@ -71,28 +73,61 @@ On Linux platforms:
    mkdir -p openPMD-api-build
    cd openPMD-api-build
 
-   # optional for some tests
-   .travis/download_samples.sh
+   # optional: for full tests
+   ../.travis/download_samples.sh
 
    # for own install prefix append:
    #   -DCMAKE_INSTALL_PREFIX=$HOME/somepath
    # for options append:
    #   -DopenPMD_USE_...=...
+   # e.g. for python support add:
+   #   -DopenPMD_USE_PYTHON=ON -DPYTHON_EXECUTABLE=$(which python)
    cmake ../openPMD-api
 
-   make -j
+   cmake --build .
 
    # optional
-   make test
+   ctest
 
-   # sudo is only required for system paths
-   sudo make install
+   # sudo might be required required for system paths
+   cmake --build . --target install
 
-On Windows platforms, replace the last steps with:
+Windows
+^^^^^^^
+
+Replace the last commands with:
+
+.. code-block:: cmd
+
+   cmake --build . --config Release
+
+   ctest -C Release
+
+   cmake --build . --config Release --target install
+
+Post "From Source" Install
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you installed to a non-system path on Linux or OSX, you need to express where your newly installed library can be found.
+
+Adjust the lines below accordingly, e.g. replace ``$HOME/somepath`` with your install location prefix in ``-DCMAKE_INSTALL_PREFIX=...``.
+CMake will summarize the install paths for you before the build step.
 
 .. code-block:: bash
 
-   cmake -G "NMake Makefiles" ../openPMD-api
+   # install prefix         |------------|
+   export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
+   export LD_LIBRARY_PATH=$HOME/somepath/lib:$LD_LIBRARY_PATH
 
-   nmake
-   nmake install
+   #                change path to your python MAJOR.MINOR version
+   export PYTHONPATH=$HOME/somepath/lib/python3.5/site-packages:$PYTHONPATH
+
+Adding those lines to your ``$HOME/.bashrc`` and re-opening your terminal will set them permanently.
+
+Set hints on Windows with the CMake printed paths accordingly, e.g.:
+
+.. code-block:: cmd
+
+   set CMAKE_PREFIX_PATH=C:\\Program Files\openPMD;%CMAKE_PREFIX_PATH%
+   set PATH=C:\\Program Files\openPMD\Lib;%PATH%
+   set PYTHONPATH=C:\\Program Files\openPMD\Lib\site-packages;%PYTHONPATH%


### PR DESCRIPTION
Improve install docs for from-source compiles. Make more general where possible (e.g. for Win), fix example for sample downloads and add python example.