### PR TITLE
CMake: Add openPMD::openPMD ALIAS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Changes to "0.3.0-alpha"
 Features
 """"""""
 
+- CMake:
+
+  - add ``openPMD::openPMD`` alias for full-source inclusion #...
+
 Bug Fixes
 """""""""
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ set(IO_SOURCE
 
 # library
 add_library(openPMD ${CORE_SOURCE} ${IO_SOURCE})
+add_library(openPMD::openPMD ALIAS openPMD)
 
 # properties
 target_compile_features(openPMD

--- a/README.md
+++ b/README.md
@@ -219,3 +219,10 @@ if(openPMD_FOUND)
     target_link_libraries(YourTarget PRIVATE openPMD::openPMD)
 endif()
 ```
+
+*Alternatively*, add the openPMD-api repository directly to your project and add it via:
+```cmake
+add_subdirectory("path/to/source/of/openPMD-api")
+
+target_link_libraries(YourTarget PRIVATE openPMD::openPMD)
+```


### PR DESCRIPTION
Adding an alias with the same name as the installed, exported target allows to include the full source-code of openPMD-api in a project similar to header-only libraries.

Instead of starting with `find_package(openPMD)`
```cmake
cmake_minimum_required(VERSION 3.10)

# supports:                       COMPONENTS MPI NOMPI HDF5 ADIOS1 ADIOS2
find_package(openPMD 0.1.0 CONFIG COMPONENTS REQUIRED)

add_executable(YourTarget 3_write_serial.cpp)

if(openPMD_FOUND) # well, it will be if REQUIRED is set
    target_link_libraries(YourTarget PUBLIC openPMD::openPMD)
endif()
```

just do:
```cmake
cmake_minimum_required(VERSION 3.10)

add_subdirectory(share/project/openPMD-api)

target_link_libraries(myProject PRIVATE openPMD::openPMD)
```