### PR TITLE
Spack: Python3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Features
 
 - CMake:
 
-  - add ``openPMD::openPMD`` alias for full-source inclusion #...
+  - add ``openPMD::openPMD`` alias for full-source inclusion #277
 
 Bug Fixes
 """""""""
@@ -30,6 +30,7 @@ Other
 - docs:
 
   - improve "Install from source" section #274
+  - Spack python 3 install command #278
 
 
 0.3.0-alpha

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Choose *one* of the install methods below to get started:
 ### [Spack](https://spack.io)
 
 ```bash
-# optional:               +python
+# optional:               +python ^python@3:
 spack install openpmd-api
 spack load --dependencies openpmd-api
 ```

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -31,7 +31,7 @@ A package for openPMD-api is available on the Spack package manager.
 
 .. code-block:: bash
 
-   # optional:               +python
+   # optional:               +python ^python@3:
    spack install openpmd-api
    spack load --dependencies openpmd-api
 


### PR DESCRIPTION
Mainline spack sadly defaults to python2. So let's explicitly tell users how to use python3 by default.

We could also increase our requirement in the package, but we do indeed (unofficially) even run with python2. Nevertheless, our official support is for Python 3, so let's install it by default as such.

Spack usage reference: https://spack.readthedocs.io/en/latest/features.html#customize-dependencies

Thx to @ritiek for the report!