### PR TITLE
Make Container constructor protected

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Bug Fixes
 """""""""
 
 - improved handling of ``fileBased`` Series and ``READ_WRITE`` access
+- expose ``Container`` constructor as ``protected`` rather than ``public`` #282
 
 Other
 """""

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -85,9 +85,7 @@ public:
     using iterator = typename InternalContainer::iterator;
     using const_iterator = typename InternalContainer::const_iterator;
 
-    Container()
-        : m_container{std::make_shared< InternalContainer >()}
-    { }
+    Container(Container const&) = default;
     virtual ~Container() { }
 
     iterator begin() noexcept { return m_container->begin(); }
@@ -130,7 +128,6 @@ public:
     mapped_type& at(key_type const& key) { return m_container->at(key); }
     mapped_type const& at(key_type const& key) const { return m_container->at(key); }
 
-public:
     /** Access the value that is mapped to a key equivalent to key, creating it if such key does not exist already.
      *
      * @param   key Key of the element to find (lvalue).
@@ -240,7 +237,9 @@ public:
     }
 
 protected:
-    std::shared_ptr< InternalContainer > m_container;
+    Container()
+        : m_container{std::make_shared< InternalContainer >()}
+    { }
 
     void clear_unchecked()
     {
@@ -261,6 +260,8 @@ protected:
 
         flushAttributes();
     }
+
+    std::shared_ptr< InternalContainer > m_container;
 };
 
 } // openPMD

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -90,7 +90,7 @@ namespace detail
             std::forward< Args >( args ) ...
         );
 
-        cl.def( py::init<>() );
+        cl.def( py::init<Map const &>() );
 
         // Register stream insertion operator (if possible)
         py::detail::map_if_insertion_operator<

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -10,6 +10,7 @@
 #endif
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/backend/Attributable.hpp"
+#include "openPMD/backend/Container.hpp"
 #if openPMD_HAVE_INVASIVE_TESTS
 #   undef private
 #   undef protected
@@ -17,7 +18,6 @@
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
-#include "openPMD/backend/Container.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/Dataset.hpp"
 using namespace openPMD;

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -39,10 +39,11 @@ class APITest(unittest.TestCase):
         self.__dirs_to_remove = []
 
         path_to_field_data = generateTestFilePath(
-                "issue-sample/no_particles/data%T.h5")
+                os.path.join("issue-sample", "no_particles", "data%T.h5"))
         path_to_particle_data = generateTestFilePath(
-                "issue-sample/no_fields/data%T.h5")
-        path_to_data = generateTestFilePath("git-sample/data%T.h5")
+                os.path.join("issue-sample", "no_fields", "data%T.h5"))
+        path_to_data = generateTestFilePath(
+                os.path.join("git-sample", "data%T.h5"))
         mode = openPMD.Access_Type.read_only
         self.__field_series = openPMD.Series(path_to_field_data, mode)
         self.__particle_series = openPMD.Series(path_to_particle_data, mode)
@@ -273,8 +274,7 @@ class APITest(unittest.TestCase):
 
     def testMesh_Container(self):
         """ Test openPMD.Mesh_Container. """
-        obj = openPMD.Mesh_Container()
-        del obj
+        self.assertRaises(TypeError, openPMD.Mesh_Container)
 
     def testParticlePatches(self):
         """ Test openPMD.ParticlePatches. """
@@ -286,8 +286,7 @@ class APITest(unittest.TestCase):
 
     def testParticle_Container(self):
         """ Test openPMD.Particle_Container. """
-        obj = openPMD.Particle_Container()
-        del obj
+        self.assertRaises(TypeError, openPMD.Particle_Container)
 
     def testRecord(self):
         """ Test openPMD.Record. """


### PR DESCRIPTION
Avoid users creating dangling objects from a user-constructed Container.

Closes #280.