### PR TITLE
Python: Particle Record Components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,10 @@ Features
   - include internally shipped pybind11 v2.2.3 #281
   - ADIOS1: enable serial API usage even if MPI is present #252 #254
 - introduce detection and specification ``%0\d+T`` of iteration padding #270
+- Python:
+
+  - add unit tests #249
+  - expose record components for particles #284
 
 Bug Fixes
 """""""""
@@ -39,7 +43,7 @@ Other
 
 - docs:
 
-  - improve "Install from source" section #274
+  - improve "Install from source" section #274 #285
   - Spack python 3 install command #278
 
 

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -32,6 +32,14 @@ class BaseRecordComponent : public Attributable
     friend
     class BaseRecord;
 
+    template<
+            typename T,
+            typename T_key,
+            typename T_container
+    >
+    friend
+    class Container;
+
 public:
     virtual ~BaseRecordComponent()
     { }

--- a/src/binding/python/BaseRecord.cpp
+++ b/src/binding/python/BaseRecord.cpp
@@ -24,6 +24,7 @@
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
+#include "openPMD/backend/BaseRecordComponent.hpp"
 
 #include <string>
 
@@ -33,6 +34,8 @@ using namespace openPMD;
 
 void init_BaseRecord(py::module &m) {
     py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Mesh_Base_Record");
+    py::class_<BaseRecord< BaseRecordComponent >, Container< BaseRecordComponent > >(m, "Particle_Base_Record");
+    py::class_<BaseRecord< RecordComponent >, Container< RecordComponent > >(m, "Base_Record");
 
     py::enum_<UnitDimension>(m, "Unit_Dimension")
         .value("L", UnitDimension::L)

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -29,11 +29,12 @@
 #include <pybind11/stl.h>
 
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/backend/MeshRecordComponent.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/Mesh.hpp"
 #include "openPMD/ParticleSpecies.hpp"
 #include "openPMD/Record.hpp"
-#include "openPMD/backend/MeshRecordComponent.hpp"
 
 #include <string>
 #include <memory>
@@ -202,12 +203,16 @@ using PyIterationContainer = Container<
 using PyMeshContainer = Container< Mesh >;
 using PyPartContainer = Container< ParticleSpecies >;
 using PyRecordContainer = Container< Record >;
+using PyRecordComponentContainer = Container< RecordComponent >;
 using PyMeshRecordComponentContainer = Container< MeshRecordComponent >;
+using PyBaseRecordComponentContainer = Container< BaseRecordComponent >;
 PYBIND11_MAKE_OPAQUE(PyIterationContainer)
 PYBIND11_MAKE_OPAQUE(PyMeshContainer)
 PYBIND11_MAKE_OPAQUE(PyPartContainer)
 PYBIND11_MAKE_OPAQUE(PyRecordContainer)
+PYBIND11_MAKE_OPAQUE(PyRecordComponentContainer)
 PYBIND11_MAKE_OPAQUE(PyMeshRecordComponentContainer)
+PYBIND11_MAKE_OPAQUE(PyBaseRecordComponentContainer)
 
 void init_Container( py::module & m ) {
     detail::bind_container< PyIterationContainer >(
@@ -226,8 +231,16 @@ void init_Container( py::module & m ) {
         m,
         "Record_Container"
     );
+    detail::bind_container< PyRecordComponentContainer >(
+        m,
+        "Record_Component_Container"
+    );
     detail::bind_container< PyMeshRecordComponentContainer >(
         m,
         "Mesh_Record_Component_Container"
+    );
+    detail::bind_container< PyBaseRecordComponentContainer >(
+        m,
+        "Base_Record_Component_Container"
     );
 }

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -22,13 +22,15 @@
 #include <pybind11/stl.h>
 
 #include "openPMD/Record.hpp"
+#include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/RecordComponent.hpp"
 
 namespace py = pybind11;
 using namespace openPMD;
 
 
 void init_Record(py::module &m) {
-    py::class_<Record>(m, "Record")
+    py::class_<Record, BaseRecord< RecordComponent > >(m, "Record")
         .def(py::init<Record const &>())
 
         .def("__repr__",

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -162,11 +162,18 @@ class APITest(unittest.TestCase):
         if found_numpy:
             self.assertEqual(y_data.dtype, np.float64)
             self.assertEqual(w_data.dtype, np.float64)
-        # TODO data test
-        # pytest.approx(value)
-        # self.assertSequenceEqual(y_data,
-        #     [-9.60001131e-06, -8.80004967e-06, -8.00007455e-06, ...])
-        # self.assertSequenceEqual(w_data, [1600000., 1600000., ...])
+
+            np.testing.assert_allclose(
+                y_data,
+                [-9.60001131e-06, -8.80004967e-06, -8.00007455e-06,
+                 -7.20008487e-06, -6.40007232e-06, -5.60002710e-06,
+                 -4.79993871e-06, -3.99980648e-06, -3.19964406e-06,
+                 -2.39947455e-06]
+            )
+            np.testing.assert_allclose(
+                w_data,
+                np.ones((10,)) * 1600000.
+            )
 
         E_x = E["x"]
         shape = E_x.shape


### PR DESCRIPTION
Add particle record component support (store/load) to the python API.

## To Do

- [x] rebase against #286