### PR TITLE
Minor fix to README source compilation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ git clone https://github.com/openPMD/openPMD-api.git
 mkdir -p openPMD-api-build
 cd openPMD-api-build
 
-# optional: for full tests
-../.travis/download_samples.sh
+# optional: for full tests, with unzip
+../openPMD-api/.travis/download_samples.sh
 
 # for own install prefix append:
 #   -DCMAKE_INSTALL_PREFIX=$HOME/somepath

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -74,7 +74,7 @@ Linux & OSX
    cd openPMD-api-build
 
    # optional: for full tests
-   ../.travis/download_samples.sh
+   ../openPMD-api/.travis/download_samples.sh
 
    # for own install prefix append:
    #   -DCMAKE_INSTALL_PREFIX=$HOME/somepath


### PR DESCRIPTION
The directory was off for the .travis/download_samples.sh script, and given that I'm on a relatively new laptop, I actually didn't have unzip installed and that crashed the download process.