### PR TITLE
C++ code checks and metrics in TravisCI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: -*,bugprone-*,cert-*,cppcoreguidelines-*,clang-analyzer-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,mpi-*,performance-*,readability-*,-clang-diagnostic-unused-command-line-argument,-*-namespace-comment*,-*-braces-around-statements,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-readability-named-parameter
+HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,14 @@ jobs:
     ###########################################################################
     # Stage: Static Code Analysis                                             #
     ###########################################################################
-    - &include_what_you_use
+    - &static_code_cpp
       stage: 'Static Code Analysis'
       sudo: true
       language: python
       python: "2.7"
       compiler: clang
       env:
+        - NAME="include_what_you_use"
         - USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
       addons:
         apt:
@@ -97,6 +98,40 @@ jobs:
       script:
         - cd $HOME/build
         - python $BIN_PATH/iwyu_tool.py -v -j 2 -p .
+    - <<: *static_code_cpp
+      sudo: false
+      env:
+        - NAME="clang-tidy"
+        - USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - clang-tidy-5.0
+            - libopenmpi-dev
+            - openmpi-bin
+            - environment-modules
+      before_install:
+        - CC=clang CXX=clang++ COMPILERSPEC="%clang@5.0.0"
+      before_script:
+        - mkdir -p $HOME/build
+        - cd $HOME/build
+        - cmake
+            "-DCMAKE_CXX_CLANG_TIDY=$(which clang-tidy-5.0);-system-headers=0"
+            -DCMAKE_BUILD_TYPE=Debug
+            -DopenPMD_USE_MPI=$USE_MPI
+            -DopenPMD_USE_HDF5=$USE_HDF5
+            -DopenPMD_USE_ADIOS1=$USE_ADIOS1
+            -DopenPMD_USE_ADIOS2=$USE_ADIOS2
+            -DopenPMD_USE_PYTHON=OFF
+            $TRAVIS_BUILD_DIR
+      script:
+        - cd $HOME/build
+        - make -j 2 2> clang-tidy.out
+        - cat clang-tidy.out
     - &static_code_python
       stage: 'Static Code Analysis'
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 
 cache:
@@ -43,6 +43,60 @@ jobs:
     ###########################################################################
     # Stage: Static Code Analysis                                             #
     ###########################################################################
+    - &include_what_you_use
+      stage: 'Static Code Analysis'
+      sudo: true
+      language: python
+      python: "2.7"
+      compiler: clang
+      env:
+        - USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - llvm-5.0-dev
+            - libclang-5.0-dev
+            - clang-5.0
+            - libopenmpi-dev
+            - openmpi-bin
+            - environment-modules
+      before_install:
+        - export CC=clang 
+        - export CXX=clang++
+        - ROOT_PATH=`llvm-config-5.0 --prefix`
+        - BIN_PATH=`llvm-config-5.0 --bindir`
+        - if [ ! -f $BIN_PATH/iwyu_tool.py ]; then
+            git clone https://github.com/include-what-you-use/include-what-you-use.git &&
+            cd include-what-you-use &&
+            git checkout clang_5.0 &&
+            mkdir build &&
+            cd build &&
+            cmake -DIWYU_LLVM_ROOT_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=$ROOT_PATH .. &&
+            make -j2 &&
+            sudo make install &&
+            cd ../.. &&
+            rm -rf include-what-you-use;
+          fi
+        - COMPILERSPEC="%clang@5.0.0"
+        - export PATH=$ROOT_PATH/bin:$PATH
+      before_script:
+        - mkdir -p $HOME/build
+        - cd $HOME/build
+        - cmake
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DCMAKE_BUILD_TYPE=Debug
+            -DopenPMD_USE_MPI=$USE_MPI
+            -DopenPMD_USE_HDF5=$USE_HDF5
+            -DopenPMD_USE_ADIOS1=$USE_ADIOS1
+            -DopenPMD_USE_ADIOS2=$USE_ADIOS2
+            -DopenPMD_USE_PYTHON=OFF
+            $TRAVIS_BUILD_DIR
+      script:
+        - cd $HOME/build
+        - python $BIN_PATH/iwyu_tool.py -v -j 2 -p .
     - &static_code_python
       stage: 'Static Code Analysis'
       language: python
@@ -115,6 +169,7 @@ jobs:
     # Clang 8.1.0-apple + Python 2.7.10 @ OSX
     - <<: *test-cpp-unit
       os: osx
+      sudo: required
       language: generic
       env:
         - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
@@ -278,7 +333,7 @@ jobs:
             cd ../.. &&
             rm -rf kcov-35 kcov-35.tar.gz;
           fi;
-        - export PATH=$HOME/.cache/kcov-35/bin:$PATH 
+        - export PATH=$HOME/.cache/kcov-35/bin:$PATH
       before_script:
         - mkdir -p $HOME/build
         - cd $HOME/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - $HOME/.cache/spack
     - $HOME/.cache/cmake-3.10.0
+    - $HOME/.cache/kcov-35
     - $HOME/Library/Caches/Homebrew
   pip: true
 
@@ -70,9 +71,9 @@ jobs:
             - gfortran-4.9
             - g++-4.9  # CMake build
       before_install: &clang50_init
-         - COMPILERSPEC="%clang@5.0.0"
+        - COMPILERSPEC="%clang@5.0.0"
       script: &script-cpp-unit
-        - mkdir -p $HOME/build 
+        - mkdir -p $HOME/build
         - cd $HOME/build
         - if [ ! -d samples/git-sample/ ]; then
             if [ "$USE_SAMPLES" = "ON" ]; then
@@ -119,7 +120,7 @@ jobs:
         - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       before_install:
-         - COMPILERSPEC="%clang@8.1.0"
+        - COMPILERSPEC="%clang@8.1.0"
       script: *script-cpp-unit
     # GCC 4.9.4
     - <<: *test-cpp-unit
@@ -137,7 +138,7 @@ jobs:
             - gcc-4.9
             - g++-4.9
       before_install: &gcc49_init
-         - CXX=g++-4.9 && CC=gcc-4.9 && COMPILERSPEC="%gcc@4.9.4"
+        - CXX=g++-4.9 && CC=gcc-4.9 && COMPILERSPEC="%gcc@4.9.4"
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       language: python
@@ -170,7 +171,7 @@ jobs:
             - gcc-7
             - g++-7
       before_install: &gcc73_init
-         - CXX=g++-7 && CC=gcc-7 && COMPILERSPEC="%gcc@7.3.0"
+        - CXX=g++-7 && CC=gcc-7 && COMPILERSPEC="%gcc@7.3.0"
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       language: python
@@ -203,7 +204,7 @@ jobs:
             - gcc-6
             - g++-6
       before_install: &gcc64_init
-         - CXX=g++-6 && CC=gcc-6 && COMPILERSPEC="%gcc@6.4.0"
+        - CXX=g++-6 && CC=gcc-6 && COMPILERSPEC="%gcc@6.4.0"
       script: *script-cpp-unit
     # GCC 6.4.0 + Python 3.6
     - <<: *test-cpp-unit
@@ -236,8 +237,75 @@ jobs:
             - libopenmpi-dev
             - openmpi-bin
       before_install: &gcc48_init
-         - CXX=g++-4.8 && CC=gcc-4.8 && COMPILERSPEC="%gcc@4.8.5"
+        - CXX=g++-4.8 && CC=gcc-4.8 && COMPILERSPEC="%gcc@4.8.5"
       script: *script-cpp-unit
+    ###########################################################################
+    # Stage: Code Coverage                                                    #
+    ###########################################################################
+    - &code_coverage
+      stage: 'Code Coverage'
+      language: python
+      python: "2.7"
+      compiler: gcc
+      env:
+        - USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+      addons:
+        apt:
+          <<: *apt_common_sources
+          packages:
+            - binutils-dev
+            - libcurl4-openssl-dev
+            - zlib1g-dev
+            - libdw-dev
+            - libiberty-dev
+            - environment-modules
+            - gfortran-7
+            - gcc-7
+            - g++-7
+            - libopenmpi-dev
+            - openmpi-bin
+      before_install:
+        - CXX=g++-7 && CC=gcc-7 && COMPILERSPEC="%gcc@7.3.0"
+        - if [ ! -f $HOME/.cache/kcov-35/bin/kcov ]; then
+            wget -O kcov-35.tar.gz https://github.com/SimonKagstrom/kcov/archive/v35.tar.gz &&
+            tar -xf kcov-35.tar.gz &&
+            cd kcov-35 &&
+            mkdir build &&
+            cd build &&
+            cmake -DCMAKE_INSTALL_PREFIX=$HOME/.cache/kcov-35 .. &&
+            make -j2 &&
+            make install &&
+            cd ../.. &&
+            rm -rf kcov-35 kcov-35.tar.gz;
+          fi;
+        - export PATH=$HOME/.cache/kcov-35/bin:$PATH 
+      before_script:
+        - mkdir -p $HOME/build
+        - cd $HOME/build
+        - if [ ! -d samples/git-sample/ ]; then
+            $TRAVIS_BUILD_DIR/.travis/download_samples.sh;
+          fi
+        - CXXFLAGS="-g -O0 -fprofile-arcs -ftest-coverage" CXX=$CXX CC=$CC
+          cmake
+            -DCMAKE_BUILD_TYPE=Debug
+            -DopenPMD_USE_MPI=$USE_MPI
+            -DopenPMD_USE_HDF5=$USE_HDF5
+            -DopenPMD_USE_ADIOS1=$USE_ADIOS1
+            -DopenPMD_USE_ADIOS2=$USE_ADIOS2
+            -DopenPMD_USE_PYTHON=OFF
+            $TRAVIS_BUILD_DIR
+        - make -j 2
+      script:
+        - mkdir -p coverage
+        - cd bin
+        # TODO code coverage with mpirun
+        - for binary in *; do
+            if [ -f $binary ]; then
+              kcov --exclude-pattern=/usr/,share/openPMD/thirdParty,/test/ ../coverage/$binary $binary;
+            fi;
+          done
+      after_script:
+        - kcov --merge --coveralls-id=$TRAVIS_JOB_ID ../coverage/merged ../coverage/*
 
 install:
   # spack install

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ addons:
 
 jobs:
   fast_finish: true
+  allow_failures:
+    - after_script: exit $?
   include:
     ###########################################################################
     # Stage: Style                                                            #
@@ -33,13 +35,31 @@ jobs:
       stage: 'Style'
       language: python
       python: "2.7"
+      env:
+        - NAME="PEP8"
       install: pip install -U flake8
       script:
         # Test Python Files for PEP8 conformance
         - flake8 --exclude=thirdParty .
     - <<: *style_python
       python: "3.6"
-    # TODO: C++ clang-format checks
+    - &style_cpp
+      stage: 'Style'
+      language: python
+      python: "2.7"
+      env:
+        - NAME="clang-format"
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-format-5.0
+      install:
+        - curl -sOL https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py
+      script:
+        - python run-clang-format.py --clang-format-executable=$(which clang-format-5.0) --extensions cpp,hpp -j 2 -e *share/openPMD* -r $TRAVIS_BUILD_DIR || exit 1
+      after_script: exit $?
     ###########################################################################
     # Stage: Static Code Analysis                                             #
     ###########################################################################
@@ -97,7 +117,12 @@ jobs:
             $TRAVIS_BUILD_DIR
       script:
         - cd $HOME/build
-        - python $BIN_PATH/iwyu_tool.py -v -j 2 -p .
+        - python $BIN_PATH/iwyu_tool.py -v -j 2 -p . > iwyu.log
+        - cat iwyu.log
+        - if [[ $(wc -l <iwyu.log) -ge 1 ]]; then
+            exit 1;
+          fi
+      after_script: exit $?
     - <<: *static_code_cpp
       sudo: false
       env:
@@ -130,8 +155,12 @@ jobs:
             $TRAVIS_BUILD_DIR
       script:
         - cd $HOME/build
-        - make -j 2 2> clang-tidy.out
-        - cat clang-tidy.out
+        - make -j 2 2> clang-tidy.log
+        - cat clang-tidy.log
+        - if [[ $(wc -l <clang-tidy.log) -ge 1 ]]; then
+            exit 1;
+          fi
+      after_script: exit $?
     - &static_code_python
       stage: 'Static Code Analysis'
       language: python

--- a/README.md
+++ b/README.md
@@ -4,28 +4,30 @@ C++ & Python API for Scientific I/O with openPMD
 [![Supported openPMD Standard](https://img.shields.io/badge/openPMD-1.0.0--1.1.0-blue.svg)](https://github.com/openPMD/openPMD-standard/releases)
 [![Documentation Status](https://readthedocs.org/projects/openpmd-api/badge/?version=latest)](https://openpmd-api.readthedocs.io/en/latest/?badge=latest)
 [![Doxygen](https://img.shields.io/badge/API-Doxygen-blue.svg)](https://www.openpmd.org/openPMD-api)
-[![Linux/OSX Build Status dev](https://img.shields.io/travis/openPMD/openPMD-api/dev.svg?label=dev)](https://travis-ci.org/openPMD/openPMD-api/branches)
-[![Windows Build Status dev](https://ci.appveyor.com/api/projects/status/x95q4n620pqk0e0t/branch/dev?svg=true)](https://ci.appveyor.com/project/ax3l/openpmd-api/branch/dev)
+[![Gitter chat](https://img.shields.io/gitter/room/openPMD/API.svg)](https://gitter.im/openPMD/API)
+![Supported Platforms][api-platforms]
 [![License](https://img.shields.io/badge/license-LGPLv3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.html)
 [![DOI](https://rodare.hzdr.de/badge/DOI/10.14278/rodare.27.svg)](https://doi.org/10.14278/rodare.27)
 
-[![C++11][api-cpp]](https://isocpp.org/) ![C++11 API: Alpha][dev-alpha]
-[![Python3][api-py3]](https://www.python.org/) ![Python3 API: Unstable][dev-unstable]
-![Supported Platforms][api-platforms]
+[![Linux/OSX Build Status dev](https://img.shields.io/travis/openPMD/openPMD-api/dev.svg?label=dev)](https://travis-ci.org/openPMD/openPMD-api/branches)
+[![Windows Build Status dev](https://ci.appveyor.com/api/projects/status/x95q4n620pqk0e0t/branch/dev?svg=true)](https://ci.appveyor.com/project/ax3l/openpmd-api/branch/dev)
+[![Coverage Status](https://coveralls.io/repos/github/openPMD/openPMD-api/badge.svg)](https://coveralls.io/github/openPMD/openPMD-api)
+[![CodeFactor](https://www.codefactor.io/repository/github/openpmd/openpmd-api/badge)](https://www.codefactor.io/repository/github/openpmd/openpmd-api)
 
-This library provides a common high-level API for openPMD writing and reading.
-It provides a common interface to I/O libraries and file formats such as HDF5 and ADIOS.
-Where supported, openPMD-api implements both serial and MPI parallel I/O capabilities.
-
-[api-cpp]: https://img.shields.io/badge/language-C%2B%2B11-yellowgreen.svg "C++11 API"
-[api-py3]: https://img.shields.io/badge/language-Python3-yellow.svg "Python3 API"
-[dev-alpha]: https://img.shields.io/badge/phase-alpha-yellowgreen.svg "Status: Alpha"
-[dev-unstable]: https://img.shields.io/badge/phase-unstable-yellow.svg "Status: Unstable"
 [api-platforms]: https://img.shields.io/badge/platforms-linux%20|%20osx%20|%20win-blue.svg "Supported Platforms"
+
+This library provides a high-level API for writing and reading structured numerical data according to [openPMD](https://www.openpmd.org/).
+It allows to build logical file structures which drive scientific I/O libraries such as HDF5 and ADIOS through a common, intuitive interface.
+Where supported, openPMD-api implements both serial and MPI parallel I/O capabilities.
 
 ## Usage
 
 ### C++
+
+[![C++11][api-cpp]](https://isocpp.org/) ![C++11 API: Alpha][dev-alpha]
+
+[api-cpp]: https://img.shields.io/badge/language-C%2B%2B11-yellowgreen.svg "C++11 API"
+[dev-alpha]: https://img.shields.io/badge/phase-alpha-yellowgreen.svg "Status: Alpha"
 
 ```cpp
 #include <openPMD/openPMD.hpp>
@@ -53,6 +55,11 @@ for( auto const& i : s.iterations ) {
 ```
 
 ### Python
+
+[![Python3][api-py3]](https://www.python.org/) ![Python3 API: Unstable][dev-unstable]
+
+[api-py3]: https://img.shields.io/badge/language-Python3-yellow.svg "Python3 API"
+[dev-unstable]: https://img.shields.io/badge/phase-unstable-yellow.svg "Status: Unstable"
 
 ```py
 import openPMD
@@ -95,7 +102,7 @@ Optional I/O backends:
 * [ADIOS1](https://www.olcf.ornl.gov/center-projects/adios) 1.13.1+
 * [ADIOS2](https://github.com/ornladios/ADIOS2) 2.1+ (*not yet implemented*)
 
-while those can be build either with or without:
+while those can be built either with or without:
 * MPI 2.1+, e.g. OpenMPI 1.6.5+ or MPICH2
 
 Optional language bindings:
@@ -210,7 +217,7 @@ First set the following environment hint if openPMD-api was *not* installed in a
 export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
 ```
 
-Use the following lines in your projects `CMakeLists.txt`:
+Use the following lines in your project's `CMakeLists.txt`:
 ```cmake
 # supports:                       COMPONENTS MPI NOMPI HDF5 ADIOS1 ADIOS2
 find_package(openPMD 0.1.0 CONFIG)
@@ -220,7 +227,7 @@ if(openPMD_FOUND)
 endif()
 ```
 
-*Alternatively*, add the openPMD-api repository directly to your project and add it via:
+*Alternatively*, add the openPMD-api repository source directly to your project and use it via:
 ```cmake
 add_subdirectory("path/to/source/of/openPMD-api")
 


### PR DESCRIPTION
This adds a few new builds to the job matrix in travis:
 - C++ code style check through [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
No custom style-configuration ```.clang-format``` that respects #134 is currently included. Thus, clang-format uses the default ```LLVM``` style and failure is expected.
**NOTE** Since creation of the custom ```.clang-format```, modification of the codebase to respect #134 and to pass this test is deferred to a later point in time, this build is marked as an *allowed failure*.
 - C++ static include analysis through [include_what_you_use](https://include-what-you-use.org/)
 **NOTE** Since modification of the codebase to pass this test is deferred to a later point in time, this build is marked as an *allowed failure*.
 - C++ static code analysis through [clang-tidy](http://clang.llvm.org/extra/clang-tidy/)
 All sensible checks that fit this project are currently applied and a few will-not-fix problems are silently excluded.
 **NOTE** Since modification of the codebase to pass this test is deferred to a later point in time, this build is marked as an *allowed failure*.
 - C++ code coverage analysis through [kcov](https://simonkagstrom.github.io/kcov/), pushed to [coveralls](https://coveralls.io/github/openPMD/openPMD-api)
  The overall coverage report is merged from the individual coverage results of all C++ API-tests in [```test/```](https://github.com/openPMD/openPMD-api/tree/0.3.1-alpha/test) and all C++ example binaries in [```examples/```](https://github.com/openPMD/openPMD-api/tree/0.3.1-alpha/examples).
  We will have to decide on a reasonable decrease in coverage percentage that will still pass. Currently, no percentage is specified, which means any percentage will pass.

Closes #122.