### PR TITLE
Fail fast during flush of empty Records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,13 @@ Changes to "0.3.1-alpha"
 Features
 """"""""
 
+- Do not assume Record structure prematurely #297
+
 Bug Fixes
 """""""""
+
+- ADIOS1 fileBased IO #297
+- ADIOS2 stub header #302
 
 Other
 """""
@@ -28,11 +33,16 @@ Other
   - measure C++ unit test coverage with coveralls
   - clang-format support
   - clang-tidy support
-  - include-what-you-use support #291
+  - include-what-you-use support #291 export headers #300
+  - OSX High Sierra support #301
+  - Individual cache per build # 303
+  - Readable build names # 308
 - remove superfluous whitespaces #292
 - readme: openPMD is for scientific data #294
 - override implies virtual #293
 - spack load: ``-r`` #298
+- default constructors and destructors #304
+- string pass-by-value #305
 
 
 0.3.1-alpha

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,8 +444,12 @@ endif()
 
 # Runtime parameter and API status checks ("asserts")
 if(openPMD_USE_VERIFY)
+    target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE "-DopenPMD_USE_VERIFY=1")
+    target_compile_definitions(openPMD.ADIOS1.Parallel PRIVATE "-DopenPMD_USE_VERIFY=1")
     target_compile_definitions(openPMD PRIVATE "-DopenPMD_USE_VERIFY=1")
 else()
+    target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE "-DopenPMD_USE_VERIFY=0")
+    target_compile_definitions(openPMD.ADIOS1.Parallel PRIVATE "-DopenPMD_USE_VERIFY=0")
     target_compile_definitions(openPMD PRIVATE "-DopenPMD_USE_VERIFY=0")
 endif()
 

--- a/examples/1_structure.cpp
+++ b/examples/1_structure.cpp
@@ -47,5 +47,10 @@ int main()
     Dataset dataset = Dataset(Datatype::DOUBLE, Extent{1});
     mass_scalar.resetDataset(dataset);
 
+    /* Required Records and RecordComponents are created automatically.
+     * Initialization has to be done explicitly by the user. */
+    electrons["position"][RecordComponent::SCALAR].resetDataset(dataset);
+    electrons["positionOffset"][RecordComponent::SCALAR].resetDataset(dataset);
+
     return 0;
 }

--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -122,7 +122,7 @@ getBP1DataType(Datatype dtype)
         case DT::DATATYPE:
             throw std::runtime_error("Meta-Datatype leaked into IO");
         case DT::UNDEFINED:
-            throw std::runtime_error("Unknown Attribute datatype");
+            throw std::runtime_error("Unknown Attribute datatype (ADIOS datatype)");
         default:
             throw std::runtime_error("Datatype not implemented in ADIOS IO");
     }

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -78,12 +78,12 @@ namespace openPMD
         virtual ADIOS_FILE* open_read(std::string const& name);
         void close(int64_t);
         void close(ADIOS_FILE*);
+        int64_t initialize_group(std::string const& name);
 
     protected:
-        int64_t m_group;
-        std::string m_groupName;
         ADIOS_READ_METHOD m_readMethod;
         std::unordered_map< Writable*, std::shared_ptr< std::string > > m_filePaths;
+        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_groups;
         std::unordered_map< std::shared_ptr< std::string >, bool > m_existsOnDisk;
         std::unordered_map< std::shared_ptr< std::string >, int64_t > m_openWriteFileHandles;
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -79,6 +79,7 @@ namespace openPMD
         void close(int64_t);
         void close(ADIOS_FILE*);
         int64_t initialize_group(std::string const& name);
+        void flush_attribute(int64_t group, std::string const& name, Attribute const&);
 
     protected:
         ADIOS_READ_METHOD m_readMethod;
@@ -88,6 +89,7 @@ namespace openPMD
         std::unordered_map< std::shared_ptr< std::string >, int64_t > m_openWriteFileHandles;
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
         std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
+        std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
     }; // ADIOS1IOHandlerImpl
 #else
     class EXPORT ADIOS1IOHandlerImpl

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -80,6 +80,7 @@ namespace openPMD
         void close(int64_t);
         void close(ADIOS_FILE*);
         int64_t initialize_group(std::string const& name);
+        void flush_attribute(int64_t group, std::string const& name, Attribute const&);
 
     protected:
         ADIOS_READ_METHOD m_readMethod;
@@ -89,6 +90,7 @@ namespace openPMD
         std::unordered_map< std::shared_ptr< std::string >, int64_t > m_openWriteFileHandles;
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
         std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
+        std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
         MPI_Comm m_mpiComm;
         MPI_Info m_mpiInfo;
     }; // ParallelADIOS1IOHandlerImpl

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -79,12 +79,12 @@ namespace openPMD
         virtual ADIOS_FILE* open_read(std::string const& name);
         void close(int64_t);
         void close(ADIOS_FILE*);
+        int64_t initialize_group(std::string const& name);
 
     protected:
-        int64_t m_group;
-        std::string m_groupName;
         ADIOS_READ_METHOD m_readMethod;
         std::unordered_map< Writable*, std::shared_ptr< std::string > > m_filePaths;
+        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_groups;
         std::unordered_map< std::shared_ptr< std::string >, bool > m_existsOnDisk;
         std::unordered_map< std::shared_ptr< std::string >, int64_t > m_openWriteFileHandles;
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -92,7 +92,7 @@ getH5DataType(Attribute const& att)
         case DT::DATATYPE:
             throw std::runtime_error("Meta-Datatype leaked into IO");
         case DT::UNDEFINED:
-            throw std::runtime_error("Unknown Attribute datatype");
+            throw std::runtime_error("Unknown Attribute datatype (HDF5 datatype)");
         default:
             throw std::runtime_error("Datatype not implemented in HDF5 IO");
     }
@@ -210,7 +210,7 @@ getH5DataSpace(Attribute const& att)
             return array_t_id;
         }
         case DT::UNDEFINED:
-            throw std::runtime_error("Unknown Attribute datatype");
+            throw std::runtime_error("Unknown Attribute datatype (HDF5 dataspace)");
         default:
             throw std::runtime_error("Datatype not implemented in HDF5 IO");
     }

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -177,7 +177,7 @@ public:
 private:
     Mesh();
 
-    void flush(std::string const&) override;
+    void flush_impl(std::string const&) override;
     void read() override;
 }; // Mesh
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -62,11 +62,11 @@ namespace traits
 
             auto& np = ret.particlePatches["numParticles"];
             auto& npc = np[RecordComponent::SCALAR];
-            npc.resetDataset(Dataset(Datatype::UINT64, {0}));
+            npc.resetDataset(Dataset(Datatype::UINT64, {1}));
             npc.parent = np.parent;
             auto& npo = ret.particlePatches["numParticlesOffset"];
             auto& npoc = npo[RecordComponent::SCALAR];
-            npoc.resetDataset(Dataset(Datatype::UINT64, {0}));
+            npoc.resetDataset(Dataset(Datatype::UINT64, {1}));
             npoc.parent = npo.parent;
         }
     };

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -50,7 +50,7 @@ public:
 private:
     Record();
 
-    void flush(std::string const&) override;
+    void flush_impl(std::string const&) override;
     void read() override;
 };  //Record
 

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -124,7 +124,7 @@ allocatePtr(Datatype dtype, uint64_t numPoints)
             break;
         case DT::UNDEFINED:
         default:
-            throw std::runtime_error("Unknown Attribute datatype");
+            throw std::runtime_error("Unknown Attribute datatype (Pointer allocation)");
     }
 
     return std::unique_ptr< void, std::function< void(void*) > >(data, del);

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -38,6 +38,9 @@ enum class UnitDimension : uint8_t
 template< typename T_elem >
 class BaseRecord : public Container< T_elem >
 {
+    friend class Iteration;
+    friend class ParticleSpecies;
+
 public:
     using key_type = typename Container< T_elem >::key_type;
     using mapped_type = typename Container< T_elem >::mapped_type;
@@ -69,7 +72,8 @@ protected:
     std::shared_ptr< bool > m_containsScalar;
 
 private:
-    void flush(std::string const&) override = 0;
+    virtual void flush(std::string const&) final;
+    virtual void flush_impl(std::string const&) = 0;
     virtual void read() = 0;
 };  //BaseRecord
 
@@ -214,5 +218,15 @@ BaseRecord< T_elem >::readBase()
         this->setAttribute("timeOffset", Attribute(*aRead.resource).template get< double >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'timeOffset'");
+}
+
+template< typename T_elem >
+inline void
+BaseRecord< T_elem >::flush(std::string const& name)
+{
+    if( this->empty() )
+        throw std::runtime_error("A Record can not be written without any contained RecordComponents");
+
+    this->flush_impl(name);
 }
 } // openPMD

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -224,8 +224,8 @@ template< typename T_elem >
 inline void
 BaseRecord< T_elem >::flush(std::string const& name)
 {
-    if( this->empty() )
-        throw std::runtime_error("A Record can not be written without any contained RecordComponents");
+    if( !this->written && this->empty() )
+        throw std::runtime_error("A Record can not be written without any contained RecordComponents: " + name);
 
     this->flush_impl(name);
 }

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -41,7 +41,7 @@ public:
 private:
     PatchRecord();
 
-    void flush(std::string const&) override;
+    void flush_impl(std::string const&) override;
     void read() override;
 };  //PatchRecord
 } // openPMD

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -37,7 +37,7 @@ namespace openPMD
 {
 #if openPMD_HAVE_ADIOS1
 #   if openPMD_USE_VERIFY
-#       define VERIFY(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error(std::string((TEXT))); }
+#       define VERIFY(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error((TEXT)); }
 #   else
 #       define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -36,6 +36,274 @@ CommonADIOS1IOHandlerImpl::close(ADIOS_FILE* f)
 }
 
 void
+CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& name, Attribute const& att)
+{
+    int nelems = 0;
+    switch( att.dtype )
+    {
+        using DT = Datatype;
+        case DT::VEC_CHAR:
+            nelems = att.get< std::vector< char > >().size();
+        break;
+        case DT::VEC_INT16:
+            nelems = att.get< std::vector< int16_t > >().size();
+        break;
+        case DT::VEC_INT32:
+            nelems = att.get< std::vector< int32_t > >().size();
+        break;
+        case DT::VEC_INT64:
+            nelems = att.get< std::vector< int64_t > >().size();
+        break;
+        case DT::VEC_UCHAR:
+            nelems = att.get< std::vector< unsigned char > >().size();
+        break;
+        case DT::VEC_UINT16:
+            nelems = att.get< std::vector< uint16_t > >().size();
+        break;
+        case DT::VEC_UINT32:
+            nelems = att.get< std::vector< uint32_t > >().size();
+        break;
+        case DT::VEC_UINT64:
+            nelems = att.get< std::vector< uint64_t > >().size();
+        break;
+        case DT::VEC_FLOAT:
+            nelems = att.get< std::vector< float > >().size();
+        break;
+        case DT::VEC_DOUBLE:
+            nelems = att.get< std::vector< double > >().size();
+        break;
+        case DT::VEC_LONG_DOUBLE:
+            nelems = att.get< std::vector< long double > >().size();
+        break;
+        case DT::VEC_STRING:
+            nelems = att.get< std::vector< std::string > >().size();
+        break;
+        case DT::ARR_DBL_7:
+            nelems = 7;
+        break;
+        case DT::UNDEFINED:
+        case DT::DATATYPE:
+            throw std::runtime_error("Unknown Attribute datatype");
+        default:
+            nelems = 1;
+    }
+
+    std::unique_ptr< void, std::function< void(void*) > > values = auxiliary::allocatePtr(att.dtype, nelems);
+    switch( att.dtype )
+    {
+        using DT = Datatype;
+        case DT::CHAR:
+        {
+            auto ptr = reinterpret_cast< char* >(values.get());
+            *ptr = att.get< char >();
+            break;
+        }
+        case DT::UCHAR:
+        {
+            auto ptr = reinterpret_cast< unsigned char* >(values.get());
+            *ptr = att.get< unsigned char >();
+            break;
+        }
+        case DT::INT16:
+        {
+            auto ptr = reinterpret_cast< int16_t* >(values.get());
+            *ptr = att.get< int16_t >();
+            break;
+        }
+        case DT::INT32:
+        {
+            auto ptr = reinterpret_cast< int32_t* >(values.get());
+            *ptr = att.get< int32_t >();
+            break;
+        }
+        case DT::INT64:
+        {
+            auto ptr = reinterpret_cast< int64_t* >(values.get());
+            *ptr = att.get< int64_t >();
+            break;
+        }
+        case DT::UINT16:
+        {
+            auto ptr = reinterpret_cast< uint16_t* >(values.get());
+            *ptr = att.get< uint16_t >();
+            break;
+        }
+        case DT::UINT32:
+        {
+            auto ptr = reinterpret_cast< uint32_t* >(values.get());
+            *ptr = att.get< uint32_t >();
+            break;
+        }
+        case DT::UINT64:
+        {
+            auto ptr = reinterpret_cast< uint64_t* >(values.get());
+            *ptr = att.get< uint64_t >();
+            break;
+        }
+        case DT::FLOAT:
+        {
+            auto ptr = reinterpret_cast< float* >(values.get());
+            *ptr = att.get< float >();
+            break;
+        }
+        case DT::DOUBLE:
+        {
+            auto ptr = reinterpret_cast< double* >(values.get());
+            *ptr = att.get< double >();
+            break;
+        }
+        case DT::LONG_DOUBLE:
+        {
+            auto ptr = reinterpret_cast< long double* >(values.get());
+            *ptr = att.get< long double >();
+            break;
+        }
+        case DT::STRING:
+        {
+            auto const & v = att.get< std::string >();
+            values = auxiliary::allocatePtr(Datatype::CHAR, v.length() + 1u);
+            strcpy((char*)values.get(), v.c_str());
+            break;
+        }
+        case DT::VEC_CHAR:
+        {
+            auto ptr = reinterpret_cast< char* >(values.get());
+            auto const& vec = att.get< std::vector< char > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_INT16:
+        {
+            auto ptr = reinterpret_cast< int16_t* >(values.get());
+            auto const& vec = att.get< std::vector< int16_t > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_INT32:
+        {
+            auto ptr = reinterpret_cast< int32_t* >(values.get());
+            auto const& vec = att.get< std::vector< int32_t > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_INT64:
+        {
+            auto ptr = reinterpret_cast< int64_t* >(values.get());
+            auto const& vec = att.get< std::vector< int64_t > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_UCHAR:
+        {
+            auto ptr = reinterpret_cast< unsigned char* >(values.get());
+            auto const& vec = att.get< std::vector< unsigned char > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_UINT16:
+        {
+            auto ptr = reinterpret_cast< uint16_t* >(values.get());
+            auto const& vec = att.get< std::vector< uint16_t > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_UINT32:
+        {
+            auto ptr = reinterpret_cast< uint32_t* >(values.get());
+            auto const& vec = att.get< std::vector< uint32_t > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_UINT64:
+        {
+            auto ptr = reinterpret_cast< uint64_t* >(values.get());
+            auto const& vec = att.get< std::vector< uint64_t > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_FLOAT:
+        {
+            auto ptr = reinterpret_cast< float* >(values.get());
+            auto const& vec = att.get< std::vector< float > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_DOUBLE:
+        {
+            auto ptr = reinterpret_cast< double* >(values.get());
+            auto const& vec = att.get< std::vector< double > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_LONG_DOUBLE:
+        {
+            auto ptr = reinterpret_cast< long double* >(values.get());
+            auto const& vec = att.get< std::vector< long double > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+                ptr[i] = vec[i];
+            break;
+        }
+        case DT::VEC_STRING:
+        {
+            auto ptr = reinterpret_cast< char** >(values.get());
+            auto const& vec = att.get< std::vector< std::string > >();
+            for( size_t i = 0; i < vec.size(); ++i )
+            {
+                size_t size = vec[i].size() + 1;
+                ptr[i] = new char[size];
+                strncpy(ptr[i], vec[i].c_str(), size);
+            }
+            break;
+        }
+        case DT::ARR_DBL_7:
+        {
+            auto ptr = reinterpret_cast< double* >(values.get());
+            auto const& arr = att.get< std::array< double, 7> >();
+            for( size_t i = 0; i < 7; ++i )
+                ptr[i] = arr[i];
+            break;
+        }
+        case DT::BOOL:
+        {
+            auto ptr = reinterpret_cast< unsigned char* >(values.get());
+            *ptr = static_cast< unsigned char >(att.get< bool >());
+            break;
+        }
+        case DT::UNDEFINED:
+        case DT::DATATYPE:
+            throw std::runtime_error("Unknown Attribute datatype");
+        default:
+            throw std::runtime_error("Datatype not implemented in ADIOS IO");
+    }
+
+    int status;
+    status = adios_define_attribute_byvalue(group,
+                                            name.c_str(),
+                                            "",
+                                            getBP1DataType(att.dtype),
+                                            nelems,
+                                            values.get());
+    VERIFY(status == err_no_error, "Internal error: Failed to define ADIOS attribute by value");
+
+    if( att.dtype == Datatype::VEC_STRING )
+    {
+        auto ptr = reinterpret_cast< char** >(values.get());
+        for( int i = 0; i < nelems; ++i )
+            delete[] ptr[i];
+    }
+}
+
+void
 CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
                                 Parameter< Operation::CREATE_FILE > const& parameters)
 {
@@ -429,256 +697,6 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
     if( m_handler->accessType == AccessType::READ_ONLY )
         throw std::runtime_error("Writing an attribute in a file opened as read only is not possible.");
 
-    Attribute att = Attribute(parameters.resource);
-
-    int nelems = 0;
-    switch( parameters.dtype )
-    {
-        using DT = Datatype;
-        case DT::VEC_CHAR:
-            nelems = att.get< std::vector< char > >().size();
-            break;
-        case DT::VEC_INT16:
-            nelems = att.get< std::vector< int16_t > >().size();
-            break;
-        case DT::VEC_INT32:
-            nelems = att.get< std::vector< int32_t > >().size();
-            break;
-        case DT::VEC_INT64:
-            nelems = att.get< std::vector< int64_t > >().size();
-            break;
-        case DT::VEC_UCHAR:
-            nelems = att.get< std::vector< unsigned char > >().size();
-            break;
-        case DT::VEC_UINT16:
-            nelems = att.get< std::vector< uint16_t > >().size();
-            break;
-        case DT::VEC_UINT32:
-            nelems = att.get< std::vector< uint32_t > >().size();
-            break;
-        case DT::VEC_UINT64:
-            nelems = att.get< std::vector< uint64_t > >().size();
-            break;
-        case DT::VEC_FLOAT:
-            nelems = att.get< std::vector< float > >().size();
-            break;
-        case DT::VEC_DOUBLE:
-            nelems = att.get< std::vector< double > >().size();
-            break;
-        case DT::VEC_LONG_DOUBLE:
-            nelems = att.get< std::vector< long double > >().size();
-            break;
-        case DT::VEC_STRING:
-            nelems = att.get< std::vector< std::string > >().size();
-            break;
-        case DT::ARR_DBL_7:
-            nelems = 7;
-            break;
-        case DT::UNDEFINED:
-        case DT::DATATYPE:
-            throw std::runtime_error("Unknown Attribute datatype");
-        default:
-            nelems = 1;
-    }
-
-    std::unique_ptr< void, std::function< void(void*) > > values = auxiliary::allocatePtr(parameters.dtype, nelems);
-    switch( parameters.dtype )
-    {
-        using DT = Datatype;
-        case DT::CHAR:
-        {
-            auto ptr = reinterpret_cast< char* >(values.get());
-            *ptr = att.get< char >();
-            break;
-        }
-        case DT::UCHAR:
-        {
-            auto ptr = reinterpret_cast< unsigned char* >(values.get());
-            *ptr = att.get< unsigned char >();
-            break;
-        }
-        case DT::INT16:
-        {
-            auto ptr = reinterpret_cast< int16_t* >(values.get());
-            *ptr = att.get< int16_t >();
-            break;
-        }
-        case DT::INT32:
-        {
-            auto ptr = reinterpret_cast< int32_t* >(values.get());
-            *ptr = att.get< int32_t >();
-            break;
-        }
-        case DT::INT64:
-        {
-            auto ptr = reinterpret_cast< int64_t* >(values.get());
-            *ptr = att.get< int64_t >();
-            break;
-        }
-        case DT::UINT16:
-        {
-            auto ptr = reinterpret_cast< uint16_t* >(values.get());
-            *ptr = att.get< uint16_t >();
-            break;
-        }
-        case DT::UINT32:
-        {
-            auto ptr = reinterpret_cast< uint32_t* >(values.get());
-            *ptr = att.get< uint32_t >();
-            break;
-        }
-        case DT::UINT64:
-        {
-            auto ptr = reinterpret_cast< uint64_t* >(values.get());
-            *ptr = att.get< uint64_t >();
-            break;
-        }
-        case DT::FLOAT:
-        {
-            auto ptr = reinterpret_cast< float* >(values.get());
-            *ptr = att.get< float >();
-            break;
-        }
-        case DT::DOUBLE:
-        {
-            auto ptr = reinterpret_cast< double* >(values.get());
-            *ptr = att.get< double >();
-            break;
-        }
-        case DT::LONG_DOUBLE:
-        {
-            auto ptr = reinterpret_cast< long double* >(values.get());
-            *ptr = att.get< long double >();
-            break;
-        }
-        case DT::STRING:
-        {
-            auto const & v = att.get< std::string >();
-            values = auxiliary::allocatePtr(Datatype::CHAR, v.length() + 1u);
-            strcpy((char*)values.get(), v.c_str());
-            break;
-        }
-        case DT::VEC_CHAR:
-        {
-            auto ptr = reinterpret_cast< char* >(values.get());
-            auto const& vec = att.get< std::vector< char > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_INT16:
-        {
-            auto ptr = reinterpret_cast< int16_t* >(values.get());
-            auto const& vec = att.get< std::vector< int16_t > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_INT32:
-        {
-            auto ptr = reinterpret_cast< int32_t* >(values.get());
-            auto const& vec = att.get< std::vector< int32_t > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_INT64:
-        {
-            auto ptr = reinterpret_cast< int64_t* >(values.get());
-            auto const& vec = att.get< std::vector< int64_t > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_UCHAR:
-        {
-            auto ptr = reinterpret_cast< unsigned char* >(values.get());
-            auto const& vec = att.get< std::vector< unsigned char > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_UINT16:
-        {
-            auto ptr = reinterpret_cast< uint16_t* >(values.get());
-            auto const& vec = att.get< std::vector< uint16_t > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_UINT32:
-        {
-            auto ptr = reinterpret_cast< uint32_t* >(values.get());
-            auto const& vec = att.get< std::vector< uint32_t > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_UINT64:
-        {
-            auto ptr = reinterpret_cast< uint64_t* >(values.get());
-            auto const& vec = att.get< std::vector< uint64_t > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_FLOAT:
-        {
-            auto ptr = reinterpret_cast< float* >(values.get());
-            auto const& vec = att.get< std::vector< float > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_DOUBLE:
-        {
-            auto ptr = reinterpret_cast< double* >(values.get());
-            auto const& vec = att.get< std::vector< double > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_LONG_DOUBLE:
-        {
-            auto ptr = reinterpret_cast< long double* >(values.get());
-            auto const& vec = att.get< std::vector< long double > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
-        case DT::VEC_STRING:
-        {
-            auto ptr = reinterpret_cast< char** >(values.get());
-            auto const& vec = att.get< std::vector< std::string > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-            {
-                size_t size = vec[i].size() + 1;
-                ptr[i] = new char[size];
-                strncpy(ptr[i], vec[i].c_str(), size);
-            }
-            break;
-        }
-        case DT::ARR_DBL_7:
-        {
-            auto ptr = reinterpret_cast< double* >(values.get());
-            auto const& arr = att.get< std::array< double, 7> >();
-            for( size_t i = 0; i < 7; ++i )
-                ptr[i] = arr[i];
-            break;
-        }
-        case DT::BOOL:
-        {
-            auto ptr = reinterpret_cast< unsigned char* >(values.get());
-            *ptr = static_cast< unsigned char >(att.get< bool >());
-            break;
-        }
-        case DT::UNDEFINED:
-        case DT::DATATYPE:
-            throw std::runtime_error("Unknown Attribute datatype");
-        default:
-            throw std::runtime_error("Datatype not implemented in ADIOS IO");
-    }
-
     std::string name = concrete_bp1_file_position(writable);
     if( !auxiliary::ends_with(name, '/') )
         name += '/';
@@ -689,21 +707,9 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
         res = m_filePaths.find(writable->parent);
     int64_t group = m_groups[res->second];
 
-    int status;
-    status = adios_define_attribute_byvalue(group,
-                                            name.c_str(),
-                                            "",
-                                            getBP1DataType(parameters.dtype),
-                                            nelems,
-                                            values.get());
-    VERIFY(status == err_no_error, "Internal error: Failed to define ADIOS attribute by value");
-
-    if( parameters.dtype == Datatype::VEC_STRING )
-    {
-        auto ptr = reinterpret_cast< char** >(values.get());
-        for( int i = 0; i < nelems; ++i )
-            delete[] ptr[i];
-    }
+    auto& attributes = m_attributeWrites[group];
+    attributes.erase(name);
+    attributes.emplace(name, parameters.resource);
 }
 
 void
@@ -735,6 +741,7 @@ CommonADIOS1IOHandlerImpl::readDataset(Writable* writable,
 
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
+    VERIFY(std::strcmp(f->path, m_filePaths.at(writable)->c_str()) == 0, "Internal Error: Invalid ADIOS read file handle");
 
     ADIOS_SELECTION* sel;
     sel = adios_selection_boundingbox(parameters.extent.size(),

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -40,7 +40,7 @@ namespace openPMD
 {
 #if openPMD_HAVE_HDF5
 #   if openPMD_USE_VERIFY
-#       define VERIFY(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error(std::string((TEXT))); }
+#       define VERIFY(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error((TEXT)); }
 #   else
 #       define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -934,7 +934,7 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
         }
         case DT::UNDEFINED:
         case DT::DATATYPE:
-            throw std::runtime_error("Unknown Attribute datatype");
+            throw std::runtime_error("Unknown Attribute datatype (HDF5 Attribute write)");
         default:
             throw std::runtime_error("Datatype not implemented in HDF5 IO");
     }
@@ -1006,7 +1006,7 @@ HDF5IOHandlerImpl::readDataset(Writable* writable,
         case DT::BOOL:
             break;
         case DT::UNDEFINED:
-            throw std::runtime_error("Unknown Attribute datatype");
+            throw std::runtime_error("Unknown Attribute datatype (HDF5 Dataset read)");
         case DT::DATATYPE:
             throw std::runtime_error("Meta-Datatype leaked into IO");
         default:

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -32,7 +32,7 @@ namespace openPMD
 {
 #if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
 #   if openPMD_USE_VERIFY
-#       define VERIFY(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error(std::string((TEXT))); }
+#       define VERIFY(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error((TEXT)); }
 #   else
 #       define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -180,7 +180,7 @@ Mesh::setTimeOffset(T to)
 }
 
 void
-Mesh::flush(std::string const& name)
+Mesh::flush_impl(std::string const& name)
 {
     if( IOHandler->accessType == AccessType::READ_ONLY )
     {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -192,12 +192,14 @@ Mesh::flush_impl(std::string const& name)
         {
             if( *m_containsScalar )
             {
-                MeshRecordComponent& r = at(RecordComponent::SCALAR);
-                r.m_writable->parent = parent;
-                r.parent = parent;
-                r.flush(name);
-                m_writable->abstractFilePosition = r.m_writable->abstractFilePosition;
-                abstractFilePosition = r.abstractFilePosition;
+                MeshRecordComponent& mrc = at(RecordComponent::SCALAR);
+                mrc.m_writable->parent = parent;
+                mrc.parent = parent;
+                mrc.flush(name);
+                IOHandler->flush();
+                m_writable->abstractFilePosition = mrc.m_writable->abstractFilePosition;
+                mrc.abstractFilePosition = m_writable->abstractFilePosition.get();
+                abstractFilePosition = mrc.abstractFilePosition;
                 written = true;
             } else
             {

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -47,7 +47,7 @@ Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
 }
 
 void
-Record::flush(std::string const& name)
+Record::flush_impl(std::string const& name)
 {
     if( IOHandler->accessType == AccessType::READ_ONLY )
     {

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -59,12 +59,14 @@ Record::flush_impl(std::string const& name)
         {
             if( *m_containsScalar )
             {
-                RecordComponent& r = at(RecordComponent::SCALAR);
-                r.m_writable->parent = parent;
-                r.parent = parent;
-                r.flush(name);
-                m_writable->abstractFilePosition = r.m_writable->abstractFilePosition;
-                abstractFilePosition = r.abstractFilePosition;
+                RecordComponent& rc = at(RecordComponent::SCALAR);
+                rc.m_writable->parent = parent;
+                rc.parent = parent;
+                rc.flush(name);
+                IOHandler->flush();
+                m_writable->abstractFilePosition = rc.m_writable->abstractFilePosition;
+                rc.abstractFilePosition = m_writable->abstractFilePosition.get();
+                abstractFilePosition = rc.abstractFilePosition;
                 written = true;
             } else
             {

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -18,6 +18,7 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+#include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/RecordComponent.hpp"
 #include "openPMD/Dataset.hpp"
 
@@ -103,6 +104,19 @@ RecordComponent::flush(std::string const& name)
                 dCreate.compression = m_dataset->compression;
                 dCreate.transform = m_dataset->transform;
                 IOHandler->enqueue(IOTask(this, dCreate));
+                if( m_chunks->empty() )
+                {
+                    /* Ensure at least one WRITE_DATASET per dataset occurs
+                     * ADIOS1 backend only creates a dataset after at least once cell has been written */
+                    Parameter< Operation::WRITE_DATASET > dWrite;
+                    auto uptr = auxiliary::allocatePtr(dCreate.dtype, 1);
+                    std::shared_ptr< void > data{std::move(uptr)};
+                    dWrite.data = data;
+                    dWrite.dtype = dCreate.dtype;
+                    dWrite.extent = Extent(getDimensionality(), 1);
+                    dWrite.offset = Offset(getDimensionality(), 0);
+                    m_chunks->push(IOTask(this, dWrite));
+                }
             }
         }
 

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -113,6 +113,8 @@ RecordComponent::flush(std::string const& name)
                     std::shared_ptr< void > data{std::move(uptr)};
                     dWrite.data = data;
                     dWrite.dtype = dCreate.dtype;
+                    if( dWrite.dtype == Datatype::UNDEFINED )
+                        throw std::runtime_error("Dataset has not been defined for Record Component " + name);
                     dWrite.extent = Extent(getDimensionality(), 1);
                     dWrite.offset = Offset(getDimensionality(), 0);
                     m_chunks->push(IOTask(this, dWrite));

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -537,7 +537,6 @@ Series::flushFileBased()
             iteration << std::setw(*m_filenamePadding) << std::setfill('0') << i.first;
             std::string filename = *m_filenamePrefix + iteration.str() + *m_filenamePostfix;
 
-            /* flush attributes to newly created iterations */
             dirty |= i.second.dirty;
             i.second.flushFileBased(filename, i.first);
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -53,6 +53,13 @@ namespace openPMD
  */
 Format determineFormat(std::string const& filename);
 
+/** Determine the default filename suffix for a given storage format.
+ *
+ * @param   f   File format to determine suffix for.
+ * @return  String containing the default filename suffix
+ */
+std::string suffix(Format f);
+
 /** Remove the filename extension of a given storage format.
  *
  * @param   filename    String containing the filename, possibly with filename extension.
@@ -633,6 +640,7 @@ Series::readFileBased(AccessType actualAccessType)
             fOpen.name = entry;
             IOHandler->enqueue(IOTask(this, fOpen));
             IOHandler->flush();
+            iterations.m_writable->parent = getWritable(this);
             iterations.parent = getWritable(this);
 
             /* allow all attributes to be set */
@@ -857,15 +865,29 @@ determineFormat(std::string const& filename)
 }
 
 std::string
+suffix(Format f)
+{
+    switch( f )
+    {
+        case Format::HDF5:
+            return ".h5";
+        case Format::ADIOS1:
+        case Format::ADIOS2:
+            return ".bp";
+        default:
+            return "";
+    }
+}
+
+std::string
 cleanFilename(std::string const& filename, Format f)
 {
     switch( f )
     {
         case Format::HDF5:
-            return auxiliary::replace_last(filename, ".h5", "");
         case Format::ADIOS1:
         case Format::ADIOS2:
-            return auxiliary::replace_last(filename, ".bp", "");
+            return auxiliary::replace_last(filename, suffix(f), "");
         default:
             return filename;
     }

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -44,10 +44,16 @@ MeshRecordComponent::read()
     Attribute a = Attribute(*aRead.resource);
     if( *aRead.dtype == DT::VEC_FLOAT )
         setPosition(a.get< std::vector< float > >());
+    else if( *aRead.dtype == DT::FLOAT )
+        setPosition(std::vector< float >({a.get< float >()}));
     else if( *aRead.dtype == DT::VEC_DOUBLE )
         setPosition(a.get< std::vector< double > >());
+    else if( *aRead.dtype == DT::DOUBLE )
+        setPosition(std::vector< double >({a.get< double >()}));
     else if( *aRead.dtype == DT::VEC_LONG_DOUBLE )
         setPosition(a.get< std::vector< long double > >());
+    else if( *aRead.dtype == DT::LONG_DOUBLE )
+        setPosition(std::vector< long double >({a.get< long double >()}));
     else
         throw std::runtime_error( "Unexpected Attribute datatype for 'position'");
 

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -41,7 +41,7 @@ PatchRecord::PatchRecord()
 { }
 
 void
-PatchRecord::flush(std::string const& path)
+PatchRecord::flush_impl(std::string const& path)
 {
     if( this->find(RecordComponent::SCALAR) == this->end() )
     {

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -91,6 +91,8 @@ PatchRecordComponent::flush(std::string const& name)
                 std::shared_ptr< void > data{std::move(uptr)};
                 dWrite.data = data;
                 dWrite.dtype = dCreate.dtype;
+                if( dWrite.dtype == Datatype::UNDEFINED )
+                    throw std::runtime_error("Dataset has not been defined for ParticlePatch RecordComponent " + name);
                 dWrite.extent = Extent(getDimensionality(), 1);
                 dWrite.offset = Offset(getDimensionality(), 0);
                 m_chunks->push(IOTask(this, dWrite));

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -18,6 +18,7 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+#include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"
 
 
@@ -81,6 +82,19 @@ PatchRecordComponent::flush(std::string const& name)
             dCreate.compression = m_dataset->compression;
             dCreate.transform = m_dataset->transform;
             IOHandler->enqueue(IOTask(this, dCreate));
+            if( m_chunks->empty() )
+            {
+                /* Ensure at least one WRITE_DATASET per dataset occurs
+                 * ADIOS1 backend only creates a dataset after at least once cell has been written */
+                Parameter< Operation::WRITE_DATASET > dWrite;
+                auto uptr = auxiliary::allocatePtr(dCreate.dtype, 1);
+                std::shared_ptr< void > data{std::move(uptr)};
+                dWrite.data = data;
+                dWrite.dtype = dCreate.dtype;
+                dWrite.extent = Extent(getDimensionality(), 1);
+                dWrite.offset = Offset(getDimensionality(), 0);
+                m_chunks->push(IOTask(this, dWrite));
+            }
         }
 
         while( !m_chunks->empty() )

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -203,6 +203,7 @@ TEST_CASE( "particleSpecies_modification_test", "[core]" )
     REQUIRE(zeros == offset.unitDimension());
 
     auto& off_x = offset["x"];
+    off_x.resetDataset(dset);
     REQUIRE(1 == off_x.unitSI());
 }
 
@@ -468,6 +469,7 @@ TEST_CASE( "structure_test", "[core]" )
     REQUIRE(o.iterations[1].particles["P"].particlePatches["extent"]["x"].IOHandler);
     REQUIRE(prc.parent == getWritable(&o.iterations[1].particles["P"].particlePatches["extent"]));
     REQUIRE(o.iterations[1].particles["P"].particlePatches["extent"]["x"].parent == getWritable(&o.iterations[1].particles["P"].particlePatches["extent"]));
+    prc.resetDataset(dset);
 #else
     std::cerr << "Invasive tests not enabled. Hierarchy is not visible.\n";
 #endif

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -102,8 +102,11 @@ TEST_CASE( "output_constructor_test", "[core]" )
 
     o.setMeshesPath("customMeshesPath").setParticlesPath("customParticlesPath");
 
-    o.iterations[1].meshes["foo"];
-    o.iterations[1].particles["bar"];
+    o.iterations[1].meshes["foo"]["baz"].resetDataset(Dataset(Datatype::DOUBLE, {1}));
+    auto species = o.iterations[1].particles["bar"];
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    species["position"][RecordComponent::SCALAR].resetDataset(dset);
+    species["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
     REQUIRE(o.openPMD() == "1.1.0");
     REQUIRE(o.openPMDextension() == static_cast<uint32_t>(0));
@@ -186,6 +189,9 @@ TEST_CASE( "particleSpecies_modification_test", "[core]" )
     REQUIRE(0 == species.numAttributes());
     REQUIRE(2 == species.size());    //position, positionOffset
     REQUIRE(1 == species.count("position"));
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    species["position"][RecordComponent::SCALAR].resetDataset(dset);
+    species["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     REQUIRE(1 == species.count("positionOffset"));
     auto& patches = species.particlePatches;
     REQUIRE(2 == patches.size());
@@ -205,7 +211,11 @@ TEST_CASE( "record_constructor_test", "[core]" )
 {
     Series o = Series("./MyOutput_%T", AccessType::CREATE);
 
-    Record& r = o.iterations[42].particles["species"]["record"];
+    ParticleSpecies ps = o.iterations[42].particles["species"];
+    Record& r = ps["record"];
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    ps["position"][RecordComponent::SCALAR].resetDataset(dset);
+    ps["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
     REQUIRE(r["x"].unitSI() == 1);
     REQUIRE(r["x"].numAttributes() == 1); /* unitSI */
@@ -223,7 +233,11 @@ TEST_CASE( "record_modification_test", "[core]" )
 {
     Series o = Series("./MyOutput_%T", AccessType::CREATE);
 
-    Record& r = o.iterations[42].particles["species"]["record"];
+    auto species = o.iterations[42].particles["species"];
+    Record& r = species["position"];
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    species["position"][RecordComponent::SCALAR].resetDataset(dset);
+    species["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
     using RUD = UnitDimension;
     r.setUnitDimension({{RUD::L, 1.},
@@ -247,7 +261,11 @@ TEST_CASE( "recordComponent_modification_test", "[core]" )
 {
     Series o = Series("./MyOutput_%T", AccessType::CREATE);
 
-    Record& r = o.iterations[42].particles["species"]["record"];
+    ParticleSpecies ps = o.iterations[42].particles["species"];
+    Record& r = ps["record"];
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    ps["position"][RecordComponent::SCALAR].resetDataset(dset);
+    ps["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
     r["x"].setUnitSI(2.55999e-7);
     r["y"].setUnitSI(4.42999e-8);
@@ -387,6 +405,9 @@ TEST_CASE( "structure_test", "[core]" )
 
     REQUIRE(1 == o.iterations[1].particles["P"].count("position"));
     REQUIRE(1 == o.iterations[1].particles["P"].count("positionOffset"));
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    o.iterations[1].particles["P"]["position"][RecordComponent::SCALAR].resetDataset(dset);
+    o.iterations[1].particles["P"]["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
     Record r = o.iterations[1].particles["P"]["PR"];
     REQUIRE(r.IOHandler);
@@ -529,6 +550,9 @@ TEST_CASE( "wrapper_test", "[core]" )
 #endif
 
     o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].resetDataset(Dataset(Datatype::UINT64, {4}));
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    o.iterations[6].particles["electrons"]["position"][RecordComponent::SCALAR].resetDataset(dset);
+    o.iterations[6].particles["electrons"]["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     ParticlePatches pp = o.iterations[6].particles["electrons"].particlePatches;
     REQUIRE(pp["numParticles"][RecordComponent::SCALAR].getDatatype() == Datatype::UINT64);
     REQUIRE(pp["numParticles"][RecordComponent::SCALAR].getExtent() == Extent{4});
@@ -573,6 +597,9 @@ TEST_CASE( "use_count_test", "[core]" )
 
 #if openPMD_HAVE_INVASIVE_TESTS
     PatchRecordComponent pprc = o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR];
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    o.iterations[6].particles["electrons"]["position"][RecordComponent::SCALAR].resetDataset(dset);
+    o.iterations[6].particles["electrons"]["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     pprc.resetDataset(Dataset(Datatype::UINT64, {4}));
     pprc.store(0, static_cast< uint64_t >(1));
     REQUIRE(static_cast< Parameter< Operation::WRITE_DATASET >* >(pprc.m_chunks->front().parameter.get())->data.use_count() == 1);

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -607,3 +607,14 @@ TEST_CASE( "use_count_test", "[core]" )
     REQUIRE(static_cast< Parameter< Operation::WRITE_DATASET >* >(pprc.m_chunks->front().parameter.get())->data.use_count() == 1);
 #endif
 }
+
+TEST_CASE( "empty_record_test", "[core]" )
+{
+    Series o = Series("./new_openpmd_output", AccessType::CREATE);
+
+    o.iterations[1].meshes["E"].setComment("No assumption about contained RecordComponents will be made");
+    REQUIRE_THROWS_WITH(o.flush(),
+                        Catch::Equals("A Record can not be written without any contained RecordComponents: E"));
+    o.iterations[1].meshes["E"][RecordComponent::SCALAR].resetDataset(Dataset(Datatype::DOUBLE, {1}));
+    o.flush();
+}

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1702,48 +1702,51 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     {
         Series o = Series("../samples/serial_fileBased_write%T.bp", AccessType::READ_ONLY);
 
-        REQUIRE(o.openPMDextension() == 1);
+        //REQUIRE(o.openPMDextension() == 1);
 
         REQUIRE(o.iterations.size() == 3);
         REQUIRE(o.iterations.count(1) == 1);
         REQUIRE(o.iterations.count(2) == 1);
         REQUIRE(o.iterations.count(3) == 1);
 
-        REQUIRE(o.iterations[1].time< float >() == 1.f);
-        REQUIRE(o.iterations[2].time< float >() == 2.f);
-        REQUIRE(o.iterations[3].time< float >() == 3.f);
+        REQUIRE(o.iterations.at(1).time< float >() == 1.f);
+        REQUIRE(o.iterations.at(2).time< float >() == 2.f);
+        REQUIRE(o.iterations.at(3).time< float >() == 3.f);
 
         for( uint64_t i = 1; i <= 3; ++i )
         {
-            Iteration iteration = o.iterations[i];
+            Iteration iteration = o.iterations.at(i);
 
             REQUIRE(iteration.particles.size() == 1);
             REQUIRE(iteration.particles.count("e") == 1);
 
-            ParticleSpecies& species = iteration.particles["e"];
+            ParticleSpecies& species = iteration.particles.at("e");
 
             REQUIRE(species.size() == 2);
             REQUIRE(species.count("position") == 1);
             REQUIRE(species.count("positionOffset") == 1);
 
-            REQUIRE(species["position"].size() == 1);
-            REQUIRE(species["position"].count("x") == 1);
-            REQUIRE(species["position"]["x"].getDatatype() == Datatype::DOUBLE);
-            REQUIRE(species["position"]["x"].getDimensionality() == 1);
-            REQUIRE(species["position"]["x"].getExtent() == Extent{4});
-            REQUIRE(species["positionOffset"].size() == 1);
-            REQUIRE(species["positionOffset"].count("x") == 1);
-            REQUIRE(species["positionOffset"]["x"].getDatatype() == Datatype::UINT64);
-            REQUIRE(species["positionOffset"]["x"].getDimensionality() == 1);
-            REQUIRE(species["positionOffset"]["x"].getExtent() == Extent{4});
+            REQUIRE(species.at("position").size() == 1);
+            REQUIRE(species.at("position").count("x") == 1);
+            REQUIRE(species.at("position").at("x").getDatatype() == Datatype::DOUBLE);
+            REQUIRE(species.at("position").at("x").getDimensionality() == 1);
+            REQUIRE(species.at("position").at("x").getExtent() == Extent{4});
+            REQUIRE(species.at("positionOffset").size() == 1);
+            REQUIRE(species.at("positionOffset").count("x") == 1);
+            REQUIRE(species.at("positionOffset").at("x").getDatatype() == Datatype::UINT64);
+            REQUIRE(species.at("positionOffset").at("x").getDimensionality() == 1);
+            REQUIRE(species.at("positionOffset").at("x").getExtent() == Extent{4});
 
-            auto position = species["position"]["x"].loadChunk< double >({0}, {4}).get();
+            auto position = species.at("position").at("x").loadChunk< double >({0}, {4});
+            auto position_raw = position.get();
+            auto positionOffset = species.at("positionOffset").at("x").loadChunk< uint64_t >({0}, {4});
+            auto positionOffset_raw = positionOffset.get();
+            o.flush();
             for( uint64_t j = 0; j < 4; ++j )
-                REQUIRE(position[j] == static_cast< double >(j));
-
-            auto positionOffset = species["positionOffset"]["x"].loadChunk< uint64_t >({0}, {4}).get();
-            for( uint64_t j = 0; j < 4; ++j )
-                REQUIRE(positionOffset[j] == j);
+            {
+                REQUIRE(position_raw[j] == static_cast< double >(j));
+                REQUIRE(positionOffset_raw[j] == j);
+            }
         }
     }
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -977,6 +977,119 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     //TODO close file, read back, verify
 }
 
+TEST_CASE( "hdf5_fileBased_write_empty_test", "[serial][hdf5]" )
+{
+    if( auxiliary::directory_exists("../samples/subdir") )
+        auxiliary::remove_directory("../samples/subdir");
+
+    Dataset dset = Dataset(Datatype::DOUBLE, {2});
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.h5", AccessType::CREATE);
+
+        ParticleSpecies& e_1 = o.iterations[1].particles["e"];
+        e_1["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_1["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[1].setTime(1.f);
+        ParticleSpecies& e_2 = o.iterations[2].particles["e"];
+        e_2["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_2["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[2].setTime(2.f);
+        ParticleSpecies& e_3 = o.iterations[3].particles["e"];
+        e_3["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_3["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[3].setTime(3.f);
+    }
+
+    REQUIRE(auxiliary::directory_exists("../samples/subdir"));
+    REQUIRE(auxiliary::file_exists("../samples/subdir/serial_fileBased_write1.h5"));
+    REQUIRE(auxiliary::file_exists("../samples/subdir/serial_fileBased_write2.h5"));
+    REQUIRE(auxiliary::file_exists("../samples/subdir/serial_fileBased_write3.h5"));
+
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.h5", AccessType::READ_ONLY);
+
+        REQUIRE(o.iterations.size() == 3);
+        REQUIRE(o.iterations.count(1) == 1);
+        REQUIRE(o.iterations.count(2) == 1);
+        REQUIRE(o.iterations.count(3) == 1);
+
+        REQUIRE(o.iterations[1].time< float >() == 1.f);
+        REQUIRE(o.iterations[2].time< float >() == 2.f);
+        REQUIRE(o.iterations[3].time< float >() == 3.f);
+
+        REQUIRE(o.iterations[1].particles.size() == 1);
+        REQUIRE(o.iterations[1].particles.count("e") == 1);
+        REQUIRE(o.iterations[2].particles.size() == 1);
+        REQUIRE(o.iterations[2].particles.count("e") == 1);
+        REQUIRE(o.iterations[3].particles.size() == 1);
+        REQUIRE(o.iterations[3].particles.count("e") == 1);
+
+        REQUIRE(o.iterations[1].particles["e"].size() == 2);
+        REQUIRE(o.iterations[1].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[1].particles["e"].count("positionOffset") == 1);
+        REQUIRE(o.iterations[2].particles["e"].size() == 2);
+        REQUIRE(o.iterations[2].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[2].particles["e"].count("positionOffset") == 1);
+        REQUIRE(o.iterations[3].particles["e"].size() == 2);
+        REQUIRE(o.iterations[3].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[3].particles["e"].count("positionOffset") == 1);
+
+        REQUIRE(o.iterations[1].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[1].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[1].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[1].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+        REQUIRE(o.iterations[2].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[2].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[2].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[2].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[2].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[2].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[2].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+        REQUIRE(o.iterations[3].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[3].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[3].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[3].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[3].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[3].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[3].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+    }
+
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.h5", AccessType::READ_WRITE);
+        ParticleSpecies& e_4 = o.iterations[4].particles["e"];
+        e_4["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_4["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[4].setTime(4.f);
+    }
+
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.h5", AccessType::READ_ONLY);
+
+        REQUIRE(o.iterations.size() == 4);
+        REQUIRE(o.iterations.count(4) == 1);
+
+        REQUIRE(o.iterations[4].time< float >() == 4.f);
+
+        REQUIRE(o.iterations[4].particles.size() == 1);
+        REQUIRE(o.iterations[4].particles.count("e") == 1);
+
+        REQUIRE(o.iterations[4].particles["e"].size() == 2);
+        REQUIRE(o.iterations[4].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[4].particles["e"].count("positionOffset") == 1);
+
+        REQUIRE(o.iterations[4].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[4].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[4].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[4].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[4].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[4].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[4].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+    }
+}
+
 TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
 {
     if( auxiliary::directory_exists("../samples/subdir") )
@@ -992,13 +1105,6 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
         std::shared_ptr< double > position_local_1(new double);
         e_1["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_1), {4}));
-
-        for( uint64_t i = 0; i < 4; ++i )
-        {
-            *position_local_1 = position_global[i];
-            e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
-        }
-
         std::vector< uint64_t > positionOffset_global(4);
         uint64_t posOff{0};
         std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1007,8 +1113,11 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
 
         for( uint64_t i = 0; i < 4; ++i )
         {
+            *position_local_1 = position_global[i];
+            e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
             *positionOffset_local_1 = positionOffset_global[i];
             e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
+            o.flush();
         }
 
         o.iterations[1].setTime(static_cast< double >(1));
@@ -1017,47 +1126,37 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
 
         std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
         e_2["position"]["x"].resetDataset(Dataset(determineDatatype<double>(), {4}));
-
-        for( uint64_t i = 0; i < 4; ++i )
-        {
-            double const position_local_2 = position_global.at(i);
-            e_2["position"]["x"].storeChunk({i}, {1}, shareRaw(&position_local_2));
-        }
-
         std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
         std::shared_ptr< uint64_t > positionOffset_local_2(new uint64_t);
         e_2["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_2), {4}));
 
         for( uint64_t i = 0; i < 4; ++i )
         {
+            double const position_local_2 = position_global.at(i);
+            e_2["position"]["x"].storeChunk({i}, {1}, shareRaw(&position_local_2));
             *positionOffset_local_2 = positionOffset_global[i];
             e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
+            o.flush();
         }
 
-        // TODO not yet written
         o.iterations[2].setTime(static_cast< double >(2));
-        o.flush();
 
         ParticleSpecies& e_3 = o.iterations[3].particles["e"];
 
         std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
         std::shared_ptr< double > position_local_3(new double);
         e_3["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_3), {4}));
-
-        for( uint64_t i = 0; i < 4; ++i )
-        {
-            *position_local_3 = position_global[i];
-            e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
-        }
-
         std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
         std::shared_ptr< uint64_t > positionOffset_local_3(new uint64_t);
         e_3["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_3), {4}));
 
         for( uint64_t i = 0; i < 4; ++i )
         {
+            *position_local_3 = position_global[i];
+            e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
             *positionOffset_local_3 = positionOffset_global[i];
             e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
+            o.flush();
         }
 
         o.setOpenPMDextension(1);
@@ -1417,87 +1516,236 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     o.flush();
 }
 
+TEST_CASE( "adios1_fileBased_write_empty_test", "[serial][adios1]" )
+{
+    if( auxiliary::directory_exists("../samples/subdir") )
+        auxiliary::remove_directory("../samples/subdir");
+
+    Dataset dset = Dataset(Datatype::DOUBLE, {2});
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.bp", AccessType::CREATE);
+
+        ParticleSpecies& e_1 = o.iterations[1].particles["e"];
+        e_1["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_1["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[1].setTime(1.f);
+        ParticleSpecies& e_2 = o.iterations[2].particles["e"];
+        e_2["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_2["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[2].setTime(2.f);
+        ParticleSpecies& e_3 = o.iterations[3].particles["e"];
+        e_3["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_3["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[3].setTime(3.f);
+    }
+
+    REQUIRE(auxiliary::directory_exists("../samples/subdir"));
+    REQUIRE(auxiliary::file_exists("../samples/subdir/serial_fileBased_write1.bp"));
+    REQUIRE(auxiliary::file_exists("../samples/subdir/serial_fileBased_write2.bp"));
+    REQUIRE(auxiliary::file_exists("../samples/subdir/serial_fileBased_write3.bp"));
+
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.bp", AccessType::READ_ONLY);
+
+        REQUIRE(o.iterations.size() == 3);
+        REQUIRE(o.iterations.count(1) == 1);
+        REQUIRE(o.iterations.count(2) == 1);
+        REQUIRE(o.iterations.count(3) == 1);
+
+        REQUIRE(o.iterations[1].time< float >() == 1.f);
+        REQUIRE(o.iterations[2].time< float >() == 2.f);
+        REQUIRE(o.iterations[3].time< float >() == 3.f);
+
+        REQUIRE(o.iterations[1].particles.size() == 1);
+        REQUIRE(o.iterations[1].particles.count("e") == 1);
+        REQUIRE(o.iterations[2].particles.size() == 1);
+        REQUIRE(o.iterations[2].particles.count("e") == 1);
+        REQUIRE(o.iterations[3].particles.size() == 1);
+        REQUIRE(o.iterations[3].particles.count("e") == 1);
+
+        REQUIRE(o.iterations[1].particles["e"].size() == 2);
+        REQUIRE(o.iterations[1].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[1].particles["e"].count("positionOffset") == 1);
+        REQUIRE(o.iterations[2].particles["e"].size() == 2);
+        REQUIRE(o.iterations[2].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[2].particles["e"].count("positionOffset") == 1);
+        REQUIRE(o.iterations[3].particles["e"].size() == 2);
+        REQUIRE(o.iterations[3].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[3].particles["e"].count("positionOffset") == 1);
+
+        REQUIRE(o.iterations[1].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[1].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[1].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[1].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+        REQUIRE(o.iterations[2].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[2].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[2].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[2].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[2].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[2].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[2].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+        REQUIRE(o.iterations[3].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[3].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[3].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[3].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[3].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[3].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[3].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+    }
+
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.bp", AccessType::READ_WRITE);
+        ParticleSpecies& e_4 = o.iterations[4].particles["e"];
+        e_4["position"][RecordComponent::SCALAR].resetDataset(dset);
+        e_4["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
+        o.iterations[4].setTime(4.f);
+    }
+
+    {
+        Series o = Series("../samples/subdir/serial_fileBased_write%T.bp", AccessType::READ_ONLY);
+
+        REQUIRE(o.iterations.size() == 4);
+        REQUIRE(o.iterations.count(4) == 1);
+
+        REQUIRE(o.iterations[4].time< float >() == 4.f);
+
+        REQUIRE(o.iterations[4].particles.size() == 1);
+        REQUIRE(o.iterations[4].particles.count("e") == 1);
+
+        REQUIRE(o.iterations[4].particles["e"].size() == 2);
+        REQUIRE(o.iterations[4].particles["e"].count("position") == 1);
+        REQUIRE(o.iterations[4].particles["e"].count("positionOffset") == 1);
+
+        REQUIRE(o.iterations[4].particles["e"]["position"].size() == 1);
+        REQUIRE(o.iterations[4].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[4].particles["e"]["positionOffset"].size() == 1);
+        REQUIRE(o.iterations[4].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(o.iterations[4].particles["e"]["position"][RecordComponent::SCALAR].getDatatype() == Datatype::DOUBLE);
+        REQUIRE(o.iterations[4].particles["e"]["position"][RecordComponent::SCALAR].getDimensionality() == 1);
+        REQUIRE(o.iterations[4].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{2});
+    }
+}
+
 TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
 {
-    Series o = Series("../samples/serial_fileBased_write%T.bp", AccessType::CREATE);
-
-    ParticleSpecies& e_1 = o.iterations[1].particles["e"];
-
-    std::vector< double > position_global(4);
-    double pos{0.};
-    std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local_1(new double);
-    e_1["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_1), {4}));
-
-    for( uint64_t i = 0; i < 4; ++i )
     {
-        *position_local_1 = position_global[i];
-        e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
+        Series o = Series("../samples/serial_fileBased_write%T.bp", AccessType::CREATE);
+
+        ParticleSpecies& e_1 = o.iterations[1].particles["e"];
+
+        std::vector< double > position_global(4);
+        double pos{0.};
+        std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
+        std::shared_ptr< double > position_local_1(new double);
+        e_1["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_1), {4}));
+        std::vector< uint64_t > positionOffset_global(4);
+        uint64_t posOff{0};
+        std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
+        std::shared_ptr< uint64_t > positionOffset_local_1(new uint64_t);
+        e_1["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_1), {4}));
+
+        for( uint64_t i = 0; i < 4; ++i )
+        {
+            *position_local_1 = position_global[i];
+            e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
+            *positionOffset_local_1 = positionOffset_global[i];
+            e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
+            o.flush();
+        }
+
+        o.iterations[1].setTime(1.f);
+
+        ParticleSpecies& e_2 = o.iterations[2].particles["e"];
+
+        std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
+        e_2["position"]["x"].resetDataset(Dataset(determineDatatype<double>(), {4}));
+        std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
+        std::shared_ptr< uint64_t > positionOffset_local_2(new uint64_t);
+        e_2["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_2), {4}));
+
+        for( uint64_t i = 0; i < 4; ++i )
+        {
+            double const position_local_2 = position_global.at(i);
+            e_2["position"]["x"].storeChunk({i}, {1}, shareRaw(&position_local_2));
+            *positionOffset_local_2 = positionOffset_global[i];
+            e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
+            o.flush();
+        }
+
+        o.iterations[2].setTime(2.f);
+
+        ParticleSpecies& e_3 = o.iterations[3].particles["e"];
+
+        std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
+        std::shared_ptr< double > position_local_3(new double);
+        e_3["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_3), {4}));
+        std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
+        std::shared_ptr< uint64_t > positionOffset_local_3(new uint64_t);
+        e_3["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_3), {4}));
+
+        for( uint64_t i = 0; i < 4; ++i )
+        {
+            *position_local_3 = position_global[i];
+            e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
+            *positionOffset_local_3 = positionOffset_global[i];
+            e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
+            o.flush();
+        }
+
+        o.setOpenPMDextension(1);
+        o.iterations[3].setTime(3.f);
     }
 
-    std::vector< uint64_t > positionOffset_global(4);
-    uint64_t posOff{0};
-    std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
-    std::shared_ptr< uint64_t > positionOffset_local_1(new uint64_t);
-    e_1["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_1), {4}));
-
-    for( uint64_t i = 0; i < 4; ++i )
     {
-        *positionOffset_local_1 = positionOffset_global[i];
-        e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
+        Series o = Series("../samples/serial_fileBased_write%T.bp", AccessType::READ_ONLY);
+
+        REQUIRE(o.openPMDextension() == 1);
+
+        REQUIRE(o.iterations.size() == 3);
+        REQUIRE(o.iterations.count(1) == 1);
+        REQUIRE(o.iterations.count(2) == 1);
+        REQUIRE(o.iterations.count(3) == 1);
+
+        REQUIRE(o.iterations[1].time< float >() == 1.f);
+        REQUIRE(o.iterations[2].time< float >() == 2.f);
+        REQUIRE(o.iterations[3].time< float >() == 3.f);
+
+        for( uint64_t i = 1; i <= 3; ++i )
+        {
+            Iteration iteration = o.iterations[i];
+
+            REQUIRE(iteration.particles.size() == 1);
+            REQUIRE(iteration.particles.count("e") == 1);
+
+            ParticleSpecies& species = iteration.particles["e"];
+
+            REQUIRE(species.size() == 2);
+            REQUIRE(species.count("position") == 1);
+            REQUIRE(species.count("positionOffset") == 1);
+
+            REQUIRE(species["position"].size() == 1);
+            REQUIRE(species["position"].count("x") == 1);
+            REQUIRE(species["position"]["x"].getDatatype() == Datatype::DOUBLE);
+            REQUIRE(species["position"]["x"].getDimensionality() == 1);
+            REQUIRE(species["position"]["x"].getExtent() == Extent{4});
+            REQUIRE(species["positionOffset"].size() == 1);
+            REQUIRE(species["positionOffset"].count("x") == 1);
+            REQUIRE(species["positionOffset"]["x"].getDatatype() == Datatype::UINT64);
+            REQUIRE(species["positionOffset"]["x"].getDimensionality() == 1);
+            REQUIRE(species["positionOffset"]["x"].getExtent() == Extent{4});
+
+            auto position = species["position"]["x"].loadChunk< double >({0}, {4}).get();
+            for( uint64_t j = 0; j < 4; ++j )
+                REQUIRE(position[j] == static_cast< double >(j));
+
+            auto positionOffset = species["positionOffset"]["x"].loadChunk< uint64_t >({0}, {4}).get();
+            for( uint64_t j = 0; j < 4; ++j )
+                REQUIRE(positionOffset[j] == j);
+        }
     }
-
-    o.iterations[1].setTime(static_cast< double >(1));
-
-    ParticleSpecies& e_2 = o.iterations[2].particles["e"];
-
-    std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local_2(new double);
-    e_2["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_2), {4}));
-
-    for( uint64_t i = 0; i < 4; ++i )
-    {
-        *position_local_2 = position_global[i];
-        e_2["position"]["x"].storeChunk({i}, {1}, position_local_2);
-    }
-
-    std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
-    std::shared_ptr< uint64_t > positionOffset_local_2(new uint64_t);
-    e_2["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_2), {4}));
-
-    for( uint64_t i = 0; i < 4; ++i )
-    {
-        *positionOffset_local_2 = positionOffset_global[i];
-        e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
-    }
-
-    o.flush();
-
-    o.iterations[2].setTime(static_cast< double >(2));
-
-    ParticleSpecies& e_3 = o.iterations[3].particles["e"];
-
-    std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local_3(new double);
-    e_3["position"]["x"].resetDataset(Dataset(determineDatatype(position_local_3), {4}));
-
-    for( uint64_t i = 0; i < 4; ++i )
-    {
-        *position_local_3 = position_global[i];
-        e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
-    }
-
-    std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
-    std::shared_ptr< uint64_t > positionOffset_local_3(new uint64_t);
-    e_3["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_3), {4}));
-
-    for( uint64_t i = 0; i < 4; ++i )
-    {
-        *positionOffset_local_3 = positionOffset_global[i];
-        e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
-    }
-
-    o.flush();
 }
 
 TEST_CASE( "hzdr_adios1_sample_content_test", "[serial][adios1]" )

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1152,8 +1152,9 @@ TEST_CASE( "hdf5_patch_test", "[serial][hdf5]" )
 {
     Series o = Series("../samples/serial_patch.h5", AccessType::CREATE);
 
-    o.iterations[1].particles["e"].particlePatches["offset"]["x"].setUnitSI(42);
     auto dset = Dataset(Datatype::DOUBLE, {1});
+    o.iterations[1].particles["e"].particlePatches["offset"]["x"].resetDataset(dset);
+    o.iterations[1].particles["e"].particlePatches["offset"]["x"].setUnitSI(42);
     o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].resetDataset(dset);
     o.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -958,7 +958,6 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     {
         position_local.at(0) = position_global[i];
         e["position"]["x"].storeChunk({i}, {1}, shareRaw(position_local));
-        o.flush();
     }
 
     std::vector< uint64_t > positionOffset_global(4);
@@ -971,7 +970,6 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     {
         positionOffset_local[0] = positionOffset_global[i];
         e["positionOffset"]["x"].storeChunk({i}, {1}, shareRaw(positionOffset_local));
-        o.flush();
     }
 
     o.flush();
@@ -999,7 +997,6 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         {
             *position_local_1 = position_global[i];
             e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
-            o.flush();
         }
 
         std::vector< uint64_t > positionOffset_global(4);
@@ -1012,7 +1009,6 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         {
             *positionOffset_local_1 = positionOffset_global[i];
             e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
-            o.flush();
         }
 
         o.iterations[1].setTime(static_cast< double >(1));
@@ -1026,7 +1022,6 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         {
             double const position_local_2 = position_global.at(i);
             e_2["position"]["x"].storeChunk({i}, {1}, shareRaw(&position_local_2));
-            o.flush();
         }
 
         std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1037,7 +1032,6 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         {
             *positionOffset_local_2 = positionOffset_global[i];
             e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
-            o.flush();
         }
 
         o.iterations[2].setTime(static_cast< double >(2));
@@ -1053,7 +1047,6 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         {
             *position_local_3 = position_global[i];
             e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
-            o.flush();
         }
 
         std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1064,7 +1057,6 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         {
             *positionOffset_local_3 = positionOffset_global[i];
             e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
-            o.flush();
         }
 
         o.setOpenPMDextension(1);
@@ -1160,6 +1152,9 @@ TEST_CASE( "hdf5_patch_test", "[serial][hdf5]" )
     Series o = Series("../samples/serial_patch.h5", AccessType::CREATE);
 
     o.iterations[1].particles["e"].particlePatches["offset"]["x"].setUnitSI(42);
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    o.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].resetDataset(dset);
+    o.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 }
 
 TEST_CASE( "hdf5_deletion_test", "[serial][hdf5]" )
@@ -1175,26 +1170,25 @@ TEST_CASE( "hdf5_deletion_test", "[serial][hdf5]" )
     o.flush();
 
     ParticleSpecies& e = o.iterations[1].particles["e"];
+    auto dset = Dataset(Datatype::DOUBLE, {1});
+    e["position"][RecordComponent::SCALAR].resetDataset(dset);
+    e["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     e.erase("deletion");
     o.flush();
 
-    e["deletion_scalar"][RecordComponent::SCALAR].resetDataset(Dataset(Datatype::DOUBLE, {1}));
+    e["deletion_scalar"][RecordComponent::SCALAR].resetDataset(dset);
     o.flush();
 
     e["deletion_scalar"].erase(RecordComponent::SCALAR);
-    o.flush();
-
     e.erase("deletion_scalar");
     o.flush();
 
     double value = 0.;
-    e["deletion_scalar_constant"][RecordComponent::SCALAR].resetDataset(Dataset(Datatype::DOUBLE, {1}));
+    e["deletion_scalar_constant"][RecordComponent::SCALAR].resetDataset(dset);
     e["deletion_scalar_constant"][RecordComponent::SCALAR].makeConstant(value);
     o.flush();
 
     e["deletion_scalar_constant"].erase(RecordComponent::SCALAR);
-    o.flush();
-
     e.erase("deletion_scalar_constant");
     o.flush();
 }
@@ -1227,12 +1221,17 @@ TEST_CASE( "hdf5_110_optional_paths", "[serial][hdf5]" )
 
     {
         Series s = Series("../samples/no_meshes_1.1.0_compliant.h5", AccessType::CREATE);
-        s.iterations[1].particles["foo"];
+        auto foo = s.iterations[1].particles["foo"];
+        Dataset dset = Dataset(Datatype::DOUBLE, {1});
+        foo["position"][RecordComponent::SCALAR].resetDataset(dset);
+        foo["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     }
 
     {
         Series s = Series("../samples/no_particles_1.1.0_compliant.h5", AccessType::CREATE);
-        s.iterations[1].meshes["foo"];
+        auto foo = s.iterations[1].meshes["foo"];
+        Dataset dset = Dataset(Datatype::DOUBLE, {1});
+        foo[RecordComponent::SCALAR].resetDataset(dset);
     }
 
     {
@@ -1353,7 +1352,6 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     {
         *position_local_1 = position_global[i];
         e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
-        o.flush();
     }
 
     std::vector< uint64_t > positionOffset_global(4);
@@ -1366,7 +1364,6 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     {
         *positionOffset_local_1 = positionOffset_global[i];
         e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
-        o.flush();
     }
 
     ParticleSpecies& e_2 = o.iterations[2].particles["e"];
@@ -1379,7 +1376,6 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     {
         *position_local_2 = position_global[i];
         e_2["position"]["x"].storeChunk({i}, {1}, position_local_2);
-        o.flush();
     }
 
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1390,7 +1386,6 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     {
         *positionOffset_local_2 = positionOffset_global[i];
         e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
-        o.flush();
     }
 
     o.flush();
@@ -1405,7 +1400,6 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     {
         *position_local_3 = position_global[i];
         e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
-        o.flush();
     }
 
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1416,7 +1410,6 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     {
         *positionOffset_local_3 = positionOffset_global[i];
         e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
-        o.flush();
     }
 
     o.flush();
@@ -1438,7 +1431,6 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     {
         *position_local_1 = position_global[i];
         e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
-        o.flush();
     }
 
     std::vector< uint64_t > positionOffset_global(4);
@@ -1451,8 +1443,10 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     {
         *positionOffset_local_1 = positionOffset_global[i];
         e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
-        o.flush();
     }
+
+    //TODO breaks openWriteFile logic when removed
+    //o.flush();
 
     ParticleSpecies& e_2 = o.iterations[2].particles["e"];
 
@@ -1464,7 +1458,6 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     {
         *position_local_2 = position_global[i];
         e_2["position"]["x"].storeChunk({i}, {1}, position_local_2);
-        o.flush();
     }
 
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1475,7 +1468,6 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     {
         *positionOffset_local_2 = positionOffset_global[i];
         e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
-        o.flush();
     }
 
     o.flush();
@@ -1490,7 +1482,6 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     {
         *position_local_3 = position_global[i];
         e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
-        o.flush();
     }
 
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1501,7 +1492,6 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     {
         *positionOffset_local_3 = positionOffset_global[i];
         e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
-        o.flush();
     }
 
     o.flush();

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1034,6 +1034,7 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
             e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
         }
 
+        // TODO not yet written
         o.iterations[2].setTime(static_cast< double >(2));
         o.flush();
 
@@ -1445,8 +1446,7 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
         e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
     }
 
-    //TODO breaks openWriteFile logic when removed
-    //o.flush();
+    o.iterations[1].setTime(static_cast< double >(1));
 
     ParticleSpecies& e_2 = o.iterations[2].particles["e"];
 
@@ -1471,6 +1471,8 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
     }
 
     o.flush();
+
+    o.iterations[2].setTime(static_cast< double >(2));
 
     ParticleSpecies& e_3 = o.iterations[3].particles["e"];
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -953,13 +953,6 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
     std::vector< double > position_local = {0.};
     e["position"]["x"].resetDataset(Dataset(determineDatatype<double>(), {4}));
-
-    for( uint64_t i = 0; i < 4; ++i )
-    {
-        position_local.at(0) = position_global[i];
-        e["position"]["x"].storeChunk({i}, {1}, shareRaw(position_local));
-    }
-
     std::vector< uint64_t > positionOffset_global(4);
     uint64_t posOff{0};
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -968,11 +961,12 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
 
     for( uint64_t i = 0; i < 4; ++i )
     {
+        position_local.at(0) = position_global[i];
+        e["position"]["x"].storeChunk({i}, {1}, shareRaw(position_local));
         positionOffset_local[0] = positionOffset_global[i];
         e["positionOffset"]["x"].storeChunk({i}, {1}, shareRaw(positionOffset_local));
+        o.flush();
     }
-
-    o.flush();
 
     //TODO close file, read back, verify
 }


### PR DESCRIPTION
Do not write write records to disk unless scalar/non-scalar ambiguity is resolved. This is done when the user creates a record component that is either scalar/nonscalar and possibly constant.

Also fixes major bugs in the ADIOS1 backend concerning ```fileBased``` output.

Closes #287.