### PR TITLE
Spack: load -r

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -106,12 +106,11 @@ install:
 
   # Add our channels.
   - cmd: conda config --set show_channel_urls true
-  - cmd: conda config --remove channels defaults
   - cmd: conda config --add channels defaults
-  - cmd: conda config --add channels conda-forge
+  - cmd: conda config --append channels conda-forge
 
   # Configure the VM.
-  - cmd: conda install -n root --quiet --yes cmake hdf5 numpy
+  - cmd: conda install -n root --quiet --yes numpy cmake hdf5
 
 before_build:
   - cmd: cd C:\projects\openpmd-api

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Other
 - remove superfluous whitespaces #292
 - readme: openPMD is for scientific data #294
 - override implies virtual #293
+- spack load: ``-r`` #298
 
 
 0.3.1-alpha

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Choose *one* of the install methods below to get started:
 ```bash
 # optional:               +python ^python@3:
 spack install openpmd-api
-spack load --dependencies openpmd-api
+spack load -r openpmd-api
 ```
 
 ### [Conda](https://conda.io)

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -33,7 +33,7 @@ A package for openPMD-api is available on the Spack package manager.
 
    # optional:               +python ^python@3:
    spack install openpmd-api
-   spack load --dependencies openpmd-api
+   spack load -r openpmd-api
 
 .. _install-conda:
 


### PR DESCRIPTION
`spack load -r` is shorter and easier to type than `--dependencies`.