### PR TITLE
Travis-CI: OSX Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -239,7 +239,7 @@ jobs:
     # Clang 8.1.0-apple + Python 2.7.10 @ OSX
     - <<: *test-cpp-unit
       os: osx
-      # osx_image: xcode8.3
+      osx_image: xcode8.3
       sudo: required
       language: generic
       env:
@@ -514,7 +514,7 @@ install:
       spack load hdf5$HDF5_VERSION $SPACK_VAR_MPI $COMPILERSPEC;
     fi
   - if [ $USE_ADIOS1 == "ON" ]; then
-      travis_wait spack install
+      travis_wait 30 spack install
         adios$ADIOS1_VERSION
         $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION
         $COMPILERSPEC &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -239,6 +239,7 @@ jobs:
     # Clang 8.1.0-apple + Python 2.7.10 @ OSX
     - <<: *test-cpp-unit
       os: osx
+      # osx_image: xcode8.3
       sudo: required
       language: generic
       env:


### PR DESCRIPTION
Update to new OSX images on Travis-CI.
[Blog announcement.](https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce)

- [x] trigger current error: [yes](https://travis-ci.org/openPMD/openPMD-api/builds/411464903)
- [x] verify it's gone with old image (xcode 8.3 on darwin17.4.0 / OSX10.12.6): [yes](https://travis-ci.org/openPMD/openPMD-api/builds/412110186)
- [x] update to new OSX image (xcode 9.4 on macosx10.9 / OSX10.13): [hmmm...](https://travis-ci.org/openPMD/openPMD-api/builds/412415787) -> follow-up!