### PR TITLE
IWYU: Public Headers

### DIFF
--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <memory>
+#include <cstddef>
 
 
 using std::cout;

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <memory>
 #include <numeric>
+#include <cstdlib>
 
 
 using std::cout;

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -24,6 +24,7 @@
 
 #include <iostream>
 #include <memory>
+#include <cstddef>
 
 
 using std::cout;

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -24,6 +24,7 @@
 #include "openPMD/backend/PatchRecord.hpp"
 
 #include <vector>
+#include <cstddef>
 
 
 namespace openPMD

--- a/include/openPMD/auxiliary/Variant.hpp
+++ b/include/openPMD/auxiliary/Variant.hpp
@@ -21,10 +21,10 @@
 #pragma once
 
 #if __cplusplus >= 201703L
-#   include <variant>
+#   include <variant> // IWYU pragma: export
 namespace variantSrc = std;
 #else
-#   include <mpark/variant.hpp>
+#   include <mpark/variant.hpp> // IWYU pragma: export
 namespace variantSrc = mpark;
 #endif
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <cstddef>
 
 
 namespace openPMD

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -20,6 +20,33 @@
  */
 #pragma once
 
+// IWYU pragma: begin_exports
+#include "openPMD/Dataset.hpp"
+#include "openPMD/Datatype.hpp"
+#include "openPMD/IterationEncoding.hpp"
+#include "openPMD/Iteration.hpp"
+#include "openPMD/Mesh.hpp"
+#include "openPMD/ParticlePatches.hpp"
+#include "openPMD/ParticleSpecies.hpp"
+#include "openPMD/RecordComponent.hpp"
+#include "openPMD/Record.hpp"
 #include "openPMD/Series.hpp"
+
+#include "openPMD/backend/Attributable.hpp"
+#include "openPMD/backend/Attribute.hpp"
+#include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/MeshRecordComponent.hpp"
+#include "openPMD/backend/PatchRecord.hpp"
+#include "openPMD/backend/PatchRecordComponent.hpp"
+#include "openPMD/backend/Writable.hpp"
+
+#include "openPMD/IO/AccessType.hpp"
+
+#include "openPMD/auxiliary/OutOfRangeMsg.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"
+#include "openPMD/auxiliary/Variant.hpp"
+
 #include "openPMD/version.hpp"
+// IWYU pragma: end_exports

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -21,6 +21,7 @@
 #include "openPMD/Dataset.hpp"
 
 #include <iostream>
+#include <cstddef>
 
 
 namespace openPMD

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -20,6 +20,7 @@ using namespace openPMD;
 #include <string>
 #include <vector>
 #include <array>
+#include <cstddef>
 
 
 TEST_CASE( "attribute_dtype_test", "[core]" )


### PR DESCRIPTION
## `openPMD.hpp`: Export all public headers

Build a proper facade header that includes all public API headers.

> `IWYU pragma`: export to tell IWYU that one header serves as the
> provider for all symbols in another, included header (e.g. facade
> headers). Use IWYU pragma: begin_exports/end_exports for a whole
> group of included headers

Ref:
  https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md

## Variant

Export wrapped underlying variant types.

## Private Headers

~~Experiment with private headers and `friend` declarations for internal includes and tests.~~

-> this will probably not help much/work well since `friend` regex would have to include tests and all internal `.cpp` files and something general such as an `openPMD/` directory could also be used in user source code.