### PR TITLE
Travis: OSX High Sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -236,17 +236,16 @@ jobs:
             - openmpi-bin
       before_install: *clang50_init
       script: *script-cpp-unit
-    # Clang 8.1.0-apple + Python 2.7.10 @ OSX
+    # Clang 9.1.0-apple + Python 2.7.15 @ OSX
     - <<: *test-cpp-unit
       os: osx
-      osx_image: xcode8.3
       sudo: required
       language: generic
       env:
         - USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       before_install:
-        - COMPILERSPEC="%clang@8.1.0"
+        - COMPILERSPEC="%clang@9.1.0"
       script: *script-cpp-unit
     # GCC 4.9.4
     - <<: *test-cpp-unit
@@ -449,7 +448,7 @@ install:
       travis_wait brew install modules &&
       brew info modules &&
       source /usr/local/opt/modules/init/bash &&
-      export TRAVIS_PYTHON_VERSION=2.7.10;
+      export TRAVIS_PYTHON_VERSION=2.7.15;
     fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then

--- a/.travis/spack/compilers.yaml
+++ b/.travis/spack/compilers.yaml
@@ -4,13 +4,13 @@ compilers:
     extra_rpaths: []
     flags: {}
     modules: []
-    operating_system: sierra
+    operating_system: highsierra
     paths:
       cc: /usr/bin/clang
       cxx: /usr/bin/clang++
       f77: null
       fc: null
-    spec: clang@8.1.0
+    spec: clang@9.1.0
     target: x86_64
 - compiler:
     environment: {}

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -7,7 +7,7 @@ packages:
       cmake@3.10.0%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
-      cmake@3.10.0%clang@8.1.0 arch=darwin-sierra-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.10.0%clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
     version: [1.6.5]
@@ -23,7 +23,7 @@ packages:
   adios:
     variants: ~zfp ~sz ~lz4 ~blosc
   python:
-    version: [2.7.14, 2.7.10, 3.5.5, 3.6.3]
+    version: [2.7.14, 2.7.15, 3.5.5, 3.6.3]
     paths:
       python@2.7.14%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@2.7.14%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
@@ -31,9 +31,9 @@ packages:
       python@2.7.14%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
-      python@2.7.10%clang@8.1.0 arch=darwin-sierra-x86_64: /usr
+      python@2.7.15%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
     buildable: False
   all:
     providers:
       mpi: [openmpi]
-    compiler: [clang@5.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.4.0, gcc@7.3.0]
+    compiler: [clang@5.0.0, clang@9.1.0, gcc@4.8.5, gcc@4.9.4, gcc@6.4.0, gcc@7.3.0]


### PR DESCRIPTION
Update to new OSX images on Travis-CI, follow-up to #299.
[Blog announcement.](https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce)

update to new OSX image (xcode 9.4 on macosx10.9 / OSX10.13):

clang 8.1->9.1
python 2.7.15