### PR TITLE
Default Constructors/Destructors

### DIFF
--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -225,8 +225,7 @@ ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
     m_impl->init();
 }
 
-ADIOS1IOHandler::~ADIOS1IOHandler()
-{ }
+ADIOS1IOHandler::~ADIOS1IOHandler() = default;
 
 std::future< void >
 ADIOS1IOHandler::flush()
@@ -312,8 +311,7 @@ ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
     throw std::runtime_error("openPMD-api built without ADIOS1 support");
 }
 
-ADIOS1IOHandler::~ADIOS1IOHandler()
-{ }
+ADIOS1IOHandler::~ADIOS1IOHandler() = default;
 
 std::future< void >
 ADIOS1IOHandler::flush()

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -46,8 +46,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
           m_impl{new ADIOS2IOHandlerImpl(this)}
 { }
 
-ADIOS2IOHandler::~ADIOS2IOHandler()
-{ }
+ADIOS2IOHandler::~ADIOS2IOHandler() = default;
 
 std::future< void >
 ADIOS2IOHandler::flush()
@@ -65,8 +64,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
     throw std::runtime_error("openPMD-api built without parallel ADIOS2 support");
 }
 
-ADIOS2IOHandler::~ADIOS2IOHandler()
-{ }
+ADIOS2IOHandler::~ADIOS2IOHandler() = default;
 
 std::future< void >
 ADIOS2IOHandler::flush()

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -242,8 +242,7 @@ ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string const& path,
     m_impl->init();
 }
 
-ParallelADIOS1IOHandler::~ParallelADIOS1IOHandler()
-{ }
+ParallelADIOS1IOHandler::~ParallelADIOS1IOHandler() = default;
 
 std::future< void >
 ParallelADIOS1IOHandler::flush()
@@ -340,8 +339,7 @@ ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string const& path,
 }
 #   endif
 
-ParallelADIOS1IOHandler::~ParallelADIOS1IOHandler()
-{ }
+ParallelADIOS1IOHandler::~ParallelADIOS1IOHandler() = default;
 
 std::future< void >
 ParallelADIOS1IOHandler::flush()

--- a/src/IO/AbstractIOHandler.cpp
+++ b/src/IO/AbstractIOHandler.cpp
@@ -44,8 +44,7 @@ AbstractIOHandler::AbstractIOHandler(std::string const& path,
           accessType{at}
 { }
 
-AbstractIOHandler::~AbstractIOHandler()
-{ }
+AbstractIOHandler::~AbstractIOHandler() = default;
 
 void
 AbstractIOHandler::enqueue(IOTask const& i)
@@ -57,8 +56,7 @@ DummyIOHandler::DummyIOHandler(std::string const& path, AccessType at)
         : AbstractIOHandler(path, at)
 { }
 
-DummyIOHandler::~DummyIOHandler()
-{ }
+DummyIOHandler::~DummyIOHandler() = default;
 
 void DummyIOHandler::enqueue(IOTask const&)
 { }

--- a/src/IO/AbstractIOHandlerImpl.cpp
+++ b/src/IO/AbstractIOHandlerImpl.cpp
@@ -28,8 +28,7 @@ AbstractIOHandlerImpl::AbstractIOHandlerImpl(AbstractIOHandler *handler)
     : m_handler{handler}
 { }
 
-AbstractIOHandlerImpl::~AbstractIOHandlerImpl()
-{ }
+AbstractIOHandlerImpl::~AbstractIOHandlerImpl() = default;
 
 std::future< void >
 AbstractIOHandlerImpl::flush()

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1449,8 +1449,7 @@ HDF5IOHandler::HDF5IOHandler(std::string const& path, AccessType at)
           m_impl{new HDF5IOHandlerImpl(this)}
 { }
 
-HDF5IOHandler::~HDF5IOHandler()
-{ }
+HDF5IOHandler::~HDF5IOHandler() = default;
 
 std::future< void >
 HDF5IOHandler::flush()
@@ -1464,8 +1463,7 @@ HDF5IOHandler::HDF5IOHandler(std::string const& path, AccessType at)
     throw std::runtime_error("openPMD-api built without HDF5 support");
 }
 
-HDF5IOHandler::~HDF5IOHandler()
-{ }
+HDF5IOHandler::~HDF5IOHandler() = default;
 
 std::future< void >
 HDF5IOHandler::flush()

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -44,8 +44,7 @@ ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
           m_impl{new ParallelHDF5IOHandlerImpl(this, comm)}
 { }
 
-ParallelHDF5IOHandler::~ParallelHDF5IOHandler()
-{ }
+ParallelHDF5IOHandler::~ParallelHDF5IOHandler() = default;
 
 std::future< void >
 ParallelHDF5IOHandler::flush()
@@ -98,8 +97,7 @@ ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
 }
 #   endif
 
-ParallelHDF5IOHandler::~ParallelHDF5IOHandler()
-{ }
+ParallelHDF5IOHandler::~ParallelHDF5IOHandler() = default;
 
 std::future< void >
 ParallelHDF5IOHandler::flush()

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -37,8 +37,7 @@ PatchRecord::setUnitDimension(std::map< UnitDimension, double > const& udim)
     return *this;
 }
 
-PatchRecord::PatchRecord()
-{ }
+PatchRecord::PatchRecord() = default;
 
 void
 PatchRecord::flush(std::string const& path)

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -33,6 +33,6 @@ Writable::Writable(Attributable* a)
           written{false}
 { }
 
-Writable::~Writable()
-{ }
+Writable::~Writable() = default;
+
 } // openPMD


### PR DESCRIPTION
Address clang-tidy [`hicpp-use-equals-default`](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html).
Use `= default` for trivial constructors and destructors.