### PR TITLE
Path Arguments: Pass-by-Value

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -46,7 +46,7 @@ namespace openPMD
         friend class ADIOS1IOHandlerImpl;
 
     public:
-        ADIOS1IOHandler(std::string const& path, AccessType);
+        ADIOS1IOHandler(std::string path, AccessType);
         ~ADIOS1IOHandler() override;
 
         std::future< void > flush() override;
@@ -63,7 +63,7 @@ namespace openPMD
         friend class ADIOS1IOHandlerImpl;
 
     public:
-        ADIOS1IOHandler(std::string const& path, AccessType);
+        ADIOS1IOHandler(std::string path, AccessType);
         ~ADIOS1IOHandler() override;
 
         std::future< void > flush() override;

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -75,7 +75,7 @@ namespace openPMD
         void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
 
         virtual int64_t open_write(Writable *);
-        virtual ADIOS_FILE* open_read(std::string const& name);
+        virtual ADIOS_FILE* open_read(std::string const & name);
         void close(int64_t);
         void close(ADIOS_FILE*);
 

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -72,7 +72,7 @@ class ADIOS2IOHandler : public AbstractIOHandler
     friend class ADIOS2IOHandlerImpl;
 
 public:
-    ADIOS2IOHandler(std::string const& path, AccessType);
+    ADIOS2IOHandler(std::string path, AccessType);
     ~ADIOS2IOHandler() override;
 
     std::future< void > flush() override;

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -46,9 +46,9 @@ namespace openPMD
 
     public:
 #   if openPMD_HAVE_MPI
-        ParallelADIOS1IOHandler(std::string const& path, AccessType, MPI_Comm);
+        ParallelADIOS1IOHandler(std::string path, AccessType, MPI_Comm);
 #   else
-        ParallelADIOS1IOHandler(std::string const& path, AccessType);
+        ParallelADIOS1IOHandler(std::string path, AccessType);
 #   endif
         ~ParallelADIOS1IOHandler() override;
 

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -76,7 +76,7 @@ namespace openPMD
         void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
 
         virtual int64_t open_write(Writable *);
-        virtual ADIOS_FILE* open_read(std::string const& name);
+        virtual ADIOS_FILE* open_read(std::string const & name);
         void close(int64_t);
         void close(ADIOS_FILE*);
 

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -74,9 +74,9 @@ class AbstractIOHandler
 {
 public:
 #if openPMD_HAVE_MPI
-    AbstractIOHandler(std::string const& path, AccessType, MPI_Comm);
+    AbstractIOHandler(std::string path, AccessType, MPI_Comm);
 #endif
-    AbstractIOHandler(std::string const& path, AccessType);
+    AbstractIOHandler(std::string path, AccessType);
     virtual ~AbstractIOHandler();
 
     /** Add provided task to queue according to FIFO.
@@ -101,7 +101,7 @@ public:
 class DummyIOHandler : public AbstractIOHandler
 {
 public:
-    DummyIOHandler(std::string const&, AccessType);
+    DummyIOHandler(std::string, AccessType);
     ~DummyIOHandler() override;
 
     /** No-op consistent with the IOHandler interface to enable library use without IO.

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -37,7 +37,7 @@ namespace openPMD
      */
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-        std::string const& path,
+        std::string path,
         AccessType accessType,
         Format format,
         MPI_Comm comm
@@ -53,7 +53,7 @@ namespace openPMD
      */
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-        std::string const& path,
+        std::string path,
         AccessType accessType,
         Format format
     );

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -34,7 +34,7 @@ class HDF5IOHandlerImpl;
 class HDF5IOHandler : public AbstractIOHandler
 {
 public:
-    HDF5IOHandler(std::string const& path, AccessType);
+    HDF5IOHandler(std::string path, AccessType);
     ~HDF5IOHandler() override;
 
     std::future< void > flush() override;

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -35,9 +35,9 @@ namespace openPMD
     {
     public:
     #if openPMD_HAVE_MPI
-        ParallelHDF5IOHandler(std::string const& path, AccessType, MPI_Comm);
+        ParallelHDF5IOHandler(std::string path, AccessType, MPI_Comm);
     #else
-        ParallelHDF5IOHandler(std::string const& path, AccessType);
+        ParallelHDF5IOHandler(std::string path, AccessType);
     #endif
         ~ParallelHDF5IOHandler() override;
 

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -31,6 +31,7 @@
 #   include <iostream>
 #   include <memory>
 #endif
+#include <utility>
 
 
 namespace openPMD
@@ -218,8 +219,8 @@ ADIOS1IOHandlerImpl::init()
 #endif
 
 #if openPMD_HAVE_ADIOS1
-ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at),
+ADIOS1IOHandler::ADIOS1IOHandler(std::string path, AccessType at)
+        : AbstractIOHandler(std::move(path), at),
           m_impl{new ADIOS1IOHandlerImpl(this)}
 {
     m_impl->init();
@@ -289,7 +290,7 @@ ADIOS1IOHandlerImpl::open_write(Writable* writable)
 }
 
 ADIOS_FILE*
-ADIOS1IOHandlerImpl::open_read( std::string const& name )
+ADIOS1IOHandlerImpl::open_read(std::string const & name)
 {
     ADIOS_FILE *f = nullptr;
     f = adios_read_open_file(name.c_str(),
@@ -306,8 +307,8 @@ ADIOS1IOHandlerImpl::open_read( std::string const& name )
 #undef CommonADIOS1IOHandlerImpl
 
 #else
-ADIOS1IOHandler::ADIOS1IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at)
+ADIOS1IOHandler::ADIOS1IOHandler(std::string path, AccessType at)
+        : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without ADIOS1 support");
 }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -20,12 +20,14 @@
  */
 #include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
 
+#include <utility>
+
 
 namespace openPMD
 {
 #if openPMD_HAVE_ADIOS2
-ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at),
+ADIOS2IOHandler::ADIOS2IOHandler(std::string path, AccessType at)
+        : AbstractIOHandler(std::move(path), at),
           m_impl{new ADIOS2IOHandlerImpl(this)}
 { }
 
@@ -41,8 +43,8 @@ ADIOS2IOHandler::flush()
 #endif
 
 #if openPMD_HAVE_ADIOS2 && !openPMD_HAVE_MPI
-ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at),
+ADIOS2IOHandler::ADIOS2IOHandler(std::string path, AccessType at)
+        : AbstractIOHandler(std::move(path), at),
           m_impl{new ADIOS2IOHandlerImpl(this)}
 { }
 
@@ -55,11 +57,11 @@ ADIOS2IOHandler::flush()
     return m_impl->flush();
 }
 #else
-ADIOS2IOHandler::ADIOS2IOHandler(std::string const& path, AccessType at)
+ADIOS2IOHandler::ADIOS2IOHandler(std::string path, AccessType at)
 #if openPMD_HAVE_MPI
-        : AbstractIOHandler(path, at, MPI_COMM_NULL)
+        : AbstractIOHandler(std::move(path), at, MPI_COMM_NULL)
 #else
-: AbstractIOHandler(path, at)
+: AbstractIOHandler(std::move(path), at)
 #endif
 {
     throw std::runtime_error("openPMD-api built without parallel ADIOS2 support");

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -233,10 +233,10 @@ ParallelADIOS1IOHandlerImpl::init()
     VERIFY(status == err_no_error, "Internal error: Failed to select ADIOS method");
 }
 
-ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string const& path,
+ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
                                                  AccessType at,
                                                  MPI_Comm comm)
-        : AbstractIOHandler(path, at, comm),
+        : AbstractIOHandler(std::move(path), at, comm),
           m_impl{new ParallelADIOS1IOHandlerImpl(this, comm)}
 {
     m_impl->init();
@@ -306,7 +306,7 @@ ParallelADIOS1IOHandlerImpl::open_write(Writable* writable)
 }
 
 ADIOS_FILE*
-ParallelADIOS1IOHandlerImpl::open_read(std::string const& name)
+ParallelADIOS1IOHandlerImpl::open_read(std::string const & name)
 {
     ADIOS_FILE *f;
     f = adios_read_open_file(name.c_str(),
@@ -324,17 +324,17 @@ ParallelADIOS1IOHandlerImpl::open_read(std::string const& name)
 
 #else
 #   if openPMD_HAVE_MPI
-ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string const& path,
+ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
                                                  AccessType at,
                                                  MPI_Comm comm)
-        : AbstractIOHandler(path, at, comm)
+        : AbstractIOHandler(std::move(path), at, comm)
 {
     throw std::runtime_error("openPMD-api built without ADIOS1 support");
 }
 #   else
-ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string const& path,
+ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
                                                  AccessType at)
-        : AbstractIOHandler(path, at)
+        : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without parallel ADIOS1 support");
 }

--- a/src/IO/AbstractIOHandler.cpp
+++ b/src/IO/AbstractIOHandler.cpp
@@ -25,22 +25,23 @@
 #include "openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp"
 
 #include <iostream>
+#include <utility>
 
 
 namespace openPMD
 {
 #if openPMD_HAVE_MPI
-AbstractIOHandler::AbstractIOHandler(std::string const& path,
+AbstractIOHandler::AbstractIOHandler(std::string path,
                                      AccessType at,
                                      MPI_Comm)
-        : directory{path},
+        : directory{std::move(path)},
           accessType{at}
 { }
 #endif
 
-AbstractIOHandler::AbstractIOHandler(std::string const& path,
+AbstractIOHandler::AbstractIOHandler(std::string path,
                                      AccessType at)
-        : directory{path},
+        : directory{std::move(path)},
           accessType{at}
 { }
 
@@ -53,8 +54,8 @@ AbstractIOHandler::enqueue(IOTask const& i)
     m_work.push(i);
 }
 
-DummyIOHandler::DummyIOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at)
+DummyIOHandler::DummyIOHandler(std::string path, AccessType at)
+        : AbstractIOHandler(std::move(path), at)
 { }
 
 DummyIOHandler::~DummyIOHandler()

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -31,7 +31,7 @@ namespace openPMD
 #if openPMD_HAVE_MPI
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-        std::string const& path,
+        std::string path,
         AccessType accessType,
         Format format,
         MPI_Comm comm
@@ -52,7 +52,7 @@ namespace openPMD
 #endif
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-        std::string const& path,
+        std::string path,
         AccessType accessType,
         Format format
     )

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1444,8 +1444,8 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
 #endif
 
 #if openPMD_HAVE_HDF5
-HDF5IOHandler::HDF5IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at),
+HDF5IOHandler::HDF5IOHandler(std::string path, AccessType at)
+        : AbstractIOHandler(std::move(path), at),
           m_impl{new HDF5IOHandlerImpl(this)}
 { }
 
@@ -1458,8 +1458,8 @@ HDF5IOHandler::flush()
     return m_impl->flush();
 }
 #else
-HDF5IOHandler::HDF5IOHandler(std::string const& path, AccessType at)
-        : AbstractIOHandler(path, at)
+HDF5IOHandler::HDF5IOHandler(std::string path, AccessType at)
+        : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without HDF5 support");
 }

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -37,10 +37,10 @@ namespace openPMD
 #       define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif
 
-ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
+ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
                                              AccessType at,
                                              MPI_Comm comm)
-        : AbstractIOHandler(path, at, comm),
+        : AbstractIOHandler(std::move(path), at, comm),
           m_impl{new ParallelHDF5IOHandlerImpl(this, comm)}
 { }
 
@@ -82,17 +82,17 @@ ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
 }
 #else
 #   if openPMD_HAVE_MPI
-ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
+ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
                                              AccessType at,
                                              MPI_Comm comm)
-        : AbstractIOHandler(path, at, comm)
+        : AbstractIOHandler(std::move(path), at, comm)
 {
     throw std::runtime_error("openPMD-api built without HDF5 support");
 }
 #   else
-ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string const& path,
+ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
                                              AccessType at)
-        : AbstractIOHandler(path, at)
+        : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without parallel support and without HDF5 support");
 }


### PR DESCRIPTION
Address clang-tidy [`modernize-pass-by-value`](https://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html).

Pass `std::string`s by value and `std::move` them where needed, e.g. in constructors.

At worst, same copy cost as before for member init. At best, add rvalue movability.