### PR TITLE
Fix #310: Name sanitization in the ADIOS backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Bug Fixes
 
 - ADIOS1 fileBased IO #297
 - ADIOS2 stub header #302
+- Name sanitization in ADIOS1 and HDF5 backends #310
 
 Other
 """""

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -395,7 +395,7 @@ CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
         if( auxiliary::starts_with(name, '/') )
             name = auxiliary::replace_first(name, "/", "");
         if( auxiliary::ends_with(name, '/') )
-            name = auxiliary::replace_first(name, "/", "");
+            name = auxiliary::replace_last(name, "/", "");
 
         std::string path = concrete_bp1_file_position(writable) + name;
 

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -200,7 +200,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         if( auxiliary::starts_with(name, '/') )
             name = auxiliary::replace_first(name, "/", "");
         if( auxiliary::ends_with(name, '/') )
-            name = auxiliary::replace_first(name, "/", "");
+            name = auxiliary::replace_last(name, "/", "");
 
         /* Open H5Object to write into */
         auto res = m_fileIDs.find(writable);


### PR DESCRIPTION
The function `createDataset` in `CommonADIOS1IOHandler.cpp` will now
sanitize '/foo/bar/' to 'foo/bar'.