### PR TITLE
Numpy: float is double

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ Features
 Bug Fixes
 """""""""
 
+- Python
+
+  - single precision support: ``numpy.float`` is an alias for ``float64`` #318
+
 Other
 """""
 

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -48,6 +48,7 @@ void init_BaseRecordComponent(py::module &m) {
         .def_property_readonly("dtype", [](BaseRecordComponent & brc) {
             using DT = Datatype;
 
+            // ref: https://docs.scipy.org/doc/numpy/user/basics.types.html
             if( brc.getDatatype() == DT::CHAR )
                 return py::dtype("b");
             else if( brc.getDatatype() == DT::UCHAR )
@@ -69,7 +70,7 @@ void init_BaseRecordComponent(py::module &m) {
             else if( brc.getDatatype() == DT::DOUBLE )
                 return py::dtype("double");
             else if( brc.getDatatype() == DT::FLOAT )
-                return py::dtype("float");
+                return py::dtype("float32"); // note: np.float is an alias for float64
             /*
             else if( brc.getDatatype() == DT::STRING )
                 return py::dtype("string_");

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -212,6 +212,7 @@ void init_RecordComponent(py::module &m) {
             // py::print( py::str(a.dtype()) );
             // py::print( py::str(buf.dtype()) );
 
+            // ref: https://docs.scipy.org/doc/numpy/user/basics.types.html
             if( a.dtype().is(py::dtype("b")) )
                 r.storeChunk( offset, extent, shareRaw( (char*)a.mutable_data() ) );
             else if( a.dtype().is(py::dtype("B")) )
@@ -232,7 +233,7 @@ void init_RecordComponent(py::module &m) {
                 r.storeChunk( offset, extent, shareRaw( (long double*)a.mutable_data() ) );
             else if( a.dtype().is(py::dtype("double")) )
                 r.storeChunk( offset, extent, shareRaw( (double*)a.mutable_data() ) );
-            else if( a.dtype().is(py::dtype("float")) )
+            else if( a.dtype().is(py::dtype("float32")) ) // note: np.float is an alias for float64
                 r.storeChunk( offset, extent, shareRaw( (float*)a.mutable_data() ) );
 /* @todo
         .value("STRING", Datatype::STRING)


### PR DESCRIPTION
As it turns out, `np.float` is an alias for `float64`.

Broke working with actual single precision floats in the Python bindings.

I found no way to underly the actual C type `float` yet, so we assume it's `float32` now... Gosh!
  https://docs.scipy.org/doc/numpy/user/basics.types.html