### PR TITLE
Python: Dataset Method Namings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Bug Fixes
 - Python
 
   - single precision support: ``numpy.float`` is an alias for ``float64`` #318
+  - ``Dataset`` method namings to underscores #319
 
 Other
 """""

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -32,7 +32,9 @@ using namespace openPMD;
 void init_Dataset(py::module &m) {
     py::class_<Dataset>(m, "Dataset")
 
-        .def(py::init<Datatype, Extent>())
+        .def(py::init<Datatype, Extent>(),
+            py::arg("dtype"), py::arg("extent")
+        )
 
         .def("__repr__",
             [](const Dataset &d) {
@@ -42,12 +44,12 @@ void init_Dataset(py::module &m) {
 
         .def_readonly("extent", &Dataset::extent)
         .def("extend", &Dataset::extend)
-        .def_readonly("chunkSize", &Dataset::chunkSize)
+        .def_readonly("chunk_size", &Dataset::chunkSize)
         .def("set_chunk_size", &Dataset::setChunkSize)
         .def_readonly("compression", &Dataset::compression)
         .def("set_compression", &Dataset::setCompression)
         .def_readonly("transform", &Dataset::transform)
-        .def("setCustomTransform", &Dataset::setCustomTransform)
+        .def("set_custom_transform", &Dataset::setCustomTransform)
         .def_readonly("rank", &Dataset::rank)
         .def_readonly("dtype", &Dataset::dtype)
     ;


### PR DESCRIPTION
Fix namings of `set_custom_transform` and `chunk_size` in Python API.

Add named arguments to constructor.

- [x] rebase and add to changelog after #318