### PR TITLE
Numpy: but C float is single

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Bug Fixes
 
 - Python
 
-  - single precision support: ``numpy.float`` is an alias for ``float64`` #318
+  - single precision support: ``numpy.float`` is an alias for ``float64`` #318 #320
   - ``Dataset`` method namings to underscores #319
 
 Other

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -70,7 +70,7 @@ void init_BaseRecordComponent(py::module &m) {
             else if( brc.getDatatype() == DT::DOUBLE )
                 return py::dtype("double");
             else if( brc.getDatatype() == DT::FLOAT )
-                return py::dtype("float32"); // note: np.float is an alias for float64
+                return py::dtype("single"); // note: np.float is an alias for float64
             /*
             else if( brc.getDatatype() == DT::STRING )
                 return py::dtype("string_");

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -233,7 +233,7 @@ void init_RecordComponent(py::module &m) {
                 r.storeChunk( offset, extent, shareRaw( (long double*)a.mutable_data() ) );
             else if( a.dtype().is(py::dtype("double")) )
                 r.storeChunk( offset, extent, shareRaw( (double*)a.mutable_data() ) );
-            else if( a.dtype().is(py::dtype("float32")) ) // note: np.float is an alias for float64
+            else if( a.dtype().is(py::dtype("single")) ) // note: np.float is an alias for float64
                 r.storeChunk( offset, extent, shareRaw( (float*)a.mutable_data() ) );
 /* @todo
         .value("STRING", Datatype::STRING)


### PR DESCRIPTION
The proper naming for the C-type float in numpy is `single`.

```python
import numpy as np

np.dtype("float")
# dtype('float64')

np.dtype("single")
# dtype('float32')
```

Follow-up to #318 

Ref: https://github.com/numpy/numpy/issues/11833