### PR TITLE
Store: More Detailed Type Mismatch Error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,13 +23,14 @@ Bug Fixes
 - avoid impact on unrelated classes in invasive tests #324
 - Python
 
-  - single precision support: ``numpy.float`` is an alias for ``float64`` #318 #320
+  - single precision support: ``numpy.float`` is an alias for ``builtins.float`` #318 #320
   - ``Dataset`` method namings to underscores #319
 
 Other
 """""
 
 - CMake: invasive tests not enabled by default #323
+- ``store_chunk``: more detailed type mismatch error #322
 
 
 0.4.0-alpha

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -28,6 +28,7 @@
 #include <limits>
 #include <queue>
 #include <string>
+#include <sstream>
 #include <stdexcept>
 
 // expose private and protected members for invasive testing
@@ -179,7 +180,15 @@ RecordComponent::storeChunk(Offset o, Extent e, std::shared_ptr<T> data)
         throw std::runtime_error("Unallocated pointer passed during chunk store.");
     Datatype dtype = determineDatatype(data);
     if( dtype != getDatatype() )
-        throw std::runtime_error("Datatypes of chunk and dataset do not match.");
+    {
+        std::ostringstream oss;
+        oss << "Datatypes of chunk data ("
+            << dtype
+            << ") and dataset ("
+            << getDatatype()
+            << ") do not match.";
+        throw std::runtime_error(oss.str());
+    }
     uint8_t dim = getDimensionality();
     if( e.size() != dim || o.size() != dim )
         throw std::runtime_error("Dimensionality of chunk and dataset do not match.");

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -24,6 +24,8 @@
 
 #include <unordered_map>
 #include <string>
+#include <sstream>
+#include <stdexcept>
 
 // expose private and protected members for invasive testing
 #ifndef OPENPMD_private
@@ -109,7 +111,15 @@ PatchRecordComponent::store(uint64_t idx, T data)
 {
     Datatype dtype = determineDatatype< T >();
     if( dtype != getDatatype() )
-        throw std::runtime_error("Datatypes of chunk and dataset do not match.");
+    {
+        std::ostringstream oss;
+        oss << "Datatypes of chunk data ("
+            << dtype
+            << ") and dataset ("
+            << getDatatype()
+            << ") do not match.";
+        throw std::runtime_error(oss.str());
+    }
 
     Extent dse = getExtent();
     if( dse[0] < idx )

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -534,6 +534,9 @@ TEST_CASE( "wrapper_test", "[core]" )
 
     MeshRecordComponent mrc3 = o.iterations[5].meshes["E"]["y"];
     o.iterations[5].meshes["E"]["y"].resetDataset(Dataset(Datatype::DOUBLE, {1}));
+    int wrongData = 42;
+    REQUIRE_THROWS_WITH(o.iterations[5].meshes["E"]["y"].storeChunk({0}, {1}, shareRaw(&wrongData)),
+                        Catch::Equals("Datatypes of chunk data (INT32) and dataset (DOUBLE) do not match."));
     std::shared_ptr< double > storeData = std::make_shared< double >(44);
     o.iterations[5].meshes["E"]["y"].storeChunk({0}, {1}, storeData);
 #if openPMD_USE_INVASIVE_TESTS
@@ -567,6 +570,8 @@ TEST_CASE( "wrapper_test", "[core]" )
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 1);
     REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 1);
 #endif
+    REQUIRE_THROWS_WITH(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].store(idx+1, 42.),
+                        Catch::Equals("Datatypes of chunk data (DOUBLE) and dataset (UINT64) do not match."));
     o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].store(idx+1, val+1);
 #if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 2);


### PR DESCRIPTION
Improve the error message for mismatched datatype and data passed to `store_chunk` by including both as well.