### PR TITLE
Invasive Tests: Only CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,7 @@ jobs:
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
             -DopenPMD_USE_PYTHON=OFF
+            -DopenPMD_USE_INVASIVE_TESTS=ON
             $TRAVIS_BUILD_DIR
       script:
         - cd $HOME/build
@@ -150,6 +151,7 @@ jobs:
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
             -DopenPMD_USE_PYTHON=OFF
+            -DopenPMD_USE_INVASIVE_TESTS=ON
             $TRAVIS_BUILD_DIR
       script:
         - cd $HOME/build
@@ -211,6 +213,7 @@ jobs:
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
             -DopenPMD_USE_PYTHON=$USE_PYTHON
+            -DopenPMD_USE_INVASIVE_TESTS=ON
             $EXTRA_CMAKE_FLAGS
             -DCMAKE_INSTALL_PREFIX=$HOME/openPMD-test-install
             $TRAVIS_BUILD_DIR
@@ -425,6 +428,7 @@ jobs:
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
             -DopenPMD_USE_PYTHON=OFF
+            -DopenPMD_USE_INVASIVE_TESTS=ON
             $TRAVIS_BUILD_DIR
         - make -j 2
       script:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Bug Fixes
 Other
 """""
 
+- CMake: invasive tests not enabled by default #323
+
 
 0.4.0-alpha
 -----------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,13 @@ openpmd_option(HDF5           "Enable HDF5 support"                       AUTO)
 openpmd_option(ADIOS1         "Enable ADIOS1 support"                     AUTO)
 openpmd_option(ADIOS2         "Enable ADIOS2 support"                     OFF)
 #openpmd_option(JSON           "Enable JSON support"                      AUTO)
-openpmd_option(INVASIVE_TESTS "Enable unit tests that modify source code" AUTO)
 openpmd_option(PYTHON         "Enable Python bindings"                    AUTO)
 
 option(openPMD_USE_INTERNAL_VARIANT  "Use internally shipped MPark.Variant" ON)
 option(openPMD_USE_INTERNAL_CATCH    "Use internally shipped Catch2"        ON)
 option(openPMD_USE_INTERNAL_PYBIND11 "Use internally shipped pybind11"      ON)
 
+option(openPMD_USE_INVASIVE_TESTS "Enable unit tests that modify source code" OFF)
 option(openPMD_USE_VERIFY "Enable internal VERIFY (assert) macro independent of build type" ON)
 
 set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
@@ -529,24 +529,19 @@ set(openPMD_PYTHON_EXAMPLE_NAMES
     3_write_serial
 )
 
-if(openPMD_USE_INVASIVE_TESTS STREQUAL AUTO)
+if(openPMD_USE_INVASIVE_TESTS)
     if(WIN32)
-        set(openPMD_HAVE_INVASIVE_TESTS FALSE)
-    else()
-        set(openPMD_HAVE_INVASIVE_TESTS TRUE)
+        message(WARNING "Invasive tests that redefine class signatures are "
+                        "known to fail on Windows!")
     endif()
-elseif(openPMD_USE_INVASIVE_TESTS)
-    set(openPMD_HAVE_INVASIVE_TESTS TRUE)
-else()
-    set(openPMD_HAVE_INVASIVE_TESTS FALSE)
 endif()
 
 if(BUILD_TESTING)
     foreach(testname ${openPMD_TEST_NAMES})
         add_executable(${testname}Tests test/${testname}Test.cpp)
 
-        if(openPMD_HAVE_INVASIVE_TESTS)
-            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_INVASIVE_TESTS=1")
+        if(openPMD_USE_INVASIVE_TESTS)
+            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_USE_INVASIVE_TESTS=1")
         endif()
 
         if(openPMD_HAVE_MPI)
@@ -853,6 +848,7 @@ message("    MPark.Variant: ${openPMD_USE_INTERNAL_VARIANT}")
 message("")
 message("  Build Type: ${CMAKE_BUILD_TYPE}")
 message("  Testing: ${BUILD_TESTING}")
+message("  Invasive Tests: ${openPMD_USE_INVASIVE_TESTS}")
 message("  Internal VERIFY: ${openPMD_USE_VERIFY}")
 message("  Build Options:")
 

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_MAIN
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
 /* make Writable::parent visible for hierarchy check */
 #   pragma clang diagnostic push
 #   pragma clang diagnostic ignored "-Wkeyword-macro"
@@ -11,7 +11,7 @@
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
 #   undef private
 #   undef protected
 #endif
@@ -112,7 +112,7 @@ struct S : public TestHelper
 
 TEST_CASE( "container_default_test", "[auxiliary]")
 {
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     Container< openPMD::test::S > c = Container< openPMD::test::S >();
     c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
     c.IOHandler = c.m_writable->IOHandler.get();
@@ -146,7 +146,7 @@ struct structure : public TestHelper
 
 TEST_CASE( "container_retrieve_test", "[auxiliary]" )
 {
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     using structure = openPMD::test::structure;
     Container< structure > c = Container< structure >();
     c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
@@ -223,7 +223,7 @@ struct Widget : public TestHelper
 
 TEST_CASE( "container_access_test", "[auxiliary]" )
 {
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     using Widget = openPMD::test::Widget;
     Container< Widget > c = Container< Widget >();
     c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_MAIN
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
 /* make Writable::parent, Writable::IOHandler visible for structure_test */
 #   pragma clang diagnostic push
 #   pragma clang diagnostic ignored "-Wkeyword-macro"
@@ -9,7 +9,7 @@
 #   pragma clang diagnostic pop
 #endif
 #include "openPMD/openPMD.hpp"
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
 #   undef private
 #   undef protected
 #endif
@@ -350,7 +350,7 @@ TEST_CASE( "mesh_modification_test", "[core]" )
 
 TEST_CASE( "structure_test", "[core]" )
 {
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     Series o = Series("./new_openpmd_output_%T", AccessType::CREATE);
 
     REQUIRE(o.IOHandler);
@@ -520,7 +520,7 @@ TEST_CASE( "wrapper_test", "[core]" )
     o.iterations[4].meshes["E"]["y"].resetDataset(Dataset(Datatype::DOUBLE, {1}));
     o.iterations[4].meshes["E"]["y"].makeConstant(value);
     MeshRecordComponent mrc2 = o.iterations[4].meshes["E"]["y"];
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(*mrc2.m_isConstant);
 #endif
     double loadData;
@@ -533,7 +533,7 @@ TEST_CASE( "wrapper_test", "[core]" )
     o.iterations[4].meshes["E"]["y"].loadChunk({0}, {1}, shareRaw(moreData));
     o.flush();
     REQUIRE(moreData[0] == value);
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[4].meshes["E"]["y"].m_chunks->empty());
     REQUIRE(mrc2.m_chunks->empty());
 #endif
@@ -542,12 +542,12 @@ TEST_CASE( "wrapper_test", "[core]" )
     o.iterations[5].meshes["E"]["y"].resetDataset(Dataset(Datatype::DOUBLE, {1}));
     std::shared_ptr< double > storeData = std::make_shared< double >(44);
     o.iterations[5].meshes["E"]["y"].storeChunk({0}, {1}, storeData);
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[5].meshes["E"]["y"].m_chunks->size() == 1);
     REQUIRE(mrc3.m_chunks->size() == 1);
 #endif
     o.flush();
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[5].meshes["E"]["y"].m_chunks->empty());
     REQUIRE(mrc3.m_chunks->empty());
 #endif
@@ -564,22 +564,22 @@ TEST_CASE( "wrapper_test", "[core]" )
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["prop"]["x"].getExtent() == Extent{7});
     size_t idx = 0;
     uint64_t val = 10;
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
     REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
 #endif
     pp["numParticles"][RecordComponent::SCALAR].store(idx, val);
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 1);
     REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 1);
 #endif
     o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].store(idx+1, val+1);
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 2);
     REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 2);
 #endif
     o.flush();
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
     REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
 #endif
@@ -598,7 +598,7 @@ TEST_CASE( "use_count_test", "[core]" )
     o.flush();
     REQUIRE(storeData.use_count() == 1);
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     PatchRecordComponent pprc = o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR];
     auto dset = Dataset(Datatype::DOUBLE, {1});
     o.iterations[6].particles["electrons"]["position"][RecordComponent::SCALAR].resetDataset(dset);

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1,7 +1,7 @@
 #define CATCH_CONFIG_MAIN
 
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
 /* make Writable::parent visible for hierarchy check */
 #   pragma clang diagnostic push
 #   pragma clang diagnostic ignored "-Wkeyword-macro"
@@ -10,7 +10,7 @@
 #   pragma clang diagnostic pop
 #endif
 #include "openPMD/openPMD.hpp"
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
 #   undef protected
 #   undef private
 #endif
@@ -31,7 +31,7 @@ using namespace openPMD;
 #if openPMD_HAVE_HDF5
 TEST_CASE( "git_hdf5_sample_structure_test", "[serial][hdf5]" )
 {
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
     try
     {
         Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_ONLY);
@@ -395,7 +395,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
         REQUIRE(o.iterations.count(400) == 1);
         REQUIRE(o.iterations.count(500) == 1);
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
         REQUIRE(*o.m_filenamePadding == 8);
 #endif
     } catch (no_such_file_error& e)
@@ -415,7 +415,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
         REQUIRE(o.iterations.count(400) == 1);
         REQUIRE(o.iterations.count(500) == 1);
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
         REQUIRE(*o.m_filenamePadding == 8);
 #endif
     } catch (no_such_file_error& e)
@@ -442,7 +442,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
         {
             Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_WRITE);
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
             REQUIRE(*o.m_filenamePadding == 8);
 #endif
 
@@ -1168,7 +1168,7 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         REQUIRE(o.iterations.count(2) == 1);
         REQUIRE(o.iterations.count(3) == 1);
 
-#if openPMD_HAVE_INVASIVE_TESTS
+#if openPMD_USE_INVASIVE_TESTS
         REQUIRE(*o.m_filenamePadding == 8);
 #endif
 


### PR DESCRIPTION
Does not enable invasive (class signature re-defining) tests by default:
- enable in Travis-CI (Linux/OSX tests)
- warn when enabled on Windows

The idea is to have a [more robust build](https://github.com/openPMD/openPMD-api/issues/175#issuecomment-417298708) on unexpected (untested) architectures and compilers by default.

Related to #175