### PR TITLE
Invasive Tests: Avoid Side Effects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Features
 Bug Fixes
 """""""""
 
+- avoid impact on unrelated classes in invasive tests #324
 - Python
 
   - single precision support: ``numpy.float`` is an alias for ``float64`` #318 #320

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -30,6 +30,11 @@
 #include <string>
 #include <stdexcept>
 
+// expose private and protected members for invasive testing
+#ifndef OPENPMD_protected
+#   define OPENPMD_protected protected
+#endif
+
 
 namespace openPMD
 {
@@ -54,7 +59,7 @@ public:
         USER,
         API,
         AUTO
-    };  //Allocation
+    }; // Allocation
 
     RecordComponent& setUnitSI(double);
 
@@ -81,7 +86,7 @@ public:
 
     constexpr static char const * const SCALAR = "\vScalar";
 
-protected:
+OPENPMD_protected:
     RecordComponent();
 
     void readBase();
@@ -92,7 +97,7 @@ protected:
 private:
     void flush(std::string const&);
     virtual void read();
-};  //RecordComponent
+}; // RecordComponent
 
 
 template< typename T >
@@ -194,4 +199,4 @@ RecordComponent::storeChunk(Offset o, Extent e, std::shared_ptr<T> data)
     dWrite.data = std::static_pointer_cast< void const >(data);
     m_chunks->push(IOTask(this, dWrite));
 }
-} // openPMD
+} // namespace openPMD

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -34,6 +34,11 @@
 
 #include <string>
 
+// expose private and protected members for invasive testing
+#ifndef OPENPMD_private
+#   define OPENPMD_private private
+#endif
+
 
 namespace openPMD
 {
@@ -231,7 +236,7 @@ public:
 
     Container< Iteration, uint64_t > iterations;
 
-private:
+OPENPMD_private:
     struct ParsedInput;
     std::unique_ptr< ParsedInput > parseInput(std::string);
     void init(std::shared_ptr< AbstractIOHandler >, std::unique_ptr< ParsedInput >);
@@ -255,5 +260,5 @@ private:
     std::shared_ptr< std::string > m_filenamePrefix;
     std::shared_ptr< std::string > m_filenamePostfix;
     std::shared_ptr< int > m_filenamePadding;
-};  //Series
-} // openPMD
+}; // Series
+} // namespace openPMD

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -32,6 +32,11 @@
 #include <string>
 #include <cstddef>
 
+// expose private and protected members for invasive testing
+#ifndef OPENPMD_protected
+#   define OPENPMD_protected protected
+#endif
+
 
 namespace openPMD
 {
@@ -141,7 +146,7 @@ public:
      */
     Attributable& setComment(std::string const& comment);
 
-protected:
+OPENPMD_protected:
     void flushAttributes();
     void readAttributes();
 
@@ -191,7 +196,7 @@ private:
     virtual void linkHierarchy(std::shared_ptr< Writable > const& w);
 
     std::shared_ptr< A_MAP > m_attributes;
-};  //Attributable
+}; // Attributable
 
 
 void
@@ -321,4 +326,4 @@ Attributable::readVectorFloatingpoint(std::string const& key) const
     }
     return vt;
 }
-} // openPMD
+} // namespace openPMD

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -23,6 +23,11 @@
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/Dataset.hpp"
 
+// expose private and protected members for invasive testing
+#ifndef OPENPMD_protected
+#   define OPENPMD_protected protected
+#endif
+
 
 namespace openPMD
 {
@@ -33,9 +38,9 @@ class BaseRecordComponent : public Attributable
     class BaseRecord;
 
     template<
-            typename T,
-            typename T_key,
-            typename T_container
+        typename T,
+        typename T_key,
+        typename T_container
     >
     friend
     class Container;
@@ -50,10 +55,10 @@ public:
 
     Datatype getDatatype() const;
 
-protected:
+OPENPMD_protected:
     BaseRecordComponent();
 
     std::shared_ptr< Dataset > m_dataset;
     std::shared_ptr< bool > m_isConstant;
-};  //BaseRecordComponent
-} // openPMD
+}; // BaseRecordComponent
+} // namespace openPMD

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -28,6 +28,11 @@
 #include <map>
 #include <string>
 
+// expose private and protected members for invasive testing
+#ifndef OPENPMD_protected
+#   define OPENPMD_protected protected
+#endif
+
 
 namespace openPMD
 {
@@ -236,7 +241,7 @@ public:
         return m_container->emplace(std::forward<Args>(args)...);
     }
 
-protected:
+OPENPMD_protected:
     Container()
         : m_container{std::make_shared< InternalContainer >()}
     { }

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -25,6 +25,11 @@
 #include <unordered_map>
 #include <string>
 
+// expose private and protected members for invasive testing
+#ifndef OPENPMD_private
+#   define OPENPMD_private private
+#endif
+
 
 namespace openPMD
 {
@@ -56,14 +61,14 @@ public:
     template< typename T >
     void store(uint64_t idx, T);
 
-private:
+OPENPMD_private:
     PatchRecordComponent();
 
     void flush(std::string const&);
     void read();
 
     std::shared_ptr< std::queue< IOTask > > m_chunks;
-};  //PatchRecordComponent
+}; // PatchRecordComponent
 
 template< typename T >
 inline std::shared_ptr< T >
@@ -118,4 +123,4 @@ PatchRecordComponent::store(uint64_t idx, T data)
     dWrite.data = std::make_shared< T >(data);
     m_chunks->push(IOTask(this, dWrite));
 }
-} // openPMD
+} // namespace openPMD

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -23,13 +23,18 @@
 #include <string>
 #include <memory>
 
+// expose private and protected members for invasive testing
+#ifndef OPENPMD_private
+#   define OPENPMD_private private
+#endif
+
 
 namespace openPMD
 {
 namespace test
 {
 struct TestHelper;
-} // test
+} // namespace test
 class AbstractFilePosition;
 class AbstractIOHandler;
 class Attributable;
@@ -72,7 +77,7 @@ public:
     Writable(Attributable* = nullptr);
     virtual ~Writable();
 
-private:
+OPENPMD_private:
     std::shared_ptr< AbstractFilePosition > abstractFilePosition;
     std::shared_ptr< AbstractIOHandler > IOHandler;
     Attributable* attributable;
@@ -80,4 +85,4 @@ private:
     bool dirty;
     bool written;
 };
-} // openPMD
+} // namespace openPMD

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -1,27 +1,19 @@
 #define CATCH_CONFIG_MAIN
 
+// expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
-/* make Writable::parent visible for hierarchy check */
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wkeyword-macro"
-#   define protected public
-#   define private public
-#   pragma clang diagnostic pop
+#   define OPENPMD_private public
+#   define OPENPMD_protected public
 #endif
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
-#if openPMD_USE_INVASIVE_TESTS
-#   undef private
-#   undef protected
-#endif
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerHelper.hpp"
 #include "openPMD/Dataset.hpp"
-using namespace openPMD;
 
 #include <catch/catch.hpp>
 
@@ -29,6 +21,8 @@ using namespace openPMD;
 #include <fstream>
 #include <string>
 #include <vector>
+
+using namespace openPMD;
 
 
 namespace openPMD

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1,19 +1,11 @@
 #define CATCH_CONFIG_MAIN
 
+// expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
-/* make Writable::parent, Writable::IOHandler visible for structure_test */
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wkeyword-macro"
-#   define protected public
-#   define private public
-#   pragma clang diagnostic pop
+#   define OPENPMD_private public
+#   define OPENPMD_protected public
 #endif
 #include "openPMD/openPMD.hpp"
-#if openPMD_USE_INVASIVE_TESTS
-#   undef private
-#   undef protected
-#endif
-using namespace openPMD;
 
 #include <catch/catch.hpp>
 
@@ -21,6 +13,8 @@ using namespace openPMD;
 #include <vector>
 #include <array>
 #include <cstddef>
+
+using namespace openPMD;
 
 
 TEST_CASE( "attribute_dtype_test", "[core]" )

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -4,9 +4,9 @@
 #define CATCH_CONFIG_RUNNER
 
 #include "openPMD/openPMD.hpp"
-using namespace openPMD;
 
 #include <catch/catch.hpp>
+
 #if openPMD_HAVE_MPI
 #   include <mpi.h>
 
@@ -16,6 +16,8 @@ using namespace openPMD;
 #   include <vector>
 #   include <array>
 #   include <memory>
+
+using namespace openPMD;
 
 
 int main(int argc, char *argv[])

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1,21 +1,12 @@
 #define CATCH_CONFIG_MAIN
 
-
+// expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
-/* make Writable::parent visible for hierarchy check */
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wkeyword-macro"
-#   define protected public
-#   define private public
-#   pragma clang diagnostic pop
+#   define OPENPMD_private public
+#   define OPENPMD_protected public
 #endif
 #include "openPMD/openPMD.hpp"
-#if openPMD_USE_INVASIVE_TESTS
-#   undef protected
-#   undef private
-#endif
 #include "openPMD/auxiliary/Filesystem.hpp"
-using namespace openPMD;
 
 #include <catch/catch.hpp>
 
@@ -26,6 +17,8 @@ using namespace openPMD;
 #include <array>
 #include <memory>
 #include <limits>
+
+using namespace openPMD;
 
 
 #if openPMD_HAVE_HDF5


### PR DESCRIPTION
Make our invasive tests less invasive by:
- only changing class signatures of own classes
- only changing required sections, no all

This avoids changing visibility attributes of included classes as a side effect, e.g. from standard libs.

Fix #175