### PR TITLE
Dataset: Fix setCompression Detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Features
 Bug Fixes
 """""""""
 
+- ``Dataset``: ``setCompression`` warning and error logic #326
 - avoid impact on unrelated classes in invasive tests #324
 - Python
 

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -62,9 +62,11 @@ Dataset::setChunkSize(Extent const& cs)
 Dataset&
 Dataset::setCompression(std::string const& format, uint8_t const level)
 {
-    if( (format == "zlib" || format == "gzip" || format == "deflate")
-        && level > 9 )
-        throw std::runtime_error("Compression level out of range for " + format);
+    if(format == "zlib" || format == "gzip" || format == "deflate")
+    {
+        if(level > 9)
+            throw std::runtime_error("Compression level out of range for " + format);
+    }
     else
         std::cerr << "Unknown compression format " << format
                   << ". This might mean that compression will not be enabled."

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -950,7 +950,10 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     uint64_t posOff{0};
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
     std::array< uint64_t, 1 > positionOffset_local = {{ 0u }};
-    e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype<uint64_t>(), {4}));
+    auto dataset = Dataset(determineDatatype<uint64_t>(), {4});
+    REQUIRE_THROWS_AS(dataset.setCompression("zlib", 10), std::runtime_error);
+    dataset.setCompression("zlib", 9);
+    e["positionOffset"]["x"].resetDataset(dataset);
 
     for( uint64_t i = 0; i < 4; ++i )
     {


### PR DESCRIPTION
Fix the warning and error logic in `Dataset::setCompression`.