### PR TITLE
Attribute Error: Remove const char signature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,7 @@ Other
 
 - CMake: invasive tests not enabled by default #323
 - ``store_chunk``: more detailed type mismatch error #322
-- ``no_such_file_error``: remove c-string constructor #325
+- ``no_such_file_error`` & ``no_such_attribute_error``: remove c-string constructor #325 #327
 
 
 0.4.0-alpha

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -50,9 +50,6 @@ class AbstractFilePosition;
 class no_such_attribute_error : public std::runtime_error
 {
 public:
-    no_such_attribute_error(char const* what_arg)
-            : std::runtime_error(what_arg)
-    { }
     no_such_attribute_error(std::string const& what_arg)
             : std::runtime_error(what_arg)
     { }


### PR DESCRIPTION
Again for `Attributable` as in  #325.

Remove the C-like string constructor.
- c-strings are casted to c++ strings in the constructor anyway
- c-strings are not C++-ish
- coverage shows the constructor is unused