### PR TITLE
set_attribute: broken numpy, list and string support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -110,7 +110,7 @@ install:
   - cmd: conda config --append channels conda-forge
 
   # Configure the VM.
-  - cmd: conda install -n root --quiet --yes numpy cmake hdf5
+  - cmd: conda install -n root --quiet --yes numpy>=1.15 cmake hdf5
 
 before_build:
   - cmd: cd C:\projects\openpmd-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -514,6 +514,10 @@ install:
           $CXXSPEC &&
         spack load py-pybind11@2.2.3 ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
       fi;
+      travis_wait spack install
+        py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION
+        $CXXSPEC &&
+      spack load py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
     fi
   - if [ $USE_HDF5 == "ON" ]; then
       travis_wait spack install

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Bug Fixes
   - single precision support: ``numpy.float`` is an alias for ``builtins.float`` #318 #320
   - ``Dataset`` method namings to underscores #319
   - container namespace ambiguity #343
+  - ``set_attribute``: broken numpy, list and string support #330
 
 Other
 """""
@@ -40,6 +41,7 @@ Other
 - ``store_chunk``: more detailed type mismatch error #322
 - ``no_such_file_error`` & ``no_such_attribute_error``: remove c-string constructor #325 #327
 - add virtual destructor to ``Attributable`` #332
+- Python: Numpy 1.15+ required #330
 
 
 0.4.0-alpha

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,4 @@ pygments
 # generate plots
 matplotlib
 scipy
-numpy
+numpy>=1.15

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -41,4 +41,4 @@ Optional: language bindings
 
   * Python 3.X+
   * pybind11 2.2.3+
-  * numpy
+  * numpy 1.15+

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -86,5 +86,13 @@ PYBIND11_MODULE(openPMD, m) {
         {"adios1", bool(openPMD_HAVE_ADIOS1)},
         {"adios2", bool(openPMD_HAVE_ADIOS2)}
     };
+
+    // TODO broken numpy if not at least v1.15.0: raise warning
+    // auto numpy = py::module::import("numpy");
+    // auto npversion = numpy.attr("__version__");
+    // std::cout << "numpy version: " << py::str(npversion) << std::endl;
+
+    // TODO allow to query runtime versions of all dependencies
+    //      (also needed in C++ frontend)
 }
 


### PR DESCRIPTION
Fix `Attributable` write:

- [x] python `buildin.float` was down-casted in binding to single, now double
- [x] string writing was broken
- [x] add numpy scalar and array support
- [x] add python array support
- [x] add list support
- [x] N-D lists/arrays/np.arrays will be flattended to 1D
- [x] unit test added for HDF5 and ADIOS1 backend

Left for future:
- [ ] list & array of numpy scalars are cropped to native python type (ok-ish - use np.array instead!)
- [ ] `get_attribute`: return lists/arrays as np.arrays, not Python lists #348
- [ ] verify numpy version at RT via `auto numpy = py::module::import("numpy"); auto version = numpy.attr("__version__");`  #349


`set_attribute` requires numpy 1.15.0+ in order to handle scalars properly (`ndim == 0`).

Refs:
  https://github.com/numpy/numpy/issues/10265
  https://github.com/pybind/pybind11/issues/1224#issuecomment-354357392

Fix #329