### PR TITLE
Attributable: virtual default destructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Other
 - CMake: invasive tests not enabled by default #323
 - ``store_chunk``: more detailed type mismatch error #322
 - ``no_such_file_error`` & ``no_such_attribute_error``: remove c-string constructor #325 #327
+- add virtual destructor to ``Attributable`` #332
 
 
 0.4.0-alpha

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -83,6 +83,7 @@ public:
     Attributable();
     Attributable(Attributable const&);
     Attributable(Attributable&&) = delete;
+    virtual ~Attributable() = default;
 
     Attributable& operator=(Attributable const&);
     Attributable& operator=(Attributable&&) = delete;


### PR DESCRIPTION
Fix clang++ 6.0 warning when binding to pybind11:
```
include/c++/6.3.0/bits/unique_ptr.h:76:2: warning: delete called on non-final 'openPMD::Attributable' that has virtual
      functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^
include/c++/6.3.0/bits/unique_ptr.h:239:4: note: in instantiation of member function
      'std::default_delete<openPMD::Attributable>::operator()' requested here
          get_deleter()(__ptr);
          ^
openPMD-api/share/openPMD/thirdParty/pybind11/include/pybind11/pybind11.h:1319:40: note: in instantiation of member function
      'std::unique_ptr<openPMD::Attributable, std::default_delete<openPMD::Attributable> >::~unique_ptr' requested here
            v_h.holder<holder_type>().~holder_type();
                                       ^
openPMD-api/share/openPMD/thirdParty/pybind11/include/pybind11/pybind11.h:1054:26: note: in instantiation of member function
      'pybind11::class_<openPMD::Attributable>::dealloc' requested here
        record.dealloc = dealloc;
                         ^
openPMD-api/src/binding/python/Attributable.cpp:192:5: note: in instantiation of function template specialization
      'pybind11::class_<openPMD::Attributable>::class_<>' requested here
    py::class_<Attributable>(m, "Attributable")
```

potentially also needed for classes such as `Iteration` and `Series`.

SO:
- https://stackoverflow.com/questions/10024796/c-virtual-functions-but-no-virtual-destructors
- https://stackoverflow.com/questions/8764353/what-does-has-virtual-method-but-non-virtual-destructor-warning-mean-durin/8764393