### PR TITLE
Travis: Skip clang-tidy & IWYU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,105 +62,105 @@ jobs:
     ###########################################################################
     # Stage: Static Code Analysis                                             #
     ###########################################################################
-    - &static_code_cpp
-      stage: 'Static Code Analysis'
-      name: clang@5.0.0 +IncludeWhatYouUse
-      sudo: true
-      language: python
-      python: "2.7"
-      compiler: clang
-      env:
-        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - llvm-5.0-dev
-            - libclang-5.0-dev
-            - clang-5.0
-            - libopenmpi-dev
-            - openmpi-bin
-            - environment-modules
-      before_install:
-        - export CC=clang
-        - export CXX=clang++
-        - ROOT_PATH=`llvm-config-5.0 --prefix`
-        - BIN_PATH=`llvm-config-5.0 --bindir`
-        - if [ ! -f $BIN_PATH/iwyu_tool.py ]; then
-            git clone https://github.com/include-what-you-use/include-what-you-use.git &&
-            cd include-what-you-use &&
-            git checkout clang_5.0 &&
-            mkdir build &&
-            cd build &&
-            cmake -DIWYU_LLVM_ROOT_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=$ROOT_PATH .. &&
-            make -j2 &&
-            sudo make install &&
-            cd ../.. &&
-            rm -rf include-what-you-use;
-          fi
-        - export PATH=$ROOT_PATH/bin:$PATH
-      before_script:
-        - mkdir -p $HOME/build
-        - cd $HOME/build
-        - cmake
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-            -DCMAKE_BUILD_TYPE=Debug
-            -DopenPMD_USE_MPI=$USE_MPI
-            -DopenPMD_USE_HDF5=$USE_HDF5
-            -DopenPMD_USE_ADIOS1=$USE_ADIOS1
-            -DopenPMD_USE_ADIOS2=$USE_ADIOS2
-            -DopenPMD_USE_PYTHON=OFF
-            -DopenPMD_USE_INVASIVE_TESTS=ON
-            $TRAVIS_BUILD_DIR
-      script:
-        - cd $HOME/build
-        - python $BIN_PATH/iwyu_tool.py -v -j 2 -p . > iwyu.log
-        - cat iwyu.log
-        - if [[ $(wc -l <iwyu.log) -ge 1 ]]; then
-            exit 1;
-          fi
-      after_script: exit $?
-    - <<: *static_code_cpp
-      name: clang-tidy@5.0.0
-      sudo: false
-      env:
-        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-            - clang-tidy-5.0
-            - libopenmpi-dev
-            - openmpi-bin
-            - environment-modules
-      before_install:
-        - CC=clang CXX=clang++
-      before_script:
-        - mkdir -p $HOME/build
-        - cd $HOME/build
-        - cmake
-            "-DCMAKE_CXX_CLANG_TIDY=$(which clang-tidy-5.0);-system-headers=0"
-            -DCMAKE_BUILD_TYPE=Debug
-            -DopenPMD_USE_MPI=$USE_MPI
-            -DopenPMD_USE_HDF5=$USE_HDF5
-            -DopenPMD_USE_ADIOS1=$USE_ADIOS1
-            -DopenPMD_USE_ADIOS2=$USE_ADIOS2
-            -DopenPMD_USE_PYTHON=OFF
-            -DopenPMD_USE_INVASIVE_TESTS=ON
-            $TRAVIS_BUILD_DIR
-      script:
-        - cd $HOME/build
-        - make -j 2 2> clang-tidy.log
-        - cat clang-tidy.log
-        - if [[ $(wc -l <clang-tidy.log) -ge 1 ]]; then
-            exit 1;
-          fi
-      after_script: exit $?
+    # - &static_code_cpp
+    #   stage: 'Static Code Analysis'
+    #   name: clang@5.0.0 +IncludeWhatYouUse
+    #   sudo: true
+    #   language: python
+    #   python: "2.7"
+    #   compiler: clang
+    #   env:
+    #     - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-trusty-5.0
+    #       packages:
+    #         - llvm-5.0-dev
+    #         - libclang-5.0-dev
+    #         - clang-5.0
+    #         - libopenmpi-dev
+    #         - openmpi-bin
+    #         - environment-modules
+    #   before_install:
+    #     - export CC=clang
+    #     - export CXX=clang++
+    #     - ROOT_PATH=`llvm-config-5.0 --prefix`
+    #     - BIN_PATH=`llvm-config-5.0 --bindir`
+    #     - if [ ! -f $BIN_PATH/iwyu_tool.py ]; then
+    #         git clone https://github.com/include-what-you-use/include-what-you-use.git &&
+    #         cd include-what-you-use &&
+    #         git checkout clang_5.0 &&
+    #         mkdir build &&
+    #         cd build &&
+    #         cmake -DIWYU_LLVM_ROOT_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=$ROOT_PATH .. &&
+    #         make -j2 &&
+    #         sudo make install &&
+    #         cd ../.. &&
+    #         rm -rf include-what-you-use;
+    #       fi
+    #     - export PATH=$ROOT_PATH/bin:$PATH
+    #   before_script:
+    #     - mkdir -p $HOME/build
+    #     - cd $HOME/build
+    #     - cmake
+    #         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    #         -DCMAKE_BUILD_TYPE=Debug
+    #         -DopenPMD_USE_MPI=$USE_MPI
+    #         -DopenPMD_USE_HDF5=$USE_HDF5
+    #         -DopenPMD_USE_ADIOS1=$USE_ADIOS1
+    #         -DopenPMD_USE_ADIOS2=$USE_ADIOS2
+    #         -DopenPMD_USE_PYTHON=OFF
+    #         -DopenPMD_USE_INVASIVE_TESTS=ON
+    #         $TRAVIS_BUILD_DIR
+    #   script:
+    #     - cd $HOME/build
+    #     - python $BIN_PATH/iwyu_tool.py -v -j 2 -p . > iwyu.log
+    #     - cat iwyu.log
+    #     - if [[ $(wc -l <iwyu.log) -ge 1 ]]; then
+    #         exit 1;
+    #       fi
+    #   after_script: exit $?
+    # - <<: *static_code_cpp
+    #   name: clang-tidy@5.0.0
+    #   sudo: false
+    #   env:
+    #     - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-trusty-5.0
+    #       packages:
+    #         - clang-5.0
+    #         - clang-tidy-5.0
+    #         - libopenmpi-dev
+    #         - openmpi-bin
+    #         - environment-modules
+    #   before_install:
+    #     - CC=clang CXX=clang++
+    #   before_script:
+    #     - mkdir -p $HOME/build
+    #     - cd $HOME/build
+    #     - cmake
+    #         "-DCMAKE_CXX_CLANG_TIDY=$(which clang-tidy-5.0);-system-headers=0"
+    #         -DCMAKE_BUILD_TYPE=Debug
+    #         -DopenPMD_USE_MPI=$USE_MPI
+    #         -DopenPMD_USE_HDF5=$USE_HDF5
+    #         -DopenPMD_USE_ADIOS1=$USE_ADIOS1
+    #         -DopenPMD_USE_ADIOS2=$USE_ADIOS2
+    #         -DopenPMD_USE_PYTHON=OFF
+    #         -DopenPMD_USE_INVASIVE_TESTS=ON
+    #         $TRAVIS_BUILD_DIR
+    #   script:
+    #     - cd $HOME/build
+    #     - make -j 2 2> clang-tidy.log
+    #     - cat clang-tidy.log
+    #     - if [[ $(wc -l <clang-tidy.log) -ge 1 ]]; then
+    #         exit 1;
+    #       fi
+    #   after_script: exit $?
     - &static_code_python
       stage: 'Static Code Analysis'
       name: pyflakes 2.7


### PR DESCRIPTION
Although both tools are very promising, we are currently not fixing their reported issues to 100%.

That would be no problem to fix them gradually, but since they do not succeed yes, travis is not caching our (dependency) build artifacts. Due to that, both take up 20min and block development time.

Proposal how to enable them: in case there are no false positives or we can add config files disabling those or actual unfixed defects, e.g. for `clang-format` we also need to [add a config file](https://github.com/ComputationalRadiationPhysics/contributing/pull/32), a PR should fix issues caused by them and enable them in the process (or later).