### PR TITLE
[WIP] Adjust some descriptions of the methods in AbstractIOHandlerImpl

### DIFF
--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -204,7 +204,6 @@ public:
   virtual void listDatasets(Writable*, Parameter< Operation::LIST_DATASETS > &) = 0;
   /** List all attributes associated with an object.
    *
-   * The operation should fail if the Writable was not marked written.
    * The attribute should be associated with the Writable.
    * The list of attribute names should be stored in the location indicated by the pointer parameters.attributes.
    */

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -94,7 +94,7 @@ public:
   /** Open all contained groups in a path, possibly recursively.
    *
    * The operation should overwrite existing file positions, even when the Writable was already marked written.
-   * The path parameters.path may contain multiple levels (e.g. first/second/third/). This path should be relative (i.e. it should not start with a slash "/").
+   * The path parameters.path may contain multiple levels (e.g. first/second/third/). This path may be relative or absolute (indicated by a leading slash "/").
    * The Writables file position should correspond to the complete opened path (i.e. first/second/third/ should be assigned to the Writables file position).
    * The Writable should be marked written when the operation completes successfully.
    */
@@ -183,7 +183,6 @@ public:
   virtual void readDataset(Writable*, Parameter< Operation::READ_DATASET > &) = 0;
   /** Read the value of an existing attribute.
    *
-   * The operation should fail if the Writable was not marked written.
    * The operation should fail if the attribute does not exist.
    * The attribute should be associated with the Writable and have the name parameters.name. This name should not contain a slash ("/").
    * The attribute datatype should be stored in the location indicated by the pointer parameters.dtype.
@@ -193,14 +192,12 @@ public:
   virtual void readAttribute(Writable*, Parameter< Operation::READ_ATT > &) = 0;
   /** List all paths/sub-groups inside a group, non-recursively.
    *
-   * The operation should fail if the Writable was not marked written.
    * The operation should fail if the Writable is not a group.
    * The list of group names should be stored in the location indicated by the pointer parameters.paths.
    */
   virtual void listPaths(Writable*, Parameter< Operation::LIST_PATHS > &) = 0;
   /** List all datasets inside a group, non-recursively.
    *
-   * The operation should fail if the Writable was not marked written.
    * The operation should fail if the Writable is not a group.
    * The list of dataset names should be stored in the location indicated by the pointer parameters.datasets.
    */


### PR DESCRIPTION
The class `AbstractIOHandlerImpl` contains a number of methods where implementing them as mandated by their documentation resulted in erroneous behaviour.
* `listPaths`, `listDatasets`, `listAttributes` and `readAttribute` alike are mandated by the documentation to fail if the `Writable` passed to them was not marked written. Neither the ADIOS nor the HDF5 backends implement  such a check and these functions are indeed often called with `Writable`s that are *not* marked written by the frontend. 
* `openPath` mandates that the `path should be relative (i.e. it should not start with a slash "/")`. In reality, the function is also called with absolute paths (e.g. path == "/data"). Checking for this turns out to be necessary for a well-functioning implementation.

This PR adjusts the documentation accordingly.