### PR TITLE
setAttribute: Explicit C-String Handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,10 @@ Features
 Bug Fixes
 """""""""
 
-- Refactor integer type system  #337
+- Refactor type system and ``Attribute`` set/get
+  - integers #337
+  - support ``long double`` reads on MSVC #184
+- ``setAttribute``: explicit C-string handling #341
 - ``Dataset``: ``setCompression`` warning and error logic #326
 - avoid impact on unrelated classes in invasive tests #324
 - Python

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -97,9 +97,15 @@ public:
      * @param   key     Key (i.e. name) to identify and store an Attributes value by.
      * @param   value   Value of Attribute stored with the provided key.
      * @return  true if key was already present, false otherwise
+     *
+     * @{
      */
     template< typename T >
     bool setAttribute(std::string const& key, T const& value);
+    bool setAttribute(std::string const& key, char const value[]);
+    /** @}
+     */
+
     /** Retrieve value of Attribute stored with provided key.
      *
      * @throw   no_such_attribute_error If no Attribute is currently stored with the provided key.
@@ -107,6 +113,7 @@ public:
      * @return  Stored Attribute in Variant form.
      */
     Attribute getAttribute(std::string const& key) const;
+
     /** Remove Attribute of provided value both logically and physically.
      *
      * @param   key Key (i.e. name) of the Attribute to remove.
@@ -230,6 +237,11 @@ Attributable::setAttribute(std::string const& key, T const& value)
                                    std::make_pair(key, Attribute(value)));
         return false;
     }
+}
+inline bool
+Attributable::setAttribute(std::string const& key, char const value[])
+{
+    return this->setAttribute(key, std::string(value));
 }
 
 extern template


### PR DESCRIPTION
Explicitly handle C-strings in order to avoid implicit casts. Makes bindings easier.

Split-off from #333