### PR TITLE
Numpy Dtype

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Changes to "0.5.0-alpha"
 Features
 """"""""
 
+- Python:
+
+  - accept & return ``numpy.dtype`` for ``Datatype`` #351
+
 Bug Fixes
 """""""""
 
@@ -47,6 +51,7 @@ Bug Fixes
 """""""""
 
 - Refactor type system and ``Attribute`` set/get
+
   - integers #337
   - support ``long double`` reads on MSVC #184
 - ``setAttribute``: explicit C-string handling #341

--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -1,0 +1,146 @@
+/* Copyright 2018 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+#include "openPMD/Datatype.hpp"
+
+#include <exception>
+
+
+namespace openPMD
+{
+    inline Datatype
+    dtype_from_numpy( pybind11::dtype const dt )
+    {
+        // ref: https://docs.scipy.org/doc/numpy/user/basics.types.html
+        // ref: https://github.com/numpy/numpy/issues/10678#issuecomment-369363551
+        if( dt.is(pybind11::dtype("b")) )
+            return Datatype::CHAR;
+        else if( dt.is(pybind11::dtype("B")) )
+            return Datatype::UCHAR;
+        else if( dt.is(pybind11::dtype("short")) )
+            return Datatype::SHORT;
+        else if( dt.is(pybind11::dtype("intc")) )
+            return Datatype::INT;
+        else if( dt.is(pybind11::dtype("int_")) )
+            return Datatype::LONG;
+        else if( dt.is(pybind11::dtype("longlong")) )
+            return Datatype::LONGLONG;
+        else if( dt.is(pybind11::dtype("ushort")) )
+            return Datatype::USHORT;
+        else if( dt.is(pybind11::dtype("uintc")) )
+            return Datatype::UINT;
+        else if( dt.is(pybind11::dtype("uint")) )
+            return Datatype::ULONG;
+        else if( dt.is(pybind11::dtype("ulonglong")) )
+            return Datatype::ULONGLONG;
+        else if( dt.is(pybind11::dtype("longdouble")) )
+            return Datatype::LONG_DOUBLE;
+        else if( dt.is(pybind11::dtype("double")) )
+            return Datatype::DOUBLE;
+        else if( dt.is(pybind11::dtype("single")) )
+            return Datatype::FLOAT;
+        else if( dt.is(pybind11::dtype("bool")) )
+            return Datatype::BOOL;
+        else
+            throw std::runtime_error("Datatype '...' not known in 'dtype_from_numpy'!"); // _s.format(dt)
+    }
+
+    inline pybind11::dtype
+    dtype_to_numpy( Datatype const dt )
+    {
+        using DT = Datatype;
+        switch( dt )
+        {
+            case DT::CHAR:
+            case DT::VEC_CHAR:
+            case DT::STRING:
+            case DT::VEC_STRING:
+                return pybind11::dtype("b");
+                break;
+            case DT::UCHAR:
+            case DT::VEC_UCHAR:
+                return pybind11::dtype("B");
+                break;
+            // case DT::SCHAR:
+            // case DT::VEC_SCHAR:
+            //     pybind11::dtype("b");
+            //     break;
+            case DT::SHORT:
+            case DT::VEC_SHORT:
+                return pybind11::dtype("short");
+                break;
+            case DT::INT:
+            case DT::VEC_INT:
+                return pybind11::dtype("intc");
+                break;
+            case DT::LONG:
+            case DT::VEC_LONG:
+                return pybind11::dtype("int_");
+                break;
+            case DT::LONGLONG:
+            case DT::VEC_LONGLONG:
+                return pybind11::dtype("longlong");
+                break;
+            case DT::USHORT:
+            case DT::VEC_USHORT:
+                return pybind11::dtype("ushort");
+                break;
+            case DT::UINT:
+            case DT::VEC_UINT:
+                return pybind11::dtype("uintc");
+                break;
+            case DT::ULONG:
+            case DT::VEC_ULONG:
+                return pybind11::dtype("uint");
+                break;
+            case DT::ULONGLONG:
+            case DT::VEC_ULONGLONG:
+                return pybind11::dtype("ulonglong");
+                break;
+            case DT::FLOAT:
+            case DT::VEC_FLOAT:
+                return pybind11::dtype("single");
+                break;
+            case DT::DOUBLE:
+            case DT::VEC_DOUBLE:
+            case DT::ARR_DBL_7:
+                return pybind11::dtype("double");
+                break;
+            case DT::LONG_DOUBLE:
+            case DT::VEC_LONG_DOUBLE:
+                return pybind11::dtype("longdouble");
+                break;
+            case DT::BOOL:
+                return pybind11::dtype("bool"); // also "?"
+                break;
+            case DT::DATATYPE:
+            case DT::UNDEFINED:
+            default:
+                throw std::runtime_error("dtype_to_numpy: Invalid Datatype '{...}'!"); // _s.format(dt)
+                break;
+        }
+    }
+} // namespace openPMD

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -24,6 +24,7 @@
 
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/Datatype.hpp"
+#include "openPMD/binding/python/Numpy.hpp"
 
 #include <sstream>
 
@@ -46,74 +47,7 @@ void init_BaseRecordComponent(py::module &m) {
 
         .def_property_readonly("unit_SI", &BaseRecordComponent::unitSI)
         .def_property_readonly("dtype", [](BaseRecordComponent & brc) {
-            using DT = Datatype;
-
-            // ref: https://docs.scipy.org/doc/numpy/user/basics.types.html
-            // ref: https://github.com/numpy/numpy/issues/10678#issuecomment-369363551
-            if( brc.getDatatype() == DT::BOOL )
-                return py::dtype("?");
-            else if( brc.getDatatype() == DT::CHAR )
-                return py::dtype("b");
-            else if( brc.getDatatype() == DT::UCHAR )
-                return py::dtype("B");
-            else if( brc.getDatatype() == DT::SHORT )
-                return py::dtype("short");
-            else if( brc.getDatatype() == DT::INT )
-                return py::dtype("intc");
-            else if( brc.getDatatype() == DT::LONG )
-                return py::dtype("int_");
-            else if( brc.getDatatype() == DT::LONGLONG )
-                return py::dtype("longlong");
-            else if( brc.getDatatype() == DT::USHORT )
-                return py::dtype("ushort");
-            else if( brc.getDatatype() == DT::UINT )
-                return py::dtype("uintc");
-            else if( brc.getDatatype() == DT::ULONG )
-                return py::dtype("uint");
-            else if( brc.getDatatype() == DT::ULONGLONG )
-                return py::dtype("ulonglong");
-            else if( brc.getDatatype() == DT::LONG_DOUBLE )
-                return py::dtype("longdouble");
-            else if( brc.getDatatype() == DT::DOUBLE )
-                return py::dtype("double");
-            else if( brc.getDatatype() == DT::FLOAT )
-                return py::dtype("single"); // note: np.float is an alias for float64
-            /*
-            else if( brc.getDatatype() == DT::STRING )
-                return py::dtype("string_");
-            else if( brc.getDatatype() == DT::VEC_CHAR )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_SHORT )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_INT )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_LONG )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_LONGLONG )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_UCHAR )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_USHORT )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_UINT )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_ULONG )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_ULONGLONG )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::ARR_DBL_7 )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_LONG_DOUBLE )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_DOUBLE )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_FLOAT )
-                return py::dtype("");
-            else if( brc.getDatatype() == DT::VEC_STRING )
-                return py::dtype("");
-            */
-            else
-                return py::dtype("void");
+            return dtype_to_numpy( brc.getDatatype() );
         })
     ;
 }

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -22,6 +22,7 @@
 #include <pybind11/stl.h>
 
 #include "openPMD/Dataset.hpp"
+#include "openPMD/binding/python/Numpy.hpp"
 
 #include <string>
 
@@ -33,6 +34,12 @@ void init_Dataset(py::module &m) {
     py::class_<Dataset>(m, "Dataset")
 
         .def(py::init<Datatype, Extent>(),
+            py::arg("dtype"), py::arg("extent")
+        )
+        .def(py::init( [](py::dtype dt, Extent e) {
+            auto const d = dtype_from_numpy( dt );
+            return new Dataset{d, e};
+        }),
             py::arg("dtype"), py::arg("extent")
         )
 
@@ -51,7 +58,9 @@ void init_Dataset(py::module &m) {
         .def_readonly("transform", &Dataset::transform)
         .def("set_custom_transform", &Dataset::setCustomTransform)
         .def_readonly("rank", &Dataset::rank)
-        .def_readonly("dtype", &Dataset::dtype)
+        .def_property_readonly("dtype", [](const Dataset &d) {
+            return dtype_to_numpy( d.dtype );
+        })
     ;
 }
 

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -22,6 +22,7 @@
 #include <pybind11/stl.h>
 
 #include "openPMD/Datatype.hpp"
+#include "openPMD/binding/python/Numpy.hpp"
 
 namespace py = pybind11;
 using namespace openPMD;
@@ -63,7 +64,10 @@ void init_Datatype(py::module &m) {
         .value("UNDEFINED", Datatype::UNDEFINED)
     ;
 
-    // 2x: determineDatatype
-    // equivalence check: decay_equiv
-    // m.def("add", [](int a, int b) { return a + b; });
+    m.def("determine_datatype", [](py::dtype const dt) {
+        return dtype_from_numpy( dt );
+    });
+    m.def("determine_datatype", [](py::array const & a) {
+        return dtype_from_numpy( a.dtype() );
+    });
 }

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -352,6 +352,8 @@ class APITest(unittest.TestCase):
         self.assertIsInstance(electrons, openPMD.ParticleSpecies)
         pos_y = electrons["position"]["y"]
         w = electrons["weighting"][openPMD.Record_Component.SCALAR]
+        assert pos_y.dtype == np.double
+        assert w.dtype == np.double
 
         self.assertSequenceEqual(pos_y.shape, [270625, ])
         self.assertSequenceEqual(w.shape, [270625, ])
@@ -476,9 +478,15 @@ class APITest(unittest.TestCase):
 
     def testDataset(self):
         """ Test openPMD.Dataset. """
-        data_type = openPMD.Datatype(1)
+        data_type = openPMD.Datatype.LONG
         extent = [1, 1, 1]
         obj = openPMD.Dataset(data_type, extent)
+        if found_numpy:
+            d = np.array((1, 1, 1, ), dtype=np.int_)
+            obj2 = openPMD.Dataset(d.dtype, d.shape)
+            assert data_type == openPMD.determine_datatype(d.dtype)
+            assert obj2.dtype == obj.dtype
+            assert obj2.dtype == obj.dtype
         del obj
 
     def testGeometry(self):


### PR DESCRIPTION
Accept the Numpy Dtype as first class type in our python (numpy) bindings.

Handle translation from/to `openPMD.Datatype` behind bindings.