### PR TITLE
Comply with constraints in IO documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Features
 
   - accept & return ``numpy.dtype`` for ``Datatype`` #351
   - better check for (unsupported) numpy array strides #353
+- comply with runtime constraints w.r.t. ``written`` status #352
 
 Bug Fixes
 """""""""

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -871,6 +871,9 @@ void
 CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                                    Parameter< Operation::READ_ATT >& parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during attribute reading");
+
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
 
@@ -1311,6 +1314,9 @@ void
 CommonADIOS1IOHandlerImpl::listPaths(Writable* writable,
                                Parameter< Operation::LIST_PATHS >& parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during path listing");
+
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
 
@@ -1359,6 +1365,9 @@ void
 CommonADIOS1IOHandlerImpl::listDatasets(Writable* writable,
                                   Parameter< Operation::LIST_DATASETS >& parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during dataset listing");
+
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
 
@@ -1388,6 +1397,9 @@ void
 CommonADIOS1IOHandlerImpl::listAttributes(Writable* writable,
                                     Parameter< Operation::LIST_ATTS >& parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during attribute listing");
+
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
 

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1066,6 +1066,9 @@ void
 HDF5IOHandlerImpl::readAttribute(Writable* writable,
                                  Parameter< Operation::READ_ATT >& parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during attribute read");
+
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
         res = m_fileIDs.find(writable->parent);
@@ -1396,6 +1399,9 @@ void
 HDF5IOHandlerImpl::listPaths(Writable* writable,
                              Parameter< Operation::LIST_PATHS > & parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during path listing");
+
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
         res = m_fileIDs.find(writable->parent);
@@ -1428,6 +1434,9 @@ void
 HDF5IOHandlerImpl::listDatasets(Writable* writable,
                                 Parameter< Operation::LIST_DATASETS >& parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during dataset listing");
+
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
         res = m_fileIDs.find(writable->parent);
@@ -1459,6 +1468,9 @@ HDF5IOHandlerImpl::listDatasets(Writable* writable,
 void HDF5IOHandlerImpl::listAttributes(Writable* writable,
                                        Parameter< Operation::LIST_ATTS >& parameters)
 {
+    if( !writable->written )
+        throw std::runtime_error("Internal error: Writable not marked written during attribute listing");
+
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
         res = m_fileIDs.find(writable->parent);

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -182,9 +182,6 @@ Iteration::flush()
 void
 Iteration::read()
 {
-    /* allow all attributes to be set */
-    written = false;
-
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 
@@ -278,8 +275,12 @@ Iteration::read()
             {
                 MeshRecordComponent& mrc = m[MeshRecordComponent::SCALAR];
                 *mrc.m_isConstant = true;
+                mrc.m_writable->parent = m.m_writable->parent;
                 mrc.parent = m.parent;
+                mrc.m_writable->abstractFilePosition = m.m_writable->abstractFilePosition;
                 mrc.abstractFilePosition = m.abstractFilePosition;
+                mrc.m_writable->written = true;
+                mrc.written = true;
             }
             m.read();
         }
@@ -331,11 +332,6 @@ Iteration::read()
     }
 
     readAttributes();
-
-    /* this file need not be flushed */
-    meshes.written = true;
-    particles.written = true;
-    written = true;
 }
 
 void

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -223,9 +223,6 @@ Mesh::flush_impl(std::string const& name)
 void
 Mesh::read()
 {
-    /* allow all attributes to be set */
-    written = false;
-
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 
@@ -314,7 +311,9 @@ Mesh::read()
         this->at(MeshRecordComponent::SCALAR).read();
     } else
     {
+        written = false;
         clear_unchecked();
+        written = true;
         Parameter< Operation::LIST_PATHS > pList;
         IOHandler->enqueue(IOTask(this, pList));
         IOHandler->flush();
@@ -350,9 +349,6 @@ Mesh::read()
     readBase();
 
     readAttributes();
-
-    /* this file need not be flushed */
-    written = true;
 }
 } // openPMD
 

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -30,10 +30,9 @@ ParticleSpecies::ParticleSpecies() = default;
 void
 ParticleSpecies::read()
 {
-    /* allow all attributes to be set */
     written = false;
-
     clear_unchecked();
+    written = true;
 
     /* obtain all non-scalar records */
     Parameter< Operation::LIST_PATHS > pList;
@@ -70,6 +69,8 @@ ParticleSpecies::read()
                 rc.parent = r.parent;
                 rc.m_writable->abstractFilePosition = r.m_writable->abstractFilePosition;
                 rc.abstractFilePosition = r.abstractFilePosition;
+                rc.m_writable->written = true;
+                rc.written = true;
             }
             r.read();
         }
@@ -98,9 +99,6 @@ ParticleSpecies::read()
     }
 
     readAttributes();
-
-    /* this file need not be flushed */
-    written = true;
 }
 
 void

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -88,16 +88,15 @@ Record::flush_impl(std::string const& name)
 void
 Record::read()
 {
-    /* allow all attributes to be set */
-    written = false;
-
     if( *m_containsScalar )
     {
         /* using operator[] will incorrectly update parent */
         this->at(RecordComponent::SCALAR).read();
     } else
     {
+        written = false;
         clear_unchecked();
+        written = true;
         Parameter< Operation::LIST_PATHS > pList;
         IOHandler->enqueue(IOTask(this, pList));
         IOHandler->flush();
@@ -133,8 +132,5 @@ Record::read()
     readBase();
 
     readAttributes();
-
-    /* this file need not be flushed */
-    written = true;
 }
 } // openPMD

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -144,13 +144,7 @@ RecordComponent::flush(std::string const& name)
 void
 RecordComponent::read()
 {
-    /* allow all attributes to be set */
-    written = false;
-
     readBase();
-
-    /* this file need not be flushed */
-    written = true;
 }
 
 void

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -32,9 +32,6 @@ MeshRecordComponent::MeshRecordComponent()
 void
 MeshRecordComponent::read()
 {
-    /* allow all attributes to be set */
-    written = false;
-
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 
@@ -58,9 +55,6 @@ MeshRecordComponent::read()
         throw std::runtime_error( "Unexpected Attribute datatype for 'position'");
 
     readBase();
-
-    /* this file need not be flushed */
-    written = true;
 }
 
 template< typename T >


### PR DESCRIPTION
Brought up in #339 - The condition `The operation should fail if the Writable was not marked written.` (for a number of operations in the [backend](https://github.com/openPMD/openPMD-api/blob/0.5.0-alpha/include/openPMD/IO/AbstractIOHandlerImpl.hpp)) was not verified and did not hold for every function call.

A detailed explaination for situations in which this could happen is avaiable in https://github.com/openPMD/openPMD-api/pull/339#issuecomment-421122622.

This PR does two things:
 - it includes the proper checks to comply with the constraints in all available backends
 - it changes the emulation of the `written` status in the frontend, s.t. the constraint can be verified without failure. This means limiting the scope of the emulation to only the required function calls during `Series` creation.