### PR TITLE
Python Record_Component: make_constant

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Features
 
   - accept & return ``numpy.dtype`` for ``Datatype`` #351
   - better check for (unsupported) numpy array strides #353
+  - implement ``Record_Component.make_constant`` #354
 - comply with runtime constraints w.r.t. ``written`` status #352
 
 Bug Fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Bug Fixes
 
 - dataOrder: mesh attribute is a string #355
 - constant scalar MeshRecords: reading corrected #358
+- Python:
+
+  - lifetime of ``Iteration.meshes/particles`` and ``Series.iterations`` members #354
 
 Other
 """""

--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -26,6 +26,7 @@
 
 #include "openPMD/Datatype.hpp"
 
+#include <string>
 #include <exception>
 
 
@@ -66,6 +67,51 @@ namespace openPMD
             return Datatype::BOOL;
         else
             throw std::runtime_error("Datatype '...' not known in 'dtype_from_numpy'!"); // _s.format(dt)
+    }
+
+    /** Return openPMD::Datatype from py::buffer_info::format
+     */
+    inline Datatype
+    dtype_from_bufferformat( std::string const & fmt )
+    {
+        using DT = Datatype;
+
+        // refs:
+        //   https://docs.scipy.org/doc/numpy-1.15.0/reference/arrays.interface.html
+        //   https://docs.python.org/3/library/struct.html#format-characters
+        // std::cout << "  scalar type '" << buf.format << "'" << std::endl;
+        // typestring: encoding + type + number of bytes
+        if( fmt.find("?") != std::string::npos )
+            return DT::BOOL;
+        else if( fmt.find("b") != std::string::npos )
+            return DT::CHAR;
+        else if( fmt.find("h") != std::string::npos )
+            return DT::SHORT;
+        else if( fmt.find("i") != std::string::npos )
+            return DT::INT;
+        else if( fmt.find("l") != std::string::npos )
+            return DT::LONG;
+        else if( fmt.find("q") != std::string::npos )
+            return DT::LONGLONG;
+        else if( fmt.find("B") != std::string::npos )
+            return DT::UCHAR;
+        else if( fmt.find("H") != std::string::npos )
+            return DT::USHORT;
+        else if( fmt.find("I") != std::string::npos )
+            return DT::UINT;
+        else if( fmt.find("L") != std::string::npos )
+            return DT::ULONG;
+        else if( fmt.find("Q") != std::string::npos )
+            return DT::ULONGLONG;
+        else if( fmt.find("f") != std::string::npos )
+            return DT::FLOAT;
+        else if( fmt.find("d") != std::string::npos )
+            return DT::DOUBLE;
+        else if( fmt.find("g") != std::string::npos )
+            return DT::LONG_DOUBLE;
+        else
+            throw std::runtime_error("dtype_from_bufferformat: Unknown "
+                "Python type '" + fmt + "'");
     }
 
     inline pybind11::dtype

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -54,7 +54,13 @@ void init_Iteration(py::module &m) {
         .def("time_unit_SI", &Iteration::timeUnitSI)
         .def("set_time_unit_SI", &Iteration::setTimeUnitSI)
 
-        .def_readwrite("meshes", &Iteration::meshes)
-        .def_readwrite("particles", &Iteration::particles)
+        .def_readwrite("meshes", &Iteration::meshes,
+            py::return_value_policy::reference,
+            // garbage collection: return value must be freed before Iteration
+            py::keep_alive<1, 0>())
+        .def_readwrite("particles", &Iteration::particles,
+            py::return_value_policy::reference,
+            // garbage collection: return value must be freed before Iteration
+            py::keep_alive<1, 0>())
     ;
 }

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -60,6 +60,9 @@ void init_Series(py::module &m) {
         .def("set_name", &Series::setName)
         .def("flush", &Series::flush)
 
-        .def_readwrite("iterations", &Series::iterations)
+        .def_readwrite("iterations", &Series::iterations,
+            py::return_value_policy::reference,
+            // garbage collection: return value must be freed before Series
+            py::keep_alive<1, 0>())
     ;
 }


### PR DESCRIPTION
Refactor numpy detection of Attributable to general method. Reuse in Record_Component bindings for make_constant.

Also fixes the lifetime of `Container` members (`iterations`, `meshes`, `particles`) in `Series` and `Iteration`. Returned (referenced) containers need to be freed before their owner classes.

- [x] depends on #358