### PR TITLE
dataOrder: string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Features
 Bug Fixes
 """""""""
 
+- dataOrder: mesh attribute is a string #355
+
 Other
 """""
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -87,13 +87,15 @@ Mesh::setGeometryParameters(std::string const& gp)
 Mesh::DataOrder
 Mesh::dataOrder() const
 {
-    return Mesh::DataOrder(getAttribute("dataOrder").get< char >());
+    return Mesh::DataOrder(getAttribute("dataOrder").get< std::string >().c_str()[0]);
 }
 
 Mesh&
 Mesh::setDataOrder(Mesh::DataOrder dor)
 {
-    setAttribute("dataOrder", static_cast<char>(dor));
+    setAttribute(
+        "dataOrder",
+        std::string(1u, static_cast<char>(dor)));
     return *this;
 }
 


### PR DESCRIPTION
Write and read openPMD dataOrder attributes (meshes, removed in openPMD 2) [as string](https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#required-attributes-for-each-mesh-record) instead of `char`.

Shown as an error for meshes in [openPMD-validator](https://github.com/openPMD/openPMD-validator).