### PR TITLE
Fix and test constant scalar Records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,12 +27,13 @@ Bug Fixes
 """""""""
 
 - dataOrder: mesh attribute is a string #355
+- constant scalar MeshRecords: reading corrected #358
 
 Other
 """""
 
+- test cases for mixed constant/non-constant Records #358
 - examples: close handles explicitly #359
-
 
 0.5.0-alpha
 -----------

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -267,20 +267,17 @@ Iteration::read()
             IOHandler->enqueue(IOTask(&m, aList));
             IOHandler->flush();
 
-            auto begin = aList.attributes->begin();
-            auto end = aList.attributes->end();
-            auto value = std::find(begin, end, "value");
-            auto shape = std::find(begin, end, "shape");
-            if( value != end && shape != end )
+            auto att_begin = aList.attributes->begin();
+            auto att_end = aList.attributes->end();
+            auto value = std::find(att_begin, att_end, "value");
+            auto shape = std::find(att_begin, att_end, "shape");
+            if( value != att_end && shape != att_end )
             {
                 MeshRecordComponent& mrc = m[MeshRecordComponent::SCALAR];
-                *mrc.m_isConstant = true;
-                mrc.m_writable->parent = m.m_writable->parent;
                 mrc.parent = m.parent;
-                mrc.m_writable->abstractFilePosition = m.m_writable->abstractFilePosition;
-                mrc.abstractFilePosition = m.abstractFilePosition;
-                mrc.m_writable->written = true;
-                mrc.written = true;
+                IOHandler->enqueue(IOTask(&mrc, pOpen));
+                IOHandler->flush();
+                *mrc.m_isConstant = true;
             }
             m.read();
         }

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -57,20 +57,17 @@ ParticleSpecies::read()
             IOHandler->enqueue(IOTask(&r, aList));
             IOHandler->flush();
 
-            auto attrBegin = aList.attributes->begin();
-            auto attrEnd = aList.attributes->end();
-            auto value = std::find(attrBegin, attrEnd, "value");
-            auto shape = std::find(attrBegin, attrEnd, "shape");
-            if( value != attrEnd && shape != attrEnd )
+            auto att_begin = aList.attributes->begin();
+            auto att_end = aList.attributes->end();
+            auto value = std::find(att_begin, att_end, "value");
+            auto shape = std::find(att_begin, att_end, "shape");
+            if( value != att_end && shape != att_end )
             {
                 RecordComponent& rc = r[RecordComponent::SCALAR];
-                *rc.m_isConstant = true;
-                rc.m_writable->parent = r.m_writable->parent;
                 rc.parent = r.parent;
-                rc.m_writable->abstractFilePosition = r.m_writable->abstractFilePosition;
-                rc.abstractFilePosition = r.abstractFilePosition;
-                rc.m_writable->written = true;
-                rc.written = true;
+                IOHandler->enqueue(IOTask(&rc, pOpen));
+                IOHandler->flush();
+                *rc.m_isConstant = true;
             }
             r.read();
         }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1445,6 +1445,40 @@ TEST_CASE( "hdf5_110_optional_paths", "[serial][hdf5]" )
         REQUIRE(s.iterations[1].particles.empty());
     }
 }
+
+TEST_CASE( "hdf5_constant_scalar", "[serial][hdf5]" )
+{
+    {
+        Series s = Series("../samples/constant_scalar.h5", AccessType::CREATE);
+        auto rho = s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR];
+        rho.resetDataset(Dataset(Datatype::CHAR, {1, 2, 3}));
+        rho.makeConstant(static_cast< char >('a'));
+
+        auto pos_x = s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR];
+        pos_x.resetDataset(Dataset(Datatype::DOUBLE, {3, 2, 1}));
+        pos_x.makeConstant(static_cast< double >(42.));
+        auto posOff_x = s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR];
+        posOff_x.resetDataset(Dataset(Datatype::INT, {3, 2, 1}));
+        posOff_x.makeConstant(static_cast< int >(-42));
+    }
+
+    {
+        Series s = Series("../samples/constant_scalar.h5", AccessType::READ_ONLY);
+        REQUIRE(s.iterations[1].meshes.count("rho") == 1);
+        REQUIRE(s.iterations[1].meshes["rho"].count(MeshRecordComponent::SCALAR) == 1);
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles.count("e") == 1);
+        REQUIRE(s.iterations[1].particles["e"].count("position") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"].count("positionOffset") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("value"));
+    }
+}
 #else
 TEST_CASE( "no_serial_hdf5", "[serial][hdf5]" )
 {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1449,17 +1449,41 @@ TEST_CASE( "hdf5_110_optional_paths", "[serial][hdf5]" )
 TEST_CASE( "hdf5_constant_scalar", "[serial][hdf5]" )
 {
     {
+        //constant scalar
         Series s = Series("../samples/constant_scalar.h5", AccessType::CREATE);
         auto rho = s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR];
         rho.resetDataset(Dataset(Datatype::CHAR, {1, 2, 3}));
         rho.makeConstant(static_cast< char >('a'));
 
-        auto pos_x = s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR];
-        pos_x.resetDataset(Dataset(Datatype::DOUBLE, {3, 2, 1}));
-        pos_x.makeConstant(static_cast< double >(42.));
-        auto posOff_x = s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR];
-        posOff_x.resetDataset(Dataset(Datatype::INT, {3, 2, 1}));
-        posOff_x.makeConstant(static_cast< int >(-42));
+        //mixed constant/non-constant
+        auto E_x = s.iterations[1].meshes["E"]["x"];
+        E_x.resetDataset(Dataset(Datatype::FLOAT, {1, 2, 3}));
+        E_x.makeConstant(static_cast< float >(13.37));
+        auto E_y = s.iterations[1].meshes["E"]["y"];
+        E_y.resetDataset(Dataset(Datatype::UINT, {1, 2, 3}));
+        std::shared_ptr< unsigned int > E(new unsigned int[6], [](unsigned int *p){ delete[] p; });
+        unsigned int e{0};
+        std::generate(E.get(), E.get() + 6, [&e]{ return e++; });
+        E_y.storeChunk({0, 0, 0}, {1, 2, 3}, E);
+
+        //constant scalar
+        auto pos = s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR];
+        pos.resetDataset(Dataset(Datatype::DOUBLE, {3, 2, 1}));
+        pos.makeConstant(static_cast< double >(42.));
+        auto posOff = s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR];
+        posOff.resetDataset(Dataset(Datatype::INT, {3, 2, 1}));
+        posOff.makeConstant(static_cast< int >(-42));
+
+        //mixed constant/non-constant
+        auto vel_x = s.iterations[1].particles["e"]["velocity"]["x"];
+        vel_x.resetDataset(Dataset(Datatype::SHORT, {3, 2, 1}));
+        vel_x.makeConstant(static_cast< short >(-1));
+        auto vel_y = s.iterations[1].particles["e"]["velocity"]["y"];
+        vel_y.resetDataset(Dataset(Datatype::ULONGLONG, {3, 2, 1}));
+        std::shared_ptr< unsigned long long > vel(new unsigned long long[6], [](unsigned long long *p){ delete[] p; });
+        unsigned long long v{0};
+        std::generate(vel.get(), vel.get() + 6, [&v]{ return v++; });
+        vel_y.storeChunk({0, 0, 0}, {3, 2, 1}, vel);
     }
 
     {
@@ -1467,16 +1491,47 @@ TEST_CASE( "hdf5_constant_scalar", "[serial][hdf5]" )
         REQUIRE(s.iterations[1].meshes.count("rho") == 1);
         REQUIRE(s.iterations[1].meshes["rho"].count(MeshRecordComponent::SCALAR) == 1);
         REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{1, 2, 3});
         REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].getAttribute("value").get< char >() == 'a');
+        REQUIRE(s.iterations[1].meshes.count("E") == 1);
+        REQUIRE(s.iterations[1].meshes["E"].count("x") == 1);
+        REQUIRE(s.iterations[1].meshes["E"]["x"].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].meshes["E"]["x"].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{1, 2, 3});
+        REQUIRE(s.iterations[1].meshes["E"]["x"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].meshes["E"]["x"].getAttribute("value").get< float >() == static_cast< float >(13.37));
+        REQUIRE(s.iterations[1].meshes["E"]["y"].getExtent() == Extent{1, 2, 3});
+        REQUIRE(s.iterations[1].meshes["E"].count("y") == 1);
+        REQUIRE(!s.iterations[1].meshes["E"]["y"].containsAttribute("shape"));
+        REQUIRE(!s.iterations[1].meshes["E"]["y"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].meshes["E"]["y"].getExtent() == Extent{1, 2, 3});
+
         REQUIRE(s.iterations[1].particles.count("e") == 1);
         REQUIRE(s.iterations[1].particles["e"].count("position") == 1);
         REQUIRE(s.iterations[1].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
         REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
         REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getAttribute("value").get< double >() == 42.);
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{3, 2, 1});
         REQUIRE(s.iterations[1].particles["e"].count("positionOffset") == 1);
         REQUIRE(s.iterations[1].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
         REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
         REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getAttribute("value").get< int >() == -42);
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getExtent() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"].count("velocity") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["velocity"].count("x") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getAttribute("value").get< short >() == -1);
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getExtent() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"]["velocity"].count("y") == 1);
+        REQUIRE(!s.iterations[1].particles["e"]["velocity"]["y"].containsAttribute("shape"));
+        REQUIRE(!s.iterations[1].particles["e"]["velocity"]["y"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["y"].getExtent() == Extent{3, 2, 1});
     }
 }
 #else

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -21,6 +21,96 @@
 using namespace openPMD;
 
 
+inline
+void constant_scalar(std::string file_ending)
+{
+    {
+        // constant scalar
+        Series s = Series("../samples/constant_scalar." + file_ending, AccessType::CREATE);
+        auto rho = s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR];
+        rho.resetDataset(Dataset(Datatype::CHAR, {1, 2, 3}));
+        rho.makeConstant(static_cast< char >('a'));
+
+        // mixed constant/non-constant
+        auto E_x = s.iterations[1].meshes["E"]["x"];
+        E_x.resetDataset(Dataset(Datatype::FLOAT, {1, 2, 3}));
+        E_x.makeConstant(static_cast< float >(13.37));
+        auto E_y = s.iterations[1].meshes["E"]["y"];
+        E_y.resetDataset(Dataset(Datatype::UINT, {1, 2, 3}));
+        std::shared_ptr< unsigned int > E(new unsigned int[6], [](unsigned int *p){ delete[] p; });
+        unsigned int e{0};
+        std::generate(E.get(), E.get() + 6, [&e]{ return e++; });
+        E_y.storeChunk({0, 0, 0}, {1, 2, 3}, E);
+
+        // constant scalar
+        auto pos = s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR];
+        pos.resetDataset(Dataset(Datatype::DOUBLE, {3, 2, 1}));
+        pos.makeConstant(static_cast< double >(42.));
+        auto posOff = s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR];
+        posOff.resetDataset(Dataset(Datatype::INT, {3, 2, 1}));
+        posOff.makeConstant(static_cast< int >(-42));
+
+        // mixed constant/non-constant
+        auto vel_x = s.iterations[1].particles["e"]["velocity"]["x"];
+        vel_x.resetDataset(Dataset(Datatype::SHORT, {3, 2, 1}));
+        vel_x.makeConstant(static_cast< short >(-1));
+        auto vel_y = s.iterations[1].particles["e"]["velocity"]["y"];
+        vel_y.resetDataset(Dataset(Datatype::ULONGLONG, {3, 2, 1}));
+        std::shared_ptr< unsigned long long > vel(new unsigned long long[6], [](unsigned long long *p){ delete[] p; });
+        unsigned long long v{0};
+        std::generate(vel.get(), vel.get() + 6, [&v]{ return v++; });
+        vel_y.storeChunk({0, 0, 0}, {3, 2, 1}, vel);
+    }
+
+    {
+        Series s = Series("../samples/constant_scalar." + file_ending, AccessType::READ_ONLY);
+        REQUIRE(s.iterations[1].meshes.count("rho") == 1);
+        REQUIRE(s.iterations[1].meshes["rho"].count(MeshRecordComponent::SCALAR) == 1);
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{1, 2, 3});
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].getAttribute("value").get< char >() == 'a');
+        REQUIRE(s.iterations[1].meshes.count("E") == 1);
+        REQUIRE(s.iterations[1].meshes["E"].count("x") == 1);
+        REQUIRE(s.iterations[1].meshes["E"]["x"].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].meshes["E"]["x"].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{1, 2, 3});
+        REQUIRE(s.iterations[1].meshes["E"]["x"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].meshes["E"]["x"].getAttribute("value").get< float >() == static_cast< float >(13.37));
+        REQUIRE(s.iterations[1].meshes["E"]["y"].getExtent() == Extent{1, 2, 3});
+        REQUIRE(s.iterations[1].meshes["E"].count("y") == 1);
+        REQUIRE(!s.iterations[1].meshes["E"]["y"].containsAttribute("shape"));
+        REQUIRE(!s.iterations[1].meshes["E"]["y"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].meshes["E"]["y"].getExtent() == Extent{1, 2, 3});
+
+        REQUIRE(s.iterations[1].particles.count("e") == 1);
+        REQUIRE(s.iterations[1].particles["e"].count("position") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getAttribute("value").get< double >() == 42.);
+        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"].count("positionOffset") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getAttribute("value").get< int >() == -42);
+        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getExtent() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"].count("velocity") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["velocity"].count("x") == 1);
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].containsAttribute("shape"));
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getAttribute("value").get< short >() == -1);
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getExtent() == Extent{3, 2, 1});
+        REQUIRE(s.iterations[1].particles["e"]["velocity"].count("y") == 1);
+        REQUIRE(!s.iterations[1].particles["e"]["velocity"]["y"].containsAttribute("shape"));
+        REQUIRE(!s.iterations[1].particles["e"]["velocity"]["y"].containsAttribute("value"));
+        REQUIRE(s.iterations[1].particles["e"]["velocity"]["y"].getExtent() == Extent{3, 2, 1});
+    }
+}
+
 #if openPMD_HAVE_HDF5
 TEST_CASE( "git_hdf5_sample_structure_test", "[serial][hdf5]" )
 {
@@ -1448,91 +1538,7 @@ TEST_CASE( "hdf5_110_optional_paths", "[serial][hdf5]" )
 
 TEST_CASE( "hdf5_constant_scalar", "[serial][hdf5]" )
 {
-    {
-        //constant scalar
-        Series s = Series("../samples/constant_scalar.h5", AccessType::CREATE);
-        auto rho = s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR];
-        rho.resetDataset(Dataset(Datatype::CHAR, {1, 2, 3}));
-        rho.makeConstant(static_cast< char >('a'));
-
-        //mixed constant/non-constant
-        auto E_x = s.iterations[1].meshes["E"]["x"];
-        E_x.resetDataset(Dataset(Datatype::FLOAT, {1, 2, 3}));
-        E_x.makeConstant(static_cast< float >(13.37));
-        auto E_y = s.iterations[1].meshes["E"]["y"];
-        E_y.resetDataset(Dataset(Datatype::UINT, {1, 2, 3}));
-        std::shared_ptr< unsigned int > E(new unsigned int[6], [](unsigned int *p){ delete[] p; });
-        unsigned int e{0};
-        std::generate(E.get(), E.get() + 6, [&e]{ return e++; });
-        E_y.storeChunk({0, 0, 0}, {1, 2, 3}, E);
-
-        //constant scalar
-        auto pos = s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR];
-        pos.resetDataset(Dataset(Datatype::DOUBLE, {3, 2, 1}));
-        pos.makeConstant(static_cast< double >(42.));
-        auto posOff = s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR];
-        posOff.resetDataset(Dataset(Datatype::INT, {3, 2, 1}));
-        posOff.makeConstant(static_cast< int >(-42));
-
-        //mixed constant/non-constant
-        auto vel_x = s.iterations[1].particles["e"]["velocity"]["x"];
-        vel_x.resetDataset(Dataset(Datatype::SHORT, {3, 2, 1}));
-        vel_x.makeConstant(static_cast< short >(-1));
-        auto vel_y = s.iterations[1].particles["e"]["velocity"]["y"];
-        vel_y.resetDataset(Dataset(Datatype::ULONGLONG, {3, 2, 1}));
-        std::shared_ptr< unsigned long long > vel(new unsigned long long[6], [](unsigned long long *p){ delete[] p; });
-        unsigned long long v{0};
-        std::generate(vel.get(), vel.get() + 6, [&v]{ return v++; });
-        vel_y.storeChunk({0, 0, 0}, {3, 2, 1}, vel);
-    }
-
-    {
-        Series s = Series("../samples/constant_scalar.h5", AccessType::READ_ONLY);
-        REQUIRE(s.iterations[1].meshes.count("rho") == 1);
-        REQUIRE(s.iterations[1].meshes["rho"].count(MeshRecordComponent::SCALAR) == 1);
-        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("shape"));
-        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{1, 2, 3});
-        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("value"));
-        REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].getAttribute("value").get< char >() == 'a');
-        REQUIRE(s.iterations[1].meshes.count("E") == 1);
-        REQUIRE(s.iterations[1].meshes["E"].count("x") == 1);
-        REQUIRE(s.iterations[1].meshes["E"]["x"].containsAttribute("shape"));
-        REQUIRE(s.iterations[1].meshes["E"]["x"].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{1, 2, 3});
-        REQUIRE(s.iterations[1].meshes["E"]["x"].containsAttribute("value"));
-        REQUIRE(s.iterations[1].meshes["E"]["x"].getAttribute("value").get< float >() == static_cast< float >(13.37));
-        REQUIRE(s.iterations[1].meshes["E"]["y"].getExtent() == Extent{1, 2, 3});
-        REQUIRE(s.iterations[1].meshes["E"].count("y") == 1);
-        REQUIRE(!s.iterations[1].meshes["E"]["y"].containsAttribute("shape"));
-        REQUIRE(!s.iterations[1].meshes["E"]["y"].containsAttribute("value"));
-        REQUIRE(s.iterations[1].meshes["E"]["y"].getExtent() == Extent{1, 2, 3});
-
-        REQUIRE(s.iterations[1].particles.count("e") == 1);
-        REQUIRE(s.iterations[1].particles["e"].count("position") == 1);
-        REQUIRE(s.iterations[1].particles["e"]["position"].count(RecordComponent::SCALAR) == 1);
-        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("shape"));
-        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
-        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].containsAttribute("value"));
-        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getAttribute("value").get< double >() == 42.);
-        REQUIRE(s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR].getExtent() == Extent{3, 2, 1});
-        REQUIRE(s.iterations[1].particles["e"].count("positionOffset") == 1);
-        REQUIRE(s.iterations[1].particles["e"]["positionOffset"].count(RecordComponent::SCALAR) == 1);
-        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("shape"));
-        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
-        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].containsAttribute("value"));
-        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getAttribute("value").get< int >() == -42);
-        REQUIRE(s.iterations[1].particles["e"]["positionOffset"][RecordComponent::SCALAR].getExtent() == Extent{3, 2, 1});
-        REQUIRE(s.iterations[1].particles["e"].count("velocity") == 1);
-        REQUIRE(s.iterations[1].particles["e"]["velocity"].count("x") == 1);
-        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].containsAttribute("shape"));
-        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getAttribute("shape").get< std::vector< uint64_t > >() == Extent{3, 2, 1});
-        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].containsAttribute("value"));
-        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getAttribute("value").get< short >() == -1);
-        REQUIRE(s.iterations[1].particles["e"]["velocity"]["x"].getExtent() == Extent{3, 2, 1});
-        REQUIRE(s.iterations[1].particles["e"]["velocity"].count("y") == 1);
-        REQUIRE(!s.iterations[1].particles["e"]["velocity"]["y"].containsAttribute("shape"));
-        REQUIRE(!s.iterations[1].particles["e"]["velocity"]["y"].containsAttribute("value"));
-        REQUIRE(s.iterations[1].particles["e"]["velocity"]["y"].getExtent() == Extent{3, 2, 1});
-    }
+    constant_scalar("h5");
 }
 #else
 TEST_CASE( "no_serial_hdf5", "[serial][hdf5]" )
@@ -2145,6 +2151,10 @@ TEST_CASE( "hzdr_adios1_sample_content_test", "[serial][adios1]" )
         std::cerr << "HZDR sample not accessible. (" << e.what() << ")\n";
         return;
     }
+}
+TEST_CASE( "adios1_constant_scalar", "[serial][adios1]" )
+{
+    constant_scalar("bp");
 }
 #else
 TEST_CASE( "no_serial_adios1", "[serial][adios]")


### PR DESCRIPTION
For constant scalar `Record`s, both the `Record` and the contained sclar `RecordComponent` are the same group in the persistent datastructure. The `RecordComponent`has not been properly assigned for `Mesh`es, which made it impossible to read back files with constant scalar `MeshRecordComponent`s.

This addresses the issue by assigning the group to both the `Record` and the `RecordComponent` for both `Mesh` and `ParticleSpecies`.

Fix #356.