### PR TITLE
Examples: Close Handles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Bug Fixes
 Other
 """""
 
+- examples: close handles explicitly #359
+
 
 0.5.0-alpha
 -----------

--- a/examples/1_structure.cpp
+++ b/examples/1_structure.cpp
@@ -26,21 +26,21 @@ using namespace openPMD;
 int main()
 {
     /* The root of any openPMD output spans across all data for all iterations is a 'Series'.
-    * Data is either in a single file or spread across multiple files. */
+     * Data is either in a single file or spread across multiple files. */
     Series series = Series("../samples/1_structure.h5", AccessType::CREATE);
 
     /* Every element that structures your file (groups and datasets for example) can be annotated with attributes. */
     series.setComment("This string will show up at the root ('/') of the output with key 'comment'.");
 
     /* Access to individual positions inside happens hierarchically, according to the openPMD standard.
-    * Creation of new elements happens on access inside the tree-like structure.
-    * Required attributes are initialized to reasonable defaults for every object. */
+     * Creation of new elements happens on access inside the tree-like structure.
+     * Required attributes are initialized to reasonable defaults for every object. */
     ParticleSpecies electrons = series.iterations[1].particles["electrons"];
 
     /* Data to be moved from memory to persistent storage is structured into Records,
-    * each holding an unbounded number of RecordComponents.
-    * If a Record only contains a single (scalar) component, it is treated slightly differently.
-    * https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#scalar-vector-and-tensor-records*/
+     * each holding an unbounded number of RecordComponents.
+     * If a Record only contains a single (scalar) component, it is treated slightly differently.
+     * https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#scalar-vector-and-tensor-records*/
     Record          mass        = electrons["mass"];
     RecordComponent mass_scalar = mass[RecordComponent::SCALAR];
 
@@ -52,5 +52,9 @@ int main()
     electrons["position"][RecordComponent::SCALAR].resetDataset(dataset);
     electrons["positionOffset"][RecordComponent::SCALAR].resetDataset(dataset);
 
+    /* The files in 'series' are still open until the object is destroyed, on
+     * which it cleanly flushes and closes all open file handles.
+     * When running out of scope on return, the 'Series' destructor is called.
+     */
     return 0;
 }

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -54,3 +54,9 @@ if __name__ == "__main__":
     #            row + 1, col + 1, 1, chunk_data[row*chunk_extent[1]+col])
     #         )
     #     print("")
+
+    # The files in 'series' are still open until the object is destroyed, on
+    # which it cleanly flushes and closes all open file handles.
+    # One can delete the object explicitly (or let it run out of scope) to
+    # trigger this.
+    del series

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -56,3 +56,9 @@ if __name__ == "__main__":
 
     series.flush()
     print("Dataset content has been fully written")
+
+    # The files in 'series' are still open until the object is destroyed, on
+    # which it cleanly flushes and closes all open file handles.
+    # One can delete the object explicitly (or let it run out of scope) to
+    # trigger this.
+    del series

--- a/examples/6_dump_filebased_series.cpp
+++ b/examples/6_dump_filebased_series.cpp
@@ -151,5 +151,9 @@ int main()
         }
     }
 
+    /* The files in 'o' are still open until the object is destroyed, on
+     * which it cleanly flushes and closes all open file handles.
+     * When running out of scope on return, the 'Series' destructor is called.
+     */
     return 0;
 }

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -38,7 +38,10 @@ write()
         o.flush();
     }
 
-    o.flush();
+    /* The files in 'o' are still open until the object is destroyed, on
+     * which it cleanly flushes and closes all open file handles.
+     * When running out of scope on return, the 'Series' destructor is called.
+     */
 }
 
 void
@@ -200,7 +203,11 @@ write2()
     double constant_value = 0.3183098861837907;
     // for datasets that only contain one unique value, openPMD offers constant records
     mesh["y"].makeConstant(constant_value);
-    f.flush();
+
+    /* The files in 'f' are still open until the object is destroyed, on
+     * which it cleanly flushes and closes all open file handles.
+     * When running out of scope on return, the 'Series' destructor is called.
+     */
 }
 
 
@@ -208,6 +215,11 @@ void
 w()
 {
     Series o = Series("../samples/serial_write_%T.h5", AccessType::CREATE);
+
+    /* The files in 'o' are still open until the object is destroyed, on
+     * which it cleanly flushes and closes all open file handles.
+     * When running out of scope on return, the 'Series' destructor is called.
+     */
 }
 
 int


### PR DESCRIPTION
Add more explicit notes and handling of `Series` object in all examples. I saw users copying the (serial) examples into Jupyter notebook cells, wondering why files have not been written and/or are broken on still open HDF5 files.

Note: HDF5 and ADIOS1 do not implement proper journaling, corrupting them if not closed properly.