### PR TITLE
Python: Particle Patches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Features
   - accept & return ``numpy.dtype`` for ``Datatype`` #351
   - better check for (unsupported) numpy array strides #353
   - implement ``Record_Component.make_constant`` #354
+  - implement ``Particle_Patches`` #362
 - comply with runtime constraints w.r.t. ``written`` status #352
 - load at once ``ParticlePatches.load()`` #364
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,8 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Mesh.cpp
         src/binding/python/ParticlePatches.cpp
         src/binding/python/ParticleSpecies.cpp
+        src/binding/python/PatchRecord.cpp
+        src/binding/python/PatchRecordComponent.cpp
         src/binding/python/Record.cpp
         src/binding/python/RecordComponent.cpp
         src/binding/python/MeshRecordComponent.cpp

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -114,7 +114,7 @@ PatchRecordComponent::store(uint64_t idx, T data)
     if( dtype != getDatatype() )
     {
         std::ostringstream oss;
-        oss << "Datatypes of chunk data ("
+        oss << "Datatypes of patch data ("
             << dtype
             << ") and dataset ("
             << getDatatype()

--- a/src/binding/python/BaseRecord.cpp
+++ b/src/binding/python/BaseRecord.cpp
@@ -25,6 +25,7 @@
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/backend/PatchRecordComponent.hpp"
 
 #include <string>
 
@@ -33,9 +34,10 @@ using namespace openPMD;
 
 
 void init_BaseRecord(py::module &m) {
-    py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Mesh_Base_Record");
-    py::class_<BaseRecord< BaseRecordComponent >, Container< BaseRecordComponent > >(m, "Particle_Base_Record");
-    py::class_<BaseRecord< RecordComponent >, Container< RecordComponent > >(m, "Base_Record");
+    py::class_<BaseRecord< RecordComponent >, Container< RecordComponent > >(m, "Base_Record_Record_Component");
+    py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Base_Record_Mesh_Record_Component");
+    py::class_<BaseRecord< BaseRecordComponent >, Container< BaseRecordComponent > >(m, "Base_Record_Base_Record_Component");
+    py::class_<BaseRecord< PatchRecordComponent >, Container< PatchRecordComponent > >(m, "Base_Record_Patch_Record_Component");
 
     py::enum_<UnitDimension>(m, "Unit_Dimension")
         .value("L", UnitDimension::L)

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -31,9 +31,13 @@
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
+#include "openPMD/backend/PatchRecordComponent.hpp"
+#include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/backend/PatchRecord.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/Mesh.hpp"
 #include "openPMD/ParticleSpecies.hpp"
+#include "openPMD/ParticlePatches.hpp"
 #include "openPMD/Record.hpp"
 
 #include <string>
@@ -202,16 +206,22 @@ using PyIterationContainer = Container<
 >;
 using PyMeshContainer = Container< Mesh >;
 using PyPartContainer = Container< ParticleSpecies >;
+using PyPatchContainer = Container< ParticlePatches >;
 using PyRecordContainer = Container< Record >;
+using PyPatchRecordContainer = Container< PatchRecord >;
 using PyRecordComponentContainer = Container< RecordComponent >;
 using PyMeshRecordComponentContainer = Container< MeshRecordComponent >;
+using PyPatchRecordComponentContainer = Container< PatchRecordComponent >;
 using PyBaseRecordComponentContainer = Container< BaseRecordComponent >;
 PYBIND11_MAKE_OPAQUE(PyIterationContainer)
 PYBIND11_MAKE_OPAQUE(PyMeshContainer)
 PYBIND11_MAKE_OPAQUE(PyPartContainer)
+PYBIND11_MAKE_OPAQUE(PyPatchContainer)
 PYBIND11_MAKE_OPAQUE(PyRecordContainer)
+PYBIND11_MAKE_OPAQUE(PyPatchRecordContainer)
 PYBIND11_MAKE_OPAQUE(PyRecordComponentContainer)
 PYBIND11_MAKE_OPAQUE(PyMeshRecordComponentContainer)
+PYBIND11_MAKE_OPAQUE(PyPatchRecordComponentContainer)
 PYBIND11_MAKE_OPAQUE(PyBaseRecordComponentContainer)
 
 void init_Container( py::module & m ) {
@@ -227,9 +237,17 @@ void init_Container( py::module & m ) {
         m,
         "Particle_Container"
     );
+    ::detail::bind_container< PyPatchContainer >(
+        m,
+        "Particle_Patches_Container"
+    );
     ::detail::bind_container< PyRecordContainer >(
         m,
         "Record_Container"
+    );
+    ::detail::bind_container< PyPatchRecordContainer >(
+        m,
+        "Patch_Record_Container"
     );
     ::detail::bind_container< PyRecordComponentContainer >(
         m,
@@ -238,6 +256,10 @@ void init_Container( py::module & m ) {
     ::detail::bind_container< PyMeshRecordComponentContainer >(
         m,
         "Mesh_Record_Component_Container"
+    );
+    ::detail::bind_container< PyPatchRecordComponentContainer >(
+        m,
+        "Patch_Record_Component_Container"
     );
     ::detail::bind_container< PyBaseRecordComponentContainer >(
         m,

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -22,6 +22,8 @@
 #include <pybind11/stl.h>
 
 #include "openPMD/ParticlePatches.hpp"
+#include "openPMD/backend/PatchRecord.hpp"
+#include "openPMD/backend/Container.hpp"
 
 #include <string>
 
@@ -30,15 +32,13 @@ using namespace openPMD;
 
 
 void init_ParticlePatches(py::module &m) {
-    py::class_<ParticlePatches>(m, "ParticlePatches")
+    py::class_<ParticlePatches, Container< PatchRecord > >(m, "Particle_Patches")
         .def("__repr__",
             [](ParticlePatches const & pp) {
-                return "<openPMD.ParticlePatches of size '" + std::to_string(pp.numPatches()) + "'>";
+                return "<openPMD.Particle_Patches of size '" + std::to_string(pp.numPatches()) + "'>";
             }
         )
 
         .def_property_readonly("num_patches", &ParticlePatches::numPatches)
-
-        // expose index / slice operator
     ;
 }

--- a/src/binding/python/PatchRecord.cpp
+++ b/src/binding/python/PatchRecord.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Fabian Koller, Axel Huebl
+/* Copyright 2018 Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -18,29 +18,19 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
-#include "openPMD/backend/Container.hpp"
 #include "openPMD/backend/PatchRecord.hpp"
+#include "openPMD/backend/PatchRecordComponent.hpp"
+#include "openPMD/backend/BaseRecord.hpp"
 
-#include <vector>
-#include <cstddef>
+namespace py = pybind11;
+using namespace openPMD;
 
 
-namespace openPMD
-{
-    class ParticlePatches : public Container< PatchRecord >
-    {
-        friend class ParticleSpecies;
-        friend class Container< ParticlePatches >;
-        friend class Container< PatchRecord >;
-
-    public:
-        size_t numPatches() const;
-
-    private:
-        ParticlePatches();
-        void read();
-    }; // ParticlePatches
-
-} // namespace openPMD
+void init_PatchRecord(py::module &m) {
+    py::class_<PatchRecord, BaseRecord< PatchRecordComponent > >(m, "Patch_Record")
+        .def("set_unit_dimension", &PatchRecord::setUnitDimension)
+    ;
+}

--- a/src/binding/python/PatchRecordComponent.cpp
+++ b/src/binding/python/PatchRecordComponent.cpp
@@ -1,0 +1,157 @@
+/* Copyright 2018 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "openPMD/backend/PatchRecordComponent.hpp"
+#include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/auxiliary/ShareRaw.hpp"
+#include "openPMD/binding/python/Numpy.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_PatchRecordComponent(py::module &m) {
+    py::class_<PatchRecordComponent, BaseRecordComponent >(m, "Patch_Record_Component")
+        .def("set_unit_SI", &PatchRecordComponent::setUnitSI)
+        .def("reset_dataset", &PatchRecordComponent::resetDataset)
+        .def_property_readonly("ndims", &PatchRecordComponent::getDimensionality)
+        .def_property_readonly("shape", &PatchRecordComponent::getExtent)
+
+        .def("load", [](PatchRecordComponent & prc) {
+
+            auto const dtype = dtype_to_numpy( prc.getDatatype() );
+            auto a = py::array( dtype, prc.getExtent()[0] );
+
+            if( prc.getDatatype() == Datatype::CHAR )
+                prc.load<char>(shareRaw((char*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::UCHAR )
+                prc.load<unsigned char>(shareRaw((unsigned char*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::SHORT )
+                prc.load<short>(shareRaw((short*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::INT )
+                prc.load<int>(shareRaw((int*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::LONG )
+                prc.load<long>(shareRaw((long*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::LONGLONG )
+                prc.load<long long>(shareRaw((long long*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::USHORT )
+                prc.load<unsigned short>(shareRaw((unsigned short*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::UINT )
+                prc.load<unsigned int>(shareRaw((unsigned int*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::ULONG )
+                prc.load<unsigned long>(shareRaw((unsigned long*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::ULONGLONG )
+                prc.load<unsigned long long>(shareRaw((unsigned long long*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::LONG_DOUBLE )
+                prc.load<long double>(shareRaw((long double*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::DOUBLE )
+                prc.load<double>(shareRaw((double*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::FLOAT )
+                prc.load<float>(shareRaw((float*) a.mutable_data()));
+            else if( prc.getDatatype() == Datatype::BOOL )
+                prc.load<bool>(shareRaw((bool*) a.mutable_data()));
+            else
+                throw std::runtime_error(std::string("Datatype not known in 'load'!"));
+
+            return a;
+        })
+
+        // all buffer types
+        .def("store", [](PatchRecordComponent & prc, uint64_t idx, py::buffer a) {
+            py::buffer_info buf = a.request();
+            auto const dtype = dtype_from_bufferformat( buf.format );
+
+            using DT = Datatype;
+
+            // Numpy: Handling of arrays and scalars
+            // work-around for https://github.com/pybind/pybind11/issues/1224
+            // -> passing numpy scalars as buffers needs numpy 1.15+
+            //    https://github.com/numpy/numpy/issues/10265
+            //    https://github.com/pybind/pybind11/issues/1224#issuecomment-354357392
+            // scalars, see PEP 3118
+            // requires Numpy 1.15+
+            if( buf.ndim == 0 ) {
+                // refs:
+                //   https://docs.scipy.org/doc/numpy-1.15.0/reference/arrays.interface.html
+                //   https://docs.python.org/3/library/struct.html#format-characters
+                // std::cout << "  scalar type '" << buf.format << "'" << std::endl;
+                // typestring: encoding + type + number of bytes
+                switch( dtype )
+                {
+                    case DT::BOOL:
+                        return prc.store( idx, *static_cast<bool*>(buf.ptr) );
+                        break;
+                    case DT::SHORT:
+                        return prc.store( idx, *static_cast<short*>(buf.ptr) );
+                        break;
+                    case DT::INT:
+                        return prc.store( idx, *static_cast<int*>(buf.ptr) );
+                        break;
+                    case DT::LONG:
+                        return prc.store( idx, *static_cast<long*>(buf.ptr) );
+                        break;
+                    case DT::LONGLONG:
+                        return prc.store( idx, *static_cast<long long*>(buf.ptr) );
+                        break;
+                    case DT::USHORT:
+                        return prc.store( idx, *static_cast<unsigned short*>(buf.ptr) );
+                        break;
+                    case DT::UINT:
+                        return prc.store( idx, *static_cast<unsigned int*>(buf.ptr) );
+                        break;
+                    case DT::ULONG:
+                        return prc.store( idx, *static_cast<unsigned long*>(buf.ptr) );
+                        break;
+                    case DT::ULONGLONG:
+                        return prc.store( idx, *static_cast<unsigned long long*>(buf.ptr) );
+                        break;
+                    case DT::FLOAT:
+                        return prc.store( idx, *static_cast<float*>(buf.ptr) );
+                        break;
+                    case DT::DOUBLE:
+                        return prc.store( idx, *static_cast<double*>(buf.ptr) );
+                        break;
+                    case DT::LONG_DOUBLE:
+                        return prc.store( idx, *static_cast<long double*>(buf.ptr) );
+                        break;
+                    default:
+                        throw std::runtime_error("store: "
+                            "Unknown Datatype!");
+                }
+            }
+            else
+            {
+                throw std::runtime_error("store: "
+                    "Only scalar values supported!");
+            }
+        }, py::arg("idx"), py::arg("data")
+        )
+        // allowed python intrinsics, after (!) buffer matching
+        .def("store", &PatchRecordComponent::store<double>,
+            py::arg("idx"), py::arg("data"))
+        .def("store", &PatchRecordComponent::store<long>,
+            py::arg("idx"), py::arg("data"))
+
+        // TODO implement convenient, patch-object level store/load
+    ;
+}

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -44,6 +44,8 @@ void init_Mesh(py::module &);
 void init_MeshRecordComponent(py::module &);
 void init_ParticlePatches(py::module &);
 void init_ParticleSpecies(py::module &);
+void init_PatchRecord(py::module &);
+void init_PatchRecordComponent(py::module &);
 void init_Record(py::module &);
 void init_RecordComponent(py::module &);
 void init_Series(py::module &);
@@ -66,6 +68,8 @@ PYBIND11_MODULE(openPMD, m) {
     init_RecordComponent(m);
     init_MeshRecordComponent(m);
     init_ParticlePatches(m);
+    init_PatchRecord(m);
+    init_PatchRecordComponent(m);
     init_ParticleSpecies(m);
     init_Record(m);
     init_Series(m);

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -626,7 +626,7 @@ TEST_CASE( "wrapper_test", "[core]" )
     std::stringstream u64str;
     u64str << determineDatatype<uint64_t>();
     REQUIRE_THROWS_WITH(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].store(idx+1, 42.),
-                        Catch::Equals("Datatypes of chunk data (DOUBLE) and dataset (" + u64str.str() + ") do not match."));
+                        Catch::Equals("Datatypes of patch data (DOUBLE) and dataset (" + u64str.str() + ") do not match."));
     o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].store(idx+1, val+1);
 #if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 2);


### PR DESCRIPTION
Expose particle patches to python bindings.

- [x] storing
- [x] loading
- [x] new `load()` at once API (rebase after #364)