### PR TITLE
Python Stride Check: Too Strict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Features
 Bug Fixes
 """""""""
 
+- Python: stride check too strict #369
+
 Other
 """""
 

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -124,12 +124,12 @@ bool setAttributeFromBufferInfo(
             // std::cout << "    stride '" << d << "': "
             //           << buf.strides[d] / buf.itemsize
             //           << " - " << buf.shape[d] << std::endl;
-            if( buf.strides[d] / buf.itemsize != buf.shape[d] ) // general criteria
+            if( buf.strides[d] != buf.shape[d] * buf.itemsize ) // general criteria
             {
-                if( buf.ndim == 1u && buf.strides[0] / buf.itemsize > buf.shape[0] )
+                if( buf.ndim == 1u && buf.strides[0] > buf.shape[0] * buf.itemsize )
                     ; // ok in 1D
-                else if( buf.ndim == 1u && buf.strides[0] / buf.itemsize == 1u )
-                    ; // ok and occurs for byte strings
+                else if( buf.strides[0] == buf.itemsize )
+                    ; // ok to stride on an element level
                 else
                     throw std::runtime_error("set_attribute: "
                         "stride handling not implemented! (key='" +

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -232,12 +232,12 @@ void init_RecordComponent(py::module &m) {
                 // std::cout << "    stride '" << d << "': "
                 //           << a.strides()[d] / a.itemsize()
                 //           << " - " << a.shape()[d] << std::endl;
-                if( a.strides()[d] / a.itemsize() != a.shape()[d] ) // general criteria
+                if( a.strides()[d] != a.shape()[d] * a.itemsize() ) // general criteria
                 {
-                    if( a.ndim() == 1u && a.strides()[0] / a.itemsize() > a.shape()[0] )
+                    if( a.ndim() == 1u && a.strides()[0] > a.shape()[0] * a.itemsize() )
                         ; // ok in 1D
-                    else if( a.ndim() == 1u && a.strides()[0] / a.itemsize() == 1u )
-                        ; // ok and occurs for byte strings
+                    else if( a.strides()[0] == a.itemsize() )
+                        ; // ok to stride on an element level
                     else
                         throw std::runtime_error("store_chunk: "
                             "stride handling not implemented!");


### PR DESCRIPTION
The stride check in Attribute and Record Component writing was too strict. One-element strides are allowed also for non-char types. Also, overlong 1D arrays are ok and should not use integer division for check.