### PR TITLE
CI: GCC 8.1.0 & Python 3.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - CXXFLAGS: "-std=c++11"
     - SPACK_ROOT: $HOME/.cache/spack
     - PATH: $PATH:$HOME/.cache/spack/bin
+    - PYBIND11_VERSION=@2.2.3
 
 addons:
   apt:
@@ -345,7 +346,7 @@ jobs:
       sudo: required
       dist: xenial
       env:
-        - CXXSPEC="%gcc@8.1.0" USE_MPI=OFF USE_PYTHON=ON USE_INTERNAL_PYBIND11=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%gcc@8.1.0" USE_MPI=OFF USE_PYTHON=ON USE_INTERNAL_PYBIND11=OFF PYBIND11_VERSION=@2.2.4 USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -531,9 +532,9 @@ install:
       spack load python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
       if [ "$USE_INTERNAL_PYBIND11" == "OFF" ]; then
         travis_wait spack install
-          py-pybind11@2.2.3 ^python@$TRAVIS_PYTHON_VERSION
+          py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION
           $CXXSPEC &&
-        spack load py-pybind11@2.2.3 ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
+        spack load py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
       fi;
       travis_wait spack install
         py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -337,6 +337,27 @@ jobs:
       before_install: &gcc64_init
         - CXX=g++-6 && CC=gcc-6
       script: *script-cpp-unit
+    # GCC 8.1.0 + Python 3.7
+    - <<: *test-cpp-unit
+      name: gcc@8.1.0 -MPI +PY@3.7 +H5 +ADIOS
+      language: python
+      python: "3.7"
+      sudo: required
+      dist: xenial
+      env:
+        - CXXSPEC="%gcc@8.1.0" USE_MPI=OFF USE_PYTHON=ON USE_INTERNAL_PYBIND11=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+      compiler: gcc
+      addons:
+        apt:
+          <<: *apt_common_sources
+          packages: &gcc81_deps
+            - environment-modules
+            - gfortran-8
+            - gcc-8
+            - g++-8
+      before_install: &gcc81_init
+        - CXX=g++-8 && CC=gcc-8
+      script: *script-cpp-unit
     # GCC 6.4.0 + Python 3.6
     - <<: *test-cpp-unit
       name: gcc@6.4.0 -MPI +PY@3.6 +H5@1.8.13 -ADIOS

--- a/.travis/spack/compilers.yaml
+++ b/.travis/spack/compilers.yaml
@@ -77,3 +77,16 @@ compilers:
       fc: /usr/bin/gfortran-7
     spec: gcc@7.3.0
     target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc: /usr/bin/gcc-8
+      cxx: /usr/bin/g++-8
+      f77: /usr/bin/gfortran-8
+      fc: /usr/bin/gfortran-8
+    spec: gcc@8.1.0
+    target: x86_64

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -6,6 +6,7 @@ packages:
       cmake@3.10.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
+      cmake@3.10.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.10.0
       cmake@3.10.0%clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
     buildable: False
@@ -16,6 +17,7 @@ packages:
       openmpi@1.6.5%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /usr
+      openmpi@1.6.5%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
       openmpi@1.6.5%clang@5.0.0 arch=linux-ubuntu14-x86_64: /usr
     buildable: False
   hdf5:
@@ -31,6 +33,7 @@ packages:
       python@2.7.14%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
+      python@3.7.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@2.7.15%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
     buildable: False
   all:


### PR DESCRIPTION
Python 3.7+ needs openssl 1.0.2+ that is not available on trusty.
Therefore, we require `sudo` and the beta `xenial` dist on travis CI ([ref](https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905)).

For CI, we already use pybind11 2.2.4 instead of 2.2.3 with Python 3.7 to avoid a deprecation warning that was fixed therein (https://github.com/pybind/pybind11/pull/1454).

Don't worry, the first run will take as usual a bit longer to build up our dependencies for the travis caches.