### PR TITLE
requirements.txt: Upper bounds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cmake>=3.10.0
-pybind11>=2.2.3
-numpy>=1.15.0
+cmake>=3.10.0,<4.0.0
+pybind11>=2.2.3,<3.0.0
+numpy>=1.15.0,<2.0.0
 setuptools>=38.6


### PR DESCRIPTION
New major releases of these dependencies would very likely cause problems and were not tested on release of this software. If they work, we can bump the bound (in packages recipes aka package builds).

For the bare software install, we don't define those bounds to allow bumping them in packaging alone without the need for a new mainline release.