### PR TITLE
store_chunk order of arguments

### DIFF
--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
     cout << "File structure and required attributes have been written\n";
 
     Offset offset = {0, 0};
-    rho.storeChunk(offset, extent, shareRaw(global_data));
+    rho.storeChunk(shareRaw(global_data), offset, extent);
     cout << "Stored the whole Dataset contents as a single chunk, "
             "ready to write content\n";
 

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     size = 3
 
     # matrix dataset to write with values 0...size*size-1
-    global_data = np.arange(size*size, dtype=np.double)
+    global_data = np.arange(size*size, dtype=np.double).reshape(3, 3)
 
     print("Set up a 2D square array ({0}x{1}) that will be written".format(
         size, size))
@@ -43,14 +43,18 @@ if __name__ == "__main__":
     rho.reset_dataset(dataset)
     print("Set the dataset properties for the scalar field rho in iteration 1")
 
-    # writing fails on already open file error
     series.flush()
     print("File structure has been written")
 
-    offset = [0, 0]
     # TODO implement slicing protocol
     # E[offset[0]:extent[0], offset[1]:extent[1]] = global_data
-    rho.store_chunk(offset, extent, global_data)
+
+    # individual chunks from input or to output record component
+    #   offset = [0, 0]
+    #   rho.store_chunk(global_data, offset, extent)
+    # whole input to zero-offset in output record component
+    rho.store_chunk(global_data)
+
     print("Stored the whole Dataset contents as a single chunk, " +
           "ready to write content")
 

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
 
         Offset chunk_offset = {static_cast< long unsigned int >(mpi_rank)};
         Extent chunk_extent = {1};
-        id.storeChunk(chunk_offset, chunk_extent, local_data);
+        id.storeChunk(local_data, chunk_offset, chunk_extent);
         if( 0 == mpi_rank )
             cout << "Stored a single chunk per MPI rank containing its contribution, "
                     "ready to write content to disk\n";

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -21,7 +21,7 @@ write()
     for( uint64_t i = 0; i < 4; ++i )
     {
         *position_local = position_global[i];
-        e["position"]["x"].storeChunk({i}, {1}, position_local);
+        e["position"]["x"].storeChunk(position_local, {i}, {1});
         o.flush();
     }
 
@@ -34,7 +34,7 @@ write()
     for( uint64_t i = 0; i < 4; ++i )
     {
         *positionOffset_local = positionOffset_global[i];
-        e["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local);
+        e["positionOffset"]["x"].storeChunk(positionOffset_local, {i}, {1});
         o.flush();
     }
 
@@ -175,7 +175,7 @@ write2()
 
         Offset o = Offset{i, 0};
         Extent e = Extent{1, 5};
-        mesh["x"].storeChunk(o, e, partial_mesh);
+        mesh["x"].storeChunk(partial_mesh, o, e);
         // operations between store and flush MUST NOT modify the pointed-to data
         f.flush();
         // after the flush completes successfully, access to the shared resource is returned to the caller
@@ -191,8 +191,8 @@ write2()
 
         o = Offset{numParticlesOffset};
         e = Extent{numParticles};
-        electrons["position"]["x"].storeChunk(o, e, partial_particlePos);
-        electrons["positionOffset"]["x"].storeChunk(o, e, partial_particleOff);
+        electrons["position"]["x"].storeChunk(partial_particlePos, o, e);
+        electrons["positionOffset"]["x"].storeChunk(partial_particleOff, o, e);
 
         electrons.particlePatches["numParticles"][RecordComponent::SCALAR].store(i, numParticles);
         electrons.particlePatches["numParticlesOffset"][RecordComponent::SCALAR].store(i, numParticlesOffset);

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
 
         o = [i, 0]
         e = [1, 5]
-        mesh["x"].store_chunk(o, e, partial_mesh)
+        mesh["x"].store_chunk(partial_mesh, o, e)
         # operations between store and flush MUST NOT modify the pointed-to
         # data
         f.flush()
@@ -165,8 +165,8 @@ if __name__ == "__main__":
 
         o = [numParticlesOffset]
         e = [numParticles]
-        electrons["position"]["x"].store_chunk(o, e, partial_particlePos)
-        electrons["positionOffset"]["x"].store_chunk(o, e, partial_particleOff)
+        electrons["position"]["x"].store_chunk(partial_particlePos, o, e)
+        electrons["positionOffset"]["x"].store_chunk(partial_particleOff, o, e)
 
         electrons.particle_patches["numParticles"][SCALAR].store(
             i, np.array([numParticles], dtype=np.uint64))

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -83,7 +83,7 @@ public:
                    std::shared_ptr< T >,
                    double targetUnitSI = std::numeric_limits< double >::quiet_NaN() );
     template< typename T >
-    void storeChunk(Offset, Extent, std::shared_ptr< T >);
+    void storeChunk(std::shared_ptr< T >, Offset, Extent);
 
     constexpr static char const * const SCALAR = "\vScalar";
 
@@ -173,7 +173,7 @@ RecordComponent::loadChunk(Offset const& o, Extent const& e, std::shared_ptr< T 
 
 template< typename T >
 inline void
-RecordComponent::storeChunk(Offset o, Extent e, std::shared_ptr<T> data)
+RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
 {
     if( *m_isConstant )
         throw std::runtime_error("Chunks can not be written for a constant RecordComponent.");

--- a/include/openPMD/auxiliary/ShareRaw.hpp
+++ b/include/openPMD/auxiliary/ShareRaw.hpp
@@ -38,7 +38,7 @@ namespace openPMD
      *
      * @warning this is a helper function to bypass the shared-pointer
      *          API for storing data behind raw pointers. Using it puts
-     *          the resposibility of buffer-consistency between stores
+     *          the responsibility of buffer-consistency between stores
      *          and flushes to the users side without an indication via
      *          reference counting.
      */

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -588,10 +588,10 @@ TEST_CASE( "wrapper_test", "[core]" )
     MeshRecordComponent mrc3 = o.iterations[5].meshes["E"]["y"];
     o.iterations[5].meshes["E"]["y"].resetDataset(Dataset(Datatype::DOUBLE, {1}));
     int wrongData = 42;
-    REQUIRE_THROWS_WITH(o.iterations[5].meshes["E"]["y"].storeChunk({0}, {1}, shareRaw(&wrongData)),
-                        Catch::Equals("Datatypes of chunk data (INT) and dataset (DOUBLE) do not match."));
+    REQUIRE_THROWS_WITH(o.iterations[5].meshes["E"]["y"].storeChunk(shareRaw(&wrongData), {0}, {1}),
+                        Catch::Equals("Datatypes of chunk data (INT) and record component (DOUBLE) do not match."));
     std::shared_ptr< double > storeData = std::make_shared< double >(44);
-    o.iterations[5].meshes["E"]["y"].storeChunk({0}, {1}, storeData);
+    o.iterations[5].meshes["E"]["y"].storeChunk(storeData, {0}, {1});
 #if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[5].meshes["E"]["y"].m_chunks->size() == 1);
     REQUIRE(mrc3.m_chunks->size() == 1);
@@ -647,7 +647,7 @@ TEST_CASE( "use_count_test", "[core]" )
     mrc.resetDataset(Dataset(determineDatatype<uint16_t>(), {42}));
     std::shared_ptr< uint16_t > storeData = std::make_shared< uint16_t >(44);
     REQUIRE(storeData.use_count() == 1);
-    mrc.storeChunk({0}, {1}, storeData);
+    mrc.storeChunk(storeData, {0}, {1});
     REQUIRE(storeData.use_count() == 2);
     o.flush();
     REQUIRE(storeData.use_count() == 1);

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -129,7 +129,7 @@ TEST_CASE( "hdf5_write_test", "[parallel][hdf5]" )
     *position_local = position_global[mpi_rank];
 
     e["position"]["x"].resetDataset(Dataset(determineDatatype(position_local), {mpi_size}));
-    e["position"]["x"].storeChunk({mpi_rank}, {1}, position_local);
+    e["position"]["x"].storeChunk(position_local, {mpi_rank}, {1});
 
     std::vector< uint64_t > positionOffset_global(mpi_size);
     uint64_t posOff{0};
@@ -138,7 +138,7 @@ TEST_CASE( "hdf5_write_test", "[parallel][hdf5]" )
     *positionOffset_local = positionOffset_global[mpi_rank];
 
     e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local), {mpi_size}));
-    e["positionOffset"]["x"].storeChunk({mpi_rank}, {1}, positionOffset_local);
+    e["positionOffset"]["x"].storeChunk(positionOffset_local, {mpi_rank}, {1});
 
     o.flush();
 }
@@ -191,8 +191,8 @@ TEST_CASE( "hdf5_write_test_zero_extent", "[parallel][hdf5]" )
         position_local.get()[i] = position_global[offset + i];
         positionOffset_local.get()[i] = positionOffset_global[offset + i];
     }
-    e["position"]["x"].storeChunk({offset}, {rank}, position_local);
-    e["positionOffset"]["x"].storeChunk({offset}, {rank}, positionOffset_local);
+    e["position"]["x"].storeChunk(position_local, {offset}, {rank});
+    e["positionOffset"]["x"].storeChunk(positionOffset_local, {offset}, {rank});
 
     //TODO read back, verify
 }
@@ -224,7 +224,7 @@ TEST_CASE( "adios_write_test", "[parallel][adios]" )
     *position_local = position_global[mpi_rank];
 
     e["position"]["x"].resetDataset(Dataset(determineDatatype(position_local), {mpi_size}));
-    e["position"]["x"].storeChunk({mpi_rank}, {1}, position_local);
+    e["position"]["x"].storeChunk(position_local, {mpi_rank}, {1});
 
     std::vector< uint64_t > positionOffset_global(mpi_size);
     uint64_t posOff{0};
@@ -233,7 +233,7 @@ TEST_CASE( "adios_write_test", "[parallel][adios]" )
     *positionOffset_local = positionOffset_global[mpi_rank];
 
     e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local), {mpi_size}));
-    e["positionOffset"]["x"].storeChunk({mpi_rank}, {1}, positionOffset_local);
+    e["positionOffset"]["x"].storeChunk(positionOffset_local, {mpi_rank}, {1});
 
     o.flush();
 }
@@ -286,8 +286,8 @@ TEST_CASE( "adios_write_test_zero_extent", "[parallel][adios]" )
         position_local.get()[i] = position_global[offset + i];
         positionOffset_local.get()[i] = positionOffset_global[offset + i];
     }
-    e["position"]["x"].storeChunk({offset}, {rank}, position_local);
-    e["positionOffset"]["x"].storeChunk({offset}, {rank}, positionOffset_local);
+    e["position"]["x"].storeChunk(position_local, {offset}, {rank});
+    e["positionOffset"]["x"].storeChunk(positionOffset_local, {offset}, {rank});
 
     //TODO read back, verify
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -131,12 +131,12 @@ void particle_patches( std::string file_ending )
             x.resetDataset(Dataset(determineDatatype<float>(), {extent}));
             std::vector<float> xd( extent );
             std::iota(xd.begin(), xd.end(), 0);
-            x.storeChunk(shareRaw(xd.data()), {0}, {extent});
+            x.storeChunk(xd);
             auto  o = e["positionOffset"][r];
             o.resetDataset(Dataset(determineDatatype<uint64_t>(), {extent}));
             std::vector<uint64_t> od( extent );
             std::iota(od.begin(), od.end(), 0);
-            o.storeChunk(shareRaw(od.data()), {0}, {extent});
+            o.storeChunk(od);
         }
 
         auto const dset_n = Dataset(determineDatatype<uint64_t>(), {num_patches, });

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -41,7 +41,7 @@ void constant_scalar(std::string file_ending)
         std::shared_ptr< unsigned int > E(new unsigned int[6], [](unsigned int *p){ delete[] p; });
         unsigned int e{0};
         std::generate(E.get(), E.get() + 6, [&e]{ return e++; });
-        E_y.storeChunk({0, 0, 0}, {1, 2, 3}, E);
+        E_y.storeChunk(E, {0, 0, 0}, {1, 2, 3});
 
         // constant scalar
         auto pos = s.iterations[1].particles["e"]["position"][RecordComponent::SCALAR];
@@ -60,7 +60,7 @@ void constant_scalar(std::string file_ending)
         std::shared_ptr< unsigned long long > vel(new unsigned long long[6], [](unsigned long long *p){ delete[] p; });
         unsigned long long v{0};
         std::generate(vel.get(), vel.get() + 6, [&v]{ return v++; });
-        vel_y.storeChunk({0, 0, 0}, {3, 2, 1}, vel);
+        vel_y.storeChunk(vel, {0, 0, 0}, {3, 2, 1});
     }
 
     {
@@ -131,12 +131,12 @@ void particle_patches( std::string file_ending )
             x.resetDataset(Dataset(determineDatatype<float>(), {extent}));
             std::vector<float> xd( extent );
             std::iota(xd.begin(), xd.end(), 0);
-            x.storeChunk({0}, {extent}, shareRaw(xd.data()));
+            x.storeChunk(shareRaw(xd.data()), {0}, {extent});
             auto  o = e["positionOffset"][r];
             o.resetDataset(Dataset(determineDatatype<uint64_t>(), {extent}));
             std::vector<uint64_t> od( extent );
             std::iota(od.begin(), od.end(), 0);
-            o.storeChunk({0}, {extent}, shareRaw(od.data()));
+            o.storeChunk(shareRaw(od.data()), {0}, {extent});
         }
 
         auto const dset_n = Dataset(determineDatatype<uint64_t>(), {num_patches, });
@@ -1231,9 +1231,9 @@ TEST_CASE( "hdf5_write_test", "[serial][hdf5]" )
     for( uint64_t i = 0; i < 4; ++i )
     {
         position_local.at(0) = position_global[i];
-        e["position"]["x"].storeChunk({i}, {1}, shareRaw(position_local));
+        e["position"]["x"].storeChunk(shareRaw(position_local), {i}, {1});
         positionOffset_local[0] = positionOffset_global[i];
-        e["positionOffset"]["x"].storeChunk({i}, {1}, shareRaw(positionOffset_local));
+        e["positionOffset"]["x"].storeChunk(shareRaw(positionOffset_local), {i}, {1});
         o.flush();
     }
 
@@ -1377,9 +1377,9 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         for( uint64_t i = 0; i < 4; ++i )
         {
             *position_local_1 = position_global[i];
-            e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
+            e_1["position"]["x"].storeChunk(position_local_1, {i}, {1});
             *positionOffset_local_1 = positionOffset_global[i];
-            e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
+            e_1["positionOffset"]["x"].storeChunk(positionOffset_local_1, {i}, {1});
             o.flush();
         }
 
@@ -1396,9 +1396,9 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         for( uint64_t i = 0; i < 4; ++i )
         {
             double const position_local_2 = position_global.at(i);
-            e_2["position"]["x"].storeChunk({i}, {1}, shareRaw(&position_local_2));
+            e_2["position"]["x"].storeChunk(shareRaw(&position_local_2), {i}, {1});
             *positionOffset_local_2 = positionOffset_global[i];
-            e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
+            e_2["positionOffset"]["x"].storeChunk(positionOffset_local_2, {i}, {1});
             o.flush();
         }
 
@@ -1416,9 +1416,9 @@ TEST_CASE( "hdf5_fileBased_write_test", "[serial][hdf5]" )
         for( uint64_t i = 0; i < 4; ++i )
         {
             *position_local_3 = position_global[i];
-            e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
+            e_3["position"]["x"].storeChunk(position_local_3, {i}, {1});
             *positionOffset_local_3 = positionOffset_global[i];
-            e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
+            e_3["positionOffset"]["x"].storeChunk(positionOffset_local_3, {i}, {1});
             o.flush();
         }
 
@@ -1783,7 +1783,7 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     for( uint64_t i = 0; i < 4; ++i )
     {
         *position_local_1 = position_global[i];
-        e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
+        e_1["position"]["x"].storeChunk(position_local_1, {i}, {1});
     }
 
     std::vector< uint64_t > positionOffset_global(4);
@@ -1795,7 +1795,7 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     for( uint64_t i = 0; i < 4; ++i )
     {
         *positionOffset_local_1 = positionOffset_global[i];
-        e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
+        e_1["positionOffset"]["x"].storeChunk(positionOffset_local_1, {i}, {1});
     }
 
     ParticleSpecies& e_2 = o.iterations[2].particles["e"];
@@ -1807,7 +1807,7 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     for( uint64_t i = 0; i < 4; ++i )
     {
         *position_local_2 = position_global[i];
-        e_2["position"]["x"].storeChunk({i}, {1}, position_local_2);
+        e_2["position"]["x"].storeChunk(position_local_2, {i}, {1});
     }
 
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1817,7 +1817,7 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     for( uint64_t i = 0; i < 4; ++i )
     {
         *positionOffset_local_2 = positionOffset_global[i];
-        e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
+        e_2["positionOffset"]["x"].storeChunk(positionOffset_local_2, {i}, {1});
     }
 
     o.flush();
@@ -1831,7 +1831,7 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     for( uint64_t i = 0; i < 4; ++i )
     {
         *position_local_3 = position_global[i];
-        e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
+        e_3["position"]["x"].storeChunk(position_local_3, {i}, {1});
     }
 
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
@@ -1841,7 +1841,7 @@ TEST_CASE( "adios1_write_test", "[serial][adios1]")
     for( uint64_t i = 0; i < 4; ++i )
     {
         *positionOffset_local_3 = positionOffset_global[i];
-        e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
+        e_3["positionOffset"]["x"].storeChunk(positionOffset_local_3, {i}, {1});
     }
 
     o.flush();
@@ -1981,9 +1981,9 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
         for( uint64_t i = 0; i < 4; ++i )
         {
             *position_local_1 = position_global[i];
-            e_1["position"]["x"].storeChunk({i}, {1}, position_local_1);
+            e_1["position"]["x"].storeChunk(position_local_1, {i}, {1});
             *positionOffset_local_1 = positionOffset_global[i];
-            e_1["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_1);
+            e_1["positionOffset"]["x"].storeChunk(positionOffset_local_1, {i}, {1});
             o.flush();
         }
 
@@ -2000,9 +2000,9 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
         for( uint64_t i = 0; i < 4; ++i )
         {
             double const position_local_2 = position_global.at(i);
-            e_2["position"]["x"].storeChunk({i}, {1}, shareRaw(&position_local_2));
+            e_2["position"]["x"].storeChunk(shareRaw(&position_local_2), {i}, {1});
             *positionOffset_local_2 = positionOffset_global[i];
-            e_2["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_2);
+            e_2["positionOffset"]["x"].storeChunk(positionOffset_local_2, {i}, {1});
             o.flush();
         }
 
@@ -2020,9 +2020,9 @@ TEST_CASE( "adios1_fileBased_write_test", "[serial][adios1]" )
         for( uint64_t i = 0; i < 4; ++i )
         {
             *position_local_3 = position_global[i];
-            e_3["position"]["x"].storeChunk({i}, {1}, position_local_3);
+            e_3["position"]["x"].storeChunk(position_local_3, {i}, {1});
             *positionOffset_local_3 = positionOffset_global[i];
-            e_3["positionOffset"]["x"].storeChunk({i}, {1}, positionOffset_local_3);
+            e_3["positionOffset"]["x"].storeChunk(positionOffset_local_3, {i}, {1});
             o.flush();
         }
 

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -658,10 +658,11 @@ class APITest(unittest.TestCase):
         for r in ["x", "y"]:
             x = e["position"][r]
             x.reset_dataset(DS(np.dtype("single"), extent))
-            x.store_chunk([0, ], extent, np.arange(10, dtype=np.single))
+            # implicit:                                        , [0, ], extent
+            x.store_chunk(np.arange(extent[0], dtype=np.single))
             o = e["positionOffset"][r]
             o.reset_dataset(DS(np.dtype("uint64"), extent))
-            o.store_chunk([0, ], extent, np.arange(extent[0], dtype=np.uint64))
+            o.store_chunk(np.arange(extent[0], dtype=np.uint64), [0, ], extent)
 
         dset = DS(np.dtype("uint64"), [num_patches, ])
         e.particle_patches["numParticles"][SCALAR].reset_dataset(dset)


### PR DESCRIPTION
The order of `storeChunk`/`store_chunk` should be changed to allow useful defaults to:
- `data`
- `offset`
- `extent`

Introduce defaults for the Python bindings to make serial I/O more simple.
Close #368 .

Also introduces an `openPMD::traits::IsContiguousContainer` trait that emulates the C++17 concept [ContiguousContainer](https://en.cppreference.com/w/cpp/named_req/ContiguousContainer). With that, the C++11 frontend `store_chunk` also gets default arguments for offset and extent for `std::array` and `std::vector` (and anything else the user implements a `openPMD::traits::IsContiguousContainer` trait for).

User-level upgrade guide documented in #385