### PR TITLE
Series: More Flexible Detection of Padding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,18 +17,26 @@ Changes to "0.6.2-alpha"
 Features
 """"""""
 
+- C++:
+
+  - ``storeChunk`` argument order changed, defaults added #386
 - Python:
 
   - ``import openPMD`` renamed to ``import openpmd_api`` #380
+  - ``store_chunk`` argument order changed, defaults added #386
   - works with Python 3.7 #376
   - setup.py for sdist #240
+- Backends: JSON support added #384 #338
 
 Bug Fixes
 """""""""
 
+- support reading series with varying or no iteration padding in filename #388
+
 Other
 """""
 
+- Docs: upgrade guide added #385
 - CI: GCC 8.1.0 & Python 3.7.0 #376
 
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -634,10 +634,8 @@ Series::readFileBased(AccessType actualAccessType)
         std::tie(isContained, padding) = isPartOfSeries(entry);
         if( isContained )
         {
+            //! @todo skip if the padding is exact the number of chars in an iteration?
             paddings.insert(padding);
-            if( paddings.size() > 1 )
-                throw std::runtime_error("Can not determine iteration padding from existing filenames. "
-                                         "Please specify '%0<N>T'.");
 
             fOpen.name = entry;
             IOHandler->enqueue(IOTask(this, fOpen));
@@ -692,8 +690,12 @@ Series::readFileBased(AccessType actualAccessType)
             std::cerr << "No matching iterations found: " << name() << std::endl;
     }
 
-    if( !paddings.empty() )
+    if( paddings.size() == 1u )
         *m_filenamePadding = *paddings.begin();
+
+    if( paddings.size() > 1u && actualAccessType == AccessType::READ_WRITE )
+        throw std::runtime_error("Cannot write to a series with inconsistent iteration padding. "
+                                 "Please specify '%0<N>T' or open as read-only.");
 }
 
 void


### PR DESCRIPTION
Fix #382 

Iteration encoding detection was too strict and was unable to read files such as

    simData_0.h5
    simData_500.h5
    simData_1000.h5

which is the current PIConGPU default way to write with libSplash.

Loosen that constrain and only enforce it if write is planned.