### PR TITLE
CMake 3.12.4+: _ROOT Vars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Other
 
 - increase pybind11 dependency to 2.2.4+ #455
 - Python: remove (inofficial) bindings for 2.7 #435
+- CMake 3.12+: apply policy ``CMP0074`` for ``<Package>_ROOT`` vars #391
 - Docs:
 
   - PyPI install method #450 #451

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,15 @@ set(openPMD_STANDARD_VERSION 1.1.0)
 list(APPEND CMAKE_MODULE_PATH "${openPMD_SOURCE_DIR}/share/openPMD/cmake")
 
 
+# CMake policies ##############################################################
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+
 # Project structure ###########################################################
 #
 # temporary build directories


### PR DESCRIPTION
Honor `<PackageName>_ROOT` variables, see
  https://cmake.org/cmake/help/v3.12/policy/CMP0074.html

Should be set to avoid warnings in CMake 3.12.4+.

- [x] verify warning arises