### PR TITLE
find_package: JSON Component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Features
   - ``store_chunk`` argument order changed, defaults added #386
   - works with Python 3.7 #376
   - setup.py for sdist #240
-- Backends: JSON support added #384 #338
+- Backends: JSON support added #384 #393 #338
 
 Bug Fixes
 """""""""

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
 
 Use the following lines in your project's `CMakeLists.txt`:
 ```cmake
-# supports:                       COMPONENTS MPI NOMPI HDF5 ADIOS1 ADIOS2
+# supports:                       COMPONENTS MPI NOMPI JSON HDF5 ADIOS1 ADIOS2
 find_package(openPMD 0.1.0 CONFIG)
 
 if(openPMD_FOUND)


### PR DESCRIPTION
The CMake `COMPONENT` called `JSON` is supported as well.

Follow-up documentation of feature landed in #384