### PR TITLE
[WIP] Fix Read-Only File Series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,6 +195,7 @@ jobs:
         - if [ ! -d samples/git-sample/ ]; then
             if [ "$USE_SAMPLES" = "ON" ]; then
               $TRAVIS_BUILD_DIR/.travis/download_samples.sh;
+              chmod u-w samples/git-sample/*.h5;
             fi
           fi
         - if [ "$USE_PYTHON" == "ON" ]; then
@@ -503,6 +504,7 @@ jobs:
         - cd $HOME/build
         - if [ ! -d samples/git-sample/ ]; then
             $TRAVIS_BUILD_DIR/.travis/download_samples.sh;
+            chmod u-w samples/git-sample/*.h5;
           fi
         - CXXFLAGS="-g -O0 -fprofile-arcs -ftest-coverage" CXX=$CXX CC=$CC
           cmake

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -101,6 +101,7 @@ Bug Fixes
 - fix ODR issue in ADIOS1 backend corrupting the ``AbstractIOHandler`` vtable #415
 - fix race condition in MPI-parallel directory creation #419
 - ADIOS1: fix use-after-free in parallel I/O method options #421
+- do not require write permissions to open ``Series`` read-only #395
 
 Other
 """""

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     cur_it.meshes["lowRez_2D_field"] = lowRez
     del lowRez
     del cur_it.meshes["generic_2D_field"]  # TODO not WORKING
-    cur_it.meshes.erase("generic_2D_field")
+    # cur_it.meshes.erase("generic_2D_field")
     # del lowRez
 
     # particles are handled very similar

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -80,6 +80,9 @@ if __name__ == "__main__":
     # del cur_it.meshes["generic_2D_field"]
     cur_it.meshes["lowRez_2D_field"] = lowRez
     del lowRez
+    del cur_it.meshes["generic_2D_field"]  # TODO not WORKING
+    cur_it.meshes.erase("generic_2D_field")
+    # del lowRez
 
     # particles are handled very similar
     electrons = cur_it.particles["electrons"]

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -33,6 +33,7 @@
 #include <queue>
 #include <stdexcept>
 #include <string>
+#include <iostream>
 
 
 namespace openPMD

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -24,6 +24,7 @@
 #include "openPMD/IO/IOTask.hpp"
 
 #include <future>
+#include <iostream>
 
 
 namespace openPMD
@@ -66,9 +67,13 @@ public:
                         openFile(i.writable, *dynamic_cast< Parameter< O::OPEN_FILE >* >(i.parameter.get()));
                         break;
                     case O::OPEN_PATH:
+                        std::cout << "Open Path: " << dynamic_cast< Parameter< O::OPEN_PATH >* >(i.parameter.get())->path
+                                  << std::endl;
                         openPath(i.writable, *dynamic_cast< Parameter< O::OPEN_PATH >* >(i.parameter.get()));
                         break;
                     case O::OPEN_DATASET:
+                        std::cout << "Open Dataset: " << dynamic_cast< Parameter< O::OPEN_DATASET >* >(i.parameter.get())->name
+                                  << std::endl;
                         openDataset(i.writable, *dynamic_cast< Parameter< O::OPEN_DATASET >* >(i.parameter.get()));
                         break;
                     case O::DELETE_FILE:
@@ -90,9 +95,13 @@ public:
                         writeAttribute(i.writable, *dynamic_cast< Parameter< O::WRITE_ATT >* >(i.parameter.get()));
                         break;
                     case O::READ_DATASET:
+                        std::cout << "Read Dataset: " << dynamic_cast< Parameter< O::READ_DATASET >* >(i.parameter.get())->extent[0]
+                                  << std::endl;
                         readDataset(i.writable, *dynamic_cast< Parameter< O::READ_DATASET >* >(i.parameter.get()));
                         break;
                     case O::READ_ATT:
+                        std::cout << "Read Attribute: " << dynamic_cast< Parameter< O::READ_ATT >* >(i.parameter.get())->name
+                                  << std::endl;
                         readAttribute(i.writable, *dynamic_cast< Parameter< O::READ_ATT >* >(i.parameter.get()));
                         break;
                     case O::LIST_PATHS:

--- a/include/openPMD/IO/AccessType.hpp
+++ b/include/openPMD/IO/AccessType.hpp
@@ -27,8 +27,8 @@ namespace openPMD
  */
 enum class AccessType
 {
-    READ_ONLY,
-    READ_WRITE,
-    CREATE
+    READ_ONLY = 0,
+    READ_WRITE = 1,
+    CREATE = 2
 };  //AccessType
 } // openPMD

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -90,7 +90,7 @@ public:
     Container< ParticleSpecies > particles; //particleSpecies?
 
 private:
-    Iteration();
+    Iteration(std::shared_ptr< Writable > const& w);
 
     void flushFileBased(std::string const&, uint64_t);
     void flushGroupBased(uint64_t);

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -175,7 +175,7 @@ public:
     Mesh& setTimeOffset(T timeOffset);
 
 private:
-    Mesh();
+    Mesh(std::shared_ptr< Writable > const& w);
 
     void flush_impl(std::string const&) override;
     void read() override;

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -39,7 +39,7 @@ namespace openPMD
         size_t numPatches() const;
 
     private:
-        ParticlePatches();
+        ParticlePatches(std::shared_ptr< Writable > const& w);
         void read();
     }; // ParticlePatches
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -56,11 +56,13 @@ namespace traits
         void operator()(T & ret)
         {
             /* enforce these two RecordComponents as required by the standard */
-            auto udl = std::array< double, 7 >({1., 0., 0., 0., 0., 0., 0.});
-            auto& po = ret.init("position"); // .setUnitDimension({{UnitDimension::L, 1}});
-            po.initAttribute("unitDimension", udl);
-            auto& pp = ret.init("positionOffset"); //.setUnitDimension({{UnitDimension::L, 1}});
-            pp.initAttribute("unitDimension", udl);
+            //auto udl = std::array< double, 7 >({1., 0., 0., 0., 0., 0., 0.});
+            //auto& po = 
+            ret.init("position"); // .setUnitDimension({{UnitDimension::L, 1}});
+            //po.initAttribute("unitDimension", udl);
+            //auto& pp = 
+            ret.init("positionOffset"); //.setUnitDimension({{UnitDimension::L, 1}});
+            //pp.initAttribute("unitDimension", udl);
             ret.particlePatches.linkHierarchy(ret.m_writable);
 
             auto& np = ret.particlePatches.init("numParticles");

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -56,16 +56,19 @@ namespace traits
         void operator()(T & ret)
         {
             /* enforce these two RecordComponents as required by the standard */
-            ret["position"].setUnitDimension({{UnitDimension::L, 1}});
-            ret["positionOffset"].setUnitDimension({{UnitDimension::L, 1}});
+            auto udl = std::array< double, 7 >({1., 0., 0., 0., 0., 0., 0.});
+            auto& po = ret.init("position"); // .setUnitDimension({{UnitDimension::L, 1}});
+            po.initAttribute("unitDimension", udl);
+            auto& pp = ret.init("positionOffset"); //.setUnitDimension({{UnitDimension::L, 1}});
+            pp.initAttribute("unitDimension", udl);
             ret.particlePatches.linkHierarchy(ret.m_writable);
 
-            auto& np = ret.particlePatches["numParticles"];
-            auto& npc = np[RecordComponent::SCALAR];
+            auto& np = ret.particlePatches.init("numParticles");
+            auto& npc = np.init(RecordComponent::SCALAR);
             npc.resetDataset(Dataset(determineDatatype<uint64_t>(), {1}));
             npc.parent = np.parent;
-            auto& npo = ret.particlePatches["numParticlesOffset"];
-            auto& npoc = npo[RecordComponent::SCALAR];
+            auto& npo = ret.particlePatches.init("numParticlesOffset");
+            auto& npoc = npo.init(RecordComponent::SCALAR);
             npoc.resetDataset(Dataset(determineDatatype<uint64_t>(), {1}));
             npoc.parent = npo.parent;
         }

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -48,7 +48,7 @@ public:
     Record& setTimeOffset(T);
 
 private:
-    Record();
+    Record(std::shared_ptr< Writable > const& w);
 
     void flush_impl(std::string const&) override;
     void read() override;

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -149,7 +149,7 @@ public:
     constexpr static char const * const SCALAR = "\vScalar";
 
 OPENPMD_protected:
-    RecordComponent();
+    RecordComponent(std::shared_ptr< Writable > const& w);
 
     void readBase();
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -71,6 +71,7 @@ class Attributable
     friend class BaseRecordComponent;
     friend class ParticleSpecies;
     friend class ParticlePatches;
+    friend class PatchRecordComponent;
     template<
         typename T,
         typename T_key,

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -42,7 +42,7 @@ namespace openPMD
 {
 namespace traits
 {
-    template< typename T >
+    template< typename T, bool Init >
     struct GenerationPolicy;
 } // traits
 class AbstractFilePosition;
@@ -68,13 +68,16 @@ class Attributable
     friend Writable* getWritable(Attributable*);
     template< typename T_elem >
     friend class BaseRecord;
+    friend class BaseRecordComponent;
+    friend class ParticleSpecies;
+    friend class ParticlePatches;
     template<
         typename T,
         typename T_key,
         typename T_container
     >
     friend class Container;
-    template< typename T >
+    template< typename T, bool Init >
     friend struct traits::GenerationPolicy;
     friend class Iteration;
     friend class Series;

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -212,6 +212,7 @@ template< typename T >
 inline void
 Attributable::initAttribute(std::string const& key, T const& value)
 {
+    std::cout << "initAttribute " << key << std::endl;
     auto it = m_attributes->lower_bound(key);
     if( it != m_attributes->end() && !m_attributes->key_comp()(key, it->first) )
     {

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -89,8 +89,9 @@ BaseRecord< T_elem >::BaseRecord()
         : Container< T_elem >(),
           m_containsScalar{std::make_shared< bool >(false)}
 {
-    this->setAttribute("unitDimension",
-                       std::array< double, 7 >{{0., 0., 0., 0., 0., 0., 0.}});
+//    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
+//        this->setAttribute("unitDimension",
+//                           std::array< double, 7 >{{0., 0., 0., 0., 0., 0., 0.}});
 }
 
 
@@ -192,7 +193,7 @@ BaseRecord< T_elem >::readBase()
     this->IOHandler->enqueue(IOTask(this, aRead));
     this->IOHandler->flush();
     if( *aRead.dtype == DT::ARR_DBL_7 )
-        this->setAttribute("unitDimension", Attribute(*aRead.resource).template get< std::array< double, 7 > >());
+        this->initAttribute("unitDimension", Attribute(*aRead.resource).template get< std::array< double, 7 > >());
     else if( *aRead.dtype == DT::VEC_DOUBLE )
     {
         auto vec = Attribute(*aRead.resource).template get< std::vector< double > >();
@@ -202,7 +203,7 @@ BaseRecord< T_elem >::readBase()
             std::copy(vec.begin(),
                       vec.end(),
                       arr.begin());
-            this->setAttribute("unitDimension", arr);
+            this->initAttribute("unitDimension", arr);
         } else
             throw std::runtime_error("Unexpected Attribute datatype for 'unitDimension'");
     }
@@ -213,9 +214,9 @@ BaseRecord< T_elem >::readBase()
     this->IOHandler->enqueue(IOTask(this, aRead));
     this->IOHandler->flush();
     if( *aRead.dtype == DT::FLOAT )
-        this->setAttribute("timeOffset", Attribute(*aRead.resource).template get< float >());
+        this->initAttribute("timeOffset", Attribute(*aRead.resource).template get< float >());
     else if( *aRead.dtype == DT::DOUBLE )
-        this->setAttribute("timeOffset", Attribute(*aRead.resource).template get< double >());
+        this->initAttribute("timeOffset", Attribute(*aRead.resource).template get< double >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'timeOffset'");
 }

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -65,7 +65,7 @@ public:
     virtual std::array< double, 7 > unitDimension() const;
 
 protected:
-    BaseRecord();
+    BaseRecord(std::shared_ptr< Writable > const& w);
 
     void readBase();
 
@@ -85,13 +85,19 @@ BaseRecord< T_elem >::BaseRecord(BaseRecord const& b)
 { }
 
 template< typename T_elem >
-BaseRecord< T_elem >::BaseRecord()
+BaseRecord< T_elem >::BaseRecord(
+    std::shared_ptr< Writable > const& w
+)
         : Container< T_elem >(),
           m_containsScalar{std::make_shared< bool >(false)}
 {
-//    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
-//        this->setAttribute("unitDimension",
-//                           std::array< double, 7 >{{0., 0., 0., 0., 0., 0., 0.}});
+    if( w )
+        this->linkHierarchy( w );
+    std::cout << "BaseRecord constructor" << std::endl;
+    std::cout << this->IOHandler << std::endl;
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
+        this->setAttribute("unitDimension",
+                           std::array< double, 7 >{{0., 0., 0., 0., 0., 0., 0.}});
 }
 
 

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -192,6 +192,7 @@ template< typename T_elem >
 inline void
 BaseRecord< T_elem >::readBase()
 {
+    std::cout << "BaseRecord::readBase()" << std::endl;
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -200,7 +200,10 @@ BaseRecord< T_elem >::readBase()
     this->IOHandler->enqueue(IOTask(this, aRead));
     this->IOHandler->flush();
     if( *aRead.dtype == DT::ARR_DBL_7 )
-        this->initAttribute("unitDimension", Attribute(*aRead.resource).template get< std::array< double, 7 > >());
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            this->initAttribute("unitDimension", Attribute(*aRead.resource).template get< std::array< double, 7 > >());
+        else
+            this->setAttribute("unitDimension", Attribute(*aRead.resource).template get< std::array< double, 7 > >());
     else if( *aRead.dtype == DT::VEC_DOUBLE )
     {
         auto vec = Attribute(*aRead.resource).template get< std::vector< double > >();
@@ -210,7 +213,10 @@ BaseRecord< T_elem >::readBase()
             std::copy(vec.begin(),
                       vec.end(),
                       arr.begin());
-            this->initAttribute("unitDimension", arr);
+            if( this->IOHandler->accessType == AccessType::READ_ONLY )
+                this->initAttribute("unitDimension", arr);
+            else
+                this->setAttribute("unitDimension", arr);
         } else
             throw std::runtime_error("Unexpected Attribute datatype for 'unitDimension'");
     }
@@ -221,9 +227,15 @@ BaseRecord< T_elem >::readBase()
     this->IOHandler->enqueue(IOTask(this, aRead));
     this->IOHandler->flush();
     if( *aRead.dtype == DT::FLOAT )
-        this->initAttribute("timeOffset", Attribute(*aRead.resource).template get< float >());
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            this->initAttribute("timeOffset", Attribute(*aRead.resource).template get< float >());
+        else
+            this->setAttribute("timeOffset", Attribute(*aRead.resource).template get< float >());
     else if( *aRead.dtype == DT::DOUBLE )
-        this->initAttribute("timeOffset", Attribute(*aRead.resource).template get< double >());
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            this->initAttribute("timeOffset", Attribute(*aRead.resource).template get< double >());
+        else
+            this->setAttribute("timeOffset", Attribute(*aRead.resource).template get< double >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'timeOffset'");
 }

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -56,7 +56,7 @@ public:
     Datatype getDatatype() const;
 
 OPENPMD_protected:
-    BaseRecordComponent();
+    BaseRecordComponent(std::shared_ptr< Writable > const& w);
 
     std::shared_ptr< Dataset > m_dataset;
     std::shared_ptr< bool > m_isConstant;

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -44,7 +44,7 @@ namespace traits
      * ::insert of a new element. The passed parameter is an iterator to the
      * newly added element.
      */
-    template< typename U >
+    template< typename U, bool Init = false >
     struct GenerationPolicy
     {
         template< typename T >
@@ -145,10 +145,10 @@ public:
         }
         else
         {
-            T t = T();
-            t.linkHierarchy(m_writable);
+            T t = T(m_writable);
+            // t.linkHierarchy(m_writable);
             auto& ret = m_container->insert({key, std::move(t)}).first->second;
-            traits::GenerationPolicy< T > gen;
+            traits::GenerationPolicy< T, true > gen;
             gen(ret);
             return ret;
         }
@@ -173,8 +173,8 @@ public:
                 throw std::out_of_range(out_of_range_msg(key));
             }
 
-            T t = T();
-            t.linkHierarchy(m_writable);
+            T t = T(m_writable);
+            // t.linkHierarchy(m_writable);
             auto& ret = m_container->insert({key, std::move(t)}).first->second;
             traits::GenerationPolicy< T > gen;
             gen(ret);
@@ -200,8 +200,8 @@ public:
                 throw std::out_of_range(out_of_range_msg(key));
             }
 
-            T t = T();
-            t.linkHierarchy(m_writable);
+            T t = T(m_writable);
+            // t.linkHierarchy(m_writable);
             auto& ret = m_container->insert({std::move(key), std::move(t)}).first->second;
             traits::GenerationPolicy< T > gen;
             gen(ret);

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -133,6 +133,27 @@ public:
     mapped_type& at(key_type const& key) { return m_container->at(key); }
     mapped_type const& at(key_type const& key) const { return m_container->at(key); }
 
+    // @todo protect me
+    virtual mapped_type& init(key_type const key)
+    {
+        auto it = m_container->find(key);
+        if( it != m_container->end() )
+        {
+            // must not exist already!
+            auxiliary::OutOfRangeMsg const out_of_range_msg;
+            throw std::out_of_range(out_of_range_msg(key));
+        }
+        else
+        {
+            T t = T();
+            t.linkHierarchy(m_writable);
+            auto& ret = m_container->insert({key, std::move(t)}).first->second;
+            traits::GenerationPolicy< T > gen;
+            gen(ret);
+            return ret;
+        }
+    }
+
     /** Access the value that is mapped to a key equivalent to key, creating it if such key does not exist already.
      *
      * @param   key Key of the element to find (lvalue).

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -40,7 +40,7 @@ class MeshRecordComponent : public RecordComponent
     friend class Mesh;
 
 private:
-    MeshRecordComponent();
+    MeshRecordComponent(std::shared_ptr< Writable > const& w);
     void read() override;
 
 public:

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -39,9 +39,9 @@ public:
     PatchRecord& setUnitDimension(std::map< UnitDimension, double > const&);
 
 private:
-    PatchRecord();
+    PatchRecord(std::shared_ptr< Writable > const& w);
 
     void flush_impl(std::string const&) override;
     void read() override;
-};  //PatchRecord
+}; // PatchRecord
 } // openPMD

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -65,7 +65,7 @@ public:
     //! @todo add support for constant patch record components
 
 OPENPMD_private:
-    PatchRecordComponent();
+    PatchRecordComponent(std::shared_ptr< Writable > const& w);
 
     void flush(std::string const&);
     void read();

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -159,6 +159,8 @@ ADIOS1IOHandlerImpl::flush()
                     readDataset(i.writable, *dynamic_cast< Parameter< O::READ_DATASET >* >(i.parameter.get()));
                     break;
                 case O::READ_ATT:
+                    std::cout << "Read Attribute: " << dynamic_cast< Parameter< O::READ_ATT >* >(i.parameter.get())->name
+                              << std::endl;
                     readAttribute(i.writable, *dynamic_cast< Parameter< O::READ_ATT >* >(i.parameter.get()));
                     break;
                 case O::LIST_PATHS:

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -877,6 +877,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
         throw std::runtime_error("Internal error: Writable not marked written during attribute reading");
 
     ADIOS_FILE* f;
+    m_filePaths.at(writable);
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
 
     std::string attrname = concrete_bp1_file_position(writable);

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -415,6 +415,9 @@ HDF5IOHandlerImpl::openPath(Writable* writable,
                             Parameter< Operation::OPEN_PATH > const& parameters)
 {
     auto res = m_fileIDs.find(writable->parent);
+
+    std::cout << "openPath 1: " << concrete_h5_file_position(writable->parent) << std::endl;
+
     hid_t node_id, path_id;
     node_id = H5Gopen(res->second,
                       concrete_h5_file_position(writable->parent).c_str(),
@@ -423,10 +426,13 @@ HDF5IOHandlerImpl::openPath(Writable* writable,
 
     /* Sanitize path */
     std::string path = parameters.path;
+    std::cout << "openPath parameters.path: " << path << std::endl;
     if( auxiliary::starts_with(path, '/') )
         path = auxiliary::replace_first(path, "/", "");
     if( !auxiliary::ends_with(path, '/') )
         path += '/';
+
+    std::cout << "openPath 2: " << path << std::endl;
 
     path_id = H5Gopen(node_id,
                       path.c_str(),

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -451,6 +451,8 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
                                Parameter< Operation::OPEN_DATASET > & parameters)
 {
     auto res = m_fileIDs.find(writable->parent);
+    std::cout << "openDataset: " << parameters.name
+              << " (parent " << concrete_h5_file_position(writable->parent).c_str() << ")" << std::endl;
     hid_t node_id, dataset_id;
     node_id = H5Gopen(res->second,
                       concrete_h5_file_position(writable->parent).c_str(),

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -78,6 +78,21 @@ ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
             std::cerr << "Internal error: Failed to close HDF5 file (parallel)\n";
         m_openFileIDs.erase(file);
     }
+
+    if( m_datasetTransferProperty != H5P_DEFAULT )
+    {
+        status = H5Pclose(m_datasetTransferProperty);
+        m_datasetTransferProperty = H5P_DEFAULT;
+        if( status < 0 )
+            std::cerr <<  "Internal error: Failed to close HDF5 dataset transfer property (parallel)\n";
+    }
+    if( m_fileAccessProperty != H5P_DEFAULT )
+    {
+        status = H5Pclose(m_fileAccessProperty);
+        m_fileAccessProperty = H5P_DEFAULT;
+        if( status < 0 )
+            std::cerr << "Internal error: Failed to close HDF5 file access property (parallel)\n";
+    }
 }
 #else
 #   if openPMD_HAVE_MPI

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -194,30 +194,42 @@ Iteration::read()
     aRead.name = "dt";
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
-    if( *aRead.dtype == DT::FLOAT )
-        initAttribute("dt", Attribute(*aRead.resource).get< float >());
-    else if( *aRead.dtype == DT::DOUBLE )
-        initAttribute("dt", Attribute(*aRead.resource).get< double >());
-    else
-        throw std::runtime_error("Unexpected Attribute datatype for 'dt'");
+    // FIXME if is likely a hack: dt and time change per iteration
+    if( !containsAttribute("dt") )
+    {
+        if( *aRead.dtype == DT::FLOAT )
+            initAttribute("dt", Attribute(*aRead.resource).get< float >());
+        else if( *aRead.dtype == DT::DOUBLE )
+            initAttribute("dt", Attribute(*aRead.resource).get< double >());
+        else
+            throw std::runtime_error("Unexpected Attribute datatype for 'dt'");
+    }
 
     aRead.name = "time";
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
-    if( *aRead.dtype == DT::FLOAT )
-        initAttribute("time", Attribute(*aRead.resource).get< float >());
-    else if( *aRead.dtype == DT::DOUBLE )
-        initAttribute("time", Attribute(*aRead.resource).get< double >());
-    else
-        throw std::runtime_error("Unexpected Attribute datatype for 'time'");
+    // FIXME if is likely a hack: dt and time change per iteration
+    if( !containsAttribute("time") )
+    {
+        if( *aRead.dtype == DT::FLOAT )
+            initAttribute("time", Attribute(*aRead.resource).get< float >());
+        else if( *aRead.dtype == DT::DOUBLE )
+            initAttribute("time", Attribute(*aRead.resource).get< double >());
+        else
+            throw std::runtime_error("Unexpected Attribute datatype for 'time'");
+    }
 
     aRead.name = "timeUnitSI";
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
-    if( *aRead.dtype == DT::DOUBLE )
-        initAttribute("timeUnitSI", Attribute(*aRead.resource).get< double >());
-    else
-        throw std::runtime_error("Unexpected Attribute datatype for 'timeUnitSI'");
+    // FIXME if is likely a hack: dt and time and timeUnitSI change per iteration
+    if( !containsAttribute("timeUnitSI") )
+    {
+        if( *aRead.dtype == DT::DOUBLE )
+            initAttribute("timeUnitSI", Attribute(*aRead.resource).get< double >());
+        else
+            throw std::runtime_error("Unexpected Attribute datatype for 'timeUnitSI'");
+    }
 
     /* Find the root point [Series] of this file,
      * meshesPath and particlesPath are stored there */

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -334,6 +334,7 @@ Iteration::read()
 
         for( auto const& species_name : *pList.paths )
         {
+            std::cout << "reading species: " << species_name << std::endl;
             ParticleSpecies& p = particles.init(species_name);
             pOpen.path = species_name;
             IOHandler->enqueue(IOTask(&p, pOpen));

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -255,8 +255,10 @@ Iteration::read()
     {
         Parameter< Operation::OPEN_PATH > pOpen;
         pOpen.path = s->meshesPath();
+        std::cout << "iteration: open meshes path..." << std::endl;
         IOHandler->enqueue(IOTask(&meshes, pOpen));
 
+        std::cout << "iteration: meshes read attributes..." << std::endl;
         meshes.readAttributes();
 
         /* obtain all non-scalar meshes */
@@ -266,6 +268,7 @@ Iteration::read()
         Parameter< Operation::LIST_ATTS > aList;
         for( auto const& mesh_name : *pList.paths )
         {
+            std::cout << "iteration: mesh.init(" << mesh_name << ")" << std::endl;
             Mesh& m = meshes.init(mesh_name);
             pOpen.path = mesh_name;
             aList.attributes->clear();
@@ -279,6 +282,7 @@ Iteration::read()
             auto shape = std::find(att_begin, att_end, "shape");
             if( value != att_end && shape != att_end )
             {
+                std::cout << "iteration: mesh contains constant scalar" << std::endl;
                 *m.m_containsScalar = true;
                 MeshRecordComponent& mrc = m.init(MeshRecordComponent::SCALAR);
                 mrc.parent = m.parent;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -276,11 +276,12 @@ Iteration::read()
             auto shape = std::find(att_begin, att_end, "shape");
             if( value != att_end && shape != att_end )
             {
+                *m.m_containsScalar = true;
                 MeshRecordComponent& mrc = m.init(MeshRecordComponent::SCALAR);
                 mrc.parent = m.parent;
-                IOHandler->enqueue(IOTask(&mrc, pOpen));
-                IOHandler->flush();
                 *mrc.m_isConstant = true;
+                //IOHandler->enqueue(IOTask(&mrc, pOpen));
+                IOHandler->flush();
             }
             m.read();
         }
@@ -293,19 +294,29 @@ Iteration::read()
         Parameter< Operation::OPEN_DATASET > dOpen;
         for( auto const& mesh_name : *dList.datasets )
         {
+            std::cout << "open scalar mesh: " << mesh_name << std::endl;
             Mesh& m = meshes.init(mesh_name);
+            *m.m_containsScalar = true;
             dOpen.name = mesh_name;
             IOHandler->enqueue(IOTask(&m, dOpen));
             IOHandler->flush();
             MeshRecordComponent& mrc = m.init(MeshRecordComponent::SCALAR);
+            std::cout << "Mesh " << mesh_name << ": parent " << m.parent << std::endl;
+            std::cout << "is scalar? " << *(m.m_containsScalar) << std::endl;
             mrc.parent = m.parent;
+            mrc.m_writable->parent = m.parent;
             IOHandler->enqueue(IOTask(&mrc, dOpen));
+            //IOHandler->enqueue(IOTask(&m, dOpen));
             IOHandler->flush();
+            std::cout << "init flush done!" << std::endl;
             mrc.written = false;
             mrc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
+            std::cout << "reset done!" << std::endl;
             mrc.written = true;
             m.read();
+            std::cout << "read done!" << std::endl;
         }
+        std::cout << "finished scalar meshes!" << std::endl;
     }
 
     if( hasParticles )

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -28,11 +28,14 @@
 
 namespace openPMD
 {
-Iteration::Iteration()
+Iteration::Iteration(std::shared_ptr< Writable > const& w)
         : meshes{Container< Mesh >()},
           particles{Container< ParticleSpecies >()}
 {
-    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
+    if( w )
+        this->linkHierarchy(w);
+
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
     {
         setTime(static_cast< double >(0));
         setDt(static_cast< double >(1));

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -243,7 +243,10 @@ Mesh::read()
     if( *aRead.dtype == DT::STRING )
     {
         std::string tmpGeometry = Attribute(*aRead.resource).get< std::string >();
-        initAttribute("geometry", tmpGeometry);
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("geometry", tmpGeometry);
+        else
+            setAttribute("geometry", tmpGeometry);
         /*
         if( "cartesian" == tmpGeometry )
             initAttribute("geometry", Geometry::cartesian);
@@ -264,13 +267,22 @@ Mesh::read()
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
     if( *aRead.dtype == DT::CHAR )
-        //setDataOrder(static_cast<DataOrder>(Attribute(*aRead.resource).get< char >()));
-        initAttribute(aRead.name, Attribute(*aRead.resource).get< std::string >());
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, Attribute(*aRead.resource).get< std::string >());
+        else
+            setDataOrder(static_cast<DataOrder>(Attribute(*aRead.resource).get< char >()));
+    }
     else if( *aRead.dtype == DT::STRING )
     {
         std::string tmpDataOrder = Attribute(*aRead.resource).get< std::string >();
         if( tmpDataOrder.size() == 1 )
-            initAttribute(aRead.name, tmpDataOrder);
+        {
+            if( this->IOHandler->accessType == AccessType::READ_ONLY )
+                initAttribute(aRead.name, tmpDataOrder);
+            else
+                setAttribute(aRead.name, tmpDataOrder);
+        }
         else
             throw std::runtime_error("Unexpected Attribute value for 'dataOrder': " + tmpDataOrder);
     }
@@ -281,24 +293,52 @@ Mesh::read()
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
     if( *aRead.dtype == DT::VEC_STRING )
-        initAttribute(aRead.name, Attribute(*aRead.resource).get< std::vector< std::string > >());
-    //else if( *aRead.dtype == DT::STRING )
-    //    initAttribute(aRead.name, {Attribute(*aRead.resource).get< std::string >()});
-    //else
-    //    throw std::runtime_error("Unexpected Attribute datatype for 'axisLabels'");
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, Attribute(*aRead.resource).get< std::vector< std::string > >());
+        else
+            setAttribute(aRead.name, Attribute(*aRead.resource).get< std::vector< std::string > >());
+    else if( *aRead.dtype == DT::STRING )
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, std::vector< std::string >{Attribute(*aRead.resource).get< std::string >()});
+        else
+            setAttribute(aRead.name, std::vector< std::string >{Attribute(*aRead.resource).get< std::string >()});
+    }
+    else
+        throw std::runtime_error("Unexpected Attribute datatype for 'axisLabels'");
 
     aRead.name = "gridSpacing";
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
     Attribute a = Attribute(*aRead.resource);
     if( *aRead.dtype == DT::VEC_FLOAT )
-        initAttribute(aRead.name, a.get< std::vector< float > >());
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, a.get< std::vector< float > >());
+        else
+            setAttribute(aRead.name, a.get< std::vector< float > >());
+    }
     else if( *aRead.dtype == DT::FLOAT )
-        initAttribute(aRead.name, std::vector< float >({a.get< float >()}));
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, std::vector< float >({a.get< float >()}));
+        else
+            setAttribute(aRead.name, std::vector< float >({a.get< float >()}));
+    }
     else if( *aRead.dtype == DT::VEC_DOUBLE )
-        initAttribute(aRead.name, a.get< std::vector< double > >());
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, a.get< std::vector< double > >());
+        else
+            setAttribute(aRead.name, a.get< std::vector< double > >());
+    }
     else if( *aRead.dtype == DT::DOUBLE )
-        initAttribute(aRead.name, std::vector< double >({a.get< double >()}));
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, std::vector< double >({a.get< double >()}));
+        else
+            setAttribute(aRead.name, std::vector< double >({a.get< double >()}));
+    }
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'gridSpacing'");
 
@@ -306,17 +346,32 @@ Mesh::read()
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
     if( *aRead.dtype == DT::VEC_DOUBLE )
-        initAttribute(aRead.name, Attribute(*aRead.resource).get< std::vector< double > >());
-    //else if( *aRead.dtype == DT::DOUBLE )
-    //    initAttribute(aRead.name, {Attribute(*aRead.resource).get< double >()});
-    //else
-    //    throw std::runtime_error("Unexpected Attribute datatype for 'gridGlobalOffset'");
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, Attribute(*aRead.resource).get< std::vector< double > >());
+        else
+            setAttribute(aRead.name, Attribute(*aRead.resource).get< std::vector< double > >());
+    }
+    else if( *aRead.dtype == DT::DOUBLE )
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, std::vector< double >{Attribute(*aRead.resource).get< double >()});
+        else
+            setAttribute(aRead.name, std::vector< double >{Attribute(*aRead.resource).get< double >()});
+    }
+    else
+        throw std::runtime_error("Unexpected Attribute datatype for 'gridGlobalOffset'");
 
     aRead.name = "gridUnitSI";
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
     if( *aRead.dtype == DT::DOUBLE )
-        initAttribute(aRead.name, Attribute(*aRead.resource).get< double >());
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute(aRead.name, Attribute(*aRead.resource).get< double >());
+        else
+            setAttribute(aRead.name, Attribute(*aRead.resource).get< double >());
+    }
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'gridUnitSI'");
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -194,6 +194,7 @@ Mesh::setTimeOffset(T to)
 void
 Mesh::flush_impl(std::string const& name)
 {
+    std::cout << "Mesh::flush_impl" << std::endl;
     if( IOHandler->accessType == AccessType::READ_ONLY )
     {
         for( auto& comp : *this )
@@ -364,6 +365,7 @@ Mesh::read()
         Parameter< Operation::OPEN_PATH > pOpen;
         for( auto const& component : *pList.paths )
         {
+            std::cout << "Mesh OPEN_PATH component: " << component << std::endl;
             MeshRecordComponent& rc = this->init(component);
             pOpen.path = component;
             IOHandler->enqueue(IOTask(&rc, pOpen));

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -26,11 +26,13 @@
 
 namespace openPMD
 {
-Mesh::Mesh()
+Mesh::Mesh(std::shared_ptr< Writable > const& w) :
+    BaseRecord(w)
 {
-    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
+    std::cout << "mesh constructor!" << std::endl;
+    std::cout << this->IOHandler << std::endl;
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
     {
-
         setTimeOffset(0.f);
 
         setGeometry(Geometry::cartesian);
@@ -40,6 +42,10 @@ Mesh::Mesh()
         setGridSpacing(std::vector< double >{1});
         setGridGlobalOffset({0});
         setGridUnitSI(1);
+
+        std::cout << "set unit dimen!" << std::endl;
+        setAttribute("unitDimension",
+                     std::array< double, 7 >{{0., 0., 0., 0., 0., 0., 0.}});
     }
 }
 

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -23,7 +23,11 @@
 
 namespace openPMD
 {
-ParticlePatches::ParticlePatches() = default;
+ParticlePatches::ParticlePatches(std::shared_ptr< Writable > const& w)
+{
+    if( w )
+        this->linkHierarchy(w);
+}
 
 size_t
 ParticlePatches::numPatches() const

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -41,6 +41,7 @@ ParticlePatches::numPatches() const
 void
 ParticlePatches::read()
 {
+    std::cout << "ParticlePatches::read()" << std::endl;
     Parameter< Operation::LIST_PATHS > pList;
     IOHandler->enqueue(IOTask(this, pList));
     IOHandler->flush();
@@ -48,7 +49,9 @@ ParticlePatches::read()
     Parameter< Operation::OPEN_PATH > pOpen;
     for( auto const& record_name : *pList.paths )
     {
-        PatchRecord& pr = (*this)[record_name];
+        std::cout << "ParticlePatches::read() record_name: " << record_name << std::endl;
+        //PatchRecord& pr = (*this)[record_name];
+        PatchRecord& pr = this->init(record_name);
         pOpen.path = record_name;
         IOHandler->enqueue(IOTask(&pr, pOpen));
         pr.read();
@@ -61,13 +64,18 @@ ParticlePatches::read()
     Parameter< Operation::OPEN_DATASET > dOpen;
     for( auto const& component_name : *dList.datasets )
     {
+        std::cout << "ParticlePatches::read() component_name: " << component_name << std::endl;
         if( !("numParticles" == component_name || "numParticlesOffset" == component_name) )
             throw std::runtime_error("Unexpected record component" + component_name + "in particlePatch");
 
-        PatchRecord& pr = Container< PatchRecord >::operator[](component_name);
-        PatchRecordComponent& prc = pr[RecordComponent::SCALAR];
+        std::cout << "init PatchRecord" << std::endl;
+        // PatchRecord& pr = Container< PatchRecord >::init(component_name);
+        PatchRecord& pr = this->init(component_name);
+        std::cout << "init PatchRecordComponent" << std::endl;
+        PatchRecordComponent& prc = pr.init(RecordComponent::SCALAR);
         prc.parent = pr.parent;
         dOpen.name = component_name;
+        std::cout << "iohandler" << std::endl;
         IOHandler->enqueue(IOTask(&pr, dOpen));
         IOHandler->enqueue(IOTask(&prc, dOpen));
         IOHandler->flush();

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -66,18 +66,24 @@ ParticlePatches::read()
     {
         std::cout << "ParticlePatches::read() component_name: " << component_name << std::endl;
         if( !("numParticles" == component_name || "numParticlesOffset" == component_name) )
-            throw std::runtime_error("Unexpected record component" + component_name + "in particlePatch");
+            throw std::runtime_error("Unexpected record component " + component_name + " in particlePatch");
 
         std::cout << "init PatchRecord" << std::endl;
+        PatchRecord& pr = Container< PatchRecord >::operator[](component_name);
+        *pr.m_containsScalar = true;
         // PatchRecord& pr = Container< PatchRecord >::init(component_name);
-        PatchRecord& pr = this->init(component_name);
+        std::cout << "init patch record component_name: " << component_name << std::endl;
+        //PatchRecord& pr = this->init(component_name);
+        //PatchRecord& pr = (*this)[component_name];
         std::cout << "init PatchRecordComponent" << std::endl;
-        PatchRecordComponent& prc = pr.init(RecordComponent::SCALAR);
+        //PatchRecordComponent& prc = pr.init(RecordComponent::SCALAR);
+        PatchRecordComponent& prc = pr[RecordComponent::SCALAR];
         prc.parent = pr.parent;
+        //prc.m_writable->parent = pr.parent;
         dOpen.name = component_name;
         std::cout << "iohandler" << std::endl;
         IOHandler->enqueue(IOTask(&pr, dOpen));
-        IOHandler->enqueue(IOTask(&prc, dOpen));
+        //IOHandler->enqueue(IOTask(&prc, dOpen));
         IOHandler->flush();
 
         if( determineDatatype< uint64_t >() != *dOpen.dtype )

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -36,6 +36,7 @@ ParticleSpecies::ParticleSpecies(std::shared_ptr< Writable > const& w) :
 void
 ParticleSpecies::read()
 {
+    std::cout << "ParticleSpecies::read()" << std::endl;
     written = false;
     clear_unchecked();
     written = true;

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -25,7 +25,13 @@
 
 namespace openPMD
 {
-ParticleSpecies::ParticleSpecies() = default;
+ParticleSpecies::ParticleSpecies(std::shared_ptr< Writable > const& w) :
+    Container< Record >(),
+    particlePatches(w)
+{
+    if( w )
+        this->linkHierarchy(w);
+}
 
 void
 ParticleSpecies::read()

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -25,9 +25,11 @@
 
 namespace openPMD
 {
-Record::Record()
+Record::Record(std::shared_ptr< Writable > const& w) :
+    BaseRecord(w)
 {
-    // setTimeOffset(0.f);
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
+        setTimeOffset(0.f);
 }
 
 Record::Record(Record const&) = default;

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -27,7 +27,7 @@ namespace openPMD
 {
 Record::Record()
 {
-    setTimeOffset(0.f);
+    // setTimeOffset(0.f);
 }
 
 Record::Record(Record const&) = default;
@@ -90,10 +90,28 @@ Record::read()
 {
     if( *m_containsScalar )
     {
+        std::cout << "record contains scalar!" << std::endl;
+        //written = false;
+        //clear_unchecked();
+        //written = true;
         /* using operator[] will incorrectly update parent */
-        this->at(RecordComponent::SCALAR).read();
+        //this->at(RecordComponent::SCALAR).read();
+        auto& rc = (*this)[RecordComponent::SCALAR];
+/*
+        auto& rc = this->init(RecordComponent::SCALAR);
+        rc.parent = parent;
+        rc.m_writable->parent = parent;
+        Parameter< Operation::OPEN_DATASET > dOpen;
+        IOHandler->enqueue(IOTask(&rc, dOpen));
+        IOHandler->flush();
+        rc.written = false;
+        rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
+        rc.written = true;
+*/
+        rc.read();
     } else
     {
+        std::cout << "record contains vector!" << std::endl;
         written = false;
         clear_unchecked();
         written = true;
@@ -104,7 +122,7 @@ Record::read()
         Parameter< Operation::OPEN_PATH > pOpen;
         for( auto const& component : *pList.paths )
         {
-            RecordComponent& rc = (*this)[component];
+            RecordComponent& rc = this->init(component);
             pOpen.path = component;
             IOHandler->enqueue(IOTask(&rc, pOpen));
             *rc.m_isConstant = true;
@@ -118,7 +136,7 @@ Record::read()
         Parameter< Operation::OPEN_DATASET > dOpen;
         for( auto const& component : *dList.datasets )
         {
-            RecordComponent& rc = (*this)[component];
+            RecordComponent& rc = this->init(component);
             dOpen.name = component;
             IOHandler->enqueue(IOTask(&rc, dOpen));
             IOHandler->flush();

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -28,6 +28,7 @@ namespace openPMD
 Record::Record(std::shared_ptr< Writable > const& w) :
     BaseRecord(w)
 {
+    std::cout << "Record constructor!" << std::endl;
     if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
         setTimeOffset(0.f);
 }
@@ -51,6 +52,7 @@ Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
 void
 Record::flush_impl(std::string const& name)
 {
+    std::cout << "Record::flush_impl" << std::endl;
     if( IOHandler->accessType == AccessType::READ_ONLY )
     {
         for( auto& comp : *this )
@@ -90,6 +92,7 @@ Record::flush_impl(std::string const& name)
 void
 Record::read()
 {
+    std::cout << "Record::read()" << std::endl;
     if( *m_containsScalar )
     {
         std::cout << "record contains scalar!" << std::endl;
@@ -124,6 +127,7 @@ Record::read()
         Parameter< Operation::OPEN_PATH > pOpen;
         for( auto const& component : *pList.paths )
         {
+            std::cout << "Record OPEN_PATH component: " << component << std::endl;
             RecordComponent& rc = this->init(component);
             pOpen.path = component;
             IOHandler->enqueue(IOTask(&rc, pOpen));

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -258,7 +258,10 @@ RecordComponent::readBase()
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
     if( *aRead.dtype == DT::DOUBLE )
-        initAttribute("unitSI", Attribute(*aRead.resource).get< double >());
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("unitSI", Attribute(*aRead.resource).get< double >());
+        else
+            setAttribute("unitSI", Attribute(*aRead.resource).get< double >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -31,11 +31,12 @@
 
 namespace openPMD
 {
-RecordComponent::RecordComponent()
-        : m_chunks{std::make_shared< std::queue< IOTask > >()},
+RecordComponent::RecordComponent(std::shared_ptr< Writable > const& w)
+        : BaseRecordComponent(w),
+          m_chunks{std::make_shared< std::queue< IOTask > >()},
           m_constantValue{std::make_shared< Attribute >(-1)}
 {
-    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
         setUnitSI(1);
     resetDataset(Dataset(Datatype::CHAR, {1}));
 }

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -36,9 +36,17 @@ RecordComponent::RecordComponent(std::shared_ptr< Writable > const& w)
           m_chunks{std::make_shared< std::queue< IOTask > >()},
           m_constantValue{std::make_shared< Attribute >(-1)}
 {
+    std::cout << "RecordComponent constructor!" << std::endl;
     if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
+    {
         setUnitSI(1);
-    resetDataset(Dataset(Datatype::CHAR, {1}));
+        resetDataset(Dataset(Datatype::CHAR, {1}));
+    }
+    else
+    {
+        written = true;
+        dirty = false;
+    }
 }
 
 RecordComponent&
@@ -51,6 +59,7 @@ RecordComponent::setUnitSI(double usi)
 RecordComponent&
 RecordComponent::resetDataset(Dataset d)
 {
+    std::cout << "RecordComponent::resetDataset!" << std::endl;
     if( written )
         throw std::runtime_error("A Records Dataset can not (yet) be changed after it has been written.");
     if( d.extent.empty() )
@@ -79,6 +88,7 @@ RecordComponent::getExtent() const
 void
 RecordComponent::flush(std::string const& name)
 {
+    std::cout << "RecordComponent::flush" << std::endl;
     if( IOHandler->accessType == AccessType::READ_ONLY )
     {
         while( !m_chunks->empty() )
@@ -152,11 +162,13 @@ RecordComponent::read()
 void
 RecordComponent::readBase()
 {
+    std::cout << "RecordComponent::readBase()" << std::endl;
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 
     if( *m_isConstant )
     {
+        std::cout << "RecordComponent::readBase() isConstant" << std::endl;
         aRead.name = "value";
         IOHandler->enqueue(IOTask(this, aRead));
         IOHandler->flush();

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -35,7 +35,8 @@ RecordComponent::RecordComponent()
         : m_chunks{std::make_shared< std::queue< IOTask > >()},
           m_constantValue{std::make_shared< Attribute >(-1)}
 {
-    setUnitSI(1);
+    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
+        setUnitSI(1);
     resetDataset(Dataset(Datatype::CHAR, {1}));
 }
 
@@ -244,7 +245,7 @@ RecordComponent::readBase()
     IOHandler->enqueue(IOTask(this, aRead));
     IOHandler->flush();
     if( *aRead.dtype == DT::DOUBLE )
-        setUnitSI(Attribute(*aRead.resource).get< double >());
+        initAttribute("unitSI", Attribute(*aRead.resource).get< double >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -482,7 +482,7 @@ Series::init(std::shared_ptr< AbstractIOHandler > ioHandler,
     m_filenamePostfix = std::make_shared< std::string >(input->filenamePostfix);
     m_filenamePadding = std::make_shared< int >(input->filenamePadding);
 
-    if( IOHandler->accessType == AccessType::READ_ONLY || IOHandler->accessType == AccessType::READ_WRITE )
+    if( this->IOHandler->accessType == AccessType::READ_ONLY || this->IOHandler->accessType == AccessType::READ_WRITE )
     {
         /* Allow creation of values in Containers and setting of Attributes
          * Would throw for AccessType::READ_ONLY */

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -181,94 +181,94 @@ Attributable::readAttributes()
         switch( *aRead.dtype )
         {
             case DT::CHAR:
-                setAttribute(att, a.get< char >());
+                initAttribute(att, a.get< char >());
                 break;
             case DT::UCHAR:
-                setAttribute(att, a.get< unsigned char >());
+                initAttribute(att, a.get< unsigned char >());
                 break;
             case DT::SHORT:
-                setAttribute(att, a.get< short >());
+                initAttribute(att, a.get< short >());
                 break;
             case DT::INT:
-                setAttribute(att, a.get< int >());
+                initAttribute(att, a.get< int >());
                 break;
             case DT::LONG:
-                setAttribute(att, a.get< long >());
+                initAttribute(att, a.get< long >());
                 break;
             case DT::LONGLONG:
-                setAttribute(att, a.get< long long >());
+                initAttribute(att, a.get< long long >());
                 break;
             case DT::USHORT:
-                setAttribute(att, a.get< unsigned short >());
+                initAttribute(att, a.get< unsigned short >());
                 break;
             case DT::UINT:
-                setAttribute(att, a.get< unsigned int >());
+                initAttribute(att, a.get< unsigned int >());
                 break;
             case DT::ULONG:
-                setAttribute(att, a.get< unsigned long >());
+                initAttribute(att, a.get< unsigned long >());
                 break;
             case DT::ULONGLONG:
-                setAttribute(att, a.get< unsigned long long >());
+                initAttribute(att, a.get< unsigned long long >());
                 break;
             case DT::FLOAT:
-                setAttribute(att, a.get< float >());
+                initAttribute(att, a.get< float >());
                 break;
             case DT::DOUBLE:
-                setAttribute(att, a.get< double >());
+                initAttribute(att, a.get< double >());
                 break;
             case DT::LONG_DOUBLE:
-                setAttribute(att, a.get< long double >());
+                initAttribute(att, a.get< long double >());
                 break;
             case DT::STRING:
-                setAttribute(att, a.get< std::string >());
+                initAttribute(att, a.get< std::string >());
                 break;
             case DT::VEC_CHAR:
-                setAttribute(att, a.get< std::vector< char > >());
+                initAttribute(att, a.get< std::vector< char > >());
                 break;
             case DT::VEC_SHORT:
-                setAttribute(att, a.get< std::vector< short > >());
+                initAttribute(att, a.get< std::vector< short > >());
                 break;
             case DT::VEC_INT:
-                setAttribute(att, a.get< std::vector< int > >());
+                initAttribute(att, a.get< std::vector< int > >());
                 break;
             case DT::VEC_LONG:
-                setAttribute(att, a.get< std::vector< long > >());
+                initAttribute(att, a.get< std::vector< long > >());
                 break;
             case DT::VEC_LONGLONG:
-                setAttribute(att, a.get< std::vector< long long > >());
+                initAttribute(att, a.get< std::vector< long long > >());
                 break;
             case DT::VEC_UCHAR:
-                setAttribute(att, a.get< std::vector< unsigned char > >());
+                initAttribute(att, a.get< std::vector< unsigned char > >());
                 break;
             case DT::VEC_USHORT:
-                setAttribute(att, a.get< std::vector< unsigned short > >());
+                initAttribute(att, a.get< std::vector< unsigned short > >());
                 break;
             case DT::VEC_UINT:
-                setAttribute(att, a.get< std::vector< unsigned int > >());
+                initAttribute(att, a.get< std::vector< unsigned int > >());
                 break;
             case DT::VEC_ULONG:
-                setAttribute(att, a.get< std::vector< unsigned long > >());
+                initAttribute(att, a.get< std::vector< unsigned long > >());
                 break;
             case DT::VEC_ULONGLONG:
-                setAttribute(att, a.get< std::vector< unsigned long long > >());
+                initAttribute(att, a.get< std::vector< unsigned long long > >());
                 break;
             case DT::VEC_FLOAT:
-                setAttribute(att, a.get< std::vector< float > >());
+                initAttribute(att, a.get< std::vector< float > >());
                 break;
             case DT::VEC_DOUBLE:
-                setAttribute(att, a.get< std::vector< double > >());
+                initAttribute(att, a.get< std::vector< double > >());
                 break;
             case DT::VEC_LONG_DOUBLE:
-                setAttribute(att, a.get< std::vector< long double > >());
+                initAttribute(att, a.get< std::vector< long double > >());
                 break;
             case DT::VEC_STRING:
-                setAttribute(att, a.get< std::vector< std::string > >());
+                initAttribute(att, a.get< std::vector< std::string > >());
                 break;
             case DT::ARR_DBL_7:
-                setAttribute(att, a.get< std::array< double, 7 > >());
+                initAttribute(att, a.get< std::array< double, 7 > >());
                 break;
             case DT::BOOL:
-                setAttribute(att, a.get< bool >());
+                initAttribute(att, a.get< bool >());
                 break;
             case DT::DATATYPE:
             case DT::UNDEFINED:

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -39,10 +39,13 @@ BaseRecordComponent::resetDatatype(Datatype d)
     return *this;
 }
 
-BaseRecordComponent::BaseRecordComponent()
+BaseRecordComponent::BaseRecordComponent(std::shared_ptr< Writable > const& w)
         : m_dataset{std::make_shared< Dataset >(Dataset(Datatype::UNDEFINED, {}))},
           m_isConstant{std::make_shared< bool >(false)}
-{ }
+{
+    if( w )
+        this->linkHierarchy(w);
+}
 
 Datatype
 BaseRecordComponent::getDatatype() const

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -26,6 +26,7 @@ namespace openPMD
 MeshRecordComponent::MeshRecordComponent(std::shared_ptr< Writable > const& w)
         : RecordComponent(w)
 {
+    std::cout << "MeshRecordComponent constructor" << std::endl;
     if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
         setPosition(std::vector< double >{0});
 }
@@ -33,6 +34,7 @@ MeshRecordComponent::MeshRecordComponent(std::shared_ptr< Writable > const& w)
 void
 MeshRecordComponent::read()
 {
+    std::cout << "MeshRecordComponent::read()" << std::endl;
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -23,10 +23,10 @@
 
 namespace openPMD
 {
-MeshRecordComponent::MeshRecordComponent()
-        : RecordComponent()
+MeshRecordComponent::MeshRecordComponent(std::shared_ptr< Writable > const& w)
+        : RecordComponent(w)
 {
-    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
         setPosition(std::vector< double >{0});
 }
 

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -26,7 +26,8 @@ namespace openPMD
 MeshRecordComponent::MeshRecordComponent()
         : RecordComponent()
 {
-    setPosition(std::vector< double >{0});
+    if( IOHandler && IOHandler->accessType != AccessType::READ_ONLY )
+        setPosition(std::vector< double >{0});
 }
 
 void
@@ -40,17 +41,17 @@ MeshRecordComponent::read()
     IOHandler->flush();
     Attribute a = Attribute(*aRead.resource);
     if( *aRead.dtype == DT::VEC_FLOAT )
-        setPosition(a.get< std::vector< float > >());
+        initAttribute("position", a.get< std::vector< float > >());
     else if( *aRead.dtype == DT::FLOAT )
-        setPosition(std::vector< float >({a.get< float >()}));
+        initAttribute("position", std::vector< float >({a.get< float >()}));
     else if( *aRead.dtype == DT::VEC_DOUBLE )
-        setPosition(a.get< std::vector< double > >());
+        initAttribute("position", a.get< std::vector< double > >());
     else if( *aRead.dtype == DT::DOUBLE )
-        setPosition(std::vector< double >({a.get< double >()}));
+        initAttribute("position", std::vector< double >({a.get< double >()}));
     else if( *aRead.dtype == DT::VEC_LONG_DOUBLE )
-        setPosition(a.get< std::vector< long double > >());
+        initAttribute("position", a.get< std::vector< long double > >());
     else if( *aRead.dtype == DT::LONG_DOUBLE )
-        setPosition(std::vector< long double >({a.get< long double >()}));
+        initAttribute("position", std::vector< long double >({a.get< long double >()}));
     else
         throw std::runtime_error( "Unexpected Attribute datatype for 'position'");
 

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -43,17 +43,47 @@ MeshRecordComponent::read()
     IOHandler->flush();
     Attribute a = Attribute(*aRead.resource);
     if( *aRead.dtype == DT::VEC_FLOAT )
-        initAttribute("position", a.get< std::vector< float > >());
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("position", a.get< std::vector< float > >());
+        else
+            setAttribute("position", a.get< std::vector< float > >());
+    }
     else if( *aRead.dtype == DT::FLOAT )
-        initAttribute("position", std::vector< float >({a.get< float >()}));
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("position", std::vector< float >({a.get< float >()}));
+        else
+            setAttribute("position", std::vector< float >({a.get< float >()}));
+    }
     else if( *aRead.dtype == DT::VEC_DOUBLE )
-        initAttribute("position", a.get< std::vector< double > >());
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("position", a.get< std::vector< double > >());
+        else
+            setAttribute("position", a.get< std::vector< double > >());
+    }
     else if( *aRead.dtype == DT::DOUBLE )
-        initAttribute("position", std::vector< double >({a.get< double >()}));
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("position", std::vector< double >({a.get< double >()}));
+        else
+            setAttribute("position", std::vector< double >({a.get< double >()}));
+    }
     else if( *aRead.dtype == DT::VEC_LONG_DOUBLE )
-        initAttribute("position", a.get< std::vector< long double > >());
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("position", a.get< std::vector< long double > >());
+        else
+            setAttribute("position", a.get< std::vector< long double > >());
+    }
     else if( *aRead.dtype == DT::LONG_DOUBLE )
-        initAttribute("position", std::vector< long double >({a.get< long double >()}));
+    {
+        if( this->IOHandler->accessType == AccessType::READ_ONLY )
+            initAttribute("position", std::vector< long double >({a.get< long double >()}));
+        else
+            setAttribute("position", std::vector< long double >({a.get< long double >()}));
+    }
     else
         throw std::runtime_error( "Unexpected Attribute datatype for 'position'");
 

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -88,7 +88,8 @@ PatchRecord::read()
     Parameter< Operation::OPEN_DATASET > dOpen;
     for( auto const& component_name : *dList.datasets )
     {
-        PatchRecordComponent& prc = (*this)[component_name];
+        //PatchRecordComponent& prc = (*this)[component_name];
+        PatchRecordComponent& prc = this->init(component_name);
         dOpen.name = component_name;
         IOHandler->enqueue(IOTask(&prc, dOpen));
         IOHandler->flush();

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -61,7 +61,7 @@ PatchRecord::read()
     IOHandler->flush();
 
     if( *aRead.dtype == Datatype::ARR_DBL_7 )
-        this->setAttribute("unitDimension", Attribute(*aRead.resource).template get< std::array< double, 7 > >());
+        this->initAttribute("unitDimension", Attribute(*aRead.resource).template get< std::array< double, 7 > >());
     else if( *aRead.dtype == Datatype::VEC_DOUBLE )
     {
         auto vec = Attribute(*aRead.resource).template get< std::vector< double > >();
@@ -71,7 +71,7 @@ PatchRecord::read()
             std::copy(vec.begin(),
                       vec.end(),
                       arr.begin());
-            this->setAttribute("unitDimension", arr);
+            this->initAttribute("unitDimension", arr);
         } else
             throw std::runtime_error("Unexpected Attribute datatype for 'unitDimension'");
     }

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -37,7 +37,10 @@ PatchRecord::setUnitDimension(std::map< UnitDimension, double > const& udim)
     return *this;
 }
 
-PatchRecord::PatchRecord() = default;
+PatchRecord::PatchRecord(std::shared_ptr< Writable > const& w) :
+    BaseRecord< PatchRecordComponent >(w)
+{
+}
 
 void
 PatchRecord::flush_impl(std::string const& path)

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -29,7 +29,8 @@ namespace openPMD
 PatchRecordComponent&
 PatchRecordComponent::setUnitSI(double usi)
 {
-    setAttribute("unitSI", usi);
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
+        setAttribute("unitSI", usi);
     return *this;
 }
 
@@ -61,8 +62,9 @@ PatchRecordComponent::getExtent() const
     return m_dataset->extent;
 }
 
-PatchRecordComponent::PatchRecordComponent()
-    : m_chunks{std::make_shared< std::queue< IOTask > >()}
+PatchRecordComponent::PatchRecordComponent(std::shared_ptr< Writable > const& w)
+    : BaseRecordComponent{w},
+      m_chunks{std::make_shared< std::queue< IOTask > >()}
 {
     setUnitSI(1);
 }

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -66,6 +66,9 @@ PatchRecordComponent::PatchRecordComponent(std::shared_ptr< Writable > const& w)
     : BaseRecordComponent{w},
       m_chunks{std::make_shared< std::queue< IOTask > >()}
 {
+    //if( w )
+    //    this->linkHierarchy(w);
+
     if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
         setUnitSI(1);
     //else

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -38,7 +38,7 @@ PatchRecordComponent&
 PatchRecordComponent::resetDataset(Dataset d)
 {
     if( written )
-        throw std::runtime_error("A Records Dataset can not (yet) be changed after it has been written.");
+        throw std::runtime_error("A PatchRecords Dataset can not (yet) be changed after it has been written.");
     if( d.extent.empty() )
       throw std::runtime_error("Dataset extent must be at least 1D.");
     if( std::any_of(d.extent.begin(), d.extent.end(),
@@ -66,7 +66,13 @@ PatchRecordComponent::PatchRecordComponent(std::shared_ptr< Writable > const& w)
     : BaseRecordComponent{w},
       m_chunks{std::make_shared< std::queue< IOTask > >()}
 {
-    setUnitSI(1);
+    if( this->IOHandler && this->IOHandler->accessType != AccessType::READ_ONLY )
+        setUnitSI(1);
+    //else
+    //{
+    //    written = true;
+    //    dirty = false;
+    //}
 }
 
 void

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -30,8 +30,10 @@ namespace test
 {
 struct TestHelper : public Attributable
 {
-    TestHelper()
+    TestHelper(std::shared_ptr< Writable > const& /*w*/)
     {
+        //if( w )
+        //    this->linkHierarchy( w );
         m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
         IOHandler = m_writable->IOHandler.get();
     }
@@ -96,8 +98,8 @@ namespace test
 {
 struct S : public TestHelper
 {
-    S()
-        : TestHelper()
+    S(std::shared_ptr< Writable > const& w)
+        : TestHelper(w)
     { }
 };
 } // test
@@ -123,8 +125,8 @@ namespace test
 {
 struct structure : public TestHelper
 {
-    structure()
-        : TestHelper()
+    structure(std::shared_ptr< Writable > const& w)
+        : TestHelper(w)
     { }
 
     std::string string_ = "Hello, world!";
@@ -145,7 +147,7 @@ TEST_CASE( "container_retrieve_test", "[auxiliary]" )
     c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
     c.IOHandler = c.m_writable->IOHandler.get();
 
-    structure s;
+    structure s(c.m_writable);
     std::string text = "The openPMD standard, short for open standard for particle-mesh data files is not a file format per se. It is a standard for meta data and naming schemes.";
     s.setText(text);
     c["entry"] = s;
@@ -203,12 +205,12 @@ namespace test
 {
 struct Widget : public TestHelper
 {
-    Widget()
-        : TestHelper()
+    Widget(std::shared_ptr< Writable > const& w)
+        : TestHelper(w)
     { }
 
-    Widget(int)
-        : TestHelper()
+    Widget(std::shared_ptr< Writable > const& w, int)
+        : TestHelper(w)
     { }
 };
 } // test
@@ -222,13 +224,13 @@ TEST_CASE( "container_access_test", "[auxiliary]" )
     c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
     c.IOHandler = c.m_writable->IOHandler.get();
 
-    c["firstWidget"] = Widget(0);
+    c["firstWidget"] = Widget(c.m_writable, 0);
     REQUIRE(c.size() == 1);
 
-    c["firstWidget"] = Widget(1);
+    c["firstWidget"] = Widget(c.m_writable, 1);
     REQUIRE(c.size() == 1);
 
-    c["secondWidget"] = Widget(2);
+    c["secondWidget"] = Widget(c.m_writable, 2);
     REQUIRE(c.size() == 2);
     REQUIRE(c.erase("firstWidget") == true);
     REQUIRE(c.size() == 1);
@@ -254,8 +256,8 @@ namespace test
 {
 struct AttributedWidget : public TestHelper
 {
-    AttributedWidget()
-        : TestHelper()
+    AttributedWidget(std::shared_ptr< Writable > const& w)
+        : TestHelper(w)
     { }
 
     Attribute::resource get(std::string key)
@@ -269,7 +271,7 @@ struct AttributedWidget : public TestHelper
 TEST_CASE( "attributable_access_test", "[auxiliary]" )
 {
     using AttributedWidget = openPMD::test::AttributedWidget;
-    AttributedWidget a = AttributedWidget();
+    AttributedWidget a = AttributedWidget(nullptr);
 
     a.setAttribute("key", std::string("value"));
     REQUIRE(a.numAttributes() == 1);
@@ -302,8 +304,8 @@ namespace test
 {
 struct Dotty : public TestHelper
 {
-    Dotty()
-        : TestHelper()
+    Dotty(std::shared_ptr< Writable > const& w)
+        : TestHelper(w)
     {
         setAtt1(1);
         setAtt2(2);
@@ -322,7 +324,7 @@ struct Dotty : public TestHelper
 
 TEST_CASE( "dot_test", "[auxiliary]" )
 {
-    openPMD::test::Dotty d;
+    openPMD::test::Dotty d(nullptr);
     REQUIRE(d.att1() == 1);
     REQUIRE(d.att2() == static_cast<double>(2));
     REQUIRE(d.att3() == "3");


### PR DESCRIPTION
Fix #394

Opening a HDF5 `Series` as read-only fails if the files are not *writable*.

For some reason, on `open()` in HDF5 we thing that our `m_handler->accessType` is `READ_WRITE` when opened with `READ_ONLY`... [This hack](https://github.com/openPMD/openPMD-api/blob/0.6.3-alpha/src/Series.cpp#L487-L491) might be the origin. Hush, that will need a lot of refactoring.