### PR TITLE
Replace MPI::Init and MPI::Finalize with MPI_Init and MPI_Finalize

### DIFF
--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -22,7 +22,7 @@ using namespace openPMD;
 
 int main(int argc, char *argv[])
 {
-    MPI::Init();
+    MPI_Init(&argc, &argv);
 
     Catch::Session session;
     int result = 0;
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
         if( result == 0 )
             result = session.run();
     }
-    MPI::Finalize();
+    MPI_Finalize();
     return result;
 }
 #else


### PR DESCRIPTION
Replaces the deprecated functions `MPI::Init()` and `MPI::Finalize()` in the parallel tests with their non-deprecated alternatives `MPI_Init()` and `MPI_Finalize()`.