### PR TITLE
Parallel Benchmark: Cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Changelog
 
 [Summary]
 
-Changes to "0.6.2-alpha"
+Changes to "0.6.3-alpha"
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Features
@@ -27,11 +27,12 @@ Features
   - works with Python 3.7 #376
   - setup.py for sdist #240
 - Backends: JSON support added #384 #393 #338
+- Parallel benchmark added #346 #398
 
 Bug Fixes
 """""""""
 
-- support reading series with varying or no iteration padding in filename #388
+- spurious MPI C++11 API usage in ParallelIOTest removed #396
 
 Other
 """""
@@ -39,6 +40,23 @@ Other
 - Docs: upgrade guide added #385
 - CI: GCC 8.1.0 & Python 3.7.0 #376
 - CMake: treat third party libraries properly as ``IMPORTED`` #389
+
+
+0.6.3-alpha
+-----------
+**Date:** 2018-11-12
+
+Reading Varying Iteration Padding Reading
+
+Support reading series with varying iteration padding (or no padding at all) as currently used in PIConGPU.
+
+Changes to "0.6.2-alpha"
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bug Fixes
+"""""""""
+
+- support reading series with varying or no iteration padding in filename #388
 
 
 0.6.2-alpha

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,7 +580,7 @@ set(openPMD_EXAMPLE_NAMES
     5_write_parallel
     6_dump_filebased_series
     7_extended_write_serial
-    8_mpi_benchmark
+    8_benchmark_parallel
 )
 set(openPMD_PYTHON_EXAMPLE_NAMES
     2_read_serial

--- a/docs/source/utilities/8_benchmark_parallel.cpp
+++ b/docs/source/utilities/8_benchmark_parallel.cpp
@@ -1,0 +1,1 @@
+../../../examples/8_benchmark_parallel.cpp

--- a/docs/source/utilities/8_mpi_benchmark.cpp
+++ b/docs/source/utilities/8_mpi_benchmark.cpp
@@ -1,1 +1,0 @@
-../../../examples/8_mpi_benchmark.cpp

--- a/docs/source/utilities/benchmark.rst
+++ b/docs/source/utilities/benchmark.rst
@@ -50,4 +50,4 @@ root rank will be populated with data, i.e. all ranks' data will be collected in
 
 Example usage
 
-.. literalinclude:: 8_mpi_benchmark.cpp
+.. literalinclude:: 8_benchmark_parallel.cpp

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -1,11 +1,10 @@
 #include <openPMD/openPMD.hpp>
-#include <openPMD/Series.hpp>
 #include <openPMD/benchmark/mpi/MPIBenchmark.hpp>
 #include <openPMD/benchmark/mpi/RandomDatasetFiller.hpp>
 #include <openPMD/benchmark/mpi/OneDimensionalBlockSlicer.hpp>
 
 #if openPMD_HAVE_MPI
-#include <mpi.h>
+#   include <mpi.h>
 #endif
 
 #include <iostream>
@@ -100,8 +99,7 @@ int main(
     // Take notice that results will be collected into the root rank's report object, the other
     // ranks' reports will be empty. The root rank is specified by the first parameter of runBenchmark,
     // the default being 0.
-    auto
-        res =
+    auto res =
         benchmark.runBenchmark<std::chrono::high_resolution_clock>();
 
     int rank;
@@ -109,16 +107,11 @@ int main(
         MPI_COMM_WORLD,
         &rank
     );
-    if (rank == 0)
+    if( rank == 0 )
     {
-        for (auto
-                 it =
-                 res.durations
-                     .begin();
-             it !=
-             res.durations
-                 .end();
-             it++)
+        for( auto it = res.durations.begin();
+             it != res.durations.end();
+             it++ )
         {
             auto time = it->second;
             std::cout << "on rank " << std::get<res.RANK>(it->first)

--- a/include/openPMD/benchmark/mpi/BlockSlicer.hpp
+++ b/include/openPMD/benchmark/mpi/BlockSlicer.hpp
@@ -21,10 +21,6 @@
 
 #pragma once
 
-#if openPMD_HAVE_MPI
-
-
-#include <mpi.h>
 #include "openPMD/Dataset.hpp"
 
 
@@ -41,7 +37,7 @@ namespace openPMD
          * Associate the current thread with its cuboid.
          * @param totalExtent The total extent of the cuboid.
          * @param size The number of threads to be used (not greater than MPI size).
-         * @param comm MPI communicator.
+         * @param rank The MPI rank.
          * @return A pair of the cuboid's offset and extent.
          */
         virtual std::pair<
@@ -50,8 +46,7 @@ namespace openPMD
         > sliceBlock(
             Extent & totalExtent,
             int size,
-            MPI_Comm comm
+            int rank
         ) = 0;
     };
 }
-#endif

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -292,6 +292,11 @@ namespace openPMD
             this->communicator,
             &actualSize
         );
+        int rank;
+        MPI_Comm_rank(
+            this->communicator,
+            &rank
+        );
         size = std::min(
             size,
             actualSize
@@ -299,7 +304,7 @@ namespace openPMD
         return m_blockSlicer->sliceBlock(
             totalExtent,
             size,
-            communicator
+            rank
         );
     }
 

--- a/include/openPMD/benchmark/mpi/OneDimensionalBlockSlicer.hpp
+++ b/include/openPMD/benchmark/mpi/OneDimensionalBlockSlicer.hpp
@@ -21,12 +21,8 @@
 
 #pragma once
 
-#if openPMD_HAVE_MPI
-
-
 #include "openPMD/Dataset.hpp"
 #include "openPMD/benchmark/mpi/BlockSlicer.hpp"
-#include <mpi.h>
 
 
 namespace openPMD
@@ -45,8 +41,7 @@ namespace openPMD
         > sliceBlock(
             Extent & totalExtent,
             int size,
-            MPI_Comm comm
+            int rank
         ) override;
     };
 }
-#endif

--- a/src/benchmark/mpi/OneDimensionalBlockSlicer.cpp
+++ b/src/benchmark/mpi/OneDimensionalBlockSlicer.cpp
@@ -26,9 +26,6 @@
 
 namespace openPMD
 {
-#if openPMD_HAVE_MPI
-
-
     OneDimensionalBlockSlicer::OneDimensionalBlockSlicer( Extent::value_type dim ) :
         m_dim { dim }
     {}
@@ -40,15 +37,9 @@ namespace openPMD
     > OneDimensionalBlockSlicer::sliceBlock(
         Extent & totalExtent,
         int size,
-        MPI_Comm comm
+        int rank
     )
     {
-        int rank;
-        MPI_Comm_rank(
-            comm,
-            &rank
-        );
-
         Offset offs(
             totalExtent.size( ),
             0
@@ -102,7 +93,4 @@ namespace openPMD
             std::move( localExtent )
         );
     }
-
-
-#endif
 }


### PR DESCRIPTION
Clean leftovers from new MPI benchmark in #346.

- properly add auxiliary benchmark sources
- properly name for build with MPI only
- fix BlockSlicer API: no MPI needed
- includes
- add changelog