### PR TITLE
Catch: Put Implementation Separate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,28 @@ if(openPMD_USE_INVASIVE_TESTS)
 endif()
 
 if(BUILD_TESTING)
+    # compile Catch2 implementation part separately
+    add_library(CatchRunner test/CatchRunner.cpp)  # Always MPI_Init with Serial Fallback
+    add_library(CatchMain   test/CatchMain.cpp)    # Serial only
+    target_compile_features(CatchRunner PUBLIC cxx_std_11)
+    target_compile_features(CatchMain   PUBLIC cxx_std_11)
+    set_target_properties(CatchRunner CatchMain PROPERTIES
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
+        POSITION_INDEPENDENT_CODE ON
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+    )
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        target_compile_options(CatchRunner PUBLIC "/bigobj")
+        target_compile_options(CatchMain   PUBLIC "/bigobj")
+    endif()
+    target_link_libraries(CatchRunner PRIVATE openPMD::thirdparty::Catch2)
+    target_link_libraries(CatchMain   PRIVATE openPMD::thirdparty::Catch2)
+    if(openPMD_HAVE_MPI)
+        target_link_libraries(CatchRunner PUBLIC MPI::MPI_C MPI::MPI_CXX)
+        target_compile_definitions(CatchRunner PUBLIC "-DopenPMD_HAVE_MPI=1")
+    endif()
+
     foreach(testname ${openPMD_TEST_NAMES})
         add_executable(${testname}Tests test/${testname}Test.cpp)
 
@@ -624,6 +646,11 @@ if(BUILD_TESTING)
         endif()
         target_link_libraries(${testname}Tests PRIVATE openPMD)
         target_link_libraries(${testname}Tests PRIVATE openPMD::thirdparty::Catch2)
+        if(${testname} MATCHES "Parallel.+$")
+            target_link_libraries(${testname}Tests PRIVATE CatchRunner)
+        else()
+            target_link_libraries(${testname}Tests PRIVATE CatchMain)
+        endif()
     endforeach()
 endif()
 

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_MAIN
-
 // expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
 #   define OPENPMD_private public
@@ -21,6 +19,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <iostream>
 
 using namespace openPMD;
 

--- a/test/CatchMain.cpp
+++ b/test/CatchMain.cpp
@@ -1,0 +1,4 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+

--- a/test/CatchRunner.cpp
+++ b/test/CatchRunner.cpp
@@ -1,0 +1,37 @@
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch.hpp>
+
+#if openPMD_HAVE_MPI
+#   include <mpi.h>
+
+int main(int argc, char *argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    Catch::Session session;
+    int result = 0;
+    {
+        // Indicates a command line parsing
+        result = session.applyCommandLine( argc, argv );
+        // RT tests
+        if( result == 0 )
+            result = session.run();
+    }
+    MPI_Finalize();
+    return result;
+}
+#else
+int main(int argc, char *argv[])
+{
+    Catch::Session session;
+    int result = 0;
+    {
+        // Indicates a command line parsing
+        result = session.applyCommandLine( argc, argv );
+        // RT tests
+        if( result == 0 )
+            result = session.run();
+    }
+    return result;
+}
+#endif

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_MAIN
-
 // expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
 #   define OPENPMD_private public
@@ -15,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <sstream>
+#include <iostream>
 
 using namespace openPMD;
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1,8 +1,6 @@
 /* Running this test in parallel with MPI requires MPI::Init.
  * To guarantee a correct call to Init, launch the tests manually.
  */
-#define CATCH_CONFIG_RUNNER
-
 #include "openPMD/openPMD.hpp"
 
 #include <catch2/catch.hpp>
@@ -19,37 +17,7 @@
 
 using namespace openPMD;
 
-
-int main(int argc, char *argv[])
-{
-    MPI_Init(&argc, &argv);
-
-    Catch::Session session;
-    int result = 0;
-    {
-        // Indicates a command line parsing
-        result = session.applyCommandLine( argc, argv );
-        // RT tests
-        if( result == 0 )
-            result = session.run();
-    }
-    MPI_Finalize();
-    return result;
-}
 #else
-int main(int argc, char *argv[])
-{
-    Catch::Session session;
-    int result = 0;
-    {
-        // Indicates a command line parsing
-        result = session.applyCommandLine( argc, argv );
-        // RT tests
-        if( result == 0 )
-            result = session.run();
-    }
-    return result;
-}
 
 TEST_CASE( "none", "[parallel]" )
 { }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_MAIN
-
 // expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
 #   define OPENPMD_private public


### PR DESCRIPTION
Put main functions that pull most implementations into [separate `.cpp` file](https://github.com/catchorg/Catch2/blob/v2.5.0/docs/slow-compiles.md#practical-example).

Can also be used as preparation for PCHs.

From tests on my laptop with
```bash
. ../.travis/download_samples.sh
time cmake .. -DopenPMD_USE_PYTHON=OFF -DBUILD_EXAMPLES=OFF
time make -j 2
```

Before:
```
real	3m3,792s
user	5m24,528s
sys	0m8,980s
```

After:
```
real	2m32,870s
user	4m42,620s
sys	0m8,020s
```

Online with Travis-CI:
[Before](https://travis-ci.org/openPMD/openPMD-api/builds/462217557)
[After](https://travis-ci.org/openPMD/openPMD-api/builds/466568833) (went down by 2-3 min)
[Merge Commit ](https://travis-ci.org/openPMD/openPMD-api/builds/466637357)

AppVeyor:
[Before](https://ci.appveyor.com/project/ax3l/openpmd-api/builds/20700231)
[After](https://ci.appveyor.com/project/ax3l/openpmd-api/builds/20930620) (went up?!)
[Merge Commit](https://ci.appveyor.com/project/ax3l/openpmd-api/builds/20934960)