### PR TITLE
CMake: More Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,14 +684,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     if(NOT openPMD_HAVE_PYTHON)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
     endif()
-    string(CONCAT CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} "
-            "-Wno-unknown-pragmas")
-    # silence HDF5 (FIXME: -isystem should be enough)
-    string(CONCAT CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} "
-                  "-Wno-reserved-id-macro -Wno-deprecated -Wno-old-style-cast "
-                  "-Wno-cpp")
-    # older clangs: silence unknown warnings
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
     # pybind11 does not fix -Wshadow https://github.com/pybind/pybind11/issues/1267
@@ -699,8 +691,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if(NOT openPMD_HAVE_PYTHON)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow -Wpedantic")
     endif()
-    string(CONCAT CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} "
-            "-Wno-unknown-pragmas")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Warning C4503: "decorated name length exceeded, name was truncated"
     # Symbols longer than 4096 chars are truncated


### PR DESCRIPTION
With `-isystem` for HDF5, we should be able to check more warnings.