### PR TITLE
IMPORTED Targets: Fix Downstream Use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,7 @@ Other
 - CI: GCC 8.1.0 & Python 3.7.0 #376
 - CMake:
 
-  - treat third party libraries properly as ``IMPORTED`` #389
+  - treat third party libraries properly as ``IMPORTED`` #389 #403
   - Catch2: separate implementation and tests #399 #400
   - enable check for more warnings #401
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,10 +127,8 @@ else()
 endif()
 if(openPMD_HAVE_JSON)
     add_library(openPMD::thirdparty::nlohmann_json INTERFACE IMPORTED)
-    #target_link_libraries(openPMD::thirdparty::nlohmann_json
-    #    INTERFACE nlohmann_json::nlohmann_json)
-    get_target_property(lib_include_dirs nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
-    target_include_directories(openPMD::thirdparty::nlohmann_json SYSTEM INTERFACE ${lib_include_dirs})
+    target_link_libraries(openPMD::thirdparty::nlohmann_json
+        INTERFACE nlohmann_json::nlohmann_json)
 endif()
 
 # external library: HDF5 (optional)
@@ -387,7 +385,9 @@ endif()
 
 # JSON Backend
 if(openPMD_HAVE_JSON)
-    target_link_libraries(openPMD PRIVATE openPMD::thirdparty::nlohmann_json)
+    #target_link_libraries(openPMD PRIVATE openPMD::thirdparty::nlohmann_json)
+    target_include_directories(openPMD SYSTEM PRIVATE
+        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_JSON=1")
 else()
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_JSON=0")

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -4,6 +4,14 @@ include(CMakeFindDependencyMacro)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
 
+add_library(openPMD::thirdparty::mpark_variant INTERFACE IMPORTED)
+set(openPMD_USE_INTERNAL_VARIANT @openPMD_USE_INTERNAL_VARIANT@)
+if(NOT openPMD_USE_INTERNAL_VARIANT)
+    find_dependency(mpark_variant)
+    target_link_libraries(openPMD::thirdparty::mpark_variant
+        INTERFACE mpark_variant)
+endif()
+
 set(openPMD_HAVE_MPI @openPMD_HAVE_MPI@)
 if(openPMD_HAVE_MPI)
     find_dependency(MPI)


### PR DESCRIPTION
Follow-up to use CMake third party librarys as IMPORTED.
Make sure
- `PRIVATE` JSON target does not leak into install
- variant target is known

Follow-up to #389 in order to fix reported issues when used in third-party libs: https://github.com/openPMD/openPMD-api/pull/389#issuecomment-446970532