### PR TITLE
load_chunk order of arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,10 +20,12 @@ Features
 - C++:
 
   - ``storeChunk`` argument order changed, defaults added #386
+  - ``loadChunk`` argument order changed, defaults added #408
 - Python:
 
   - ``import openPMD`` renamed to ``import openpmd_api`` #380 #392
   - ``store_chunk`` argument order changed, defaults added #386
+  - ``load_chunk`` defaults added #408
   - works with Python 3.7 #376
   - setup.py for sdist #240
 - Backends: JSON support added #384 #393 #338

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -45,6 +45,24 @@ The new order allows to make use of defaults in many cases in order reduce compl
    #                                      offset=[0, ],
    #                                      extent=particlePos_x.shape)
 
+``load_chunk`` Method
+"""""""""""""""""""""
+
+The ``loadChunk<T>`` method with on-the-fly allocation has default arguments for offset and extent now.
+Called without arguments, it will read the whole record component.
+
+.. code-block:: python3
+
+   E_x = series.iterations[100].meshes["E"]["x"]
+
+   # old code
+   all_data = E_x.load_chunk(np.zeros(E_x.shape), E_x.shape)
+
+   # new code
+   all_data = E_x.load_chunk()
+
+   series.flush()
+
 C++
 ^^^
 
@@ -72,3 +90,36 @@ The new order allows to make use of defaults in many cases in order reduce compl
     *                        .storeChunk(shareRaw(particlePos_x),
     *                                    {0},
     *                                    {particlePos_x.size()})  */
+
+``loadChunk`` Method
+""""""""""""""""""""
+
+The order of arguments in the pre-allocated data overload of the ``loadChunk`` method for record components has changed.
+The new order allows was introduced for consistency with ``storeChunk``.
+
+.. code-block:: cpp
+
+   float loadOnePos;
+
+   // old code
+   electrons["position"]["x"].loadChunk({0}, {1}, shareRaw(&loadOnePos));
+
+   // new code
+   electrons["position"]["x"].loadChunk(shareRaw(&loadOnePos), {0}, {1});
+
+   series.flush();
+
+The ``loadChunk<T>`` method with on-the-fly allocation got default arguments for offset and extent.
+Called without arguments, it will read the whole record component.
+
+.. code-block:: cpp
+
+   MeshRecordComponent E_x = series.iterations[100].meshes["E"]["x"];
+
+   // old code
+   auto all_data = E_x.loadChunk<double>({0, 0, 0}, E_x.getExtent());
+
+   // new code
+   auto all_data = E_x.loadChunk<double>();
+
+   series.flush();

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -76,6 +76,13 @@ int main()
         cout << '\n';
     }
 
+    auto all_data = E_x.loadChunk<double>();
+    series.flush();
+    cout << "Full E/x starts with:\n\t{";
+    for( size_t col = 0; col < extent[1] && col < 5; ++col )
+        cout << all_data.get()[col] << ", ";
+    cout << "...}\n";
+
     /* The files in 'series' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.
      * When running out of scope on return, the 'Series' destructor is called.

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -55,6 +55,11 @@ if __name__ == "__main__":
     #         )
     #     print("")
 
+    all_data = E_x.load_chunk()
+    series.flush()
+    print("Full E/x is of shape {0} and starts with:".format(all_data.shape))
+    print(all_data[0, 0, :5])
+
     # The files in 'series' are still open until the object is destroyed, on
     # which it cleanly flushes and closes all open file handles.
     # One can delete the object explicitly (or let it run out of scope) to

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -570,15 +570,18 @@ TEST_CASE( "wrapper_test", "[core]" )
     REQUIRE(*mrc2.m_isConstant);
 #endif
     double loadData;
-    mrc2.loadChunk({0}, {1}, shareRaw(&loadData));
+    mrc2.loadChunk(shareRaw(&loadData), {0}, {1});
     o.flush();
     REQUIRE(loadData == value);
     value = 43.;
     mrc2.makeConstant(value);
     std::array< double, 1 > moreData = {{ 112233. }};
-    o.iterations[4].meshes["E"]["y"].loadChunk({0}, {1}, shareRaw(moreData));
+    o.iterations[4].meshes["E"]["y"].loadChunk(shareRaw(moreData), {0}, {1});
     o.flush();
     REQUIRE(moreData[0] == value);
+    auto all_data = o.iterations[4].meshes["E"]["y"].loadChunk<double>();
+    o.flush();
+    REQUIRE(all_data.get()[0] == value);
 #if openPMD_USE_INVASIVE_TESTS
     REQUIRE(o.iterations[4].meshes["E"]["y"].m_chunks->empty());
     REQUIRE(mrc2.m_chunks->empty());


### PR DESCRIPTION
Follow-up to #386 for consistency.

Introduces default arguments to the `load_chunk`/`loadChunk<T>` methods for convenience:

```python
   E_x = series.iterations[100].meshes["E"]["x"]

   # old code
   all_data = E_x.load_chunk(np.zeros(E_x.shape), E_x.shape)

   # new code
   all_data = E_x.load_chunk()

   series.flush()
```

Moves the `data` argument in the `loadChunk` method to the first position for consistency with `storeChunk`. Unfortunately, can not introduce default arguments on that overload as well due to C++ ambiguity with the `loadChunk<T>` method.

Close #387