### PR TITLE
SerialIOTest: Use After Free in Patches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Bug Fixes
 """""""""
 
 - spurious MPI C++11 API usage in ParallelIOTest removed #396
+- use-after-free in SerialIOTest #409
 
 Other
 """""

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -161,6 +161,7 @@ void particle_patches( std::string file_ending )
             std::vector<uint64_t> od( extent );
             std::iota(od.begin(), od.end(), 0);
             o.storeChunk(od);
+            s.flush();
         }
 
         auto const dset_n = Dataset(determineDatatype<uint64_t>(), {num_patches, });


### PR DESCRIPTION
Fix a user-after-free in the SerialIOTest testing particle patches.
Found with clang's (6.0) address sanitizer.