### PR TITLE
IOTask: AbstractParameter Slice Safety

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Bug Fixes
 Other
 """""
 
+- modernize ``IOTask``'s ``AbstractParameter`` for slice safety #410
 - Docs: upgrade guide added #385
 - CI: GCC 8.1.0 & Python 3.7.0 #376
 - IOTask: init all parameters' members #420


### PR DESCRIPTION
The `IOTask` constructor caused [problems with Clang 4.0.1 on OSX](https://github.com/conda-forge/openpmd-api-feedstock/pull/15), where the `Parameter< Operation::CREATE_FILE >` does seem not to copy the `name` member. Thanks to @mingwandroid for first seeing this and debugging a lot with me!

~~It turns out that we copy the `AbstractParameter` base class, which leads to object slicing.~~
Probably implicit copy constructors are weirdly handled in this old Clang version, so we make them explicitly deleted as the core guidelines recommend.

Also, `IOTasks` might better have an explicit copy constructor since we copy it around (`std::queue::push()`, etc.)

https://stackoverflow.com/questions/274626/what-is-object-slicing
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-copy-virtual
https://en.wikipedia.org/wiki/Object_slicing