### PR TITLE
Benchmark: Slicer & Filler Destructors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Features
   - works with Python 3.7 #376
   - setup.py for sdist #240
 - Backends: JSON support added #384 #393 #338
-- Parallel benchmark added #346 #398 #402
+- Parallel benchmark added #346 #398 #402 #411
 
 Bug Fixes
 """""""""

--- a/include/openPMD/benchmark/mpi/BlockSlicer.hpp
+++ b/include/openPMD/benchmark/mpi/BlockSlicer.hpp
@@ -48,5 +48,9 @@ namespace openPMD
             int size,
             int rank
         ) = 0;
+
+        /** This class will be derived from
+         */
+        virtual ~BlockSlicer() = default;
     };
 }

--- a/include/openPMD/benchmark/mpi/DatasetFiller.hpp
+++ b/include/openPMD/benchmark/mpi/DatasetFiller.hpp
@@ -43,6 +43,10 @@ namespace openPMD
 
         explicit DatasetFiller( Extent::value_type numberOfItems = 0 );
 
+        /** This class will be derived from
+         */
+        virtual ~DatasetFiller() = default;
+
         /**
          * Create a shared pointer of m_numberOfItems items of type T.
          * Should take roughly the same amount of time per call as long as


### PR DESCRIPTION
Classes with virtual functions that are derived from need a virtual destructor. Otherwise undefined behavior will occur when an instance is deleted via a pointer to a base class.

https://stackoverflow.com/questions/10024796/c-virtual-functions-but-no-virtual-destructors

Fixes:
  https://github.com/openPMD/openPMD-api/issues/37#issuecomment-447014373