### PR TITLE
Travis-CI: Clang 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ cache:
 env:
   global:
     - BUILD: ~/buildTmp
-    - CXXFLAGS: "-std=c++11"
+    - CXXFLAGS: "-Werror"
     - SPACK_ROOT: $HOME/.cache/spack
     - PATH: $PATH:$HOME/.cache/spack/bin
     - PYBIND11_VERSION=@2.2.3
+    - USE_JSON: ON
 
 addons:
   apt:
@@ -206,10 +207,11 @@ jobs:
               export EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DopenPMD_USE_INTERNAL_PYBIND11=OFF";
             fi;
           fi
-        - CXXFLAGS="-Werror" CXX=$CXX CC=$CC
+        - CXXFLAGS=${CXXFLAGS} CXX=${CXX} CC=${CC}
           cmake
             -DCMAKE_BUILD_TYPE=Debug
             -DopenPMD_USE_MPI=$USE_MPI
+            -DopenPMD_USE_JSON=$USE_JSON
             -DopenPMD_USE_HDF5=$USE_HDF5
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
@@ -239,10 +241,44 @@ jobs:
             - libopenmpi-dev
             - openmpi-bin
       script: *script-cpp-unit
+    # Clang 7.0.0 + Python 3.7.1 @ Xenial
+    - <<: *test-cpp-unit
+      name: clang@7.0.0 +MPI +PY@3.7 +H5 +ADIOS1
+      dist: xenial
+      language: python
+      python: "3.7"
+      env:
+        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+      compiler: clang
+      addons:
+        apt:
+          <<: *apt_common_sources
+          packages:
+            - *clang50_deps
+            - libopenmpi-dev
+            - openmpi-bin
+      script: *script-cpp-unit
+      before_install: &clang_init
+        - CXX=clang++ && CC=clang && CXXFLAGS="-Werror -Wno-deprecated"
+    # Clang 7.0.0 + Address Sanitizer @ Xenial
+    - <<: *test-cpp-unit
+      name: clang@7.0.0 -MPI -PY -H5 -ADIOS1 -JSON +AddressSanitize
+      dist: xenial
+      language: python
+      python: "3.7"
+      env:
+        # FIXME: #414 then enable JSON again
+        - CXXSPEC="%clang@7.0.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=OFF USE_ADIOS1=OFF USE_ADIOS2=OFF USE_JSON=OFF USE_SAMPLES=ON
+      compiler: clang
+      script: *script-cpp-unit
+      before_install:
+        - CXX=clang++ && CC=clang && CXXFLAGS="-fsanitize=address"
+        - export ASAN_OPTIONS=detect_odr_violation=0  # this must be fixed: #413
     # Clang 9.1.0-apple + Python 2.7.15 @ OSX
     - <<: *test-cpp-unit
       name: AppleClang@9.1.0 -MPI +PY@2.7 +H5 +ADIOS1
       os: osx
+      osx_image: xcode9.4
       sudo: required
       language: generic
       env:

--- a/.travis/spack/compilers.yaml
+++ b/.travis/spack/compilers.yaml
@@ -30,6 +30,19 @@ compilers:
     extra_rpaths: []
     flags: {}
     modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc: /usr/local/clang-7.0.0/bin/clang
+      cxx: /usr/local/clang-7.0.0/bin/clang++
+      f77: /usr/bin/gfortran-4.9
+      fc: /usr/bin/gfortran-4.9
+    spec: clang@7.0.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
     operating_system: ubuntu14.04
     paths:
       cc: /usr/bin/gcc-4.8

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -8,10 +8,11 @@ packages:
       cmake@3.11.0%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
+      cmake@3.11.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
-    version: [1.6.5]
+    version: [1.6.5, 1.10.2]
     paths:
       openmpi@1.6.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
@@ -19,24 +20,26 @@ packages:
       openmpi@1.6.5%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
       openmpi@1.6.5%clang@5.0.0 arch=linux-ubuntu14-x86_64: /usr
+      openmpi@1.10.2%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
     buildable: False
   hdf5:
     version: [1.10.1, 1.8.13]
   adios:
     variants: ~zfp ~sz ~lz4 ~blosc
   python:
-    version: [2.7.14, 2.7.15, 3.5.5, 3.6.3]
+    version: [2.7.14, 2.7.15, 3.5.5, 3.6.3, 3.7.1]
     paths:
+      python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@2.7.14%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@2.7.14%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@2.7.14%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@2.7.14%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
-      python@3.7.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
+      python@3.7.1%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@2.7.15%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
     buildable: False
   all:
     providers:
       mpi: [openmpi]
-    compiler: [clang@5.0.0, clang@9.1.0, gcc@4.8.5, gcc@4.9.4, gcc@6.4.0, gcc@7.3.0]
+    compiler: [clang@5.0.0, clang@7.0.0, clang@9.1.0, gcc@4.8.5, gcc@4.9.4, gcc@6.4.0, gcc@7.3.0]

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -28,7 +28,9 @@ int main(
     // given that you provide it with an appropriate DatasetFillerProvider
     // (template parameter of the Benchmark class).
     using type = long int;
+#if openPMD_HAVE_ADIOS1 || openPMD_HAVE_HDF5
     openPMD::Datatype dt = openPMD::determineDatatype<type>();
+#endif
 
     // Total (in this case 4D) dataset across all MPI ranks.
     // Will be the same for all configured benchmarks.

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -195,7 +195,7 @@ namespace detail
             }
         );
 
-        return cl;
+        return std::move(cl);
     }
 } // namespace detail
 


### PR DESCRIPTION
Add clang 7 coverage in CI.

Also adds a `-fsanitze=address` entry which currently only enables a backend-free run.
After #414 is fixed we can enable JSON as well. Also uncovered an ODR issue with ADIOS: #413 

Fixing an unused var warning in the MPI benchmark and an unnecessary copy in the python bindings for `Container` in this PR as well.