### PR TITLE
RecordComponent: storeChunk Use-after-Free

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,13 +263,12 @@ jobs:
         - CXX=clang++ && CC=clang && CXXFLAGS="-Werror -Wno-deprecated"
     # Clang 7.0.0 + Address Sanitizer @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 -MPI -PY -H5 -ADIOS1 -JSON +AddressSanitize
+      name: clang@7.0.0 -MPI -PY -H5 -ADIOS1 +JSON +AddressSanitize
       dist: xenial
       language: python
       python: "3.7"
       env:
-        # FIXME: #414 then enable JSON again
-        - CXXSPEC="%clang@7.0.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=OFF USE_ADIOS1=OFF USE_ADIOS2=OFF USE_JSON=OFF USE_SAMPLES=ON
+        - CXXSPEC="%clang@7.0.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=OFF USE_ADIOS1=OFF USE_ADIOS2=OFF USE_JSON=ON USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
       before_install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Features
 
 - C++:
 
-  - ``storeChunk`` argument order changed, defaults added #386
+  - ``storeChunk`` argument order changed, defaults added #386 #416
   - ``loadChunk`` argument order changed, defaults added #408
 - Python:
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -144,7 +144,7 @@ public:
     typename std::enable_if<
         traits::IsContiguousContainer< T_ContiguousContainer >::value
     >::type
-    storeChunk(T_ContiguousContainer, Offset = {0u}, Extent = {-1u});
+    storeChunk(T_ContiguousContainer &, Offset = {0u}, Extent = {-1u});
 
     constexpr static char const * const SCALAR = "\vScalar";
 
@@ -330,7 +330,7 @@ template< typename T_ContiguousContainer >
 inline typename std::enable_if<
     traits::IsContiguousContainer< T_ContiguousContainer >::value
 >::type
-RecordComponent::storeChunk(T_ContiguousContainer data, Offset o, Extent e)
+RecordComponent::storeChunk(T_ContiguousContainer & data, Offset o, Extent e)
 {
     uint8_t dim = getDimensionality();
 


### PR DESCRIPTION
Fix #414

`RecordComponent::storeChunk` for STL containers introduced in #386. Accidentally creates a container copy (expensive) which then is using the data from the temporary during `flush()` (segfault).