### PR TITLE
Add Coverity Scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -499,6 +499,40 @@ jobs:
           done
       after_script:
         - kcov --merge --coveralls-id=$TRAVIS_JOB_ID ../coverage/merged ../coverage/*
+    - stage: 'Code Coverage'
+      name: Coverity
+      if: branch = coverity_scan
+      sudo: required
+      dist: xenial
+      language: python
+      python: "3.6"
+      compiler: gcc
+      before_install:
+        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-certificates.crt
+      install:
+        - export CXXFLAGS="-Wall -Wextra"
+        # adios.pc file has typo: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900811
+        # ... but xenial only ships 1.9.0
+        # - sed -i 's/find_package(ADIOS 1\.13\.1/find_package(ADIOS/g' CMakeLists.txt
+      script:
+        # nothing to do but required by Travis
+        - echo "Coverity scan! (script)"
+      addons:
+        apt:
+          packages:
+            - libopenmpi-dev
+            - openmpi-bin
+            - libhdf5-openmpi-dev
+            - libadios-dev
+            - libadios-bin
+        coverity_scan:
+          project:
+            name: "openPMD/openPMD-api"
+            description: "C++ & Python API for Scientific I/O with openPMD"
+          notification_email: axel.huebl@plasma.ninja
+          build_command_prepend: "mkdir coverity_build; cd coverity_build; . ../.travis/download_samples.sh; cmake .. -DPYTHON_EXECUTABLE:FILEPATH=$(which python); cd .."
+          build_command: "make -C coverity_build -j 2"
+          branch_pattern: coverity_scan
 
 install:
   # spack install

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ C++ & Python API for Scientific I/O with openPMD
 
 [![Linux/OSX Build Status dev](https://img.shields.io/travis/openPMD/openPMD-api/dev.svg?label=dev)](https://travis-ci.org/openPMD/openPMD-api/branches)
 [![Windows Build Status dev](https://ci.appveyor.com/api/projects/status/x95q4n620pqk0e0t/branch/dev?svg=true)](https://ci.appveyor.com/project/ax3l/openpmd-api/branch/dev)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/17602/badge.svg)](https://scan.coverity.com/projects/openpmd-openpmd-api)
 [![Coverage Status](https://coveralls.io/repos/github/openPMD/openPMD-api/badge.svg)](https://coveralls.io/github/openPMD/openPMD-api)
 [![CodeFactor](https://www.codefactor.io/repository/github/openpmd/openpmd-api/badge)](https://www.codefactor.io/repository/github/openpmd/openpmd-api)
 


### PR DESCRIPTION
Adding support for [coverity](https://scan.coverity.com).

Coverity is a static code analyzer. It will be run whenever we push to the `coverity_scan` branch (with [limits](https://scan.coverity.com/faq#frequency)). Please write me if anyone else needs "admin" access for their site.

Secure `COVERITY_SCAN_TOKEN` var was added to [Travis' repo settings](https://travis-ci.org/openPMD/openPMD-api/settings) by me.