### PR TITLE
MPI Parallel mkdir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Bug Fixes
 - spurious MPI C++11 API usage in ParallelIOTest removed #396
 - use-after-free in SerialIOTest #409
 - fix ODR issue in ADIOS1 backend corrupting the ``AbstractIOHandler`` vtable #415
+- fix race condition in MPI-parallel directory creation #419
 
 Other
 """""

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -120,7 +120,13 @@ create_directories( std::string const& path )
         if( !token.empty() )
             partialPath += token + directory_separator;
         if( !directory_exists( partialPath ) )
-            success = success && mk(partialPath);
+        {
+            bool partial_success = mk(partialPath);
+            if( !partial_success )
+                // did someone else just race us to create this dir?
+                if( !directory_exists( partialPath ) )
+                    success = success && partial_success;
+        }
     }
     return success;
 }


### PR DESCRIPTION
Expect that someone races us for mkdir of a partial path. Fail only if really no dir exists now. (The closest we can come to `mkdir -p`)

Fix #418.

This now creates even more load on the FS, but should be stable. Don't have access to an MPI communicator at that point and FS-sync might not necessarily be MPI-sync.