### PR TITLE
Parallel ADIOS1: Heap-Use-After Free

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Bug Fixes
 - use-after-free in SerialIOTest #409
 - fix ODR issue in ADIOS1 backend corrupting the ``AbstractIOHandler`` vtable #415
 - fix race condition in MPI-parallel directory creation #419
+- ADIOS1: fix use-after-free in parallel I/O method options #421
 
 Other
 """""

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -308,16 +308,16 @@ ParallelADIOS1IOHandlerImpl::initialize_group(std::string const &name)
     std::stringstream params;
     params << "num_aggregators=" << getEnvNum("OPENPMD_ADIOS_NUM_AGGREGATORS", "1")
            << ";num_ost=" << getEnvNum("OPENPMD_ADIOS_NUM_OST", "0")
-           << ";have_metadata_file=" << getEnvNum("OPENPMD_ADIOS_HAVE_METADATA_FILE", "0")
+           << ";have_metadata_file=" << getEnvNum("OPENPMD_ADIOS_HAVE_METADATA_FILE", "1")
            << ";verbose=2";
-    char const* c = params.str().c_str();
+    std::string params_str = params.str(); // important: copy out of temporary!
 
     int status;
     int64_t group;
     ADIOS_STATISTICS_FLAG noStatistics = adios_stat_no;
     status = adios_declare_group(&group, name.c_str(), "", noStatistics);
     VERIFY(status == err_no_error, "Internal error: Failed to declare ADIOS group");
-    status = adios_select_method(group, "MPI_AGGREGATE", c, "");
+    status = adios_select_method(group, "MPI_AGGREGATE", params_str.c_str(), "");
     VERIFY(status == err_no_error, "Internal error: Failed to select ADIOS method");
     return group;
 }


### PR DESCRIPTION
When passing the parameters to the `adios_select_method`, c-pointer of a temporary c++ string was taken which results in a heap-use-after-free.

We saw this as [sporadic occurring/missing meta-data file](https://travis-ci.org/openPMD/openPMD-api/jobs/476288957), e.g. https://github.com/openPMD/openPMD-api/issues/37#issuecomment-447014373 .

Also, change the default to create a meta-data file unless deactivated in performance tuning. Otherwise, too confusing for users to always run `bpmeta` (and not possible e.g. during our MPI benchmark that does a write-then-read).

Found with clang (6.0) and `-fsantize=address` plus exports:
```
export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=0:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1
```

Refs:
https://github.com/google/sanitizers/wiki/AddressSanitizer
https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterReturn