### PR TITLE
ParallelIOTest: Fix Delete Mismatch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Bug Fixes
 """""""""
 
 - spurious MPI C++11 API usage in ParallelIOTest removed #396
+- `new []`/`delete` mismatch in ParallelIOTest #422
 - use-after-free in SerialIOTest #409
 - fix ODR issue in ADIOS1 backend corrupting the ``AbstractIOHandler`` vtable #415
 - fix race condition in MPI-parallel directory creation #419

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -138,7 +138,7 @@ TEST_CASE( "hdf5_write_test_zero_extent", "[parallel][hdf5]" )
     std::vector< double > position_global(num_cells);
     double pos{1.};
     std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local(new double[rank]);
+    std::shared_ptr< double > position_local(new double[rank], [](double *p) { delete[] p;});
     uint64_t offset;
     if( rank != 0 )
         offset = ((rank-1)*(rank-1) + (rank-1))/2;
@@ -150,7 +150,7 @@ TEST_CASE( "hdf5_write_test_zero_extent", "[parallel][hdf5]" )
     std::vector< uint64_t > positionOffset_global(num_cells);
     uint64_t posOff{1};
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
-    std::shared_ptr< uint64_t > positionOffset_local(new uint64_t[rank]);
+    std::shared_ptr< uint64_t > positionOffset_local(new uint64_t[rank], [](uint64_t *p) { delete[] p;});
 
     e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local), {num_cells}));
 
@@ -233,7 +233,7 @@ TEST_CASE( "adios_write_test_zero_extent", "[parallel][adios]" )
     std::vector< double > position_global(num_cells);
     double pos{1.};
     std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local(new double[rank]);
+    std::shared_ptr< double > position_local(new double[rank], [](double *p) {delete[] p;});
     uint64_t offset;
     if( rank != 0 )
         offset = ((rank-1)*(rank-1) + (rank-1))/2;
@@ -245,7 +245,7 @@ TEST_CASE( "adios_write_test_zero_extent", "[parallel][adios]" )
     std::vector< uint64_t > positionOffset_global(num_cells);
     uint64_t posOff{1};
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
-    std::shared_ptr< uint64_t > positionOffset_local(new uint64_t[rank]);
+    std::shared_ptr< uint64_t > positionOffset_local(new uint64_t[rank], [](uint64_t *p) {delete[] p;});
 
     e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local), {num_cells}));
 


### PR DESCRIPTION
Fix `new[]`/`delete` mismatches with `shared_ptr` data in
ParallelIOTest.

Found with clang (6.0) and `-fsantize=address` plus exports:
```
export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=0:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1
```

Refs:
https://github.com/google/sanitizers/wiki/AddressSanitizer
https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterReturn