### PR TITLE
CI: Minimal Clang-Tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,5 @@
-Checks: -*,bugprone-*,cert-*,cppcoreguidelines-*,clang-analyzer-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,mpi-*,performance-*,readability-*,-clang-diagnostic-unused-command-line-argument,-*-namespace-comment*,-*-braces-around-statements,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-readability-named-parameter
+# Future consideration: cppcoreguidelines-*,clang-analyzer-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,readability-*,-clang-diagnostic-unused-command-line-argument,-*-namespace-comment*,-*-braces-around-statements,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-readability-named-parameter
+# FIXME: all performance-* reports
+# FIXME: all cert-* reports
+Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*
 HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ addons:
 
 jobs:
   fast_finish: true
-  allow_failures:
-    - after_script: exit $?
   include:
     ###########################################################################
     # Stage: Style                                                            #
@@ -45,32 +43,31 @@ jobs:
     - <<: *style_python
       name: PY@3.6 +PEP8
       python: "3.6"
-    - &style_cpp
-      stage: 'Style'
-      name: clang-format@5.0.0
-      language: python
-      python: "2.7"
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-format-5.0
-      install:
-        - curl -sOL https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py
-      script:
-        - python run-clang-format.py --clang-format-executable=$(which clang-format-5.0) --extensions cpp,hpp -j 2 -e *share/openPMD* -r $TRAVIS_BUILD_DIR || exit 1
-      after_script: exit $?
+    # - &style_cpp
+    #   stage: 'Style'
+    #   name: clang-format@5.0.0
+    #   language: python
+    #   python: "2.7"
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - llvm-toolchain-trusty-5.0
+    #       packages:
+    #         - clang-format-5.0
+    #   install:
+    #     - curl -sOL https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py
+    #   script:
+    #     - python run-clang-format.py --clang-format-executable=$(which clang-format-5.0) --extensions cpp,hpp -j 2 -e *share/openPMD* -r $TRAVIS_BUILD_DIR || exit 1
     ###########################################################################
     # Stage: Static Code Analysis                                             #
     ###########################################################################
-    # - &static_code_cpp
-    #   stage: 'Static Code Analysis'
+    - &static_code_cpp
+      stage: 'Static Code Analysis'
     #   name: clang@5.0.0 +IncludeWhatYouUse
     #   sudo: true
-    #   language: python
-    #   python: "2.7"
-    #   compiler: clang
+      language: python
+      python: "2.7"
+      compiler: clang
     #   env:
     #     - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
     #   addons:
@@ -120,49 +117,48 @@ jobs:
     #     - cd $HOME/build
     #     - python $BIN_PATH/iwyu_tool.py -v -j 2 -p . > iwyu.log
     #     - cat iwyu.log
-    #     - if [[ $(wc -l <iwyu.log) -ge 1 ]]; then
+    #     - if [[ $(wc -m <iwyu.log) -gt 1 ]]; then
     #         exit 1;
     #       fi
-    #   after_script: exit $?
     # - <<: *static_code_cpp
-    #   name: clang-tidy@5.0.0
-    #   sudo: false
-    #   env:
-    #     - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #         - llvm-toolchain-trusty-5.0
-    #       packages:
-    #         - clang-5.0
-    #         - clang-tidy-5.0
-    #         - libopenmpi-dev
-    #         - openmpi-bin
-    #         - environment-modules
-    #   before_install:
-    #     - CC=clang CXX=clang++
-    #   before_script:
-    #     - mkdir -p $HOME/build
-    #     - cd $HOME/build
-    #     - cmake
-    #         "-DCMAKE_CXX_CLANG_TIDY=$(which clang-tidy-5.0);-system-headers=0"
-    #         -DCMAKE_BUILD_TYPE=Debug
-    #         -DopenPMD_USE_MPI=$USE_MPI
-    #         -DopenPMD_USE_HDF5=$USE_HDF5
-    #         -DopenPMD_USE_ADIOS1=$USE_ADIOS1
-    #         -DopenPMD_USE_ADIOS2=$USE_ADIOS2
-    #         -DopenPMD_USE_PYTHON=OFF
-    #         -DopenPMD_USE_INVASIVE_TESTS=ON
-    #         $TRAVIS_BUILD_DIR
-    #   script:
-    #     - cd $HOME/build
-    #     - make -j 2 2> clang-tidy.log
-    #     - cat clang-tidy.log
-    #     - if [[ $(wc -l <clang-tidy.log) -ge 1 ]]; then
-    #         exit 1;
-    #       fi
-    #   after_script: exit $?
+      name: clang-tidy@5.0.0 +MPI -PY +H5 +ADIOS1 +JSON
+      sudo: false
+      env:
+        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - clang-tidy-5.0
+            - libopenmpi-dev
+            - openmpi-bin
+            - environment-modules
+      before_install:
+        - CC=clang CXX=clang++
+      before_script:
+        - mkdir -p $HOME/build
+        - cd $HOME/build
+        - $TRAVIS_BUILD_DIR/.travis/download_samples.sh
+        - cmake
+            "-DCMAKE_CXX_CLANG_TIDY=$(which clang-tidy-5.0);-system-headers=0"
+            -DCMAKE_BUILD_TYPE=Release
+            -DopenPMD_USE_MPI=$USE_MPI
+            -DopenPMD_USE_HDF5=$USE_HDF5
+            -DopenPMD_USE_ADIOS1=$USE_ADIOS1
+            -DopenPMD_USE_ADIOS2=$USE_ADIOS2
+            -DopenPMD_USE_PYTHON=$USE_PYTHON
+            -DopenPMD_USE_INVASIVE_TESTS=ON
+            $TRAVIS_BUILD_DIR
+      script:
+        - cd $HOME/build
+        - make -j 2 2> clang-tidy.log
+        - cat clang-tidy.log
+        - if [[ $(wc -m <clang-tidy.log) -gt 1 ]]; then
+            exit 1;
+          fi
     - &static_code_python
       stage: 'Static Code Analysis'
       name: pyflakes 2.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Other
 - modernize ``IOTask``'s ``AbstractParameter`` for slice safety #410
 - Docs: upgrade guide added #385
 - CI: GCC 8.1.0 & Python 3.7.0 #376
+- CI: (re-)activate Clang-Tidy #423
 - IOTask: init all parameters' members #420
 - CMake:
 


### PR DESCRIPTION
Re-enable Clang-Tidy in CI with passing checks. Allow to become stricter later.