### PR TITLE
Mesh: attribute setters const ref

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,10 @@ Other
 - CI: GCC 8.1.0 & Python 3.7.0 #376
 - CI: (re-)activate Clang-Tidy #423
 - IOTask: init all parameters' members #420
-- KDevelop project files to `.gitignore` #424
+- KDevelop project files to ``.gitignore`` #424
+- C++:
+
+  - ``Mesh``'s ``setAxisLabels|GridSpacing|GridGlobalOffset`` passed as ``const &`` #425
 - CMake:
 
   - treat third party libraries properly as ``IMPORTED`` #389 #403

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -110,7 +110,7 @@ public:
      * @param   axisLabels  vector containing N (string) elements, where N is the number of dimensions in the simulation.
      * @return  Reference to modified mesh.
      */
-    Mesh& setAxisLabels(std::vector< std::string > axisLabels);
+    Mesh& setAxisLabels(std::vector< std::string > const & axisLabels);
 
     /**
      * @tparam  T   Floating point type of user-selected precision (e.g. float, double).
@@ -126,7 +126,7 @@ public:
      * @return  Reference to modified mesh.
      */
     template< typename T >
-    Mesh& setGridSpacing(std::vector< T > gridSpacing);
+    Mesh& setGridSpacing(std::vector< T > const & gridSpacing);
 
     /**
      * @return  Vector of (double) representing the start of the current domain of the simulation (position of the beginning of the first cell) in simulation units.
@@ -138,7 +138,7 @@ public:
      * @param   gridGlobalOffset    vector containing N (double) elements, where N is the number of dimensions in the simulation.
      * @return  Reference to modified mesh.
      */
-    Mesh& setGridGlobalOffset(std::vector< double > gridGlobalOffset);
+    Mesh& setGridGlobalOffset(std::vector< double > const & gridGlobalOffset);
 
     /**
      * @return  Unit-conversion factor to multiply each value in Mesh::gridSpacing and Mesh::gridGlobalOffset, in order to convert from simulation units to SI units.

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -106,7 +106,7 @@ Mesh::axisLabels() const
 }
 
 Mesh&
-Mesh::setAxisLabels(std::vector< std::string > als)
+Mesh::setAxisLabels(std::vector< std::string > const & als)
 {
     setAttribute("axisLabels", als);
     return *this;
@@ -114,7 +114,7 @@ Mesh::setAxisLabels(std::vector< std::string > als)
 
 template< typename T >
 Mesh&
-Mesh::setGridSpacing(std::vector< T > gs)
+Mesh::setGridSpacing(std::vector< T > const & gs)
 {
     static_assert(std::is_floating_point< T >::value, "Type of attribute must be floating point");
 
@@ -124,13 +124,13 @@ Mesh::setGridSpacing(std::vector< T > gs)
 
 template
 Mesh&
-Mesh::setGridSpacing(std::vector< float > gs);
+Mesh::setGridSpacing(std::vector< float > const & gs);
 template
 Mesh&
-Mesh::setGridSpacing(std::vector< double > gs);
+Mesh::setGridSpacing(std::vector< double > const & gs);
 template
 Mesh&
-Mesh::setGridSpacing(std::vector< long double > gs);
+Mesh::setGridSpacing(std::vector< long double > const & gs);
 
 std::vector< double >
 Mesh::gridGlobalOffset() const
@@ -139,7 +139,7 @@ Mesh::gridGlobalOffset() const
 }
 
 Mesh&
-Mesh::setGridGlobalOffset(std::vector< double > ggo)
+Mesh::setGridGlobalOffset(std::vector< double > const & ggo)
 {
     setAttribute("gridGlobalOffset", ggo);
     return *this;


### PR DESCRIPTION
Pass attribute setters of containers that will be forwarded as const ref anyway as such, to avoid copies. Also more consistent with other setters.