### PR TITLE
BaseRecord: Shared Linking on OSX

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Bug Fixes
 """""""""
 
 - spurious MPI C++11 API usage in ParallelIOTest removed #396
+- spurious symbol issues on OSX #427
 - `new []`/`delete` mismatch in ParallelIOTest #422
 - use-after-free in SerialIOTest #409
 - fix ODR issue in ADIOS1 backend corrupting the ``AbstractIOHandler`` vtable #415

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -133,4 +133,8 @@ Record::read()
 
     readAttributes();
 }
+
+template
+BaseRecord<RecordComponent>::mapped_type&
+BaseRecord<RecordComponent>::operator[](std::string&& key);
 } // openPMD


### PR DESCRIPTION
Add explicit symbols for `BaseRecord` move operator.

Seen as linking issue for `1_structure` on OSX with Clang 4.0.1 from conda.