### PR TITLE
JSON Backend: Avoid Tmp Copies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ Features
   - ``load_chunk`` defaults added #408
   - works with Python 3.7 #376
   - setup.py for sdist #240
-- Backends: JSON support added #384 #393 #338
+- Backends: JSON support added #384 #393 #338 #429
 - Parallel benchmark added #346 #398 #402 #411
 
 Bug Fixes

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -293,7 +293,7 @@ namespace openPMD
         // full operating system path of the given file
         std::string fullPath( File );
 
-        std::string fullPath( std::string );
+        std::string fullPath( std::string const & );
 
         // from a path specification /a/b/c, remove the last
         // "folder" (i.e. modify the string to equal /a/b)

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -53,7 +53,6 @@ namespace openPMD
 
     std::future< void > JSONIOHandlerImpl::flush( )
     {
-
         AbstractIOHandlerImpl::flush( );
         for( auto const & file: m_dirty )
         {
@@ -463,7 +462,7 @@ namespace openPMD
         );
         // be careful not to create the group by accident
         // the loop will execute at least once
-        for( auto folder: splitPath )
+        for( auto const & folder: splitPath )
         {
             auto it = j->find( folder );
             if( it == j->end( ) )
@@ -806,7 +805,7 @@ namespace openPMD
     }
 
 
-    std::string JSONIOHandlerImpl::fullPath( std::string fileName )
+    std::string JSONIOHandlerImpl::fullPath( std::string const & fileName )
     {
         if( auxiliary::ends_with(
             m_handler->directory,
@@ -1452,7 +1451,7 @@ namespace openPMD
     {
         nlohmann::json j;
         CppToJSON< T > ctj;
-        for( auto a: v )
+        for( auto const & a: v )
         {
             j.push_back( ctj( a ) );
         }
@@ -1475,7 +1474,7 @@ namespace openPMD
     {
         nlohmann::json j;
         CppToJSON< T > ctj;
-        for( auto a: v )
+        for( auto const & a: v )
         {
             j.push_back( ctj( a ) );
         }
@@ -1555,8 +1554,6 @@ namespace openPMD
         }
     }
 
-
 #endif
 
-
-} // openPMD
+} // namespace openPMD

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1453,7 +1453,7 @@ namespace openPMD
         CppToJSON< T > ctj;
         for( auto const & a: v )
         {
-            j.push_back( ctj( a ) );
+            j.emplace_back( ctj( a ) );
         }
         return j;
     }
@@ -1476,7 +1476,7 @@ namespace openPMD
         CppToJSON< T > ctj;
         for( auto const & a: v )
         {
-            j.push_back( ctj( a ) );
+            j.emplace_back( ctj( a ) );
         }
         return j;
     }
@@ -1499,9 +1499,9 @@ namespace openPMD
     {
         std::vector< T > v;
         JsonToCpp< T > jtp;
-        for( auto & j: json )
+        for( auto const & j: json )
         {
-            v.push_back( jtp( j ) );
+            v.emplace_back( jtp( j ) );
         }
         return v;
     }
@@ -1524,7 +1524,7 @@ namespace openPMD
         > a;
         JsonToCpp< T > jtp;
         size_t i = 0;
-        for( auto & j: json )
+        for( auto const & j: json )
         {
             a[i] = jtp( j );
             i++;


### PR DESCRIPTION
Adds (`const`) references where applicable to avoid temporary copies in the JSON backend.

@franzpoeschel can you please review they are all safe and ok?

Found initially via clang-tidy `performance-*` checks.