### PR TITLE
Docs: Particle Writing Python

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Other
 
 - modernize ``IOTask``'s ``AbstractParameter`` for slice safety #410
 - Docs: upgrade guide added #385
+- Docs: python particle writing example #430
 - CI: GCC 8.1.0 & Python 3.7.0 #376
 - CI: (re-)activate Clang-Tidy #423
 - IOTask: init all parameters' members #420

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,6 +586,7 @@ set(openPMD_PYTHON_EXAMPLE_NAMES
     2_read_serial
     3_write_serial
     7_extended_write_serial
+    9_particle_write_serial
 )
 
 if(openPMD_USE_INVASIVE_TESTS)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,6 +66,7 @@ Usage
    usage/firststeps
    usage/serial
    usage/parallel
+   usage/examples
 
 ***********
 Development

--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -1,0 +1,31 @@
+.. _usage-examples:
+
+All Examples
+============
+
+The full list of examples is contained in our ``examples/`` folder:
+
+C++
+---
+
+- `1_structure.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/1_structure.cpp>`_: creating a first series
+- `2_read_serial.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/2_read_serial.cpp>`_: reading a mesh
+- `3_write_serial.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/3_write_serial.cpp>`_: writing a mesh
+- `4_read_parallel.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/4_read_parallel.cpp>`_: MPI-parallel mesh read
+- `5_write_parallel.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/5_write_parallel.cpp>`_: MPI-parallel mesh write
+- `6_dump_filebased_series.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/6_dump_filebased_series.cpp>`_: detailed reading with a file-based series
+- `7_extended_write_serial.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/7_extended_write_serial.cpp>`_: particle writing with patches and constant records
+- `8_benchmark_parallel.cpp <https://github.com/openPMD/openPMD-api/blob/dev/examples/8_benchmark_parallel.cpp>`_: a MPI-parallel IO-benchmark
+
+Python
+------
+
+- `2_read_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/2_read_serial.py>`_: reading a mesh
+- `3_write_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/3_write_serial.py>`_: writing a mesh
+- `7_extended_write_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/7_extended_write_serial.py>`_: particle writing with patches and constant records
+- `9_particle_write_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/9_particle_write_serial.py>`_: writing particles
+
+Unit Tests
+----------
+
+Our unit tests in the ``test/`` folder might also be informative for advanced developers.

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -1,0 +1,65 @@
+from openpmd_api import Series, Access_Type, Dataset, Mesh_Record_Component, \
+    Unit_Dimension
+import numpy as np
+
+
+SCALAR = Mesh_Record_Component.SCALAR
+
+
+if __name__ == "__main__":
+    # open file for writing
+    f = Series(
+        "../samples/7_particle_write_serial_py.h5",
+        Access_Type.create
+    )
+
+    # all required openPMD attributes will be set to reasonable default values
+    # (all ones, all zeros, empty strings,...)
+    # manually setting them enforces the openPMD standard
+    f.set_meshes_path("fields")
+    f.set_particles_path("particles")
+
+    # new iteration
+    cur_it = f.iterations[0]
+
+    # particles
+    electrons = cur_it.particles["electrons"]
+    electrons.set_attribute(
+        "Electrons... the necessary evil for ion acceleration! ",
+        "Just kidding.")
+
+    # let's set a weird user-defined record this time
+    electrons["displacement"].set_unit_dimension({Unit_Dimension.M: 1})
+    electrons["displacement"][SCALAR].set_unit_SI(1.e-6)
+    dset = Dataset(np.dtype("float64"), extent=[2])
+    electrons["displacement"][SCALAR].reset_dataset(dset)
+    electrons["displacement"][SCALAR].make_constant(42.43)
+    # don't like it anymore? remove it with:
+    # del electrons["displacement"]
+
+    electrons["weighting"][SCALAR].set_unit_SI(1.e-5)
+
+    particlePos_x = np.random.rand(234).astype(np.float32)
+    particlePos_y = np.random.rand(234).astype(np.float32)
+    d = Dataset(particlePos_x.dtype, extent=particlePos_x.shape)
+    electrons["position"]["x"].reset_dataset(d)
+    electrons["position"]["y"].reset_dataset(d)
+
+    particleOff_x = np.arange(234, dtype=np.uint)
+    particleOff_y = np.arange(234, dtype=np.uint)
+    d = Dataset(particleOff_x.dtype, particleOff_x.shape)
+    electrons["positionOffset"]["x"].reset_dataset(d)
+    electrons["positionOffset"]["y"].reset_dataset(d)
+
+    electrons["position"]["x"].store_chunk(particlePos_x)
+    electrons["position"]["y"].store_chunk(particlePos_y)
+    electrons["positionOffset"]["x"].store_chunk(particleOff_x)
+    electrons["positionOffset"]["y"].store_chunk(particleOff_y)
+
+    # at any point in time you may decide to dump already created output to
+    # disk note that this will make some operations impossible (e.g. renaming
+    # files)
+    f.flush()
+
+    # now the file is closed
+    del f


### PR DESCRIPTION
Close #383.

Add a python particle writing example. Add a section in the manual that links all examples.