### PR TITLE
Remove All Python 2.7 Traces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ jobs:
     ###########################################################################
     - &style_python
       stage: 'Style'
-      name: PY@2.7 +PEP8
+      name: PY@3.5 +PEP8
       language: python
-      python: "2.7"
+      python: "3.5"
       install: pip install -U flake8
       script:
         # Test Python Files for PEP8 conformance
@@ -66,7 +66,7 @@ jobs:
     #   name: clang@5.0.0 +IncludeWhatYouUse
     #   sudo: true
       language: python
-      python: "2.7"
+      python: "3.6"
       compiler: clang
     #   env:
     #     - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
@@ -161,9 +161,9 @@ jobs:
           fi
     - &static_code_python
       stage: 'Static Code Analysis'
-      name: pyflakes 2.7
+      name: pyflakes 3.5
       language: python
-      python: "2.7"
+      python: "3.5"
       install: pip install -U pyflakes
       script:
         # Warnings, unused code, etc.
@@ -225,7 +225,7 @@ jobs:
     - <<: *test-cpp-unit
       name: clang@5.0.0 +MPI -PY +H5 +ADIOS1
       language: python
-      python: "2.7"
+      python: "3.6"
       env:
         - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
@@ -382,11 +382,11 @@ jobs:
             - openmpi-bin
       before_install: *gcc73_init
       script: *script-cpp-unit
-    # GCC 6.4.0 + Python 2.7
+    # GCC 6.4.0 + Python 3.5
     - <<: *test-cpp-unit
-      name: gcc@6.4.0 -MPI +PY@2.7 +H5 +ADIOS@1.13.1
+      name: gcc@6.4.0 -MPI +PY@3.5 +H5 +ADIOS@1.13.1
       language: python
-      python: "2.7"
+      python: "3.5"
       env:
         - CXXSPEC="%gcc@6.4.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON ADIOS1_VERSION=@1.13.1 USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -289,9 +289,9 @@ jobs:
       script: *script-cpp-unit
       before_install:
         - CXX=clang++ && CC=clang && CXXFLAGS="-Werror -fsanitize=address"
-    # Clang 9.1.0-apple + Python 2.7.15 @ OSX "highsierra"
+    # Clang 9.1.0-apple + Python 3.7.2 @ OSX "highsierra"
     - <<: *test-cpp-unit
-      name: AppleClang@9.1.0 -MPI +PY@2.7 +H5 +ADIOS1
+      name: AppleClang@9.1.0 -MPI +PY@3.7 +H5 +ADIOS1
       os: osx
       osx_image: xcode9.4
       sudo: required
@@ -300,16 +300,15 @@ jobs:
         - CXXSPEC="%clang@9.1.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
-    # Clang 10.0.0-apple + Python 2.7.15 @ OSX "mojave" with libc++
+    # Clang 10.0.0-apple + Python 3.7.2 @ OSX "mojave" with libc++
     - <<: *test-cpp-unit
-      name: AppleClang@10.0.0 -MPI +PY@2.7 +H5 +ADIOS1 libc++
+      name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 +ADIOS1 libc++
       os: osx
       osx_image: xcode10.1
       sudo: required
       language: generic
       env:
-        # FIXME: with python 3+ we can remove the -Wno-deprecated-register
-        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -Wno-deprecated-register" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
     # GCC 4.9.4
@@ -576,10 +575,12 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       travis_wait brew upgrade --cleanup;
       travis_wait brew upgrade --cleanup &&
+      travis_wait brew install python3 &&
       travis_wait brew install modules &&
       brew info modules &&
       source /usr/local/opt/modules/init/bash &&
-      export TRAVIS_PYTHON_VERSION=2.7.15;
+      export PATH=/usr/local/opt/python/libexec/bin:$PATH;
+      export TRAVIS_PYTHON_VERSION=3.7.2;
     fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -33,9 +33,9 @@ packages:
     paths:
       python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@3.6.3%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6
-      python@2.7.14%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
+      python@3.6.3%clang@5.0.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
       python@2.7.14%gcc@7.3.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
-      python@2.7.14%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
+      python@3.5.5%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@2.7.14%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python2.7
       python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -29,7 +29,7 @@ packages:
   adios:
     variants: ~zfp ~sz ~lz4 ~blosc
   python:
-    version: [2.7.14, 2.7.15, 3.5.5, 3.6.3, 3.7.1]
+    version: [2.7.14, 2.7.15, 3.5.5, 3.6.3, 3.7.1, 3.7.2]
     paths:
       python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@3.6.3%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6
@@ -40,8 +40,8 @@ packages:
       python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
       python@3.7.1%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
-      python@2.7.15%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
-      python@2.7.15%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr
+      python@3.7.2%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
+      python@3.7.2%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
     buildable: False
   all:
     providers:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,15 @@ if(openPMD_USE_PYTHON STREQUAL AUTO)
             set(openPMD_HAVE_PYTHON FALSE)
         endif()
     endif()
+    if(openPMD_HAVE_PYTHON AND
+       PYTHON_VERSION_MAJOR LESS 3)
+        set(openPMD_HAVE_PYTHON FALSE)
+        message(STATUS "python: Found version "
+                       "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} "
+                       "is NOT supported. Set for example "
+                       "-DPYTHON_EXECUTABLE=$(which python3) "
+                       "to use 3.5+.")
+    endif()
 elseif(openPMD_USE_PYTHON)
     if(openPMD_USE_INTERNAL_PYBIND11)
         add_subdirectory("${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/pybind11")
@@ -266,6 +275,13 @@ elseif(openPMD_USE_PYTHON)
         find_package(pybind11 2.2.4 CONFIG REQUIRED)  # 2.3.0
         set(openPMD_HAVE_PYTHON TRUE)
         message(STATUS "pybind11: Found version ${pybind11_VERSION}")
+    endif()
+    if(PYTHON_VERSION_MAJOR LESS 3)
+        message(FATAL_ERROR "python: Found version "
+                            "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} "
+                            "is NOT supported. Set for example "
+                            "-DPYTHON_EXECUTABLE=$(which python3) "
+                            "to use 3.5+.")
     endif()
 else()
     set(openPMD_HAVE_PYTHON FALSE)

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -9,7 +9,6 @@ License: LGPLv3+
 import openpmd_api as api
 
 import os
-import sys
 import shutil
 import unittest
 import ctypes
@@ -187,8 +186,7 @@ class APITest(unittest.TestCase):
         # TODO remove the .value and handle types directly?
         series.set_attribute("byte_c", ctypes.c_byte(30).value)
         series.set_attribute("ubyte_c", ctypes.c_ubyte(50).value)
-        if sys.version_info >= (3, 0):
-            series.set_attribute("char_c", ctypes.c_char(100).value)  # 'd'
+        series.set_attribute("char_c", ctypes.c_char(100).value)  # 'd'
         series.set_attribute("int16_c", ctypes.c_int16(2).value)
         series.set_attribute("int32_c", ctypes.c_int32(3).value)
         series.set_attribute("int64_c", ctypes.c_int64(4).value)
@@ -208,31 +206,24 @@ class APITest(unittest.TestCase):
             api.Access_Type.read_only
         )
 
-        if sys.version_info >= (3, 0):
-            self.assertEqual(series.get_attribute("char"), "c")
-            self.assertEqual(series.get_attribute("pystring"), "howdy!")
-            self.assertEqual(series.get_attribute("pystring2"), "howdy, too!")
-            self.assertEqual(bytes(series.get_attribute("pystring3")),
-                             b"howdy, again!")
-        else:
-            self.assertEqual(chr(series.get_attribute("char")), "c")
-            # we don't officially support Python 2, so it's fine if
-            # strings are returned as weird list of int (of ascii codes)
+        self.assertEqual(series.get_attribute("char"), "c")
+        self.assertEqual(series.get_attribute("pystring"), "howdy!")
+        self.assertEqual(series.get_attribute("pystring2"), "howdy, too!")
+        self.assertEqual(bytes(series.get_attribute("pystring3")),
+                         b"howdy, again!")
         self.assertEqual(series.get_attribute("pyint"), 13)
         self.assertAlmostEqual(series.get_attribute("pyfloat"), 3.1416)
         self.assertEqual(series.get_attribute("pybool"), False)
 
         if found_numpy:
-            if sys.version_info >= (3, 0):
-                # scalar numpy types are broken in Python 2
-                self.assertEqual(series.get_attribute("int16"), 234)
-                self.assertEqual(series.get_attribute("int32"), 43)
-                self.assertEqual(series.get_attribute("int64"), 987654321)
-                self.assertAlmostEqual(series.get_attribute("single"), 1.234)
-                self.assertAlmostEqual(series.get_attribute("double"),
-                                       1.234567)
-                self.assertAlmostEqual(series.get_attribute("longdouble"),
-                                       1.23456789)
+            self.assertEqual(series.get_attribute("int16"), 234)
+            self.assertEqual(series.get_attribute("int32"), 43)
+            self.assertEqual(series.get_attribute("int64"), 987654321)
+            self.assertAlmostEqual(series.get_attribute("single"), 1.234)
+            self.assertAlmostEqual(series.get_attribute("double"),
+                                   1.234567)
+            self.assertAlmostEqual(series.get_attribute("longdouble"),
+                                   1.23456789)
             # array of ... (will be returned as list)
             self.assertListEqual(series.get_attribute("arr_int16"),
                                  [np.int16(23), np.int16(26), ])
@@ -286,8 +277,7 @@ class APITest(unittest.TestCase):
         # c_types
         self.assertEqual(series.get_attribute("byte_c"), 30)
         self.assertEqual(series.get_attribute("ubyte_c"), 50)
-        if sys.version_info >= (3, 0):
-            self.assertEqual(chr(series.get_attribute("char_c")), 'd')
+        self.assertEqual(chr(series.get_attribute("char_c")), 'd')
         self.assertEqual(series.get_attribute("int16_c"), 2)
         self.assertEqual(series.get_attribute("int32_c"), 3)
         self.assertEqual(series.get_attribute("int64_c"), 4)
@@ -323,9 +313,8 @@ class APITest(unittest.TestCase):
         extent = [42, 24, 11]
 
         # write one of each supported types
-        if sys.version_info >= (3, 0):
-            ms["char"][SCALAR].reset_dataset(DS(DT.CHAR, extent))
-            ms["char"][SCALAR].make_constant("c")
+        ms["char"][SCALAR].reset_dataset(DS(DT.CHAR, extent))
+        ms["char"][SCALAR].make_constant("c")
         ms["pyint"][SCALAR].reset_dataset(DS(DT.INT, extent))
         ms["pyint"][SCALAR].make_constant(13)
         ms["pyfloat"][SCALAR].reset_dataset(DS(DT.DOUBLE, extent))
@@ -369,32 +358,30 @@ class APITest(unittest.TestCase):
         o = [1, 2, 3]
         e = [1, 1, 1]
 
-        if sys.version_info >= (3, 0):
-            self.assertEqual(ms["char"][SCALAR].load_chunk(o, e), ord('c'))
+        self.assertEqual(ms["char"][SCALAR].load_chunk(o, e), ord('c'))
         self.assertEqual(ms["pyint"][SCALAR].load_chunk(o, e), 13)
         self.assertEqual(ms["pyfloat"][SCALAR].load_chunk(o, e), 3.1416)
         self.assertEqual(ms["pybool"][SCALAR].load_chunk(o, e), False)
 
         if found_numpy:
-            if sys.version_info >= (3, 0):
-                self.assertTrue(ms["int16"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('int16'))
-                self.assertTrue(ms["int32"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('int32'))
-                self.assertTrue(ms["int64"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('int64'))
-                self.assertTrue(ms["uint16"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('uint16'))
-                self.assertTrue(ms["uint32"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('uint32'))
-                self.assertTrue(ms["uint64"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('uint64'))
-                self.assertTrue(ms["single"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('single'))
-                self.assertTrue(ms["double"][SCALAR].load_chunk(o, e).dtype ==
-                                np.dtype('double'))
-                self.assertTrue(ms["longdouble"][SCALAR].load_chunk(o, e).dtype
-                                == np.dtype('longdouble'))
+            self.assertTrue(ms["int16"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('int16'))
+            self.assertTrue(ms["int32"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('int32'))
+            self.assertTrue(ms["int64"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('int64'))
+            self.assertTrue(ms["uint16"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('uint16'))
+            self.assertTrue(ms["uint32"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('uint32'))
+            self.assertTrue(ms["uint64"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('uint64'))
+            self.assertTrue(ms["single"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('single'))
+            self.assertTrue(ms["double"][SCALAR].load_chunk(o, e).dtype ==
+                            np.dtype('double'))
+            self.assertTrue(ms["longdouble"][SCALAR].load_chunk(o, e).dtype
+                            == np.dtype('longdouble'))
 
             self.assertEqual(ms["int16"][SCALAR].load_chunk(o, e),
                              np.int16(234))
@@ -408,11 +395,10 @@ class APITest(unittest.TestCase):
                              np.uint32(32))
             self.assertEqual(ms["uint64"][SCALAR].load_chunk(o, e),
                              np.uint64(9876543210))
-            if sys.version_info >= (3, 0):
-                self.assertEqual(ms["single"][SCALAR].load_chunk(o, e),
-                                 np.single(1.234))
-                self.assertEqual(ms["longdouble"][SCALAR].load_chunk(o, e),
-                                 np.longdouble(1.23456789))
+            self.assertEqual(ms["single"][SCALAR].load_chunk(o, e),
+                             np.single(1.234))
+            self.assertEqual(ms["longdouble"][SCALAR].load_chunk(o, e),
+                             np.longdouble(1.23456789))
             self.assertEqual(ms["double"][SCALAR].load_chunk(o, e),
                              np.double(1.234567))
 
@@ -714,24 +700,17 @@ class APITest(unittest.TestCase):
             numParticles, np.array([10, 113], np.uint64))
         np.testing.assert_almost_equal(
             numParticlesOffset, np.array([0, 10], np.uint64))
-        if sys.version_info >= (3, 0):
-            np.testing.assert_almost_equal(
-                extent_x, [10., 113.])
-            np.testing.assert_almost_equal(
-                extent_y, [123., 123.])
-            np.testing.assert_almost_equal(
-                offset_x, [0., 10.])
-            np.testing.assert_almost_equal(
-                offset_y, [0., 0.])
+        np.testing.assert_almost_equal(
+            extent_x, [10., 113.])
+        np.testing.assert_almost_equal(
+            extent_y, [123., 123.])
+        np.testing.assert_almost_equal(
+            offset_x, [0., 10.])
+        np.testing.assert_almost_equal(
+            offset_y, [0., 0.])
 
     def testParticlePatches(self):
         self.assertRaises(TypeError, api.Particle_Patches)
-
-        # skip test in Python 2:
-        #   scalar numpy arrays do not overload to py::buffer type
-        #   and are casted to Python instrinsic int
-        if sys.version_info < (3, 0):
-            return
 
         backend_filesupport = {
             'hdf5': 'h5',


### PR DESCRIPTION
We never officially supported Python 2, but I had some parts in here. Nevertheless, Numpy scalar support and other quirks like strings are so painful, that is makes no sense to allow and support it really.

Therefore, we enforce Python 3 now in all places and remove it from CI. Also, Python 2 is soon [to be buried](https://pythonclock.org/) community-wide [anyway](https://python3statement.org/) :)