### PR TITLE
FindADIOS: Cross-Compile Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Bug Fixes
 """""""""
 
 - fix compilation with C++17 for python bindings #438
+- ``FindADIOS.cmake``: Cross-Compile Support #436
 
 Other
 """""

--- a/share/openPMD/cmake/FindADIOS.cmake
+++ b/share/openPMD/cmake/FindADIOS.cmake
@@ -224,9 +224,9 @@ if(ADIOS_FOUND)
 
         # find static lib: absolute path in -L then default
         if(_LIB MATCHES "^glib")
-            find_library(_LIB_DIR NAMES ${_LIB} PATHS ${ADIOS_LIBRARY_DIRS} NAMES glib-2.0 CMAKE_FIND_ROOT_PATH_BOTH)
+            find_library(_LIB_DIR NAMES ${_LIB} PATHS ${ADIOS_LIBRARY_DIRS} NAMES glib-2.0)
         else()
-            find_library(_LIB_DIR NAMES ${_LIB} PATHS ${ADIOS_LIBRARY_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
+            find_library(_LIB_DIR NAMES ${_LIB} PATHS ${ADIOS_LIBRARY_DIRS})
         endif()
 
         if(_LIB MATCHES "^.*nompi.*$")


### PR DESCRIPTION
Add cross-compile support to `FindADIOS.cmake` script. The search for transitive dependencies in `CMAKE_FIND_ROOT_PATH` is controlled via the `CMAKE_FIND_ROOT_PATH_MODE_LIBRARY` switch, e.g. in a toolchain file, and should not be overwritten on a per-call basis.

First seen on new conda-forge toolchain for OSX with @mingwandroid