### PR TITLE
pybind11: C++17 variant trait

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Features
 Bug Fixes
 """""""""
 
+- fix compilation with C++17 for python bindings #438
+
 Other
 """""
 

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -34,6 +34,8 @@
 
 // std::variant
 //   https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
+// in C++17 mode already defined in <pybind11/stl.h>
+#if __cplusplus < 201703L
 namespace pybind11 {
 namespace detail {
     template< typename... Ts >
@@ -43,6 +45,7 @@ namespace detail {
 
 } // namespace detail
 } // namespace pybind11
+#endif
 
 namespace py = pybind11;
 using namespace openPMD;


### PR DESCRIPTION
When building for C++17 with GCC 7.3 we don't need to define a variant trait as `pybind11/stl.h` already does that for us.

Related to #437