### PR TITLE
IOTask Parameters: Export Symbols

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Bug Fixes
 
 - fix compilation with C++17 for python bindings #438
 - ``FindADIOS.cmake``: Cross-Compile Support #436
+- ADIOS1: fix runtime crash with libc++ (e.g. OSX) #442
 
 Other
 """""

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -30,6 +30,12 @@
 #include <string>
 #include <utility>
 
+#if _MSC_VER
+#   define EXPORT __declspec( dllexport )
+#else
+#   define EXPORT __attribute__((visibility("default")))
+#endif
+
 
 namespace openPMD
 {
@@ -41,7 +47,12 @@ getWritable(Attributable*);
 
 /** Type of IO operation between logical and persistent data.
  */
-enum class Operation
+#if defined(__GNUC__) && (__GNUC__ < 6) && !defined(__clang__)
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43407
+enum class Operation : EXPORT unsigned int
+#else
+enum class EXPORT Operation
+#endif
 {
     CREATE_FILE,
     OPEN_FILE,
@@ -66,7 +77,7 @@ enum class Operation
     LIST_ATTS
 };  //Operation
 
-struct AbstractParameter
+struct EXPORT AbstractParameter
 {
     virtual ~AbstractParameter() = default;
     AbstractParameter() = default;
@@ -87,7 +98,7 @@ struct AbstractParameter
  * @tparam  Operation   Type of Operation to be executed.
  */
 template< Operation >
-struct Parameter : public AbstractParameter
+struct EXPORT Parameter : public AbstractParameter
 {
     Parameter() = delete;
     Parameter(Parameter const &) = delete;
@@ -95,7 +106,7 @@ struct Parameter : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::CREATE_FILE > : public AbstractParameter
+struct EXPORT Parameter< Operation::CREATE_FILE > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
@@ -111,7 +122,7 @@ struct Parameter< Operation::CREATE_FILE > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::OPEN_FILE > : public AbstractParameter
+struct EXPORT Parameter< Operation::OPEN_FILE > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
@@ -127,7 +138,7 @@ struct Parameter< Operation::OPEN_FILE > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::DELETE_FILE > : public AbstractParameter
+struct EXPORT Parameter< Operation::DELETE_FILE > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
@@ -143,7 +154,7 @@ struct Parameter< Operation::DELETE_FILE > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::CREATE_PATH > : public AbstractParameter
+struct EXPORT Parameter< Operation::CREATE_PATH > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {};
@@ -159,7 +170,7 @@ struct Parameter< Operation::CREATE_PATH > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::OPEN_PATH > : public AbstractParameter
+struct EXPORT Parameter< Operation::OPEN_PATH > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {};
@@ -175,7 +186,7 @@ struct Parameter< Operation::OPEN_PATH > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::DELETE_PATH > : public AbstractParameter
+struct EXPORT Parameter< Operation::DELETE_PATH > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {};
@@ -191,7 +202,7 @@ struct Parameter< Operation::DELETE_PATH > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::LIST_PATHS > : public AbstractParameter
+struct EXPORT Parameter< Operation::LIST_PATHS > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), paths(p.paths) {};
@@ -208,7 +219,7 @@ struct Parameter< Operation::LIST_PATHS > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::CREATE_DATASET > : public AbstractParameter
+struct EXPORT Parameter< Operation::CREATE_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -232,7 +243,7 @@ struct Parameter< Operation::CREATE_DATASET > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::EXTEND_DATASET > : public AbstractParameter
+struct EXPORT Parameter< Operation::EXTEND_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -250,7 +261,7 @@ struct Parameter< Operation::EXTEND_DATASET > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::OPEN_DATASET > : public AbstractParameter
+struct EXPORT Parameter< Operation::OPEN_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -271,7 +282,7 @@ struct Parameter< Operation::OPEN_DATASET > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::DELETE_DATASET > : public AbstractParameter
+struct EXPORT Parameter< Operation::DELETE_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
@@ -287,7 +298,7 @@ struct Parameter< Operation::DELETE_DATASET > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::WRITE_DATASET > : public AbstractParameter
+struct EXPORT Parameter< Operation::WRITE_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -308,7 +319,7 @@ struct Parameter< Operation::WRITE_DATASET > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::READ_DATASET > : public AbstractParameter
+struct EXPORT Parameter< Operation::READ_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -329,7 +340,7 @@ struct Parameter< Operation::READ_DATASET > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::LIST_DATASETS > : public AbstractParameter
+struct EXPORT Parameter< Operation::LIST_DATASETS > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -347,7 +358,7 @@ struct Parameter< Operation::LIST_DATASETS > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::DELETE_ATT > : public AbstractParameter
+struct EXPORT Parameter< Operation::DELETE_ATT > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
@@ -363,7 +374,7 @@ struct Parameter< Operation::DELETE_ATT > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::WRITE_ATT > : public AbstractParameter
+struct EXPORT Parameter< Operation::WRITE_ATT > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -382,7 +393,7 @@ struct Parameter< Operation::WRITE_ATT > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::READ_ATT > : public AbstractParameter
+struct EXPORT Parameter< Operation::READ_ATT > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -403,7 +414,7 @@ struct Parameter< Operation::READ_ATT > : public AbstractParameter
 };
 
 template<>
-struct Parameter< Operation::LIST_ATTS > : public AbstractParameter
+struct EXPORT Parameter< Operation::LIST_ATTS > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
@@ -429,7 +440,7 @@ struct Parameter< Operation::LIST_ATTS > : public AbstractParameter
  * 3) concrete Writable object corresponding to both a local representation in
  *    openPMD-api and a persistent object in a file on disk
  */
-class IOTask
+class EXPORT IOTask
 {
 public:
     /** Constructor for self-contained description of single IO operation.
@@ -465,3 +476,5 @@ public:
     std::shared_ptr< AbstractParameter > parameter;
 };  // IOTask
 } // namespace openPMD
+
+#undef EXPORT


### PR DESCRIPTION
Try to avoid a [`dynamic_cast` nullptr issue](https://github.com/openPMD/openPMD-api/blob/0.7.0-alpha/src/IO/ADIOS/ADIOS1IOHandler.cpp#L100) with the ADIOS1 wrapper libraries with `libc++`. The parameter symbols should not be hidden in one translation unit but exposed in another.

This fixes a segfault as soon as the ADIOS1 backend is used in a `libc++` stack, e.g. on OSX, where the `dynamic_cast` in the external ADIOS1 wrapper library for `Parameter*`'s returned a `nullptr` due to the reasons linked below (inconsistent visibility causes issues).

References:
- http://www.russellmcc.com/posts/2013-08-03-rtti.html
- https://stackoverflow.com/questions/49316779/dynamic-cast-dynamic-cast-fails-with-dylib-on-osx-xcode
- https://github.com/conda-forge/openpmd-api-feedstock/pull/13 https://github.com/conda-forge/openpmd-api-feedstock/pull/14 https://github.com/conda-forge/openpmd-api-feedstock/pull/17
- #441 ([ok?!](https://travis-ci.org/openPMD/openPMD-api/jobs/480360168)), #444 ([reproduced: fails with segfault](https://travis-ci.org/openPMD/openPMD-api/jobs/480644238))
- #254