### PR TITLE
Doc: Spack Variant Updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,10 +27,12 @@ Bug Fixes
 Other
 """""
 
+- CI: clang libc++ coverage #441 #444
 - Docs:
 
   - additional release workflows for maintainers #439
   - ADIOS1 backend options in manual #440
+  - updated Spack variants #445
 
 
 0.7.0-alpha

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Choose *one* of the install methods below to get started:
 ### [Spack](https://spack.io)
 
 ```bash
-# optional:               +python ^python@3:
+# optional:               +python +adios1 -mpi
 spack install openpmd-api
 spack load -r openpmd-api
 ```

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -31,7 +31,7 @@ A package for openPMD-api is available on the Spack package manager.
 
 .. code-block:: bash
 
-   # optional:               +python ^python@3:
+   # optional:               +python +adios1 -mpi
    spack install openpmd-api
    spack load -r openpmd-api
 


### PR DESCRIPTION
Update the spack variant options.

Python3+ is now the default and ADIOS1 needs to be explicitly enabled for now, since it broke too often in Spack mainline due to SZ API changes, which is not the first thing I want to throw in a new user's face.