### PR TITLE
mpi4py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -640,6 +640,12 @@ install:
         py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION
         $CXXSPEC &&
       spack load py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
+      if [ $USE_MPI == "ON" ]; then
+        travis_wait spack install
+          py-mpi4py ^python@$TRAVIS_PYTHON_VERSION
+          $CXXSPEC &&
+        spack load py-mpi4py ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
+      fi;
     fi
   - if [ $USE_HDF5 == "ON" ]; then
       travis_wait spack install

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,8 @@
 Changelog
 =========
 
-0.7.2-alpha
------------
+0.8.0-beta
+----------
 **Date:** TBA
 
 [Title]
@@ -17,6 +17,8 @@ Changes to "0.7.1-alpha"
 Features
 """"""""
 
+- Python: mpi4py support added #454
+
 Bug Fixes
 """""""""
 
@@ -24,6 +26,7 @@ Other
 """""
 
 - increase pybind11 dependency to 2.2.4+ #455
+- Python: remove (inofficial) bindings for 2.7 #435
 - Docs:
 
   - PyPI install method #450 #451

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,10 +574,6 @@ if(openPMD_HAVE_PYTHON)
         PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
         COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
     )
-
-    #if(openPMD_HAVE_MPI)
-    #    target_link_libraries(openPMD.py PRIVATE PythonModule::mpi4py)
-    #endif()
 endif()
 
 # tests
@@ -868,6 +864,16 @@ endif()
 # Python Examples
 if(openPMD_HAVE_PYTHON)
     if(EXISTS "${openPMD_BINARY_DIR}/samples/git-sample/")
+        execute_process(COMMAND ${PYTHON_EXECUTABLE}
+            -m mpi4py
+            -c "import mpi4py.MPI"
+            RESULT_VARIABLE MPI4PY_RETURN)
+
+        if(NOT MPI4PY_RETURN EQUAL 0)
+            message(STATUS "Note: mpi4py not found. "
+                           "Skipping MPI-parallel Python examples.")
+        endif()
+
         foreach(examplename ${openPMD_PYTHON_EXAMPLE_NAMES})
             add_custom_command(TARGET openPMD.py POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy
@@ -875,12 +881,25 @@ if(openPMD_HAVE_PYTHON)
                         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
             )
             if(BUILD_TESTING)
-                add_test(NAME Example.py.${examplename}
-                    COMMAND ${PYTHON_EXECUTABLE}
-                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
-                    WORKING_DIRECTORY
-                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-                )
+                if(${examplename} MATCHES "^.*_parallel$")
+                    if(openPMD_HAVE_MPI AND MPI4PY_RETURN EQUAL 0)
+                        # see https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html
+                        add_test(NAME Example.py.${examplename}
+                            COMMAND ${MPI_TEST_EXE} ${PYTHON_EXECUTABLE} -m mpi4py
+                                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
+                            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+                        )
+                    else()
+                        continue()
+                    endif()
+                else()
+                    add_test(NAME Example.py.${examplename}
+                        COMMAND ${PYTHON_EXECUTABLE}
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
+                        WORKING_DIRECTORY
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+                    )
+                endif()
                 if(WIN32)
                     string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BASEDIR ${openPMD_BINARY_DIR})
                     string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,8 @@ set(openPMD_EXAMPLE_NAMES
 set(openPMD_PYTHON_EXAMPLE_NAMES
     2_read_serial
     3_write_serial
+    4_read_parallel
+    5_write_parallel
     7_extended_write_serial
     9_particle_write_serial
 )

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Optional language bindings:
   * Python 3.5 - 3.7
   * pybind 2.2.4+
   * numpy 1.15+
+  * mpi4py 2.1+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ conda install -c conda-forge openpmd-api
 [![PyPI Downloads](https://img.shields.io/pypi/dm/openPMD-api.svg)](https://pypi.org/project/openPMD-api)
 
 ```bash
-# optional:             --user
+# optional:            [mpi] --user
 pip install openPMD-api
 ```
 

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -44,3 +44,4 @@ Optional: language bindings
   * Python 3.5 - 3.7
   * pybind11 2.2.4+
   * numpy 1.15+
+  * mpi4py 2.1+

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -67,7 +67,7 @@ Please feel free to `report <https://github.com/openPMD/openPMD-api/issues/new/c
 
 .. code-block:: bash
 
-   # optional:             --user
+   # optional:            [mpi] --user
    pip install openPMD-api
 
 .. _install-cmake:

--- a/examples/4_read_parallel.py
+++ b/examples/4_read_parallel.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""
+This file is part of the openPMD-api.
+
+Copyright 2019 openPMD contributors
+Authors: Axel Huebl
+License: LGPLv3+
+"""
+import openpmd_api
+
+# https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html
+# on import: calls MPI_Init_thread()
+# exit hook: calls MPI_Finalize()
+from mpi4py import MPI
+
+
+if __name__ == "__main__":
+    # also works with any other MPI communicator
+    comm = MPI.COMM_WORLD
+
+    series = openpmd_api.Series(
+        "../samples/git-sample/data%T.h5",
+        openpmd_api.Access_Type.read_only,
+        comm
+    )
+    if 0 == comm.rank:
+        print("Read a series in parallel with {} MPI ranks".format(
+              comm.size))
+
+    E_x = series.iterations[100].meshes["E"]["x"]
+
+    chunk_offset = [comm.rank + 1, 1, 1]
+    chunk_extent = [2, 2, 1]
+
+    chunk_data = E_x.load_chunk(chunk_offset, chunk_extent)
+
+    if 0 == comm.rank:
+        print("Queued the loading of a single chunk per MPI rank from disk, "
+              "ready to execute")
+    series.flush()
+
+    if 0 == comm.rank:
+        print("Chunks have been read from disk")
+
+    for i in range(comm.size):
+        if i == comm.rank:
+            print("Rank {} - Read chunk contains:".format(i))
+            for row in range(chunk_extent[0]):
+                for col in range(chunk_extent[1]):
+                    print("\t({}|{}|1)\t{:e}".format(
+                        row + chunk_offset[0],
+                        col + chunk_offset[1],
+                        chunk_data[row, col, 0]
+                    ), end='')
+                print("")
+
+        # this barrier is not necessary but structures the example output
+        comm.Barrier()
+
+    # The files in 'series' are still open until the object is destroyed, on
+    # which it cleanly flushes and closes all open file handles.
+    # One can delete the object explicitly (or let it run out of scope) to
+    # trigger this.
+    # In any case, this must happen before MPI_Finalize() is called
+    # (usually in the mpi4py exit hook).
+    del series

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""
+This file is part of the openPMD-api.
+
+Copyright 2019 openPMD contributors
+Authors: Axel Huebl
+License: LGPLv3+
+"""
+import openpmd_api
+import numpy as np
+
+# https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html
+# on import: calls MPI_Init_thread()
+# exit hook: calls MPI_Finalize()
+from mpi4py import MPI
+
+
+if __name__ == "__main__":
+    # also works with any other MPI communicator
+    comm = MPI.COMM_WORLD
+
+    # allocate a data set to write
+    global_data = np.arange(comm.size, dtype=np.double)
+    if 0 == comm.rank:
+        print("Set up a 1D array with one element per MPI rank ({}) "
+              "that will be written to disk".format(comm.size))
+
+    local_data = np.array([0, ], dtype=np.double)
+    local_data[0] = global_data[comm.rank]
+    if 0 == comm.rank:
+        print("Set up a 1D array with one element, representing the view of "
+              "the MPI rank")
+
+    # open file for writing
+    series = openpmd_api.Series(
+        "../samples/5_parallel_write_py.h5",
+        openpmd_api.Access_Type.create,
+        comm
+    )
+    if 0 == comm.rank:
+        print("Created an empty series in parallel with {} MPI ranks".format(
+              comm.size))
+
+    id = series.iterations[1]. \
+        meshes["id"][openpmd_api.Mesh_Record_Component.SCALAR]
+
+    datatype = openpmd_api.Datatype.DOUBLE
+    # datatype = determineDatatype(local_data)
+    dataset_extent = [comm.size, ]
+    dataset = openpmd_api.Dataset(datatype, dataset_extent)
+
+    if 0 == comm.rank:
+        print("Created a Dataset of size {} and Datatype {}".format(
+              dataset.extent[0], dataset.dtype))
+
+    id.reset_dataset(dataset)
+    if 0 == comm.rank:
+        print("Set the global on-disk Dataset properties for the scalar field "
+              "id in iteration 1")
+
+    series.flush()
+    if 0 == comm.rank:
+        print("File structure has been written to disk")
+
+    chunk_offset = [comm.rank, ]
+    chunk_extent = [1, ]
+    id.store_chunk(local_data, chunk_offset, chunk_extent)
+    if 0 == comm.rank:
+        print("Stored a single chunk per MPI rank containing its contribution,"
+              " ready to write content to disk")
+
+    series.flush()
+    if 0 == comm.rank:
+        print("Dataset content has been fully written to disk")
+
+    # The files in 'series' are still open until the object is destroyed, on
+    # which it cleanly flushes and closes all open file handles.
+    # One can delete the object explicitly (or let it run out of scope) to
+    # trigger this.
+    del series

--- a/setup.py
+++ b/setup.py
@@ -128,11 +128,9 @@ setup(
     python_requires='>=3.5, <3.8',
     # tests_require=['pytest'],
     install_requires=install_requires,
-    # extras_require = {
-    #    'GUI':  ["ipywidgets", "matplotlib", "cython"],
-    #    'plot': ["matplotlib", "cython"],
-    #    'tutorials': ["ipywidgets", "matplotlib", "wget", "cython"]
-    # },
+    extras_require={
+        'mpi': ['mpi4py'],
+    },
     # cmdclass={'test': PyTest},
     # platforms='any',
     classifiers=[

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -20,17 +20,93 @@
  */
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#if openPMD_HAVE_MPI
+//  re-implemented signatures:
+//  include <mpi4py/mpi4py.h>
+#   include <mpi.h>
+#endif
 
 #include "openPMD/Series.hpp"
+#include <string>
 
 namespace py = pybind11;
 using namespace openPMD;
+
+#if openPMD_HAVE_MPI
+    /** mpi4py communicator wrapper
+     *
+     * refs:
+     * - https://github.com/mpi4py/mpi4py/blob/3.0.0/src/mpi4py/libmpi.pxd#L35-L36
+     * - https://github.com/mpi4py/mpi4py/blob/3.0.0/src/mpi4py/MPI.pxd#L100-L105
+     * - installed: include/mpi4py/mpi4py.MPI.h
+     */
+    struct openPMD_PyMPICommObject
+    {
+        PyObject_HEAD
+        MPI_Comm ob_mpi;
+        unsigned int flags;
+    };
+    using openPMD_PyMPIIntracommObject = openPMD_PyMPICommObject;
+#endif
 
 
 void init_Series(py::module &m) {
     py::class_<Series, Attributable>(m, "Series")
 
-        .def(py::init<std::string const&, AccessType>())
+        .def(py::init<std::string const&, AccessType>(),
+            py::arg("filepath"), py::arg("access_type"))
+#if openPMD_HAVE_MPI
+        .def(py::init([](std::string const& filepath, AccessType at, py::object &comm){
+            //! @todo perform mpi4py import test and check min-version
+            //!       careful: double MPI_Init risk? only import mpi4py.MPI?
+            //!       required C-API init? probably just checks:
+            //! refs:
+            //! - https://bitbucket.org/mpi4py/mpi4py/src/3.0.0/demo/wrap-c/helloworld.c
+            //! - installed: include/mpi4py/mpi4py.MPI_api.h
+            // if( import_mpi4py() < 0 ) { here be dragons }
+
+            if( comm.ptr() == Py_None )
+                throw std::runtime_error("Series: MPI communicator cannot be None.");
+            if( comm.ptr() == nullptr )
+                throw std::runtime_error("Series: MPI communicator is a nullptr.");
+
+            // check type string to see if this is mpi4py
+            //   __str__ (pretty)
+            //   __repr__ (unambiguous)
+            //   mpi4py: <mpi4py.MPI.Intracomm object at 0x7f998e6e28d0>
+            //   pyMPI:  ... (todo)
+            py::str const comm_pystr = py::repr(comm);
+            std::string const comm_str = comm_pystr.cast<std::string>();
+            if( comm_str.substr(0, 12) != std::string("<mpi4py.MPI.") )
+                throw std::runtime_error("Series: comm is not an mpi4py communicator: " +
+                                         comm_str);
+            // only checks same layout, e.g. an `int` in `PyObject` could pass this
+            if( !py::isinstance< py::class_<openPMD_PyMPIIntracommObject> >(comm.get_type()) )
+                //! @todo add mpi4py version from above import check to error message
+                throw std::runtime_error("Series: comm has unexpected type layout in " +
+                                         comm_str +
+                                         " (Mismatched MPI at compile vs. runtime? "
+                                         "Breaking mpi4py release?)");
+
+            //! @todo other possible implementations:
+            // - pyMPI (inactive since 2008?): import mpi; mpi.WORLD
+
+            // reimplementation of mpi4py's:
+            // MPI_Comm* mpiCommPtr = PyMPIComm_Get(comm.ptr());
+            MPI_Comm* mpiCommPtr = &((openPMD_PyMPIIntracommObject*)(comm.ptr()))->ob_mpi;
+
+            if( PyErr_Occurred() )
+                throw std::runtime_error("Series: MPI communicator access error.");
+            if( mpiCommPtr == nullptr ) {
+                throw std::runtime_error("Series: MPI communicator cast failed. "
+                                         "(Mismatched MPI at compile vs. runtime?)");
+            }
+
+            return new Series(filepath, at, *mpiCommPtr);
+        }),
+            py::arg("filepath"), py::arg("access_type"), py::arg("mpi_communicator")
+        )
+#endif
 
         .def_property_readonly("openPMD", &Series::openPMD)
         .def("set_openPMD", &Series::setOpenPMD)


### PR DESCRIPTION
Add support for MPI-parallel I/O in python3 bindings.

Close #99

### To Do

- [x] CMake Logic
- [x] min. versions in docs (should work with any mpi4py version, at least for > 1.0, from what the impls for the comm type look; but [mpi4py.run](https://mpi4py.readthedocs.io/en/3.0.0/mpi4py.run.html) options are new in 2.1+)
- [x] Examples
- [ ] Unit Tests
- [x] extras in `setup.py`