### PR TITLE
OpenMPI Root: Tailored

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Bug Fixes
 - do not require write permissions to open ``Series`` read-only #395
 - loadChunk: re-enable range/extent checks for adjusted ranges #469
 - Python: stricter contiguous check for user-provided arrays #458
+- CMake tests as root: apply OpenMPI flag only if present #456
 
 Other
 """""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,7 +807,13 @@ if(BUILD_TESTING)
 
     # OpenMPI root guard: https://github.com/open-mpi/ompi/issues/4451
     if("$ENV{USER}" STREQUAL "root")
-        set(MPI_ALLOW_ROOT --allow-run-as-root)
+        # calling even --help as root will abort and warn on stderr
+        execute_process(COMMAND ${MPIEXEC_EXECUTABLE} --help
+            ERROR_VARIABLE MPIEXEC_HELP_TEXT
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            if(${MPIEXEC_HELP_TEXT} MATCHES "^.*allow-run-as-root.*$")
+                set(MPI_ALLOW_ROOT --allow-run-as-root)
+            endif()
     endif()
     set(MPI_TEST_EXE
         ${MPIEXEC_EXECUTABLE}


### PR DESCRIPTION
Only add `--allow-run-as-root` if the MPI flavor is actually OpenMPI. Check the `mpiexec` command line options first.

### To Do

- [x] runtime test (as root)