### PR TITLE
Python: Slice Protocol for Record Component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Bug Fixes
 
 - do not require write permissions to open ``Series`` read-only #395
 - loadChunk: re-enable range/extent checks for adjusted ranges #469
+- Python: stricter contiguous check for user-provided arrays #458
 
 Other
 """""

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,10 @@ Changes to "0.7.1-alpha"
 Features
 """"""""
 
-- Python: mpi4py support added #454
+- Python:
+
+  - mpi4py support added #454
+  - slice protocol for record component #458
 
 Bug Fixes
 """""""""

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -37,11 +37,7 @@ if __name__ == "__main__":
     print("Field E.x has shape {0} and datatype {1}".format(
           shape, E_x.dtype))
 
-    offset = [1, 1, 1]
-    extent = [2, 2, 1]
-    # TODO buffer protocol / numpy bindings
-    # chunk_data = E_x[1:3, 1:3, 1:2]
-    chunk_data = E_x.load_chunk(offset, extent)
+    chunk_data = E_x[1:3, 1:3, 1:2]
     # print("Queued the loading of a single chunk from disk, "
     #       "ready to execute")
     series.flush()

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -46,14 +46,7 @@ if __name__ == "__main__":
     series.flush()
     print("File structure has been written")
 
-    # TODO implement slicing protocol
-    # E[offset[0]:extent[0], offset[1]:extent[1]] = global_data
-
-    # individual chunks from input or to output record component
-    #   offset = [0, 0]
-    #   rho.store_chunk(global_data, offset, extent)
-    # whole input to zero-offset in output record component
-    rho.store_chunk(global_data)
+    rho[()] = global_data
 
     print("Stored the whole Dataset contents as a single chunk, " +
           "ready to write content")

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -62,9 +62,7 @@ if __name__ == "__main__":
     if 0 == comm.rank:
         print("File structure has been written to disk")
 
-    chunk_offset = [comm.rank, ]
-    chunk_extent = [1, ]
-    id.store_chunk(local_data, chunk_offset, chunk_extent)
+    id[comm.rank:comm.rank+1] = local_data
     if 0 == comm.rank:
         print("Stored a single chunk per MPI rank containing its contribution,"
               " ready to write content to disk")

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -147,9 +147,7 @@ if __name__ == "__main__":
         for col in [0, 1, 2, 3, 4]:
             partial_mesh[col] = mesh_x[i, col]
 
-        o = [i, 0]
-        e = [1, 5]
-        mesh["x"].store_chunk(partial_mesh, o, e)
+        mesh["x"][i, 0:5] = partial_mesh
         # operations between store and flush MUST NOT modify the pointed-to
         # data
         f.flush()
@@ -163,10 +161,10 @@ if __name__ == "__main__":
         numParticlesOffset = 2*i
         numParticles = 2
 
-        o = [numParticlesOffset]
-        e = [numParticles]
-        electrons["position"]["x"].store_chunk(partial_particlePos, o, e)
-        electrons["positionOffset"]["x"].store_chunk(partial_particleOff, o, e)
+        o = numParticlesOffset
+        u = numParticles + o
+        electrons["position"]["x"][o:u] = partial_particlePos
+        electrons["positionOffset"]["x"][o:u] = partial_particleOff
 
         electrons.particle_patches["numParticles"][SCALAR].store(
             i, np.array([numParticles], dtype=np.uint64))


### PR DESCRIPTION
Draft for supporting slices in Python `Record_Component` load and store operations.

Related to #32 and #138.

Also fixes the "padded stride" (contiguous) detection in user-provided arrays:
Strides are not the only way to create non-contiguous buffers in Python. Also, non-owned views might look like stride-free, but are actually padded strides in another buffer object. Use the underlying C API now to check if contiguous.

Refs:

- https://docs.scipy.org/doc/numpy-1.15.0/reference/arrays.indexing.html

### To Do

- [x] unit tests including exception checks
- [x] ellipsis support
- [ ] newaxis support
- [x] `[()]` and `[:, :]` support
- [x] one slice (or even one index) abbreviation support
- [x] index omission support
- [x] over-selected upper range support in slices
- [x] single index slice reduces `ndim`, but `N:N+1` and `...` does not
- [x] `load_chunk`
- [x] `store_chunk`
- [x] update more examples
- [x] changelog