### PR TITLE
Differentiate accessTypes on use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,6 +195,7 @@ jobs:
         - if [ ! -d samples/git-sample/ ]; then
             if [ "$USE_SAMPLES" = "ON" ]; then
               $TRAVIS_BUILD_DIR/.travis/download_samples.sh;
+              chmod u-w samples/git-sample/*.h5;
             fi
           fi
         - if [ "$USE_PYTHON" == "ON" ]; then
@@ -503,6 +504,7 @@ jobs:
         - cd $HOME/build
         - if [ ! -d samples/git-sample/ ]; then
             $TRAVIS_BUILD_DIR/.travis/download_samples.sh;
+            chmod u-w samples/git-sample/*.h5;
           fi
         - CXXFLAGS="-g -O0 -fprofile-arcs -ftest-coverage" CXX=$CXX CC=$CC
           cmake

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Features
 Bug Fixes
 """""""""
 
+- do not require write permissions to open ``Series`` read-only #395
+
 Other
 """""
 

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -70,12 +70,14 @@ public:
 #if openPMD_HAVE_MPI
     AbstractIOHandler(std::string path, AccessType at, MPI_Comm)
         : directory{std::move(path)},
-          accessType{at}
+          accessTypeBackend{at},
+          accessTypeFrontend{at}
     { }
 #endif
     AbstractIOHandler(std::string path, AccessType at)
         : directory{std::move(path)},
-          accessType{at}
+          accessTypeBackend{at},
+          accessTypeFrontend{at}
     { }
     virtual ~AbstractIOHandler() = default;
 
@@ -95,7 +97,8 @@ public:
     virtual std::future< void > flush() = 0;
 
     std::string const directory;
-    AccessType const accessType;
+    AccessType const accessTypeBackend;
+    AccessType const accessTypeFrontend;
     std::queue< IOTask > m_work;
 }; // AbstractIOHandler
 

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -288,7 +288,7 @@ namespace openPMD
         std::shared_ptr< FILEHANDLE > getFilehandle(
             File,
             AccessType accessType
-        ); //, AccessType accessType=this->m_handler->accessType);
+        ); //, AccessType accessTypeFrontend=this->m_handler->accessTypeFrontend);
 
         // full operating system path of the given file
         std::string fullPath( File );

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -245,7 +245,7 @@ OPENPMD_private:
     void flushGroupBased();
     void flushMeshesPath();
     void flushParticlesPath();
-    void readFileBased(AccessType);
+    void readFileBased();
     void readGroupBased();
     void readBase();
     void read();

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -208,7 +208,7 @@ template< typename T >
 inline bool
 Attributable::setAttribute(std::string const& key, T const& value)
 {
-    if( IOHandler && AccessType::READ_ONLY == IOHandler->accessType )
+    if( IOHandler && AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
     {
         auxiliary::OutOfRangeMsg const out_of_range_msg(
             "Attribute",

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -112,7 +112,7 @@ public:
      */
     void clear()
     {
-        if( AccessType::READ_ONLY == IOHandler->accessType )
+        if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
             throw std::runtime_error("Can not clear a container in a read-only Series.");
 
         clear_unchecked();
@@ -146,7 +146,7 @@ public:
             return it->second;
         else
         {
-            if( AccessType::READ_ONLY == IOHandler->accessType )
+            if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
             {
                 auxiliary::OutOfRangeMsg const out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
@@ -173,7 +173,7 @@ public:
             return it->second;
         else
         {
-            if( AccessType::READ_ONLY == IOHandler->accessType )
+            if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
             {
                 auxiliary::OutOfRangeMsg out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
@@ -202,7 +202,7 @@ public:
      */
     virtual size_type erase(key_type const& key)
     {
-        if( AccessType::READ_ONLY == IOHandler->accessType )
+        if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
         auto res = m_container->find(key);
@@ -219,7 +219,7 @@ public:
     //! @todo why does const_iterator not work compile with pybind11?
     virtual iterator erase(iterator res)
     {
-        if( AccessType::READ_ONLY == IOHandler->accessType )
+        if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
         if( res != m_container->end() && res->second.written )

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -53,7 +53,7 @@ ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
         close(f.second);
     m_openReadFileHandles.clear();
 
-    if( this->m_handler->accessType != AccessType::READ_ONLY )
+    if( this->m_handler->accessTypeBackend != AccessType::READ_ONLY )
     {
         for( auto& f : m_openWriteFileHandles )
             close(f.second);

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -350,7 +350,7 @@ void
 CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
                                 Parameter< Operation::CREATE_FILE > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Creating a file in read-only mode is not possible.");
 
     if( !writable->written )
@@ -382,7 +382,7 @@ void
 CommonADIOS1IOHandlerImpl::createPath(Writable* writable,
                                 Parameter< Operation::CREATE_PATH > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Creating a path in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -415,7 +415,7 @@ void
 CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
                                    Parameter< Operation::CREATE_DATASET > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Creating a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -695,7 +695,7 @@ void
 CommonADIOS1IOHandlerImpl::deleteFile(Writable* writable,
                                 Parameter< Operation::DELETE_FILE > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Deleting a file opened as read only is not possible.");
 
     if( writable->written )
@@ -753,7 +753,7 @@ void
 CommonADIOS1IOHandlerImpl::writeDataset(Writable* writable,
                                   Parameter< Operation::WRITE_DATASET > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Writing into a dataset in a file opened as read only is not possible.");
 
     /* file opening is deferred until the first dataset write to a file occurs */
@@ -795,7 +795,7 @@ void
 CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
                                     Parameter< Operation::WRITE_ATT > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Writing an attribute in a file opened as read only is not possible.");
 
     std::string name = concrete_bp1_file_position(writable);

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -56,7 +56,7 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
         close(f.second);
     m_openReadFileHandles.clear();
 
-    if( this->m_handler->accessType != AccessType::READ_ONLY )
+    if( this->m_handler->accessTypeBackend != AccessType::READ_ONLY )
     {
         for( auto& f : m_openWriteFileHandles )
             close(f.second);

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -33,7 +33,7 @@ namespace openPMD
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
         std::string path,
-        AccessType accessType,
+        AccessType accessTypeBackend,
         Format format,
         MPI_Comm comm
     )
@@ -41,13 +41,13 @@ namespace openPMD
         switch( format )
         {
             case Format::HDF5:
-                return std::make_shared< ParallelHDF5IOHandler >(path, accessType, comm);
+                return std::make_shared< ParallelHDF5IOHandler >(path, accessTypeBackend, comm);
             case Format::ADIOS1:
-                return std::make_shared< ParallelADIOS1IOHandler >(path, accessType, comm);
+                return std::make_shared< ParallelADIOS1IOHandler >(path, accessTypeBackend, comm);
             case Format::ADIOS2:
                 throw std::runtime_error("ADIOS2 backend not yet implemented");
             default:
-                return std::make_shared< DummyIOHandler >(path, accessType);
+                return std::make_shared< DummyIOHandler >(path, accessTypeBackend);
         }
     }
 #endif

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -95,7 +95,7 @@ void
 HDF5IOHandlerImpl::createFile(Writable* writable,
                               Parameter< Operation::CREATE_FILE > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Creating a file in read-only mode is not possible.");
 
     if( !writable->written )
@@ -110,7 +110,7 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
         if( !auxiliary::ends_with(name, ".h5") )
             name += ".h5";
         unsigned flags;
-        if( m_handler->accessType == AccessType::CREATE )
+        if( m_handler->accessTypeBackend == AccessType::CREATE )
             flags = H5F_ACC_TRUNC;
         else
             flags = H5F_ACC_EXCL;
@@ -132,7 +132,7 @@ void
 HDF5IOHandlerImpl::createPath(Writable* writable,
                               Parameter< Operation::CREATE_PATH > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Creating a path in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -190,7 +190,7 @@ void
 HDF5IOHandlerImpl::createDataset(Writable* writable,
                                  Parameter< Operation::CREATE_DATASET > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Creating a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -299,7 +299,7 @@ void
 HDF5IOHandlerImpl::extendDataset(Writable* writable,
                                  Parameter< Operation::EXTEND_DATASET > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Extending a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -353,7 +353,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
         name += ".h5";
 
     unsigned flags;
-    AccessType at = m_handler->accessType;
+    AccessType at = m_handler->accessTypeBackend;
     if( at == AccessType::READ_ONLY )
         flags = H5F_ACC_RDONLY;
     else if( at == AccessType::READ_WRITE || at == AccessType::CREATE )
@@ -511,7 +511,7 @@ void
 HDF5IOHandlerImpl::deleteFile(Writable* writable,
                               Parameter< Operation::DELETE_FILE > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Deleting a file opened as read only is not possible.");
 
     if( writable->written )
@@ -541,7 +541,7 @@ void
 HDF5IOHandlerImpl::deletePath(Writable* writable,
                               Parameter< Operation::DELETE_PATH > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -585,7 +585,7 @@ void
 HDF5IOHandlerImpl::deleteDataset(Writable* writable,
                                  Parameter< Operation::DELETE_DATASET > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -629,7 +629,7 @@ void
 HDF5IOHandlerImpl::deleteAttribute(Writable* writable,
                                    Parameter< Operation::DELETE_ATT > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Deleting an attribute in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -658,7 +658,7 @@ void
 HDF5IOHandlerImpl::writeDataset(Writable* writable,
                                 Parameter< Operation::WRITE_DATASET > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Writing into a dataset in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);
@@ -744,7 +744,7 @@ void
 HDF5IOHandlerImpl::writeAttribute(Writable* writable,
                                   Parameter< Operation::WRITE_ATT > const& parameters)
 {
-    if( m_handler->accessType == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         throw std::runtime_error("Writing an attribute in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -71,7 +71,7 @@ namespace openPMD
         Parameter< Operation::CREATE_FILE > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessType != AccessType::READ_ONLY,
+        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
             "Creating a file in read-only mode is not possible." );
 
         if( !writable->written )
@@ -87,7 +87,7 @@ namespace openPMD
 
             auto res_pair = getPossiblyExisting( name );
             File shared_name = File( name );
-            VERIFY_ALWAYS( !( m_handler->accessType == AccessType::READ_WRITE &&
+            VERIFY_ALWAYS( !( m_handler->accessTypeBackend == AccessType::READ_WRITE &&
                               ( !std::get< 2 >( res_pair ) ||
                                 auxiliary::file_exists( fullPath( std::get< 0 >( res_pair ) ) ) ) ),
                 "Can only overwrite existing file in CREATE mode." );
@@ -190,7 +190,7 @@ namespace openPMD
         Parameter< Operation::CREATE_DATASET > const & parameter
     )
     {
-        if( m_handler->accessType == AccessType::READ_ONLY )
+        if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         {
             throw std::runtime_error( "Creating a dataset in a file opened as read only is not possible." );
         }
@@ -225,7 +225,7 @@ namespace openPMD
         Parameter< Operation::EXTEND_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessType != AccessType::READ_ONLY,
+        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
             "Cannot extend a dataset in read-only mode." )
         refreshFileFromParent( writable );
         setAndGetFilePosition( writable );
@@ -355,7 +355,7 @@ namespace openPMD
         Parameter< Operation::DELETE_FILE > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessType != AccessType::READ_ONLY,
+        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
             "Cannot delete files in read-only mode" )
 
         if( !writable->written )
@@ -389,7 +389,7 @@ namespace openPMD
         Parameter< Operation::DELETE_PATH > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessType != AccessType::READ_ONLY,
+        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
             "Cannot delete paths in read-only mode" )
 
         if( !writable->written )
@@ -495,7 +495,7 @@ namespace openPMD
         Parameter< Operation::DELETE_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessType != AccessType::READ_ONLY,
+        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
             "Cannot delete datasets in read-only mode" )
 
         if( !writable->written )
@@ -550,7 +550,7 @@ namespace openPMD
         Parameter< Operation::DELETE_ATT > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessType != AccessType::READ_ONLY,
+        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
             "Cannot delete attributes in read-only mode" )
         if( !writable->written )
         {
@@ -569,7 +569,7 @@ namespace openPMD
         Parameter< Operation::WRITE_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessType != AccessType::READ_ONLY,
+        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
             "Cannot write data in read-only mode." );
 
         auto pos = setAndGetFilePosition( writable );
@@ -600,7 +600,7 @@ namespace openPMD
         Parameter< Operation::WRITE_ATT > const & parameter
     )
     {
-        if( m_handler->accessType == AccessType::READ_ONLY )
+        if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         {
             throw std::runtime_error( "Creating a dataset in a file opened as read only is not possible." );
         }

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -140,7 +140,7 @@ Iteration::flushGroupBased(uint64_t i)
 void
 Iteration::flush()
 {
-    if( IOHandler->accessType == AccessType::READ_ONLY )
+    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
     {
         for( auto& m : meshes )
             m.second.flush(m.first);

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -184,7 +184,7 @@ Mesh::setTimeOffset(T to)
 void
 Mesh::flush_impl(std::string const& name)
 {
-    if( IOHandler->accessType == AccessType::READ_ONLY )
+    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
     {
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -101,7 +101,7 @@ ParticleSpecies::read()
 void
 ParticleSpecies::flush(std::string const& path)
 {
-    if( IOHandler->accessType == AccessType::READ_ONLY )
+    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
     {
         for( auto& record : *this )
             record.second.flush(record.first);

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -49,7 +49,7 @@ Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
 void
 Record::flush_impl(std::string const& name)
 {
-    if( IOHandler->accessType == AccessType::READ_ONLY )
+    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
     {
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -77,7 +77,7 @@ RecordComponent::getExtent() const
 void
 RecordComponent::flush(std::string const& name)
 {
-    if( IOHandler->accessType == AccessType::READ_ONLY )
+    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
     {
         while( !m_chunks->empty() )
         {

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -71,7 +71,7 @@ Attributable::getAttribute(std::string const& key) const
 bool
 Attributable::deleteAttribute(std::string const& key)
 {
-    if( AccessType::READ_ONLY == IOHandler->accessType )
+    if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
         throw std::runtime_error("Can not delete an Attribute in a read-only Series.");
 
     auto it = m_attributes->find(key);

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -44,7 +44,7 @@ PatchRecord::flush_impl(std::string const& path)
 {
     if( this->find(RecordComponent::SCALAR) == this->end() )
     {
-        if( IOHandler->accessType != AccessType::READ_ONLY )
+        if( IOHandler->accessTypeFrontend != AccessType::READ_ONLY )
             Container< PatchRecordComponent >::flush(path);
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -70,7 +70,7 @@ PatchRecordComponent::PatchRecordComponent()
 void
 PatchRecordComponent::flush(std::string const& name)
 {
-    if( IOHandler->accessType == AccessType::READ_ONLY )
+    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
     {
         while( !m_chunks->empty() )
         {


### PR DESCRIPTION
For frontend, use a seperate accessType variable that may change during the first read of a fileBased Series (required for setting values in case of READ_ONLY).
For the backend, continue using the same immutable accessType as before (desired by the user).

Fix #394.