### PR TITLE
CMake: Find Package _ROOT Env Policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Other
 
 - increase pybind11 dependency to 2.2.4+ #455
 - Python: remove (inofficial) bindings for 2.7 #435
-- CMake 3.12+: apply policy ``CMP0074`` for ``<Package>_ROOT`` vars #391
+- CMake 3.12+: apply policy ``CMP0074`` for ``<Package>_ROOT`` vars #391 #464
 - Docs:
 
   - PyPI install method #450 #451

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -2,6 +2,12 @@
 #   https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-a-package-configuration-file
 include(CMakeFindDependencyMacro)
 
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
 
 add_library(openPMD::thirdparty::mpark_variant INTERFACE IMPORTED)


### PR DESCRIPTION
Also set new CMake 3.12+ policy in config package.

Follow-up to #391