### PR TITLE
MPark.Variant: 1.4.0+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Other
 - increase pybind11 dependency to 2.2.4+ #455
 - Python: remove (inofficial) bindings for 2.7 #435
 - CMake 3.12+: apply policy ``CMP0074`` for ``<Package>_ROOT`` vars #391 #464
+- MPark.Variant: updated to 1.4.0+ #465
 - Docs:
 
   - PyPI install method #450 #451

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,9 +369,9 @@ if(openPMD_USE_INTERNAL_VARIANT)
     target_include_directories(openPMD::thirdparty::mpark_variant SYSTEM INTERFACE
         $<BUILD_INTERFACE:${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/variant/include>
     )
-    message(STATUS "MPark.Variant: Using INTERNAL version 1.3.0")
+    message(STATUS "MPark.Variant: Using INTERNAL version 1.4.0")
 else()
-    find_package(mpark_variant 1.3.0 REQUIRED)
+    find_package(mpark_variant 1.4.0 REQUIRED)
     target_link_libraries(openPMD::thirdparty::mpark_variant
         INTERFACE mpark_variant)
     message(STATUS "MPark.Variant: Found version ${mpark_variant_VERSION}")

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Required:
 * C++11 capable compiler, e.g. g++ 4.8+, clang 3.9+, VS 2015+
 
 Shipped internally in `share/openPMD/thirdParty/`:
-* [MPark.Variant](https://github.com/mpark/variant) 1.3.0+ ([BSL-1.0](https://github.com/mpark/variant/blob/master/LICENSE.md))
+* [MPark.Variant](https://github.com/mpark/variant) 1.4.0+ ([BSL-1.0](https://github.com/mpark/variant/blob/master/LICENSE.md))
 * [Catch2](https://github.com/catchorg/Catch2) 2.3.0+ ([BSL-1.0](https://github.com/catchorg/Catch2/blob/master/LICENSE.txt))
 * [pybind11](https://github.com/pybind/pybind11) 2.2.4+ ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
 * [NLohmann-JSON](https://github.com/nlohmann/json) 3.4.0+ ([MIT](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT))
@@ -208,7 +208,7 @@ The following options allow to switch to external installs:
 
 | CMake Option                    | Values     | Library       | Version |
 |---------------------------------|------------|---------------|---------|
-| `openPMD_USE_INTERNAL_VARIANT`  | **ON**/OFF | MPark.Variant |  1.3.0+ |
+| `openPMD_USE_INTERNAL_VARIANT`  | **ON**/OFF | MPark.Variant |  1.4.0+ |
 | `openPMD_USE_INTERNAL_CATCH`    | **ON**/OFF | Catch2        |  2.3.0+ |
 | `openPMD_USE_INTERNAL_PYBIND11` | **ON**/OFF | pybind11      |  2.2.4+ |
 | `openPMD_USE_INTERNAL_JSON`     | **ON**/OFF | NLohmann-JSON |  3.4.0+ |

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -71,7 +71,7 @@ The following options allow to switch to external installs of dependencies:
 ================================= =========== ======== ============= ========
 CMake Option                      Values      Installs Library       Version
 ================================= =========== ======== ============= ========
-``openPMD_USE_INTERNAL_VARIANT``  **ON**/OFF  Yes      MPark.Variant   1.3.0+
+``openPMD_USE_INTERNAL_VARIANT``  **ON**/OFF  Yes      MPark.Variant   1.4.0+
 ``openPMD_USE_INTERNAL_CATCH``    **ON**/OFF  No       Catch2          2.3.0+
 ``openPMD_USE_INTERNAL_PYBIND11`` **ON**/OFF  No       pybind11        2.2.4+
 ``openPMD_USE_INTERNAL_JSON``     **ON**/OFF  No       NLohmann-JSON   3.4.0+

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -19,7 +19,7 @@ Shipped internally
 
 The following libraries are shipped internally in ``share/openPMD/thirdParty/`` for convenience:
 
-* `MPark.Variant <https://github.com/mpark/variant>`_ 1.3.0+ (`BSL-1.0 <https://github.com/mpark/variant/blob/master/LICENSE.md>`_)
+* `MPark.Variant <https://github.com/mpark/variant>`_ 1.4.0+ (`BSL-1.0 <https://github.com/mpark/variant/blob/master/LICENSE.md>`_)
 * `Catch2 <https://github.com/catchorg/Catch2>`_ 2.3.0+ (`BSL-1.0 <https://github.com/catchorg/Catch2/blob/master/LICENSE.txt>`_)
 * `pybind11 <https://github.com/pybind/pybind11>`_ 2.2.4+ (`new BSD <https://github.com/pybind/pybind11/blob/master/LICENSE>`_)
 * `NLohmann-JSON <https://github.com/nlohmann/json>`_ 3.4.0+ (`MIT <https://github.com/nlohmann/json/blob/develop/LICENSE.MIT>`_)

--- a/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
+++ b/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
@@ -217,6 +217,10 @@ namespace std {
 #error "MPark.Variant requires C++11 support."
 #endif
 
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif
@@ -229,17 +233,34 @@ namespace std {
 #define __has_feature(x) 0
 #endif
 
+#if __has_attribute(always_inline) || defined(__GNUC__)
+#define MPARK_ALWAYS_INLINE __attribute__((__always_inline__)) inline
+#elif defined(_MSC_VER)
+#define MPARK_ALWAYS_INLINE __forceinline
+#else
+#define MPARK_ALWAYS_INLINE inline
+#endif
+
 #if __has_builtin(__builtin_addressof) || \
     (defined(__GNUC__) && __GNUC__ >= 7) || defined(_MSC_VER)
 #define MPARK_BUILTIN_ADDRESSOF
 #endif
 
-#if __has_builtin(__builtin_unreachable)
+#if __has_builtin(__builtin_unreachable) || defined(__GNUC__)
+#define MPARK_BUILTIN_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define MPARK_BUILTIN_UNREACHABLE __assume(false)
+#else
 #define MPARK_BUILTIN_UNREACHABLE
 #endif
 
 #if __has_builtin(__type_pack_element)
 #define MPARK_TYPE_PACK_ELEMENT
+#endif
+
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 200704 && \
+    !(defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ == 9)
+#define MPARK_CPP11_CONSTEXPR
 #endif
 
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
@@ -273,6 +294,7 @@ namespace std {
 
 #if !defined(__GLIBCXX__) || __has_include(<codecvt>)  // >= libstdc++-5
 #define MPARK_TRIVIALITY_TYPE_TRAITS
+#define MPARK_INCOMPLETE_TYPE_TRAITS
 #endif
 
 #endif  // MPARK_CONFIG_HPP
@@ -328,10 +350,8 @@ namespace mpark {
 #include <utility>
 
 
-#define RETURN(...)                                          \
-  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { \
-    return __VA_ARGS__;                                      \
-  }
+#define MPARK_RETURN(...) \
+  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
 
 namespace mpark {
   namespace lib {
@@ -434,7 +454,7 @@ namespace mpark {
       struct equal_to {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -444,7 +464,7 @@ namespace mpark {
       struct not_equal_to {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -454,7 +474,7 @@ namespace mpark {
       struct less {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -464,7 +484,7 @@ namespace mpark {
       struct greater {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -474,7 +494,7 @@ namespace mpark {
       struct less_equal {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -484,7 +504,7 @@ namespace mpark {
       struct greater_equal {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
       };
 #endif
     }  // namespace cpp14
@@ -521,48 +541,107 @@ namespace mpark {
             static constexpr bool value = decltype(test<T>(0))::value;
           };
 
-          template <typename T, bool = is_swappable<T>::value>
+          template <bool IsSwappable, typename T>
           struct is_nothrow_swappable {
             static constexpr bool value =
                 noexcept(swap(std::declval<T &>(), std::declval<T &>()));
           };
 
           template <typename T>
-          struct is_nothrow_swappable<T, false> : std::false_type {};
+          struct is_nothrow_swappable<false, T> : std::false_type {};
 
         }  // namespace swappable
       }  // namespace detail
 
       using detail::swappable::is_swappable;
-      using detail::swappable::is_nothrow_swappable;
+
+      template <typename T>
+      using is_nothrow_swappable =
+          detail::swappable::is_nothrow_swappable<is_swappable<T>::value, T>;
 
       // <functional>
+      namespace detail {
+
+        template <typename T>
+        struct is_reference_wrapper : std::false_type {};
+
+        template <typename T>
+        struct is_reference_wrapper<std::reference_wrapper<T>>
+            : std::true_type {};
+
+        template <bool, int>
+        struct Invoke;
+
+        template <>
+        struct Invoke<true /* pmf */, 0 /* is_base_of */> {
+          template <typename R, typename T, typename Arg, typename... Args>
+          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+            MPARK_RETURN((lib::forward<Arg>(arg).*pmf)(lib::forward<Args>(args)...))
+        };
+
+        template <>
+        struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */> {
+          template <typename R, typename T, typename Arg, typename... Args>
+          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+            MPARK_RETURN((lib::forward<Arg>(arg).get().*pmf)(lib::forward<Args>(args)...))
+        };
+
+        template <>
+        struct Invoke<true /* pmf */, 2 /* otherwise */> {
+          template <typename R, typename T, typename Arg, typename... Args>
+          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+            MPARK_RETURN(((*lib::forward<Arg>(arg)).*pmf)(lib::forward<Args>(args)...))
+        };
+
+        template <>
+        struct Invoke<false /* pmo */, 0 /* is_base_of */> {
+          template <typename R, typename T, typename Arg>
+          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+            MPARK_RETURN(lib::forward<Arg>(arg).*pmo)
+        };
+
+        template <>
+        struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */> {
+          template <typename R, typename T, typename Arg>
+          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+            MPARK_RETURN(lib::forward<Arg>(arg).get().*pmo)
+        };
+
+        template <>
+        struct Invoke<false /* pmo */, 2 /* otherwise */> {
+          template <typename R, typename T, typename Arg>
+          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+              MPARK_RETURN((*lib::forward<Arg>(arg)).*pmo)
+        };
+
+        template <typename R, typename T, typename Arg, typename... Args>
+        inline constexpr auto invoke(R T::*f, Arg &&arg, Args &&... args)
+          MPARK_RETURN(
+              Invoke<std::is_function<R>::value,
+                     (std::is_base_of<T, lib::decay_t<Arg>>::value
+                          ? 0
+                          : is_reference_wrapper<lib::decay_t<Arg>>::value
+                                ? 1
+                                : 2)>::invoke(f,
+                                              lib::forward<Arg>(arg),
+                                              lib::forward<Args>(args)...))
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4100)
 #endif
-      template <typename F, typename... As>
-      inline constexpr auto invoke(F &&f, As &&... as)
-          RETURN(lib::forward<F>(f)(lib::forward<As>(as)...))
+        template <typename F, typename... Args>
+        inline constexpr auto invoke(F &&f, Args &&... args)
+          MPARK_RETURN(lib::forward<F>(f)(lib::forward<Args>(args)...))
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+      }  // namespace detail
 
-      template <typename B, typename T, typename D>
-      inline constexpr auto invoke(T B::*pmv, D &&d)
-          RETURN(lib::forward<D>(d).*pmv)
-
-      template <typename Pmv, typename Ptr>
-      inline constexpr auto invoke(Pmv pmv, Ptr &&ptr)
-          RETURN((*lib::forward<Ptr>(ptr)).*pmv)
-
-      template <typename B, typename T, typename D, typename... As>
-      inline constexpr auto invoke(T B::*pmf, D &&d, As &&... as)
-          RETURN((lib::forward<D>(d).*pmf)(lib::forward<As>(as)...))
-
-      template <typename Pmf, typename Ptr, typename... As>
-      inline constexpr auto invoke(Pmf pmf, Ptr &&ptr, As &&... as)
-          RETURN(((*lib::forward<Ptr>(ptr)).*pmf)(lib::forward<As>(as)...))
+      template <typename F, typename... Args>
+      inline constexpr auto invoke(F &&f, Args &&... args)
+        MPARK_RETURN(detail::invoke(lib::forward<F>(f),
+                                    lib::forward<Args>(args)...))
 
       namespace detail {
 
@@ -612,10 +691,48 @@ namespace mpark {
       template <typename R, typename F, typename... Args>
       using is_invocable_r = detail::is_invocable_r<void, R, F, Args...>;
 
+      namespace detail {
+
+        template <bool Invocable, typename F, typename... Args>
+        struct is_nothrow_invocable {
+          static constexpr bool value =
+              noexcept(lib::invoke(std::declval<F>(), std::declval<Args>()...));
+        };
+
+        template <typename F, typename... Args>
+        struct is_nothrow_invocable<false, F, Args...> : std::false_type {};
+
+        template <bool Invocable, typename R, typename F, typename... Args>
+        struct is_nothrow_invocable_r {
+          private:
+          inline static R impl() {
+            return lib::invoke(std::declval<F>(), std::declval<Args>()...);
+          }
+
+          public:
+          static constexpr bool value = noexcept(impl());
+        };
+
+        template <typename R, typename F, typename... Args>
+        struct is_nothrow_invocable_r<false, R, F, Args...> : std::false_type {};
+
+      }  // namespace detail
+
+      template <typename F, typename... Args>
+      using is_nothrow_invocable = detail::
+          is_nothrow_invocable<is_invocable<F, Args...>::value, F, Args...>;
+
+      template <typename R, typename F, typename... Args>
+      using is_nothrow_invocable_r =
+          detail::is_nothrow_invocable_r<is_invocable_r<R, F, Args...>::value,
+                                         R,
+                                         F,
+                                         Args...>;
+
       // <memory>
 #ifdef MPARK_BUILTIN_ADDRESSOF
       template <typename T>
-      inline constexpr T *addressof(T &arg) {
+      inline constexpr T *addressof(T &arg) noexcept {
         return __builtin_addressof(arg);
       }
 #else
@@ -640,19 +757,19 @@ namespace mpark {
         using has_addressof = bool_constant<has_addressof_impl::impl<T>()>;
 
         template <typename T>
-        inline constexpr T *addressof(T &arg, std::true_type) {
+        inline constexpr T *addressof(T &arg, std::true_type) noexcept {
           return std::addressof(arg);
         }
 
         template <typename T>
-        inline constexpr T *addressof(T &arg, std::false_type) {
+        inline constexpr T *addressof(T &arg, std::false_type) noexcept {
           return &arg;
         }
 
       }  // namespace detail
 
       template <typename T>
-      inline constexpr T *addressof(T &arg) {
+      inline constexpr T *addressof(T &arg) noexcept {
         return detail::addressof(arg, detail::has_addressof<T>{});
       }
 #endif
@@ -675,7 +792,7 @@ namespace mpark {
     using size_constant = std::integral_constant<std::size_t, N>;
 
     template <std::size_t I, typename T>
-    struct indexed_type : size_constant<I>, identity<T> {};
+    struct indexed_type : size_constant<I> { using type = T; };
 
     template <bool... Bs>
     using all = std::is_same<integer_sequence<bool, true, Bs...>,
@@ -750,7 +867,7 @@ namespace mpark {
   }  // namespace lib
 }  // namespace mpark
 
-#undef RETURN
+#undef MPARK_RETURN
 
 #endif  // MPARK_LIB_HPP
 
@@ -789,7 +906,7 @@ namespace mpark {
 
   class bad_variant_access : public std::exception {
     public:
-    virtual const char *what() const noexcept { return "bad_variant_access"; }
+    virtual const char *what() const noexcept override { return "bad_variant_access"; }
   };
 
   [[noreturn]] inline void throw_bad_variant_access() {
@@ -797,9 +914,7 @@ namespace mpark {
     throw bad_variant_access{};
 #else
     std::terminate();
-#ifdef MPARK_BUILTIN_UNREACHABLE
-    __builtin_unreachable();
-#endif
+    MPARK_BUILTIN_UNREACHABLE;
 #endif
   }
 
@@ -847,7 +962,7 @@ namespace mpark {
   template <std::size_t I, typename... Ts>
   struct variant_alternative<I, variant<Ts...>> {
     static_assert(I < sizeof...(Ts),
-                  "Index out of bounds in std::variant_alternative<>");
+                  "index out of bounds in `std::variant_alternative<>`");
     using type = lib::type_pack_element_t<I, Ts...>;
   };
 
@@ -930,9 +1045,11 @@ namespace mpark {
 
 #ifdef MPARK_CPP14_CONSTEXPR
     template <typename... Traits>
-    inline constexpr Trait common_trait(Traits... traits) {
+    inline constexpr Trait common_trait(Traits... traits_) {
       Trait result = Trait::TriviallyAvailable;
-      for (Trait t : {traits...}) {
+      lib::array<Trait, sizeof...(Traits)> traits = {{traits_...}};
+      for (std::size_t i = 0; i < sizeof...(Traits); ++i) {
+        Trait t = traits[i];
         if (static_cast<int>(t) > static_cast<int>(result)) {
           result = t;
         }
@@ -1024,8 +1141,13 @@ namespace mpark {
       struct base {
         template <std::size_t I, typename V>
         inline static constexpr AUTO_REFREF get_alt(V &&v)
+#ifdef _MSC_VER
+          AUTO_REFREF_RETURN(recursive_union::get_alt(
+              lib::forward<V>(v).data_, in_place_index_t<I>{}))
+#else
           AUTO_REFREF_RETURN(recursive_union::get_alt(
               data(lib::forward<V>(v)), in_place_index_t<I>{}))
+#endif
       };
 
       struct variant {
@@ -1038,106 +1160,259 @@ namespace mpark {
 
     namespace visitation {
 
+#if defined(MPARK_CPP14_CONSTEXPR) && !defined(_MSC_VER)
+#define MPARK_VARIANT_SWITCH_VISIT
+#endif
+
       struct base {
+        template <typename Visitor, typename... Vs>
+        using dispatch_result_t = decltype(
+            lib::invoke(std::declval<Visitor>(),
+                        access::base::get_alt<0>(std::declval<Vs>())...));
+
+        template <typename Expected>
+        struct expected {
+          template <typename Actual>
+          inline static constexpr bool but_got() {
+            return std::is_same<Expected, Actual>::value;
+          }
+        };
+
+        template <typename Expected, typename Actual>
+        struct visit_return_type_check {
+          static_assert(
+              expected<Expected>::template but_got<Actual>(),
+              "`visit` requires the visitor to have a single return type");
+
+          template <typename Visitor, typename... Alts>
+          inline static constexpr DECLTYPE_AUTO invoke(Visitor &&visitor,
+                                                       Alts &&... alts)
+            DECLTYPE_AUTO_RETURN(lib::invoke(lib::forward<Visitor>(visitor),
+                                             lib::forward<Alts>(alts)...))
+        };
+
+#ifdef MPARK_VARIANT_SWITCH_VISIT
+        template <bool B, typename R, typename... ITs>
+        struct dispatcher;
+
+        template <typename R, typename... ITs>
+        struct dispatcher<false, R, ITs...> {
+          template <std::size_t B, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch(
+              F &&, typename ITs::type &&..., Vs &&...) {
+            MPARK_BUILTIN_UNREACHABLE;
+          }
+
+          template <std::size_t I, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F &&, Vs &&...) {
+            MPARK_BUILTIN_UNREACHABLE;
+          }
+
+          template <std::size_t B, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_at(std::size_t,
+                                                             F &&,
+                                                             Vs &&...) {
+            MPARK_BUILTIN_UNREACHABLE;
+          }
+        };
+
+        template <typename R, typename... ITs>
+        struct dispatcher<true, R, ITs...> {
+          template <std::size_t B, typename F>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch(
+              F &&f, typename ITs::type &&... visited_vs) {
+            using Expected = R;
+            using Actual = decltype(lib::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<ITs::value>(
+                    lib::forward<typename ITs::type>(visited_vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<ITs::value>(
+                    lib::forward<typename ITs::type>(visited_vs))...);
+          }
+
+          template <std::size_t B, typename F, typename V, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch(
+              F &&f, typename ITs::type &&... visited_vs, V &&v, Vs &&... vs) {
+#define MPARK_DISPATCH(I)                                                   \
+  dispatcher<(I < lib::decay_t<V>::size()),                                 \
+             R,                                                             \
+             ITs...,                                                        \
+             lib::indexed_type<I, V>>::                                     \
+      template dispatch<0>(lib::forward<F>(f),                              \
+                           lib::forward<typename ITs::type>(visited_vs)..., \
+                           lib::forward<V>(v),                              \
+                           lib::forward<Vs>(vs)...)
+
+#define MPARK_DEFAULT(I)                                                      \
+  dispatcher<(I < lib::decay_t<V>::size()), R, ITs...>::template dispatch<I>( \
+      lib::forward<F>(f),                                                     \
+      lib::forward<typename ITs::type>(visited_vs)...,                        \
+      lib::forward<V>(v),                                                     \
+      lib::forward<Vs>(vs)...)
+
+            switch (v.index()) {
+              case B + 0: return MPARK_DISPATCH(B + 0);
+              case B + 1: return MPARK_DISPATCH(B + 1);
+              case B + 2: return MPARK_DISPATCH(B + 2);
+              case B + 3: return MPARK_DISPATCH(B + 3);
+              case B + 4: return MPARK_DISPATCH(B + 4);
+              case B + 5: return MPARK_DISPATCH(B + 5);
+              case B + 6: return MPARK_DISPATCH(B + 6);
+              case B + 7: return MPARK_DISPATCH(B + 7);
+              case B + 8: return MPARK_DISPATCH(B + 8);
+              case B + 9: return MPARK_DISPATCH(B + 9);
+              case B + 10: return MPARK_DISPATCH(B + 10);
+              case B + 11: return MPARK_DISPATCH(B + 11);
+              case B + 12: return MPARK_DISPATCH(B + 12);
+              case B + 13: return MPARK_DISPATCH(B + 13);
+              case B + 14: return MPARK_DISPATCH(B + 14);
+              case B + 15: return MPARK_DISPATCH(B + 15);
+              case B + 16: return MPARK_DISPATCH(B + 16);
+              case B + 17: return MPARK_DISPATCH(B + 17);
+              case B + 18: return MPARK_DISPATCH(B + 18);
+              case B + 19: return MPARK_DISPATCH(B + 19);
+              case B + 20: return MPARK_DISPATCH(B + 20);
+              case B + 21: return MPARK_DISPATCH(B + 21);
+              case B + 22: return MPARK_DISPATCH(B + 22);
+              case B + 23: return MPARK_DISPATCH(B + 23);
+              case B + 24: return MPARK_DISPATCH(B + 24);
+              case B + 25: return MPARK_DISPATCH(B + 25);
+              case B + 26: return MPARK_DISPATCH(B + 26);
+              case B + 27: return MPARK_DISPATCH(B + 27);
+              case B + 28: return MPARK_DISPATCH(B + 28);
+              case B + 29: return MPARK_DISPATCH(B + 29);
+              case B + 30: return MPARK_DISPATCH(B + 30);
+              case B + 31: return MPARK_DISPATCH(B + 31);
+              default: return MPARK_DEFAULT(B + 32);
+            }
+
+#undef MPARK_DEFAULT
+#undef MPARK_DISPATCH
+          }
+
+          template <std::size_t I, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F &&f,
+                                                               Vs &&... vs) {
+            using Expected = R;
+            using Actual = decltype(
+                lib::invoke(lib::forward<F>(f),
+                            access::base::get_alt<I>(lib::forward<Vs>(vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<I>(lib::forward<Vs>(vs))...);
+          }
+
+          template <std::size_t B, typename F, typename V, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_at(std::size_t index,
+                                                             F &&f,
+                                                             V &&v,
+                                                             Vs &&... vs) {
+            static_assert(lib::all<(lib::decay_t<V>::size() ==
+                                    lib::decay_t<Vs>::size())...>::value,
+                          "all of the variants must be the same size.");
+#define MPARK_DISPATCH_AT(I)                                               \
+  dispatcher<(I < lib::decay_t<V>::size()), R>::template dispatch_case<I>( \
+      lib::forward<F>(f), lib::forward<V>(v), lib::forward<Vs>(vs)...)
+
+#define MPARK_DEFAULT(I)                                                 \
+  dispatcher<(I < lib::decay_t<V>::size()), R>::template dispatch_at<I>( \
+      index, lib::forward<F>(f), lib::forward<V>(v), lib::forward<Vs>(vs)...)
+
+            switch (index) {
+              case B + 0: return MPARK_DISPATCH_AT(B + 0);
+              case B + 1: return MPARK_DISPATCH_AT(B + 1);
+              case B + 2: return MPARK_DISPATCH_AT(B + 2);
+              case B + 3: return MPARK_DISPATCH_AT(B + 3);
+              case B + 4: return MPARK_DISPATCH_AT(B + 4);
+              case B + 5: return MPARK_DISPATCH_AT(B + 5);
+              case B + 6: return MPARK_DISPATCH_AT(B + 6);
+              case B + 7: return MPARK_DISPATCH_AT(B + 7);
+              case B + 8: return MPARK_DISPATCH_AT(B + 8);
+              case B + 9: return MPARK_DISPATCH_AT(B + 9);
+              case B + 10: return MPARK_DISPATCH_AT(B + 10);
+              case B + 11: return MPARK_DISPATCH_AT(B + 11);
+              case B + 12: return MPARK_DISPATCH_AT(B + 12);
+              case B + 13: return MPARK_DISPATCH_AT(B + 13);
+              case B + 14: return MPARK_DISPATCH_AT(B + 14);
+              case B + 15: return MPARK_DISPATCH_AT(B + 15);
+              case B + 16: return MPARK_DISPATCH_AT(B + 16);
+              case B + 17: return MPARK_DISPATCH_AT(B + 17);
+              case B + 18: return MPARK_DISPATCH_AT(B + 18);
+              case B + 19: return MPARK_DISPATCH_AT(B + 19);
+              case B + 20: return MPARK_DISPATCH_AT(B + 20);
+              case B + 21: return MPARK_DISPATCH_AT(B + 21);
+              case B + 22: return MPARK_DISPATCH_AT(B + 22);
+              case B + 23: return MPARK_DISPATCH_AT(B + 23);
+              case B + 24: return MPARK_DISPATCH_AT(B + 24);
+              case B + 25: return MPARK_DISPATCH_AT(B + 25);
+              case B + 26: return MPARK_DISPATCH_AT(B + 26);
+              case B + 27: return MPARK_DISPATCH_AT(B + 27);
+              case B + 28: return MPARK_DISPATCH_AT(B + 28);
+              case B + 29: return MPARK_DISPATCH_AT(B + 29);
+              case B + 30: return MPARK_DISPATCH_AT(B + 30);
+              case B + 31: return MPARK_DISPATCH_AT(B + 31);
+              default: return MPARK_DEFAULT(B + 32);
+            }
+
+#undef MPARK_DEFAULT
+#undef MPARK_DISPATCH_AT
+          }
+        };
+#else
         template <typename T>
-        inline static constexpr const T &at(const T &elem) {
+        inline static constexpr const T &at(const T &elem) noexcept {
           return elem;
         }
 
         template <typename T, std::size_t N, typename... Is>
         inline static constexpr const lib::remove_all_extents_t<T> &at(
-            const lib::array<T, N> &elems, std::size_t i, Is... is) {
+            const lib::array<T, N> &elems, std::size_t i, Is... is) noexcept {
           return at(elems[i], is...);
         }
 
         template <typename F, typename... Fs>
-        inline static constexpr int visit_visitor_return_type_check() {
-          static_assert(lib::all<std::is_same<F, Fs>::value...>::value,
-                        "`mpark::visit` requires the visitor to have a single "
-                        "return type.");
-          return 0;
+        inline static constexpr lib::array<lib::decay_t<F>, sizeof...(Fs) + 1>
+        make_farray(F &&f, Fs &&... fs) {
+          return {{lib::forward<F>(f), lib::forward<Fs>(fs)...}};
         }
 
-        template <typename... Fs>
-        inline static constexpr lib::array<
-            lib::common_type_t<lib::decay_t<Fs>...>,
-            sizeof...(Fs)>
-        make_farray(Fs &&... fs) {
-          using result = lib::array<lib::common_type_t<lib::decay_t<Fs>...>,
-                                    sizeof...(Fs)>;
-          return visit_visitor_return_type_check<lib::decay_t<Fs>...>(),
-                 result{{lib::forward<Fs>(fs)...}};
-        }
-
-        template <std::size_t... Is>
-        struct dispatcher {
-          template <typename F, typename... Vs>
-          struct impl {
-            inline static constexpr DECLTYPE_AUTO dispatch(F f, Vs... vs)
-              DECLTYPE_AUTO_RETURN(lib::invoke(
-                  static_cast<F>(f),
-                  access::base::get_alt<Is>(static_cast<Vs>(vs))...))
-          };
-        };
-
-        template <typename F, typename... Vs, std::size_t... Is>
-        inline static constexpr AUTO make_dispatch(lib::index_sequence<Is...>)
-          AUTO_RETURN(&dispatcher<Is...>::template impl<F, Vs...>::dispatch)
-
-        template <std::size_t I, typename F, typename... Vs>
-        inline static constexpr AUTO make_fdiagonal_impl()
-          AUTO_RETURN(make_dispatch<F, Vs...>(
-              lib::index_sequence<lib::indexed_type<I, Vs>::value...>{}))
-
-        template <typename F, typename... Vs, std::size_t... Is>
-        inline static constexpr AUTO make_fdiagonal_impl(
-            lib::index_sequence<Is...>)
-          AUTO_RETURN(make_farray(make_fdiagonal_impl<Is, F, Vs...>()...))
-
-        template <typename F, typename V, typename... Vs>
-        inline static constexpr /* auto * */ auto make_fdiagonal()
-            -> decltype(make_fdiagonal_impl<F, V, Vs...>(
-                lib::make_index_sequence<lib::decay_t<V>::size()>{})) {
-          static_assert(lib::all<(lib::decay_t<V>::size() ==
-                                  lib::decay_t<Vs>::size())...>::value,
-                        "all of the variants must be the same size.");
-          return make_fdiagonal_impl<F, V, Vs...>(
-              lib::make_index_sequence<lib::decay_t<V>::size()>{});
-        }
-
-#ifdef MPARK_RETURN_TYPE_DEDUCTION
-        template <typename F, typename... Vs, typename Is>
-        inline static constexpr auto make_fmatrix_impl(Is is) {
-          return make_dispatch<F, Vs...>(is);
-        }
-
-        template <typename F,
-                  typename... Vs,
-                  typename Is,
-                  std::size_t... Js,
-                  typename... Ls>
-        inline static constexpr auto make_fmatrix_impl(
-            Is, lib::index_sequence<Js...>, Ls... ls) {
-          return make_farray(make_fmatrix_impl<F, Vs...>(
-              lib::push_back_t<Is, Js>{}, ls...)...);
-        }
-
-        template <typename F, typename... Vs>
-        inline static constexpr auto make_fmatrix() {
-          return make_fmatrix_impl<F, Vs...>(
-              lib::index_sequence<>{},
-              lib::make_index_sequence<lib::decay_t<Vs>::size()>{}...);
-        }
-#else
         template <typename F, typename... Vs>
         struct make_fmatrix_impl {
+
+          template <std::size_t... Is>
+          inline static constexpr dispatch_result_t<F, Vs...> dispatch(
+              F &&f, Vs &&... vs) {
+            using Expected = dispatch_result_t<F, Vs...>;
+            using Actual = decltype(lib::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<Is>(lib::forward<Vs>(vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<Is>(lib::forward<Vs>(vs))...);
+          }
+
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+          template <std::size_t... Is>
+          inline static constexpr auto impl(lib::index_sequence<Is...>) {
+            return &dispatch<Is...>;
+          }
+
+          template <typename Is, std::size_t... Js, typename... Ls>
+          inline static constexpr auto impl(Is,
+                                            lib::index_sequence<Js...>,
+                                            Ls... ls) {
+            return make_farray(impl(lib::push_back_t<Is, Js>{}, ls...)...);
+          }
+#else
           template <typename...>
           struct impl;
 
-          template <typename Is>
-          struct impl<Is> {
+          template <std::size_t... Is>
+          struct impl<lib::index_sequence<Is...>> {
             inline constexpr AUTO operator()() const
-              AUTO_RETURN(make_dispatch<F, Vs...>(Is{}))
+              AUTO_RETURN(&dispatch<Is...>)
           };
 
           template <typename Is, std::size_t... Js, typename... Ls>
@@ -1146,8 +1421,17 @@ namespace mpark {
               AUTO_RETURN(
                   make_farray(impl<lib::push_back_t<Is, Js>, Ls...>{}()...))
           };
+#endif
         };
 
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+        template <typename F, typename... Vs>
+        inline static constexpr auto make_fmatrix() {
+          return make_fmatrix_impl<F, Vs...>::impl(
+              lib::index_sequence<>{},
+              lib::make_index_sequence<lib::decay_t<Vs>::size()>{}...);
+        }
+#else
         template <typename F, typename... Vs>
         inline static constexpr AUTO make_fmatrix()
           AUTO_RETURN(
@@ -1155,86 +1439,141 @@ namespace mpark {
                   lib::index_sequence<>,
                   lib::make_index_sequence<lib::decay_t<Vs>::size()>...>{}())
 #endif
-      };  // namespace base
 
-      template <typename F, typename... Vs>
-      using FDiagonal = decltype(base::make_fdiagonal<F, Vs...>());
+        template <typename F, typename... Vs>
+        struct make_fdiagonal_impl {
+          template <std::size_t I>
+          inline static constexpr dispatch_result_t<F, Vs...> dispatch(
+              F &&f, Vs &&... vs) {
+            using Expected = dispatch_result_t<F, Vs...>;
+            using Actual = decltype(
+                lib::invoke(lib::forward<F>(f),
+                            access::base::get_alt<I>(lib::forward<Vs>(vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<I>(lib::forward<Vs>(vs))...);
+          }
 
-      template <typename F, typename... Vs>
-      struct fdiagonal {
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4268)
-#endif
-        static constexpr FDiagonal<F, Vs...> value =
-            base::make_fdiagonal<F, Vs...>();
-#ifdef _MSC_VER
-#pragma warning(pop)
+          template <std::size_t... Is>
+          inline static constexpr AUTO impl(lib::index_sequence<Is...>)
+            AUTO_RETURN(make_farray(&dispatch<Is>...))
+        };
+
+        template <typename F, typename V, typename... Vs>
+        inline static constexpr auto make_fdiagonal()
+            -> decltype(make_fdiagonal_impl<F, V, Vs...>::impl(
+                lib::make_index_sequence<lib::decay_t<V>::size()>{})) {
+          static_assert(lib::all<(lib::decay_t<V>::size() ==
+                                  lib::decay_t<Vs>::size())...>::value,
+                        "all of the variants must be the same size.");
+          return make_fdiagonal_impl<F, V, Vs...>::impl(
+              lib::make_index_sequence<lib::decay_t<V>::size()>{});
+        }
 #endif
       };
 
+#if !defined(MPARK_VARIANT_SWITCH_VISIT) && \
+    (!defined(_MSC_VER) || _MSC_VER >= 1910)
       template <typename F, typename... Vs>
-      constexpr FDiagonal<F, Vs...> fdiagonal<F, Vs...>::value;
-
-      template <typename F, typename... Vs>
-      using FMatrix = decltype(base::make_fmatrix<F, Vs...>());
+      using fmatrix_t = decltype(base::make_fmatrix<F, Vs...>());
 
       template <typename F, typename... Vs>
       struct fmatrix {
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4268)
-#endif
-        static constexpr FMatrix<F, Vs...> value =
+        static constexpr fmatrix_t<F, Vs...> value =
             base::make_fmatrix<F, Vs...>();
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
       };
 
       template <typename F, typename... Vs>
-      constexpr FMatrix<F, Vs...> fmatrix<F, Vs...>::value;
+      constexpr fmatrix_t<F, Vs...> fmatrix<F, Vs...>::value;
+
+      template <typename F, typename... Vs>
+      using fdiagonal_t = decltype(base::make_fdiagonal<F, Vs...>());
+
+      template <typename F, typename... Vs>
+      struct fdiagonal {
+        static constexpr fdiagonal_t<F, Vs...> value =
+            base::make_fdiagonal<F, Vs...>();
+      };
+
+      template <typename F, typename... Vs>
+      constexpr fdiagonal_t<F, Vs...> fdiagonal<F, Vs...>::value;
+#endif
 
       struct alt {
         template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
-                                                           Visitor &&visitor,
-                                                           Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(base::at(
-              fdiagonal<Visitor &&,
-                        decltype(as_base(lib::forward<Vs>(vs)))...>::value,
-              index)(lib::forward<Visitor>(visitor),
-                     as_base(lib::forward<Vs>(vs))...))
-
-        template <typename Visitor, typename... Vs>
         inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
                                                         Vs &&... vs)
+#ifdef MPARK_VARIANT_SWITCH_VISIT
+          DECLTYPE_AUTO_RETURN(
+              base::dispatcher<
+                  true,
+                  base::dispatch_result_t<Visitor,
+                                          decltype(as_base(
+                                              lib::forward<Vs>(vs)))...>>::
+                  template dispatch<0>(lib::forward<Visitor>(visitor),
+                                       as_base(lib::forward<Vs>(vs))...))
+#elif !defined(_MSC_VER) || _MSC_VER >= 1910
           DECLTYPE_AUTO_RETURN(base::at(
               fmatrix<Visitor &&,
                       decltype(as_base(lib::forward<Vs>(vs)))...>::value,
               vs.index()...)(lib::forward<Visitor>(visitor),
                              as_base(lib::forward<Vs>(vs))...))
+#else
+          DECLTYPE_AUTO_RETURN(base::at(
+              base::make_fmatrix<Visitor &&,
+                      decltype(as_base(lib::forward<Vs>(vs)))...>(),
+              vs.index()...)(lib::forward<Visitor>(visitor),
+                             as_base(lib::forward<Vs>(vs))...))
+#endif
+
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
+                                                           Visitor &&visitor,
+                                                           Vs &&... vs)
+#ifdef MPARK_VARIANT_SWITCH_VISIT
+          DECLTYPE_AUTO_RETURN(
+              base::dispatcher<
+                  true,
+                  base::dispatch_result_t<Visitor,
+                                          decltype(as_base(
+                                              lib::forward<Vs>(vs)))...>>::
+                  template dispatch_at<0>(index,
+                                          lib::forward<Visitor>(visitor),
+                                          as_base(lib::forward<Vs>(vs))...))
+#elif !defined(_MSC_VER) || _MSC_VER >= 1910
+          DECLTYPE_AUTO_RETURN(base::at(
+              fdiagonal<Visitor &&,
+                        decltype(as_base(lib::forward<Vs>(vs)))...>::value,
+              index)(lib::forward<Visitor>(visitor),
+                     as_base(lib::forward<Vs>(vs))...))
+#else
+          DECLTYPE_AUTO_RETURN(base::at(
+              base::make_fdiagonal<Visitor &&,
+                        decltype(as_base(lib::forward<Vs>(vs)))...>(),
+              index)(lib::forward<Visitor>(visitor),
+                     as_base(lib::forward<Vs>(vs))...))
+#endif
       };
 
       struct variant {
         private:
-        template <typename Visitor, typename... Values>
-        struct visit_exhaustive_visitor_check {
-          static_assert(
-              lib::is_invocable<Visitor, Values...>::value,
-              "`mpark::visit` requires the visitor to be exhaustive.");
+        template <typename Visitor>
+        struct visitor {
+          template <typename... Values>
+          inline static constexpr bool does_not_handle() {
+            return lib::is_invocable<Visitor, Values...>::value;
+          }
+        };
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4100)
-#endif
-          inline constexpr DECLTYPE_AUTO operator()(Visitor &&visitor,
-                                                    Values &&... values) const
+        template <typename Visitor, typename... Values>
+        struct visit_exhaustiveness_check {
+          static_assert(visitor<Visitor>::template does_not_handle<Values...>(),
+                        "`visit` requires the visitor to be exhaustive.");
+
+          inline static constexpr DECLTYPE_AUTO invoke(Visitor &&visitor,
+                                                       Values &&... values)
             DECLTYPE_AUTO_RETURN(lib::invoke(lib::forward<Visitor>(visitor),
                                              lib::forward<Values>(values)...))
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
         };
 
         template <typename Visitor>
@@ -1244,11 +1583,11 @@ namespace mpark {
           template <typename... Alts>
           inline constexpr DECLTYPE_AUTO operator()(Alts &&... alts) const
             DECLTYPE_AUTO_RETURN(
-                visit_exhaustive_visitor_check<
+                visit_exhaustiveness_check<
                     Visitor,
-                    decltype((lib::forward<Alts>(alts).value))...>{}(
-                    lib::forward<Visitor>(visitor_),
-                    lib::forward<Alts>(alts).value...))
+                    decltype((lib::forward<Alts>(alts).value))...>::
+                    invoke(lib::forward<Visitor>(visitor_),
+                           lib::forward<Alts>(alts).value...))
         };
 
         template <typename Visitor>
@@ -1256,6 +1595,12 @@ namespace mpark {
           AUTO_RETURN(value_visitor<Visitor>{lib::forward<Visitor>(visitor)})
 
         public:
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
+                                                        Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(alt::visit_alt(lib::forward<Visitor>(visitor),
+                                              lib::forward<Vs>(vs).impl_...))
+
         template <typename Visitor, typename... Vs>
         inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
                                                            Visitor &&visitor,
@@ -1266,10 +1611,11 @@ namespace mpark {
                                 lib::forward<Vs>(vs).impl_...))
 
         template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
-                                                        Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(alt::visit_alt(lib::forward<Visitor>(visitor),
-                                              lib::forward<Vs>(vs).impl_...))
+        inline static constexpr DECLTYPE_AUTO visit_value(Visitor &&visitor,
+                                                          Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(
+              visit_alt(make_value_visitor(lib::forward<Visitor>(visitor)),
+                        lib::forward<Vs>(vs)...))
 
         template <typename Visitor, typename... Vs>
         inline static constexpr DECLTYPE_AUTO visit_value_at(std::size_t index,
@@ -1279,13 +1625,6 @@ namespace mpark {
               visit_alt_at(index,
                            make_value_visitor(lib::forward<Visitor>(visitor)),
                            lib::forward<Vs>(vs)...))
-
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_value(Visitor &&visitor,
-                                                          Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              visit_alt(make_value_visitor(lib::forward<Visitor>(visitor)),
-                        lib::forward<Vs>(vs)...))
       };
 
     }  // namespace visitation
@@ -1411,13 +1750,13 @@ namespace mpark {
 #endif
     };
 
-#if defined(_MSC_VER) && _MSC_VER < 1910
-#define INHERITING_CTOR(type, base)               \
+#if !defined(_MSC_VER) || _MSC_VER >= 1910
+#define MPARK_INHERITING_CTOR(type, base) using base::base;
+#else
+#define MPARK_INHERITING_CTOR(type, base)         \
   template <typename... Args>                     \
   inline explicit constexpr type(Args &&... args) \
       : base(lib::forward<Args>(args)...) {}
-#else
-#define INHERITING_CTOR(type, base) using base::base;
 #endif
 
     template <typename Traits, Trait = Traits::destructible_trait>
@@ -1430,7 +1769,7 @@ namespace mpark {
     using super = base<destructible_trait, Ts...>;                        \
                                                                           \
     public:                                                               \
-    INHERITING_CTOR(destructor, super)                                    \
+    MPARK_INHERITING_CTOR(destructor, super)                              \
     using super::operator=;                                               \
                                                                           \
     destructor(const destructor &) = default;                             \
@@ -1472,7 +1811,7 @@ namespace mpark {
       using super = destructor<Traits>;
 
       public:
-      INHERITING_CTOR(constructor, super)
+      MPARK_INHERITING_CTOR(constructor, super)
       using super::operator=;
 
       protected:
@@ -1488,9 +1827,9 @@ namespace mpark {
 
       template <std::size_t I, typename T, typename... Args>
       inline static T &construct_alt(alt<I, T> &a, Args &&... args) {
-        ::new (static_cast<void *>(lib::addressof(a)))
+        auto *result = ::new (static_cast<void *>(lib::addressof(a)))
             alt<I, T>(in_place_t{}, lib::forward<Args>(args)...);
-        return a.value;
+        return result->value;
       }
 
       template <typename Rhs>
@@ -1525,7 +1864,7 @@ namespace mpark {
     using super = constructor<traits<Ts...>>;                                \
                                                                              \
     public:                                                                  \
-    INHERITING_CTOR(move_constructor, super)                                 \
+    MPARK_INHERITING_CTOR(move_constructor, super)                           \
     using super::operator=;                                                  \
                                                                              \
     move_constructor(const move_constructor &) = default;                    \
@@ -1563,7 +1902,7 @@ namespace mpark {
     using super = move_constructor<traits<Ts...>>;                           \
                                                                              \
     public:                                                                  \
-    INHERITING_CTOR(copy_constructor, super)                                 \
+    MPARK_INHERITING_CTOR(copy_constructor, super)                           \
     using super::operator=;                                                  \
                                                                              \
     definition                                                               \
@@ -1595,7 +1934,7 @@ namespace mpark {
       using super = copy_constructor<Traits>;
 
       public:
-      INHERITING_CTOR(assignment, super)
+      MPARK_INHERITING_CTOR(assignment, super)
       using super::operator=;
 
       template <std::size_t I, typename... Args>
@@ -1683,7 +2022,7 @@ namespace mpark {
     using super = assignment<traits<Ts...>>;                             \
                                                                          \
     public:                                                              \
-    INHERITING_CTOR(move_assignment, super)                              \
+    MPARK_INHERITING_CTOR(move_assignment, super)                        \
     using super::operator=;                                              \
                                                                          \
     move_assignment(const move_assignment &) = default;                  \
@@ -1723,7 +2062,7 @@ namespace mpark {
     using super = move_assignment<traits<Ts...>>;                        \
                                                                          \
     public:                                                              \
-    INHERITING_CTOR(copy_assignment, super)                              \
+    MPARK_INHERITING_CTOR(copy_assignment, super)                        \
     using super::operator=;                                              \
                                                                          \
     copy_assignment(const copy_assignment &) = default;                  \
@@ -1755,7 +2094,7 @@ namespace mpark {
       using super = copy_assignment<traits<Ts...>>;
 
       public:
-      INHERITING_CTOR(impl, super)
+      MPARK_INHERITING_CTOR(impl, super)
       using super::operator=;
 
       template <std::size_t I, typename Arg>
@@ -1825,6 +2164,8 @@ namespace mpark {
                }[this->index()];
       }
     };
+
+#undef MPARK_INHERITING_CTOR
 
     template <std::size_t I, typename T>
     struct overload_leaf {
@@ -2069,7 +2410,7 @@ namespace mpark {
   namespace detail {
     template <std::size_t I, typename V>
     struct generic_get_impl {
-      constexpr generic_get_impl(int) {}
+      constexpr generic_get_impl(int) noexcept {}
 
       constexpr AUTO_REFREF operator()(V &&v) const
         AUTO_REFREF_RETURN(
@@ -2162,11 +2503,26 @@ namespace mpark {
     return get_if<detail::find_index_checked<T, Ts...>::value>(v);
   }
 
+  namespace detail {
+    template <typename RelOp>
+    struct convert_to_bool {
+      template <typename Lhs, typename Rhs>
+      inline constexpr bool operator()(Lhs &&lhs, Rhs &&rhs) const {
+        static_assert(std::is_convertible<lib::invoke_result_t<RelOp, Lhs, Rhs>,
+                                          bool>::value,
+                      "relational operators must return a type"
+                      " implicitly convertible to bool");
+        return lib::invoke(
+            RelOp{}, lib::forward<Lhs>(lhs), lib::forward<Rhs>(rhs));
+      }
+    };
+  }  // namespace detail
+
   template <typename... Ts>
   inline constexpr bool operator==(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::equal_to;
+    using equal_to = detail::convert_to_bool<lib::equal_to>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.index() != rhs.index()) return false;
     if (lhs.valueless_by_exception()) return true;
@@ -2182,7 +2538,7 @@ namespace mpark {
   inline constexpr bool operator!=(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::not_equal_to;
+    using not_equal_to = detail::convert_to_bool<lib::not_equal_to>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.index() != rhs.index()) return true;
     if (lhs.valueless_by_exception()) return false;
@@ -2198,7 +2554,7 @@ namespace mpark {
   inline constexpr bool operator<(const variant<Ts...> &lhs,
                                   const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::less;
+    using less = detail::convert_to_bool<lib::less>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (rhs.valueless_by_exception()) return false;
     if (lhs.valueless_by_exception()) return true;
@@ -2217,7 +2573,7 @@ namespace mpark {
   inline constexpr bool operator>(const variant<Ts...> &lhs,
                                   const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::greater;
+    using greater = detail::convert_to_bool<lib::greater>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.valueless_by_exception()) return false;
     if (rhs.valueless_by_exception()) return true;
@@ -2236,7 +2592,7 @@ namespace mpark {
   inline constexpr bool operator<=(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::less_equal;
+    using less_equal = detail::convert_to_bool<lib::less_equal>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.valueless_by_exception()) return true;
     if (rhs.valueless_by_exception()) return false;
@@ -2256,7 +2612,7 @@ namespace mpark {
   inline constexpr bool operator>=(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::greater_equal;
+    using greater_equal = detail::convert_to_bool<lib::greater_equal>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (rhs.valueless_by_exception()) return true;
     if (lhs.valueless_by_exception()) return false;
@@ -2363,14 +2719,14 @@ namespace mpark {
     namespace hash {
 
       template <typename H, typename K>
-      constexpr bool meets_requirements() {
+      constexpr bool meets_requirements() noexcept {
         return std::is_copy_constructible<H>::value &&
                std::is_move_constructible<H>::value &&
                lib::is_invocable_r<std::size_t, H, const K &>::value;
       }
 
       template <typename K>
-      constexpr bool is_enabled() {
+      constexpr bool is_enabled() noexcept {
         using H = std::hash<K>;
         return meets_requirements<H, K>() &&
                std::is_default_constructible<H>::value &&


### PR DESCRIPTION
Update dependencies and internally shipped MPark.Variant library to v1.4.0.

https://github.com/mpark/variant/releases/tag/v1.4.0

Related to #443