### PR TITLE
Docs: Invasive Tests not Default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Other
   - PyPI install method #450 #451
   - more info on MPI #449
   - new "first steps" section #473
+  - update invasive test info #474
 
 
 0.7.1-alpha

--- a/README.md
+++ b/README.md
@@ -195,12 +195,12 @@ CMake controls options with prefixed `-D`, e.g. `-DopenPMD_USE_MPI=OFF`:
 | `openPMD_USE_ADIOS1`         | **AUTO**/ON/OFF  | ADIOS1 backend (`.bp` files)                                                 |
 | `openPMD_USE_ADIOS2`         | AUTO/ON/**OFF**  | ADIOS2 backend (`.bp` files) <sup>1</sup>                                    |
 | `openPMD_USE_PYTHON`         | **AUTO**/ON/OFF  | Enable Python bindings                                                       |
-| `openPMD_USE_INVASIVE_TESTS` | **AUTO**/ON/OFF  | Enable unit tests that modify source code <sup>2</sup>                       |
+| `openPMD_USE_INVASIVE_TESTS` | ON/**OFF**       | Enable unit tests that modify source code <sup>2</sup>                       |
 | `openPMD_USE_VERIFY`         | **ON**/OFF       | Enable internal VERIFY (assert) macro independent of build type <sup>3</sup> |
 | `PYTHON_EXECUTABLE`          | (first found)    | Path to Python executable                                                    |
 
 <sup>1</sup> *not yet implemented*
-<sup>2</sup> *e.g. C++ keywords, currently disabled only for MSVC*
+<sup>2</sup> *e.g. changes C++ visibility keywords, breaks MSVC*
 <sup>3</sup> *this includes most pre-/post-condition checks, disabling without specific cause is highly discouraged*
 
 Additionally, the following libraries are shipped internally.

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -20,14 +20,14 @@ CMake Option                   Values          Description
 ``openPMD_USE_ADIOS1``         **AUTO**/ON/OFF ADIOS1 backend (``.bp`` files)
 ``openPMD_USE_ADIOS2``         AUTO/ON/**OFF** ADIOS2 backend (``.bp`` files) :sup:`1`
 ``openPMD_USE_PYTHON``         **AUTO**/ON/OFF Enable Python bindings
-``openPMD_USE_INVASIVE_TESTS`` **AUTO**/ON/OFF Enable unit tests that modify source code :sup:`2`
+``openPMD_USE_INVASIVE_TESTS`` ON/**OFF**      Enable unit tests that modify source code :sup:`2`
 ``openPMD_USE_VERIFY``         **ON**/OFF      Enable internal VERIFY (assert) macro independent of build type :sup:`3`
 ``PYTHON_EXECUTABLE``          (first found)   Path to Python executable
 ============================== =============== ========================================================================
 
 :sup:`1` *not yet implemented*
 
-:sup:`2` e.g. C++ keywords, currently disabled only for MSVC
+:sup:`2` e.g. changes C++ visibility keywords, breaks MSVC
 
 :sup:`3` this includes most pre-/post-condition checks, disabling without specific cause is highly discouraged
 


### PR DESCRIPTION
Invasive tests are not on by default anymore.

Changed since #175 #176 #323 #324 