### PR TITLE
First Read/Write: Typos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ Other
 
   - PyPI install method #450 #451
   - more info on MPI #449
-  - new "first steps" section #473
+  - new "first steps" section #473 #478
   - update invasive test info #474
 
 

--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -4,7 +4,7 @@ First Read
 ==========
 
 Step-by-step: how to read openPMD data?
-We are using the examples files from `openPMD-example-datasets <https://github.com/openPMD/openPMD-example-datasets>`_.
+We are using the examples files from `openPMD-example-datasets <https://github.com/openPMD/openPMD-example-datasets>`_ (``example-3d.tar.gz``).
 
 .. raw:: html
 
@@ -87,7 +87,7 @@ C++11
 
    auto series = api::Series(
        "data%T.h5",
-       AccessType::READ_ONLY);
+       api::AccessType::READ_ONLY);
 
 
 Python
@@ -130,23 +130,24 @@ C++11
 
 .. code-block:: cpp
 
-   std::cout
-       << "Author: "
-       << s.author() << "\n"
-       << "openPMD version: "
-       << s.openPMD() << "\n";
+   std::cout << "openPMD version: "
+       << series.openPMD() << "\n";
+
+   if( series.containsAttribute("author") )
+       std::cout << "Author: "
+           << series.author() << "\n";
 
 Python
 ^^^^^^
 
 .. code-block:: python3
 
-   print(
-       "Author: {0}"
-       "openPMD version: {1}"
-       .format(
-           s.author,
-           s.openPMD))
+   print("openPMD version: ",
+         series.openPMD)
+
+   if( series.contains_attribute("author") )
+       print("Author: ",
+             series.author)
 
 Record
 ------
@@ -179,8 +180,7 @@ Python
 Units
 -----
 
-On read, units are automatically converted to SI unless otherwise specified (not yet implemented).
-Even without the name "E" we can check the `dimensionality <https://en.wikipedia.org/wiki/Dimensional_analysis>`_ of a record to understand its purpose.
+Even without understanding the name "E" we can check the `dimensionality <https://en.wikipedia.org/wiki/Dimensional_analysis>`_ of a record to understand its purpose.
 
 C++11
 ^^^^^
@@ -188,10 +188,13 @@ C++11
 .. code-block:: cpp
 
    // unit system agnostic dimension
-   auto E_unitDim = E.getUnitDimension();
+   auto E_unitDim = E.unitDimension();
 
    // ...
    // api::UnitDimension::M
+
+   // conversion to SI
+   double x_unit = E_x.unitSI();
 
 Python
 ^^^^^^
@@ -204,16 +207,22 @@ Python
    # ...
    # api.Unit_Dimension.M
 
+   # conversion to SI
+   x_unit = E_x.unit_SI
+
 .. note::
 
    This example is not yet written :-)
+
+   In the future, units are automatically converted to a selected unit system (not yet implemented).
+   For now, please multiply your read data (``x_data``) with ``x_unit`` to covert to SI, otherwise the raw, potentially awkwardly scaled data is taken.
 
 Register Chunk
 --------------
 
 We can load record components partially and in parallel or at once.
 Reading small data one by one is is a performance killer for I/O.
-Therefore, we register the data to be loaded first and then flush it in collectively.
+Therefore, we register all data to be loaded first and then flush it in collectively.
 
 C++11
 ^^^^^
@@ -271,18 +280,18 @@ C++11
 
    auto extent = E_x.getExtent();
 
-   cout << "First values in E_x "
+   std::cout << "First values in E_x "
            "of shape: ";
    for( auto const& dim : extent )
-       cout << dim << ', ';
-   cout << "\n"
+       std::cout << dim << ", ";
+   std::cout << "\n";
 
    for( size_t col = 0;
         col < extent[1] && col < 5;
         ++col )
-       cout << x_data.get()[col]
-            << ", ";
-   cout << "\n";
+       std::cout << x_data.get()[col]
+                 << ", ";
+   std::cout << "\n";
 
 
 Python

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -85,7 +85,7 @@ C++11
 
    auto series = api::Series(
        "myOutput/data_%05T.h5",
-       AccessType::CREATE);
+       api::AccessType::CREATE);
 
 
 Python
@@ -127,11 +127,11 @@ C++11
 
 .. code-block:: cpp
 
-   s.setAuthor(
+   series.setAuthor(
        "Axel Huebl <a.huebl@hzdr.de>");
-   s.setMachine(
+   series.setMachine(
        "Hall Probe 5000, Model 3");
-   s.setAttribute(
+   series.setAttribute(
        "dinner", "Pizza and Coke");
    i.setAttribute(
        "vacuum", true);
@@ -141,11 +141,11 @@ Python
 
 .. code-block:: python3
 
-   s.set_author(
+   series.set_author(
        "Axel Huebl <a.huebl@hzdr.de>")
-   s.set_machine(
+   series.set_machine(
        "Hall Probe 5000, Model 3")
-   s.set_attribute(
+   series.set_attribute(
        "dinner", "Pizza and Coke")
    i.set_attribute(
        "vacuum", True)
@@ -164,14 +164,14 @@ C++11
    std::vector<float> x_data(
        150 * 300);
    std::iota(
-       global_data.begin(),
-       global_data.end(),
+       x_data.begin(),
+       x_data.end(),
        0.);
 
    float y_data = 4.f;
 
-   std::vector<float> y_data(x_data);
-   for( auto& c : y_data )
+   std::vector<float> z_data(x_data);
+   for( auto& c : z_data )
        c -= 8000.f;
 
 Python
@@ -210,7 +210,7 @@ C++11
    auto B_z = B["z"];
 
    auto dataset = api::Dataset(
-       determineDatatype<float>(),
+       api::determineDatatype<float>(),
        {150, 300});
    B_x.resetDataset(dataset);
    B_y.resetDataset(dataset);
@@ -278,14 +278,14 @@ Python
 
 .. tip::
 
-   Annotating the `dimensionality <https://en.wikipedia.org/wiki/Dimensional_analysis>`_ of a record allows us to read data sets with *arbitrary names* and understand their purpose simply by *dimensionality*.
+   Annotating the `dimensionality <https://en.wikipedia.org/wiki/Dimensional_analysis>`_ of a record allows us to read data sets with *arbitrary names* and understand their purpose simply by *dimensional analysis*.
 
 Register Chunk
 --------------
 
 We can write record components partially and in parallel or at once.
 Writing very small data one by one is is a performance killer for I/O.
-Therefore, we register the data to be written first and then flush it out collectively.
+Therefore, we register all data to be written first and then flush it out collectively.
 
 C++11
 ^^^^^
@@ -293,11 +293,13 @@ C++11
 .. code-block:: cpp
 
    B_x.storeChunk(
-       api::shareRaw(x_data));
+       api::shareRaw(x_data),
+       {0, 0}, {150, 300});
    B_z.storeChunk(
-       api::shareRaw(z_data));
+       api::shareRaw(z_data),
+       {0, 0}, {150, 300});
 
-   B_x.makeConstant(y_data);
+   B_y.makeConstant(y_data);
 
 Python
 ^^^^^^
@@ -306,10 +308,12 @@ Python
 
    B_x.store_chunk(x_data)
 
+
    B_z.store_chunk(z_data)
 
 
-   B_x.make_constant(y_data)
+
+   B_y.make_constant(y_data)
 
 .. attention::
 


### PR DESCRIPTION
Fix typos in the new "first read/write" section of the manual.
Test C++ part.

Follow-up to #473