### PR TITLE
Doc: Clang Sanitize with Hidden Symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,7 +701,17 @@ endif()
 #
 # TODO: LEGACY! Use CMake TOOLCHAINS instead!
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,memory,undefined")
+    # list(APPEND CMAKE_CXX_FLAGS "-fsanitize=address") # address, memory, undefined
+    # list(APPEND CMAKE_EXE_LINKER_FLAGS "-fsanitize=address")
+    # list(APPEND CMAKE_SHARED_LINKER_FLAGS "-fsanitize=address")
+    # list(APPEND CMAKE_MODULE_LINKER_FLAGS "-fsanitize=address")
+
+    # note: might still need a
+    #   export LD_PRELOAD=libclang_rt.asan.so
+    # or on Debian 9 with Clang 6.0
+    #   export LD_PRELOAD=/usr/lib/llvm-6.0/lib/clang/6.0.0/lib/linux/libclang_rt.asan-x86_64.so
+    # at runtime when used with symbol-hidden code (e.g. pybind11 module)
+
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
     # pybind11 does not fix -Wshadow https://github.com/pybind/pybind11/issues/1267


### PR DESCRIPTION
Document in `CMakeLists.txt` how to use address sanitizers with symbol hiding, e.g. when checking a python module.

Refs:
- https://stackoverflow.com/questions/50610323/undefined-symbol-asan-option-detect-stack-use-after-return
- https://stackoverflow.com/questions/50621054/getting-undefined-symbol-asan-memset-when-trying-to-use-clang-address-sanitiz