### PR TITLE
Doc: AccessType

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Other
   - more info on MPI #449
   - new "first steps" section #473 #478
   - update invasive test info #474
+  - more info on ``AccessType`` #483
 
 
 0.7.1-alpha

--- a/include/openPMD/IO/AccessType.hpp
+++ b/include/openPMD/IO/AccessType.hpp
@@ -23,12 +23,12 @@
 
 namespace openPMD
 {
-/** File access permissions to use during IO.
- */
-enum class AccessType
-{
-    READ_ONLY,
-    READ_WRITE,
-    CREATE
-};  //AccessType
-} // openPMD
+    /** File access mode to use during IO.
+     */
+    enum class AccessType
+    {
+        READ_ONLY,  //!< open series as read-only, fails if series is not found
+        READ_WRITE, //!< open existing series as writable
+        CREATE      //!< create new series and truncate existing (files)
+    }; // AccessType
+} // namespace openPMD


### PR DESCRIPTION
Document the behavior of `AccessType` in a Series.
Close #152


@C0nsultant Did I document those correctly? The following questions in behavior arise to me:

### `CREATE`

If we open a new base `filePath` do we actively seek for existing files (for file-based encoding) with this pattern and remove them? I think we should, otherwise funnily mixed series might be created (imagine someone re-running a simulation and overwriting existing data half-way).

We might also want to add a mode that does create and truncates only iterations that are newly created (I think that's what we do right now in file-based access, right?). We should made both `create` modes behave consistent for file- and group-based series (from a user point of view).

Idea:
- `CREATE` truncates all existing iterations (independent if in file- or grou-based mode)
- `CREATE_ITERATION` truncates only newly written iterations

Alternatively and maybe better: allow/document to express the second mode in `READ_WRITE` (by just deleting an iteration explicitly).

### `READ_WRITE`

Anything I missed here?