### PR TITLE
Series Flush Type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -244,6 +244,7 @@ Features
 
   - ``manylinux2010`` wheels for PyPI #523
   - add ``pyproject.toml`` for build dependencies (PEP-518) #527
+- Series: flush type "direct" (new default) and "defer" (previous default) #484
 
 Bug Fixes
 """""""""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,6 +524,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Container.cpp
         src/binding/python/Dataset.cpp
         src/binding/python/Datatype.cpp
+        src/binding/python/FlushType.cpp
         src/binding/python/Iteration.cpp
         src/binding/python/IterationEncoding.cpp
         src/binding/python/Mesh.cpp

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -28,6 +28,52 @@ The CMake option ``-DopenPMD_USE_JSON`` has been removed (as it is always ``ON``
 Previously, omitting a file ending in the ``Series`` constructor chose a "dummy" no-operation file backend.
 This was confusing and instead a runtime error is now thrown.
 
+Python
+^^^^^^
+
+``.flush()`` Method
+"""""""""""""""""""
+
+The ``Series.flush()`` method for ``load_chunk`` and ``store_chunk`` as well as particle patch ``load``/``store`` is now only needed in ``defer``-red flush mode.
+By default, a series will be opened with the new ``direct`` mode, which can be less performant for large-scale or many-var I/O but is more convenient.
+
+In order to restore the old default, set the new ``Series.set_flush`` method to ``Flush_Type.defer``.
+Both modes will be supported in the future and ``Flush_Type.defer`` is recommended for all high-throughput workloads.
+
+.. code-block:: python3
+
+   import openPMD_api as api
+
+   s = api.Series(
+       "data_%T.h5",
+       api.Access_Type.create)
+
+   # new default: api.Flush_Type.direct
+   s.set_flush(api.Flush_Type.defer)
+
+C++
+^^^
+
+``.flush()`` Method
+"""""""""""""""""""
+
+The ``Series::flush()`` method for ``loadChunk`` and ``storeChunk`` as well as particle patch ``load``/``store`` is now only needed in ``DEFER``-red flush mode.
+By default, a series will be opened with the new ``DIRECT`` mode, which can be less performant for large-scale or many-var I/O but is more convenient.
+
+In order to restore the old default, set the new ``Series::setFlush`` method to ``FlushType::DEFER``.
+Both modes will be supported in the future and ``FlushType::DEFER`` is recommended for all high-throughput workloads.
+
+.. code-block:: python3
+
+   #include <openPMD/openPMD.hpp>
+
+   s = openPMD::Series(
+       "data_%T.h5",
+       openPMD::AccessType::CREATE);
+
+   // new default: openPMD::FlushType::DIRECT
+   s.setFlush(openPMD::FlushType::DEFER);
+
 
 0.9.0-alpha
 -----------

--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -89,6 +89,9 @@ C++11
        "data%T.h5",
        api::AccessType::READ_ONLY);
 
+   // optional: accumulate heavy load
+   //    operations until .flush()
+   // series.setFlush(api::FlushType::DEFER);
 
 Python
 ^^^^^^
@@ -98,6 +101,10 @@ Python
    series = api.Series(
        "data%T.h5",
        api.Access_Type.read_only)
+
+   # optional: accumulate heavy load
+   #   operations until .flush()
+   # series.set_flush(api.Flush_Type.defer)
 
 Iteration
 ---------
@@ -271,6 +278,11 @@ Python
 .. code-block:: python3
 
    series.flush()
+
+.. note::
+
+   You can *skip this step* if your series flush mode is *not* ``FlushType::DEFER``/``Flush_Type.defer``.
+   With the convenient default (``FlushType::DIRECT``/``Flush_Type.direct``), we call ``flush()`` implicitly in ``load_chunk()``.
 
 Data
 -----

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -87,6 +87,9 @@ C++11
        "myOutput/data_%05T.h5",
        api::AccessType::CREATE);
 
+   // optional: accumulate heavy store
+   //    operations until .flush()
+   // series.setFlush(api::FlushType::DEFER);
 
 Python
 ^^^^^^
@@ -96,6 +99,10 @@ Python
    series = api.Series(
        "myOutput/data_%05T.h5",
        api.Access_Type.create)
+
+   # optional: accumulate heavy store
+   #   operations until .flush()
+   # series.set_flush(api.Flush_Type.defer)
 
 Iteration
 ---------
@@ -344,6 +351,11 @@ Python
 .. code-block:: python3
 
    series.flush()
+
+.. note::
+
+   You can *skip this step* if your series flush mode is *not* ``FlushType::DEFER``/``Flush_Type.defer``.
+   With the convenient default (``FlushType::DIRECT``/``Flush_Type.direct``), we call ``flush()`` implicitly in ``store_chunk()``.
 
 Close
 -----

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -37,6 +37,9 @@ int main()
     cout << "Read a Series with openPMD standard version "
          << series.openPMD() << '\n';
 
+    // accumulate load/store I/O operations until .flush()
+    // series.setFlush(FlushType::DEFER);
+
     cout << "The Series contains " << series.iterations.size() << " iterations:";
     for( auto const& i : series.iterations )
         cout << "\n\t" << i.first;
@@ -64,7 +67,8 @@ int main()
     auto chunk_data = E_x.loadChunk<double>(chunk_offset, chunk_extent);
     cout << "Queued the loading of a single chunk from disk, "
             "ready to execute\n";
-    series.flush();
+    // in FlushType::DEFER, call now:
+    // series.flush();
     cout << "Chunk has been read from disk\n"
          << "Read chunk contains:\n";
     for( size_t row = 0; row < chunk_extent[0]; ++row )
@@ -77,7 +81,8 @@ int main()
     }
 
     auto all_data = E_x.loadChunk<double>();
-    series.flush();
+    // in FlushType::DEFER, call now:
+    // series.flush();
     cout << "Full E/x starts with:\n\t{";
     for( size_t col = 0; col < extent[1] && col < 5; ++col )
         cout << all_data.get()[col] << ", ";

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -15,6 +15,9 @@ if __name__ == "__main__":
     print("Read a Series with openPMD standard version %s" %
           series.openPMD)
 
+    # accumulate load/store I/O operations until .flush()
+    # series.set_flush(openpmd_api.Flush_Type.defer)
+
     print("The Series contains {0} iterations:".format(len(series.iterations)))
     for i in series.iterations:
         print("\t {0}".format(i))
@@ -38,9 +41,10 @@ if __name__ == "__main__":
           shape, E_x.dtype))
 
     chunk_data = E_x[1:3, 1:3, 1:2]
-    # print("Queued the loading of a single chunk from disk, "
-    #       "ready to execute")
-    series.flush()
+
+    # in Flush_Type.defer, call now:
+    # series.flush()
+
     print("Chunk has been read from disk\n"
           "Read chunk contains:")
     print(chunk_data)
@@ -52,7 +56,10 @@ if __name__ == "__main__":
     #     print("")
 
     all_data = E_x.load_chunk()
-    series.flush()
+
+    # in Flush_Type.defer, call now:
+    # series.flush()
+
     print("Full E/x is of shape {0} and starts with:".format(all_data.shape))
     print(all_data[0, 0, :5])
 

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
     );
     cout << "Created an empty " << series.iterationEncoding() << " Series\n";
 
+    // accumulate load/store I/O operations until .flush()
+    // series.setFlush(FlushType::DEFER);
+
     MeshRecordComponent rho =
       series
           .iterations[1]
@@ -63,7 +66,8 @@ int main(int argc, char *argv[])
     rho.resetDataset(dataset);
     cout << "Set the dataset properties for the scalar field rho in iteration 1\n";
 
-    series.flush();
+    // in FlushType::DEFER, call now:
+    // series.flush();
     cout << "File structure and required attributes have been written\n";
 
     Offset offset = {0, 0};
@@ -71,7 +75,8 @@ int main(int argc, char *argv[])
     cout << "Stored the whole Dataset contents as a single chunk, "
             "ready to write content\n";
 
-    series.flush();
+    // in FlushType::DEFER, call now:
+    // series.flush();
     cout << "Dataset content has been fully written\n";
 
     /* The files in 'series' are still open until the object is destroyed, on

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -26,6 +26,9 @@ if __name__ == "__main__":
         openpmd_api.Access_Type.create
     )
 
+    # accumulate load/store I/O operations until .flush()
+    # series.set_flush(openpmd_api.Flush_Type.defer)
+
     print("Created an empty {0} Series".format(series.iteration_encoding))
 
     print(len(series.iterations))
@@ -40,16 +43,12 @@ if __name__ == "__main__":
     rho.reset_dataset(dataset)
     print("Set the dataset properties for the scalar field rho in iteration 1")
 
-    series.flush()
-    print("File structure has been written")
-
     rho[()] = data
 
-    print("Stored the whole Dataset contents as a single chunk, " +
-          "ready to write content")
+    # in Flush_Type.defer, call now:
+    # series.flush()
 
-    series.flush()
-    print("Dataset content has been fully written")
+    print("Stored the whole Dataset contents as a single chunk")
 
     # The files in 'series' are still open until the object is destroyed, on
     # which it cleanly flushes and closes all open file handles.

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
         if( 0 == mpi_rank )
             cout << "Read a series in parallel with " << mpi_size << " MPI ranks\n";
 
+        // accumulate load/store I/O operations until .flush()
+        // series.setFlush(FlushType::DEFER);
+
         MeshRecordComponent E_x = series.iterations[100].meshes["E"]["x"];
 
         Offset chunk_offset = {
@@ -67,7 +70,8 @@ int main(int argc, char *argv[])
         if( 0 == mpi_rank )
             cout << "Queued the loading of a single chunk per MPI rank from disk, "
                     "ready to execute\n";
-        series.flush();
+        // in FlushType::DEFER, call now:
+        // series.flush();
 
         if( 0 == mpi_rank )
             cout << "Chunks have been read from disk\n";

--- a/examples/4_read_parallel.py
+++ b/examples/4_read_parallel.py
@@ -24,6 +24,10 @@ if __name__ == "__main__":
         openpmd_api.Access_Type.read_only,
         comm
     )
+
+    # accumulate load/store I/O operations until .flush()
+    # series.set_flush(openpmd_api.Flush_Type.defer)
+
     if 0 == comm.rank:
         print("Read a series in parallel with {} MPI ranks".format(
               comm.size))
@@ -38,7 +42,8 @@ if __name__ == "__main__":
     if 0 == comm.rank:
         print("Queued the loading of a single chunk per MPI rank from disk, "
               "ready to execute")
-    series.flush()
+    # in Flush_Type.defer, call now:
+    # series.flush()
 
     if 0 == comm.rank:
         print("Chunks have been read from disk")

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
           cout << "Created an empty series in parallel with "
                << mpi_size << " MPI ranks\n";
 
+        // accumulate load/store I/O operations until .flush()
+        // series.setFlush(FlushType::DEFER);
+
         MeshRecordComponent mymesh =
             series
                 .iterations[1]
@@ -90,7 +93,8 @@ int main(int argc, char *argv[])
             cout << "Registered a single chunk per MPI rank containing its contribution, "
                     "ready to write content to disk\n";
 
-        series.flush();
+        // in FlushType::DEFER, call now:
+        // series.flush();
         if( 0 == mpi_rank )
             cout << "Dataset content has been fully written to disk\n";
     }

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -35,6 +35,10 @@ if __name__ == "__main__":
         openpmd_api.Access_Type.create,
         comm
     )
+
+    # accumulate load/store I/O operations until .flush()
+    # series.set_flush(openpmd_api.Flush_Type.defer)
+
     if 0 == comm.rank:
         print("Created an empty series in parallel with {} MPI ranks".format(
               comm.size))
@@ -61,7 +65,8 @@ if __name__ == "__main__":
         print("Registered a single chunk per MPI rank containing its "
               "contribution, ready to write content to disk")
 
-    series.flush()
+    # in Flush_Type.defer, call now:
+    # series.flush()
     if 0 == comm.rank:
         print("Dataset content has been fully written to disk")
 

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -6,8 +6,8 @@ Copyright 2018-2020 openPMD contributors
 Authors: Axel Huebl, Fabian Koller
 License: LGPLv3+
 """
-from openpmd_api import Series, Access_Type, Dataset, Mesh_Record_Component, \
-    Unit_Dimension
+from openpmd_api import Series, Access_Type, Dataset, Flush_Type, \
+    Mesh_Record_Component, Unit_Dimension
 import numpy as np
 
 
@@ -20,6 +20,9 @@ if __name__ == "__main__":
         "working/directory/2D_simData_py.h5",
         Access_Type.create
     )
+
+    # accumulate load/store I/O operations until .flush()
+    f.set_flush(Flush_Type.defer)
 
     # all required openPMD attributes will be set to reasonable default values
     # (all ones, all zeros, empty strings,...)
@@ -130,9 +133,10 @@ if __name__ == "__main__":
         {Unit_Dimension.L: 1})
     electrons.particle_patches["extent"]["x"].reset_dataset(dset)
 
-    # at any point in time you may decide to dump already created output to
-    # disk note that this will make some operations impossible (e.g. renaming
-    # files)
+    # in Flush_Type.defer:
+    #   at any point in time you may decide to dump already created output to
+    #   disk note that this will make some operations impossible (e.g. renaming
+    #   files)
     f.flush()
 
     # chunked writing of the final dataset at a time is supported
@@ -148,8 +152,9 @@ if __name__ == "__main__":
             partial_mesh[col] = mesh_x[i, col]
 
         mesh["x"][i, 0:5] = partial_mesh
-        # operations between store and flush MUST NOT modify the pointed-to
-        # data
+        # in Flush_Type.defer:
+        #   operations between store and flush MUST NOT modify the pointed-to
+        #   data
         f.flush()
         # after the flush completes successfully, access to the shared
         # resource is returned to the caller

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -6,8 +6,8 @@ Copyright 2019-2020 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-from openpmd_api import Series, Access_Type, Dataset, Mesh_Record_Component, \
-    Unit_Dimension
+from openpmd_api import Series, Access_Type, Dataset, Flush_Type, \
+    Mesh_Record_Component, Unit_Dimension
 import numpy as np
 
 
@@ -20,6 +20,9 @@ if __name__ == "__main__":
         "../samples/7_particle_write_serial_py.h5",
         Access_Type.create
     )
+
+    # FIXME GitHub issue #490
+    f.set_flush(Flush_Type.defer)
 
     # all required openPMD attributes will be set to reasonable default values
     # (all ones, all zeros, empty strings,...)

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -24,6 +24,7 @@
 #include "openPMD/IO/AccessType.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/IO/IOTask.hpp"
+#include "openPMD/IO/FlushType.hpp"
 
 #if openPMD_HAVE_MPI
 #   include <mpi.h>
@@ -70,13 +71,15 @@ class AbstractIOHandler
 public:
 #if openPMD_HAVE_MPI
     AbstractIOHandler(std::string path, AccessType at, MPI_Comm)
-        : directory{std::move(path)},
+        : flushType(FlushType::DIRECT),
+          directory{std::move(path)},
           accessTypeBackend{at},
           accessTypeFrontend{at}
     { }
 #endif
     AbstractIOHandler(std::string path, AccessType at)
-        : directory{std::move(path)},
+        : flushType(FlushType::DIRECT),
+          directory{std::move(path)},
           accessTypeBackend{at},
           accessTypeFrontend{at}
     { }
@@ -100,6 +103,7 @@ public:
     /** The currently used backend */
     virtual std::string backendName() const = 0;
 
+    FlushType flushType;
     std::string const directory;
     AccessType const accessTypeBackend;
     AccessType const accessTypeFrontend;

--- a/include/openPMD/IO/FlushType.hpp
+++ b/include/openPMD/IO/FlushType.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+
+namespace openPMD
+{
+    /** Data flush mode.
+     *
+     * Control if RecordComponent::load_chunk and RecordComponent::store_chunk
+     * operations are flushed immediately or delayed until Series::flush
+     *
+     * DIRECT-ly populating passed data buffers is considered a safe and
+     * convienient default for all small-scale I/O operations. For large-scale
+     * IO or load/store of many small chunks, consider switching to DEFER
+     * mode and ensure passed data buffers are valid and unmodified until
+     * Series::flush is called.
+     */
+    enum class FlushType //! @todo we should call this AccessMode and FlushMode ...
+    {
+        DIRECT,  //!< immediately load/store data to passed data buffers (default)
+        DEFER,   //!< load/store data to passed data buffers on Series::flush
+    }; // FlushType
+} // namespace openPMD

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -28,6 +28,7 @@
 #include <hdf5.h>
 
 #include <stack>
+#include <iostream>
 
 
 namespace openPMD
@@ -253,7 +254,13 @@ concrete_h5_file_position(Writable* w)
     std::string pos;
     while( !hierarchy.empty() )
     {
-        pos += std::dynamic_pointer_cast< HDF5FilePosition >(hierarchy.top()->abstractFilePosition)->location;
+        auto afp = hierarchy.top()->abstractFilePosition;
+
+        auto afp_h5 = std::dynamic_pointer_cast< HDF5FilePosition >(afp);
+        if( afp_h5 == nullptr )
+            std::cerr << "WARNING: invalid file position in writable stack!" << std::endl;
+        else
+            pos.append(afp_h5->location);
         hierarchy.pop();
     }
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -26,6 +26,7 @@
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AccessType.hpp"
+#include "openPMD/IO/FlushType.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/IterationEncoding.hpp"
@@ -239,6 +240,25 @@ public:
 
     /** The currently used backend */
     std::string backend() const;
+
+    /** Set the data flush mode
+     *
+     * Control if RecordComponent::load_chunk and RecordComponent::store_chunk
+     * operations are flushed immediately or delayed until Series::flush
+     *
+     * DIRECT-ly populating passed data buffers is considered a safe and
+     * convienient default for all small-scale I/O operations. For large-scale
+     * IO or load/store of many small chunks, consider switching to DEFER
+     * mode and ensure passed data buffers are valid and unmodified until
+     * Series::flush is called.
+     *
+     * Default: FlushType::DIRECT
+     */
+    void setFlush(FlushType flushType);
+
+    /** Return the data flush mode
+     */
+    FlushType getFlush();
 
     /** Execute all required remaining IO operations to write or read data.
      */

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -388,6 +388,7 @@ namespace openPMD
             AccessType::CREATE,
             m_benchmark->communicator
         );
+        series.setFlush(FlushType::DEFER);
 
         for( typename decltype( Series::iterations)::key_type i = 0;
             i < iterations;
@@ -461,6 +462,7 @@ namespace openPMD
             AccessType::READ_ONLY,
             m_benchmark->communicator
         );
+        series.setFlush(FlushType::DEFER);
 
         for( typename decltype( Series::iterations)::key_type i = 0;
             i < iterations;

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -48,6 +48,7 @@ namespace openPMD {}
 #include "openPMD/backend/Writable.hpp"
 
 #include "openPMD/IO/AccessType.hpp"
+#include "openPMD/IO/FlushType.hpp"
 
 #include "openPMD/auxiliary/Date.hpp"
 #include "openPMD/auxiliary/Deprecated.hpp"

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -359,6 +359,16 @@ Series::backend() const
     return IOHandler->backendName();
 }
 
+void Series::setFlush(FlushType flushType)
+{
+    IOHandler->flushType = flushType;
+}
+
+FlushType Series::getFlush()
+{
+    return IOHandler->flushType;
+}
+
 void
 Series::flush()
 {

--- a/src/binding/python/FlushType.cpp
+++ b/src/binding/python/FlushType.cpp
@@ -1,0 +1,35 @@
+/* Copyright 2018-2019 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "openPMD/IO/FlushType.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
+
+
+void init_FlushType(py::module &m) {
+    py::enum_<FlushType>(m, "Flush_Type")
+        .value("direct", FlushType::DIRECT)
+        .value("defer", FlushType::DEFER)
+    ;
+}

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -142,6 +142,8 @@ void init_Series(py::module &m) {
         .def("set_iteration_format", &Series::setIterationFormat)
         .def_property_readonly("name", &Series::name)
         .def("set_name", &Series::setName)
+        .def("set_flush", &Series::setFlush)
+        .def_property_readonly("flush_mode", &Series::getFlush)
         .def("flush", &Series::flush)
 
         .def_readwrite("iterations", &Series::iterations,

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -39,6 +39,7 @@ void init_BaseRecordComponent(py::module &);
 void init_Container(py::module &);
 void init_Dataset(py::module &);
 void init_Datatype(py::module &);
+void init_FlushType(py::module &);
 void init_Iteration(py::module &);
 void init_IterationEncoding(py::module &);
 void init_Mesh(py::module &);
@@ -64,6 +65,7 @@ PYBIND11_MODULE(openpmd_api, m) {
     init_BaseRecord(m);
     init_Dataset(m);
     init_Datatype(m);
+    init_FlushType(m);
     init_Iteration(m);
     init_IterationEncoding(m);
     init_Mesh(m);

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -38,6 +38,7 @@ void write_test_zero_extent( bool fileBased, std::string file_ending, bool write
     if( fileBased )
         filePath += "_%07T";
     Series o = Series( filePath.append(".").append(file_ending), AccessType::CREATE, MPI_COMM_WORLD);
+    o.setFlush(FlushType::DEFER);  // @bug crashes in DIRECT flush mode
 
     Iteration it = o.iterations[1];
     it.setAttribute("yolo", "yo");
@@ -100,6 +101,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[parallel][hdf5]" )
     try
     {
         Series o = Series("../samples/git-sample/data00000%T.h5", AccessType::READ_ONLY, MPI_COMM_WORLD);
+        o.setFlush(FlushType::DEFER);
 
         {
             double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
@@ -153,6 +155,7 @@ TEST_CASE( "hdf5_write_test", "[parallel][hdf5]" )
     uint64_t mpi_size = static_cast<uint64_t>(mpi_s);
     uint64_t mpi_rank = static_cast<uint64_t>(mpi_r);
     Series o = Series("../samples/parallel_write.h5", AccessType::CREATE, MPI_COMM_WORLD);
+    o.setFlush(FlushType::DEFER);  // @bug crashes in DIRECT flush mode
 
     o.setAuthor("Parallel HDF5");
     ParticleSpecies& e = o.iterations[1].particles["e"];
@@ -165,6 +168,8 @@ TEST_CASE( "hdf5_write_test", "[parallel][hdf5]" )
 
     e["position"]["x"].resetDataset(Dataset(determineDatatype(position_local), {mpi_size}));
     e["position"]["x"].storeChunk(position_local, {mpi_rank}, {1});
+
+    // o.flush();  // @todo why does this crash in DEFER flush mode?
 
     std::vector< uint64_t > positionOffset_global(mpi_size);
     uint64_t posOff{0};
@@ -210,6 +215,7 @@ TEST_CASE( "no_parallel_hdf5", "[parallel][hdf5]" )
 TEST_CASE( "adios_write_test", "[parallel][adios]" )
 {
     Series o = Series("../samples/parallel_write.bp", AccessType::CREATE, MPI_COMM_WORLD);
+    o.setFlush(FlushType::DEFER);  // @bug crashes in DIRECT flush mode
 
     int size{-1};
     int rank{-1};
@@ -264,6 +270,7 @@ TEST_CASE( "hzdr_adios_sample_content_test", "[parallel][adios1]" )
     {
         /* development/huebl/lwfa-bgfield-001 */
         Series o = Series("../samples/hzdr-sample/bp/checkpoint_%T.bp", AccessType::READ_ONLY, MPI_COMM_WORLD);
+        o.setFlush(FlushType::DEFER);
 
         if( o.iterations.count(0) == 1)
         {

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -112,6 +112,7 @@ class APITest(unittest.TestCase):
             "unittest_py_API." + file_ending,
             api.Access_Type.create
         )
+        self.assertEqual(series.flush_mode, api.Flush_Type.direct)
 
         # meta data
         series.set_software("nonsense")  # with unspecified version
@@ -852,6 +853,12 @@ class APITest(unittest.TestCase):
             "unittest_py_slice_API." + file_ending,
             api.Access_Type.create
         )
+
+        # FIXME GitHub issue #490
+        series.set_flush(api.Flush_Type.defer)
+
+        self.assertEqual(series.flush_mode, api.Flush_Type.defer)
+
         i = series.iterations[0]
 
         # create data to write
@@ -1028,6 +1035,10 @@ class APITest(unittest.TestCase):
             "unittest_py_particle_patches." + file_ending,
             api.Access_Type.create
         )
+
+        # FIXME GitHub issue #490
+        series.set_flush(api.Flush_Type.defer)
+
         e = series.iterations[42].particles["electrons"]
 
         for r in ["x", "y"]:
@@ -1083,7 +1094,8 @@ class APITest(unittest.TestCase):
         offset_x = e.particle_patches["offset"]["x"].load()
         offset_y = e.particle_patches["offset"]["y"].load()
 
-        series.flush()
+        # in Flush_Type.defer, call now:
+        # series.flush()
 
         np.testing.assert_almost_equal(
             numParticles, np.array([10, 113], np.uint64))


### PR DESCRIPTION
Add a new potential data flush mode to `Series`.

Although we implement a more general model of data passing and accumulating, allowing a "directly synchronous" mode will allow us to target the typical h5py Python user who just quickly wants to explore small data sets without frustration ("why is my data all zeros?").

We definitely have a continued need for our generalized, deferred, asynchronous chunk load/store mechanisms for our applications in parallel I/O and upcoming staging (think: streaming) modes. Just let us enable them explicitly as an "advanced" feature (therefore switch the default to the simple `DIRECT` mode). This is purely a user-interface change in order to target a wider audience.

The new `DIRECT` mode should also help somewhat in debugging.

Stylistic note: I think `AccessType` and `FlushType` might better be called `...Mode`?

@franzpoeschel @C0nsultant what do you think? I hope that description is not too brief, otherwise let's chat :-)
PRs to this branch that implement that mode, also in parts, very welcome.

## To Do

- [x] python bindings
- [ ] bugfix of #490
- Docs
  - [x] update first read / write
  - [x] update store/loadChunk doc strings
  - [x] add changelog
  - [x] breaking: add in upgrade guide
- [x] update examples
- [x] update and add more tests