### PR TITLE
Examples: 2D MPI Write

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Other
   - new "first steps" section #473 #478
   - update invasive test info #474
   - more info on ``AccessType`` #483
+  - improved MPI-parallel write example #496
 
 
 0.7.1-alpha

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -229,7 +229,7 @@ Python
    B_y = B["y"]
    B_z = B["z"]
 
-   auto dataset = api::Dataset(
+   dataset = api.Dataset(
        x_data.dtype,
        x_data.shape)
    B_x.reset_dataset(dataset)

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     size = 3
 
     # matrix dataset to write with values 0...size*size-1
-    global_data = np.arange(size*size, dtype=np.double).reshape(3, 3)
+    data = np.arange(size*size, dtype=np.double).reshape(3, 3)
 
     print("Set up a 2D square array ({0}x{1}) that will be written".format(
         size, size))
@@ -32,10 +32,7 @@ if __name__ == "__main__":
     rho = series.iterations[1]. \
         meshes["rho"][openpmd_api.Mesh_Record_Component.SCALAR]
 
-    datatype = openpmd_api.Datatype.DOUBLE
-    # datatype = openpmd_api.determineDatatype(global_data)
-    extent = [size, size]
-    dataset = openpmd_api.Dataset(datatype, extent)
+    dataset = openpmd_api.Dataset(data.dtype, data.shape)
 
     print("Created a Dataset of size {0}x{1} and Datatype {2}".format(
         dataset.extent[0], dataset.extent[1], dataset.dtype))
@@ -46,7 +43,7 @@ if __name__ == "__main__":
     series.flush()
     print("File structure has been written")
 
-    rho[()] = global_data
+    rho[()] = data
 
     print("Stored the whole Dataset contents as a single chunk, " +
           "ready to write content")


### PR DESCRIPTION
Enhance the parallel write example to demonstrate a 1D-decomposed, MPI-parallel write of a 2D mesh.

Fix #495 