### PR TITLE
setup.py/PyPI: Environment Variant Control

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,7 +42,7 @@ Other
 - NLohmann-JSON: updated to 3.5.0+ #467
 - Docs:
 
-  - PyPI install method #450 #451
+  - PyPI install method #450 #451 #497
   - more info on MPI #449
   - new "first steps" section #473 #478
   - update invasive test info #474

--- a/README.md
+++ b/README.md
@@ -120,11 +120,14 @@ Optional language bindings:
 
 [![Spack Package](https://img.shields.io/badge/spack.io-openpmd--api-brightgreen.svg)](https://spack.io)
 [![Conda Package](https://img.shields.io/badge/conda.io-openpmd--api-brightgreen.svg)](https://anaconda.org/conda-forge/openpmd-api)
-[![PyPI Package](https://img.shields.io/badge/pypi.org-openPMD--api-yellow.svg)](https://pypi.org/project/openPMD-api)
+[![PyPI Package](https://img.shields.io/badge/pypi.org-openpmd--api-yellow.svg)](https://pypi.org/project/openPMD-api)
+[![From Source](https://img.shields.io/badge/from_source-CMake-brightgreen.svg)](https://cmake.org)
 
 Choose *one* of the install methods below to get started:
 
 ### [Spack](https://spack.io)
+
+[![Spack Status](https://img.shields.io/badge/method-recommended-brightgreen.svg)](https://spack.io)
 
 ```bash
 # optional:               +python +adios1 -mpi
@@ -135,6 +138,7 @@ spack load -r openpmd-api
 ### [Conda](https://conda.io)
 
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openpmd-api.svg)](https://anaconda.org/conda-forge/openpmd-api)
+[![Conda Status](https://img.shields.io/badge/method-recommended-brightgreen.svg)](https://anaconda.org/conda-forge/openpmd-api)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openpmd-api.svg)](https://anaconda.org/conda-forge/openpmd-api)
 
 ```bash
@@ -146,15 +150,27 @@ conda install -c conda-forge openpmd-api
 
 [![PyPI Version](https://img.shields.io/pypi/v/openPMD-api.svg)](https://pypi.org/project/openPMD-api)
 [![PyPI Format](https://img.shields.io/pypi/format/openPMD-api.svg)](https://pypi.org/project/openPMD-api)
-[![PyPI Status](https://img.shields.io/badge/status-experimental-yellow.svg)](https://pypi.org/project/openPMD-api)
+[![PyPI Status](https://img.shields.io/badge/method-experimental-yellow.svg)](https://pypi.org/project/openPMD-api)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/openPMD-api.svg)](https://pypi.org/project/openPMD-api)
 
+Behind the scenes, this install method *compiles from source* against the found installations of HDF5, ADIOS and/or MPI (in system paths, from other package managers, or loaded via a module system, ...).
+The current status for this install method is *experimental*.
+Please feel free to [report](https://github.com/openPMD/openPMD-api/issues/new/choose) how this works for you.
+
 ```bash
-# optional:            [mpi] --user
-pip install openPMD-api
+# optional:             --user
+pip install openpmd-api
+```
+
+or with MPI support:
+```bash
+# optional:                                --user
+openPMD_USE_MPI=ON pip install openpmd-api
 ```
 
 ### From Source
+
+[![Source Status](https://img.shields.io/badge/method-advanced-brightgreen.svg)](https://cmake.org)
 
 openPMD can then be installed using [CMake](https://cmake.org/):
 

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -67,8 +67,15 @@ Please feel free to `report <https://github.com/openPMD/openPMD-api/issues/new/c
 
 .. code-block:: bash
 
-   # optional:            [mpi] --user
-   pip install openPMD-api
+   # optional:             --user
+   pip install openpmd-api
+
+or with MPI support:
+
+.. code-block:: bash
+
+   # optional:                                --user
+   openPMD_USE_MPI=ON pip install openpmd-api
 
 .. _install-cmake:
 


### PR DESCRIPTION
Unfortunately, the setuptools / pip "extras" can not be used to control build and build_ext options: https://github.com/pypa/setuptools/issues/1712

Therefore, we have to control our pip / setup.py variants at build time via environment variables, just like h5py and others.

For simplicity for the average Python user, we the default for this install method regarding MPI is changed to `OFF` unless explicitly requested.

Improve install experience reported by @ChristopherMayes in #492 for our experimental `pip`/`setup.py` install method.

Currently only expose `openPMD_USE_MPI` since everything else is sane and easy with `AUTO` detection and triggers no further downstream logic.