### PR TITLE
Manual: Link Parallel Python Examples

### DIFF
--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -22,6 +22,8 @@ Python
 
 - `2_read_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/2_read_serial.py>`_: reading a mesh
 - `3_write_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/3_write_serial.py>`_: writing a mesh
+- `4_read_parallel.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/4_read_parallel.py>`_: MPI-parallel mesh read
+- `5_write_parallel.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/5_write_parallel.py>`_: MPI-parallel mesh write
 - `7_extended_write_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/7_extended_write_serial.py>`_: particle writing with patches and constant records
 - `9_particle_write_serial.py <https://github.com/openPMD/openPMD-api/blob/dev/examples/9_particle_write_serial.py>`_: writing particles
 

--- a/docs/source/usage/parallel.rst
+++ b/docs/source/usage/parallel.rst
@@ -11,13 +11,33 @@ MPI is used on clusters, e.g. large-scale supercomputers, to communicate between
 Reading
 -------
 
+C++
+^^^
+
 .. literalinclude:: 4_read_parallel.cpp
    :language: cpp
    :lines: 21-
 
+Python
+^^^^^^
+
+.. literalinclude:: 4_read_parallel.py
+   :language: python3
+   :lines: 9-
+
 Writing
 -------
+
+C++
+^^^
 
 .. literalinclude:: 5_write_parallel.cpp
    :language: cpp
    :lines: 21-
+
+Python
+^^^^^^
+
+.. literalinclude:: 5_write_parallel.py
+   :language: python3
+   :lines: 9-


### PR DESCRIPTION
Add new parallel python examples from 0.8.0 release in manual.