### PR TITLE
CMake: Shared Libs Default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda37
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86
-      SHARED: OFF
+      SHARED: ON
 
     - TARGET_ARCH: x64
       CONDA_PY: 37

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BUILD_TYPE: "Debug"
     - PYBIND11_VERSION=@2.2.4
     - USE_JSON: ON
-    - USE_SHARED: OFF
+    - USE_SHARED: ON
 
 addons:
   apt:
@@ -310,13 +310,12 @@ jobs:
         - CXX=clang++ && CC=clang
     # Clang 7.0.0 + Python 3.7.1 + Address Sanitizer + Undefined Behavior Sanitizer @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 +MPI +PY@3.7 +H5 -ADIOS1 +JSON +ASan +UBSan
+      name: clang@7.0.0 +MPI +PY@3.7 +H5 -ADIOS1 +JSON +ASan +UBSan +STATIC
       dist: xenial
       language: python
       python: "3.7"
       env:
-        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_JSON=ON USE_SAMPLES=ON
-        #   USE_SHARED=ON
+        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SHARED=OFF USE_JSON=ON USE_SAMPLES=ON
         # sanitizer options: test as much as possible and suppress OpenMPI memory leaks
         - ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         - LSAN_OPTIONS=suppressions=${TRAVIS_BUILD_DIR}/.travis/sanitizer/clang/Leak.supp
@@ -445,13 +444,13 @@ jobs:
       script: *script-cpp-unit
     # GCC 8.1.0 + Python 3.7
     - <<: *test-cpp-unit
-      name: gcc@8.1.0 -MPI +PY@3.7 +H5 +ADIOS +SHARED
+      name: gcc@8.1.0 -MPI +PY@3.7 +H5 +ADIOS +STATIC
       language: python
       python: "3.7"
       sudo: required
       dist: xenial
       env:
-        - CXXSPEC="%gcc@8.1.0" USE_MPI=OFF USE_PYTHON=ON USE_INTERNAL_PYBIND11=OFF PYBIND11_VERSION=@2.2.4 USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SHARED=ON USE_SAMPLES=ON
+        - CXXSPEC="%gcc@8.1.0" USE_MPI=OFF USE_PYTHON=ON USE_INTERNAL_PYBIND11=OFF PYBIND11_VERSION=@2.2.4 USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SHARED=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Changes to "0.8.0-alpha"
 Features
 """"""""
 
+- CMake: Build a shared library by default #506
+
 Bug Fixes
 """""""""
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,18 @@ if(NOT CMAKE_BUILD_TYPE)
         "Choose the build type, e.g. Release or Debug." FORCE)
 endif()
 
+include(CMakeDependentOption)
+
+# change CMake default (static libs):
+# build shared libs if supported by target platform
+get_property(SHARED_LIBS_SUPPORTED GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+cmake_dependent_option(BUILD_SHARED_LIBS
+    "Build shared libraries (so/dylib/dll)."
+    ${SHARED_LIBS_SUPPORTED}
+    "SHARED_LIBS_SUPPORTED" OFF
+)
+mark_as_advanced(BUILD_SHARED_LIBS)
+
 include(CTest)
 # automatically defines: BUILD_TESTING, default is ON
 

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ The following options allow to switch to external installs:
 | `openPMD_USE_INTERNAL_PYBIND11` | **ON**/OFF | pybind11      |  2.2.4+ |
 | `openPMD_USE_INTERNAL_JSON`     | **ON**/OFF | NLohmann-JSON |  3.5.0+ |
 
-By default, this will build as a static library (`libopenPMD.a`) and installs also its headers.
-In order to build a shared library, append `-DBUILD_SHARED_LIBS=ON` to the `cmake` command.
+By default, this will build as a shared library (`libopenPMD.[so|dylib|dll]`) and installs also its headers.
+In order to build a static library, append `-DBUILD_SHARED_LIBS=OFF` to the `cmake` command.
 You can only build a static or a shared library at a time.
 
 By default, the `Release` version is built.

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -35,15 +35,15 @@ CMake Option                   Values          Description
 Shared or Static
 ----------------
 
-By default, we will build as a static library and install also its headers.
-You can only build a static (``libopenPMD.a`` or ``openPMD.lib``) or a shared library (``libopenPMD.so`` or ``openPMD.dll``) at a time.
+By default, we will build as a shared library and install also its headers.
+You can only build a static (``libopenPMD.a`` or ``openPMD.lib``) or a shared library (``libopenPMD.so`` or ``openPMD.dylib`` or ``openPMD.dll``) at a time.
 
-The following options can be tried to switch between static and shared builds and control if dependencies are linked dynamically or statically:
+The following options switch between static and shared builds and control if dependencies are linked dynamically or statically:
 
 ============================== =============== ==================================================
 CMake Option                   Values          Description
 ============================== =============== ==================================================
-``BUILD_SHARED_LIBS``          ON/**OFF**      Build the C++ API as shared library
+``BUILD_SHARED_LIBS``          **ON**/OFF      Build the C++ API as shared library
 ``HDF5_USE_STATIC_LIBRARIES``  ON/**OFF**      Require static HDF5 library
 ``ADIOS_USE_STATIC_LIBS``      ON/**OFF**      Require static ADIOS1 library
 ============================== =============== ==================================================


### PR DESCRIPTION
Build shared libs by default. CMake defaults to static libs, but shared is to saner option for our library.

Close #505