### PR TITLE
MSVC: Warning DLL Interface STDlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,8 +728,13 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Warning C4503: "decorated name length exceeded, name was truncated"
-    # Symbols longer than 4096 chars are truncated
+    # Symbols longer than 4096 chars are truncated (and hashed instead)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -wd4503")
+    # Yes, you should build against the same C++ runtime and with same
+    # configuration (Debug/Release). MSVC does inconvenient choices for their
+    # developers, so be it. (Our Windows-users use conda-forge builds, which
+    # are consistent.)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -wd4251")
 endif ()
 
 


### PR DESCRIPTION
MSVC/Windows had the splendit idea to make different versions of their C++ runtime libs as well as Debug/Release configurations absolutely incompatible to each other.

Well, so be it. Build consistently.
We will of course use C++ stdlib classes (with templates) in our interfaces, because that's what they are made for. Implement better, Redmond.

Our Windows users will most likely only install graphically anyway, because otherwise they would be OSX or Linux users. We ship for Windows via conda-forge, which builds a consistent software stack.