### PR TITLE
Remove dummy dataset writing from PatchRecordComponent::flush()

### DIFF
--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -89,21 +89,6 @@ PatchRecordComponent::flush(std::string const& name)
             dCreate.compression = m_dataset->compression;
             dCreate.transform = m_dataset->transform;
             IOHandler->enqueue(IOTask(this, dCreate));
-            if( m_chunks->empty() )
-            {
-                /* Ensure at least one WRITE_DATASET per dataset occurs
-                 * ADIOS1 backend only creates a dataset after at least once cell has been written */
-                Parameter< Operation::WRITE_DATASET > dWrite;
-                auto uptr = auxiliary::allocatePtr(dCreate.dtype, 1);
-                std::shared_ptr< void > data{std::move(uptr)};
-                dWrite.data = data;
-                dWrite.dtype = dCreate.dtype;
-                if( dWrite.dtype == Datatype::UNDEFINED )
-                    throw std::runtime_error("Dataset has not been defined for ParticlePatch RecordComponent " + name);
-                dWrite.extent = Extent(getDimensionality(), 1);
-                dWrite.offset = Offset(getDimensionality(), 0);
-                m_chunks->push(IOTask(this, dWrite));
-            }
         }
 
         while( !m_chunks->empty() )


### PR DESCRIPTION
Proposal to fix #489, see there for the underlying issue.
As described there, the current state causes issues in other backends. Notably, ADIOS2 will not reliably delete the dummy value upon writing the actual data, so the output may contain random data at the first position.
**Proposed solution in this PR:** 
- Remove this workaround from the frontend. It addresses a backend-specific issue and should be resolved in the backend, not the frontend. The above issue supports this point.
- For now, do *not* implement an alternative solution to the issue addressed by the workaround, i.e. ADIOS variables only being physically created after writing data. *Up to discussion*.
  - *Option 1*: Keep things this way. It is a design decision in ADIOS (also ADIOS2) not to physically create variables (used for openPMD datasets) unless data is actually written and openPMD can leverage this behavior. The workaround removed in this PR tries to circumvent this behavior. *Needs to be documented in this case*.
  - *Option 2*: Implement an alternative workaround. I see no clean way to do this at the moment.

**Todo:**
- [ ] Document the changing behavior, especially in case we go with option 1.

Due to the issues described above, this should be merged *before* #482.