### PR TITLE
Allow flushing before defining position and positionOffset components of particle species

### DIFF
--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -55,9 +55,6 @@ namespace traits
         template< typename T >
         void operator()(T & ret)
         {
-            /* enforce these two RecordComponents as required by the standard */
-            ret["position"].setUnitDimension({{UnitDimension::L, 1}});
-            ret["positionOffset"].setUnitDimension({{UnitDimension::L, 1}});
             ret.particlePatches.linkHierarchy(ret.m_writable);
 
             auto& np = ret.particlePatches["numParticles"];

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -122,6 +122,17 @@ ParticleSpecies::flush(std::string const& path)
             for( auto& patch : particlePatches )
                 patch.second.flush(patch.first);
         }
+
+        iterator it = find("position");
+        if ( it != end() )
+        {
+            it->second.setUnitDimension({{UnitDimension::L, 1}});
+        }
+        it = find("positionOffset");
+        if ( it != end() )
+        {
+            it->second.setUnitDimension({{UnitDimension::L, 1}});
+        }
     }
 }
 } // openPMD

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -449,8 +449,6 @@ TEST_CASE( "structure_test", "[core]" )
     REQUIRE(o.iterations[1].particles["P"].particlePatches.IOHandler);
     REQUIRE(o.iterations[1].particles["P"].particlePatches.parent == getWritable(&o.iterations[1].particles["P"]));
 
-    REQUIRE(1 == o.iterations[1].particles["P"].count("position"));
-    REQUIRE(1 == o.iterations[1].particles["P"].count("positionOffset"));
     auto dset = Dataset(Datatype::DOUBLE, {1});
     o.iterations[1].particles["P"]["position"][RecordComponent::SCALAR].resetDataset(dset);
     o.iterations[1].particles["P"]["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -234,8 +234,6 @@ TEST_CASE( "particleSpecies_modification_test", "[core]" )
     REQUIRE(1 == particles.size());
     REQUIRE(1 == particles.count("species"));
     REQUIRE(0 == species.numAttributes());
-    REQUIRE(2 == species.size());    //position, positionOffset
-    REQUIRE(1 == species.count("position"));
     auto dset = Dataset(Datatype::DOUBLE, {1});
     species["position"][RecordComponent::SCALAR].resetDataset(dset);
     species["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -171,6 +171,41 @@ TEST_CASE( "constant_scalar", "[serial]" )
     }
 }
 
+TEST_CASE( "flush_without_position_positionOffset", "[serial]" )
+{
+    for( auto const & t : backends )
+    {
+        const std::string & file_ending = std::get< 0 >( t );
+        Series s = Series(
+            "../samples/flush_without_position_positionOffset." + file_ending,
+            AccessType::CREATE );
+        ParticleSpecies e = s.iterations[ 0 ].particles[ "e" ];
+        RecordComponent weighting = e[ "weighting" ][ RecordComponent::SCALAR ];
+        weighting.resetDataset( Dataset( Datatype::FLOAT, Extent{ 2, 2 } ) );
+        weighting.storeChunk( std::shared_ptr< float >(
+            new float[ 4 ]{},
+            []( float * ptr ) { delete[] ptr; } ),
+            { 0, 0 },
+            { 2, 2 } );
+            
+        s.flush();
+        
+        for( auto const & key : { "position", "positionOffset" } )
+        {
+            for( auto const & dim : { "x", "y", "z" } )
+            {
+                RecordComponent rc = e[ key ][ dim ];
+                rc.resetDataset( Dataset( Datatype::FLOAT , Extent{ 2, 2 } ) );
+                rc.storeChunk( std::shared_ptr< float >(
+                    new float[ 4 ]{},
+                    []( float * ptr ) { delete[] ptr; } ),
+                    { 0, 0 },
+                    { 2, 2 } );
+                    }
+        }
+    }
+}
+
 
 inline
 void particle_patches( std::string file_ending )


### PR DESCRIPTION
**Issue** The fact that the class [`ParticleSpecies`](https://github.com/openPMD/openPMD-api/blob/dev/include/openPMD/ParticleSpecies.hpp) will enforce openPMD requirements currently leads to the awkward situation that those records have to be defined using [`RecordComponent::resetDataset( … )`](https://github.com/openPMD/openPMD-api/blob/dev/include/openPMD/RecordComponent.hpp#L103) before issuing the first flush on the `Series` object. A later `RecordComponent::storeChunk( … )` is fine, but the datasets need to be defined up front.
This is (1) an awkward pitfall, (2) leads to rather confusing errors if done wrongly (`what():  A Record can not be written without any contained RecordComponents: position`) and (3) leads to ugly workarounds in workflows where the single records of a particle species are defined and written one after another (e.g. the [openPMD plugin for picongpu](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2966) that I am currently working on).

**Suggested Change** Move [these two lines](https://github.com/openPMD/openPMD-api/blob/37b525dff1fb1bdd50274d229353d8226f973065/include/openPMD/ParticleSpecies.hpp#L59) into the `flush` method override of `ParticleSpecies`, but do not create the records if not present.

**Open questions** The above solution will ensure openPMD requirements for position[Offset] records if the user remembers to create them. I have not (yet) implemented an alternative check if the user forgets to create those records. The logical location for such a check would be the destructor, but throwing exceptions in destructors is discouraged.

First commit adds new tests (and removes some existing ones), second commit will implement the suggested change.