### PR TITLE
Follow-up – Allow flushing before defining position and positionOffset components of particle species

### DIFF
--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -109,6 +109,13 @@ ParticleSpecies::flush(std::string const& path)
             patch.second.flush(patch.first);
     } else
     {
+        iterator it = find("position");
+        if ( it != end() )
+            it->second.setUnitDimension({{UnitDimension::L, 1}});
+        it = find("positionOffset");
+        if ( it != end() )
+            it->second.setUnitDimension({{UnitDimension::L, 1}});
+
         Container< Record >::flush(path);
 
         for( auto& record : *this )
@@ -121,17 +128,6 @@ ParticleSpecies::flush(std::string const& path)
             particlePatches.flush("particlePatches");
             for( auto& patch : particlePatches )
                 patch.second.flush(patch.first);
-        }
-
-        iterator it = find("position");
-        if ( it != end() )
-        {
-            it->second.setUnitDimension({{UnitDimension::L, 1}});
-        }
-        it = find("positionOffset");
-        if ( it != end() )
-        {
-            it->second.setUnitDimension({{UnitDimension::L, 1}});
         }
     }
 }


### PR DESCRIPTION
Pull request #518 contains a little bug, the unit dimensions need to be set *before* flushing.