### PR TITLE
Allow to write empty datasets

### DIFF
--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -107,6 +107,9 @@ public:
 
     template< typename T >
     RecordComponent& makeConstant(T);
+    
+    template< typename T >
+    RecordComponent& makeEmpty( uint8_t dimensions );
 
     /** Load and allocate a chunk of data
      *
@@ -159,6 +162,7 @@ OPENPMD_protected:
 private:
     void flush(std::string const&);
     virtual void read();
+    RecordComponent& makeEmpty( Dataset );
 }; // RecordComponent
 
 
@@ -172,6 +176,15 @@ RecordComponent::makeConstant(T value)
     *m_constantValue = Attribute(value);
     *m_isConstant = true;
     return *this;
+}
+
+template< typename T >
+inline RecordComponent&
+RecordComponent::makeEmpty( uint8_t dimensions )
+{
+    return makeEmpty( Dataset(
+        determineDatatype< T >(),
+        Extent( dimensions, 0 ) ) );
 }
 
 template< typename T >

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -182,6 +182,8 @@ template< typename T >
 inline RecordComponent&
 RecordComponent::makeEmpty( uint8_t dimensions )
 {
+    if ( dimensions == 0 )
+        throw std::runtime_error("Dataset extent must be at least 1D.");
     return makeEmpty( Dataset(
         determineDatatype< T >(),
         Extent( dimensions, 0 ) ) );

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -313,8 +313,10 @@ RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
 {
     if( *m_isConstant && !*m_isEmpty )
         throw std::runtime_error("Chunks can not be written for a constant RecordComponent.");
-    if( !data )
+    if( !data && !*m_isEmpty )
         throw std::runtime_error("Unallocated pointer passed during chunk store.");
+    if( *m_isEmpty && data )
+        throw std::runtime_error("Non-null pointer passed during chunk store of an empty RecordComponent.");
     Datatype dtype = determineDatatype(data);
     if( dtype != getDatatype() )
     {

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -107,7 +107,7 @@ public:
 
     template< typename T >
     RecordComponent& makeConstant(T);
-    
+
     template< typename T >
     RecordComponent& makeEmpty( uint8_t dimensions );
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -311,12 +311,12 @@ template< typename T >
 inline void
 RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
 {
-    if( *m_isConstant && !*m_isEmpty )
-        throw std::runtime_error("Chunks can not be written for a constant RecordComponent.");
-    if( !data && !*m_isEmpty )
-        throw std::runtime_error("Unallocated pointer passed during chunk store.");
-    if( *m_isEmpty && data )
-        throw std::runtime_error("Non-null pointer passed during chunk store of an empty RecordComponent.");
+    if( *m_isConstant )
+        throw std::runtime_error("Chunks cannot be written for a constant RecordComponent.");
+    if( *m_isEmpty )
+        throw std::runtime_error("Chunks cannot be written for an empty RecordComponent.");
+    if( !data )
+throw std::runtime_error("Unallocated pointer passed during chunk store.");
     Datatype dtype = determineDatatype(data);
     if( dtype != getDatatype() )
     {
@@ -348,8 +348,6 @@ RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
                                      + " - Chunk: " + std::to_string(o[i] + e[i])
                                      + ")");
 
-    if (*m_isEmpty)
-        return;
     Parameter< Operation::WRITE_DATASET > dWrite;
     dWrite.offset = o;
     dWrite.extent = e;

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -158,6 +158,9 @@ OPENPMD_protected:
 
     std::shared_ptr< std::queue< IOTask > > m_chunks;
     std::shared_ptr< Attribute > m_constantValue;
+    std::shared_ptr< bool > m_isEmpty{
+        std::make_shared< bool >( false )
+    };
 
 private:
     void flush(std::string const&);
@@ -297,7 +300,7 @@ template< typename T >
 inline void
 RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
 {
-    if( *m_isConstant )
+    if( *m_isConstant && !*m_isEmpty )
         throw std::runtime_error("Chunks can not be written for a constant RecordComponent.");
     if( !data )
         throw std::runtime_error("Unallocated pointer passed during chunk store.");
@@ -332,6 +335,8 @@ RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
                                      + " - Chunk: " + std::to_string(o[i] + e[i])
                                      + ")");
 
+    if (*m_isEmpty)
+        return;
     Parameter< Operation::WRITE_DATASET > dWrite;
     dWrite.offset = o;
     dWrite.extent = e;

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -108,6 +108,14 @@ public:
     template< typename T >
     RecordComponent& makeConstant(T);
 
+    /**
+     * Create a dataset with zero extent in each dimension.
+     * Implemented by creating a constant record component with
+     * a dummy value (default constructor of the respective datatype).
+     * @param dimensions The number of dimensions. Must be greater than
+     *                   zero.
+     * @return A reference to this RecordComponent.
+     */
     template< typename T >
     RecordComponent& makeEmpty( uint8_t dimensions );
 
@@ -158,13 +166,18 @@ OPENPMD_protected:
 
     std::shared_ptr< std::queue< IOTask > > m_chunks;
     std::shared_ptr< Attribute > m_constantValue;
-    std::shared_ptr< bool > m_isEmpty{
-        std::make_shared< bool >( false )
-    };
+    std::shared_ptr< bool > m_isEmpty = std::make_shared< bool >( false );
 
 private:
     void flush(std::string const&);
     virtual void read();
+
+    /**
+     * Internal method to be called by all methods that create an empty dataset.
+     *
+     * @param The dataset description. Must have nonzero dimensions.
+     * @return Reference to this RecordComponent instance.
+     */
     RecordComponent& makeEmpty( Dataset );
 }; // RecordComponent
 
@@ -185,8 +198,6 @@ template< typename T >
 inline RecordComponent&
 RecordComponent::makeEmpty( uint8_t dimensions )
 {
-    if ( dimensions == 0 )
-        throw std::runtime_error("Dataset extent must be at least 1D.");
     return makeEmpty( Dataset(
         determineDatatype< T >(),
         Extent( dimensions, 0 ) ) );

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -61,4 +61,25 @@ OPENPMD_protected:
     std::shared_ptr< Dataset > m_dataset;
     std::shared_ptr< bool > m_isConstant;
 }; // BaseRecordComponent
+namespace detail
+{
+template< typename RecordComponent_T >
+struct DefaultValue
+{
+    template< typename T >
+    void
+    operator()( RecordComponent_T & rc )
+    {
+        rc.makeConstant( T() );
+    }
+
+    template< unsigned n, typename... Args >
+    void
+    operator()( Args &&... )
+    {
+        throw std::runtime_error(
+            "makeEmpty: Datatype not supported by openPMD." );
+    }
+};
+} // namespace detail
 } // namespace openPMD

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -61,8 +61,17 @@ OPENPMD_protected:
     std::shared_ptr< Dataset > m_dataset;
     std::shared_ptr< bool > m_isConstant;
 }; // BaseRecordComponent
+
 namespace detail
 {
+/**
+ * Functor template to be used in combination with <switchType>"()"
+ * to set a default value for constant record components via the
+ * respective type's default constructor.
+ * Used to implement empty datasets in subclasses of BaseRecordComponent
+ * (currently RecordComponent).
+ * @param rc
+ */
 template< typename RecordComponent_T >
 struct DefaultValue
 {

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -46,16 +46,18 @@ RecordComponent::setUnitSI(double usi)
     return *this;
 }
 
-RecordComponent&
-RecordComponent::resetDataset(Dataset d)
+RecordComponent &
+RecordComponent::resetDataset( Dataset d )
 {
     if( written )
-        throw std::runtime_error("A Records Dataset can not (yet) be changed after it has been written.");
-    if( d.extent.empty() )
-        throw std::runtime_error("Dataset extent must be at least 1D.");
-    if( std::any_of(d.extent.begin(), d.extent.end(),
-                    [](Extent::value_type const& i) { return i == 0u; }) )
-        throw std::runtime_error("Dataset extent must not be zero in any dimension.");
+        throw std::runtime_error( "A Records Dataset can not (yet) be changed "
+                                  "after it has been written." );
+    if( d.extent.empty() ||
+        std::any_of(
+            d.extent.begin(),
+            d.extent.end(),
+            []( Extent::value_type const & i ) { return i == 0u; } ) )
+        return makeEmpty( d );
 
     *m_dataset = d;
     dirty = true;
@@ -72,6 +74,24 @@ Extent
 RecordComponent::getExtent() const
 {
     return m_dataset->extent;
+}
+
+RecordComponent&
+RecordComponent::makeEmpty( Dataset d )
+{
+    if( written )
+        throw std::runtime_error(
+            "A recordComponent can not (yet) be made"
+            " empty after it has been written.");
+    
+    *m_dataset = d;
+    dirty = true;
+    static detail::DefaultValue< RecordComponent > dv;
+    switchType(
+        d.dtype,
+        dv,
+        *this );
+    return *this;
 }
 
 void

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -85,6 +85,7 @@ RecordComponent::makeEmpty( Dataset d )
             "A recordComponent can not (yet) be made"
             " empty after it has been written.");
 
+    *m_isEmpty = true;
     *m_dataset = d;
     dirty = true;
     static detail::DefaultValue< RecordComponent > dv;

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -50,7 +50,7 @@ RecordComponent &
 RecordComponent::resetDataset( Dataset d )
 {
     if( written )
-        throw std::runtime_error( "A Records Dataset can not (yet) be changed "
+        throw std::runtime_error( "A record's Dataset cannot (yet) be changed "
                                   "after it has been written." );
     if( d.extent.empty() )
         throw std::runtime_error("Dataset extent must be at least 1D.");
@@ -82,8 +82,10 @@ RecordComponent::makeEmpty( Dataset d )
 {
     if( written )
         throw std::runtime_error(
-            "A recordComponent can not (yet) be made"
+            "A RecordComponent cannot (yet) be made"
             " empty after it has been written.");
+    if( d.extent.size() == 0 )
+        throw std::runtime_error("Dataset extent must be at least 1D.");
 
     *m_isEmpty = true;
     *m_dataset = d;

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -52,8 +52,9 @@ RecordComponent::resetDataset( Dataset d )
     if( written )
         throw std::runtime_error( "A Records Dataset can not (yet) be changed "
                                   "after it has been written." );
-    if( d.extent.empty() ||
-        std::any_of(
+    if( d.extent.empty() )
+        throw std::runtime_error("Dataset extent must be at least 1D.");
+    if( std::any_of(
             d.extent.begin(),
             d.extent.end(),
             []( Extent::value_type const & i ) { return i == 0u; } ) )
@@ -83,7 +84,7 @@ RecordComponent::makeEmpty( Dataset d )
         throw std::runtime_error(
             "A recordComponent can not (yet) be made"
             " empty after it has been written.");
-    
+
     *m_dataset = d;
     dirty = true;
     static detail::DefaultValue< RecordComponent > dv;

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -680,5 +680,7 @@ TEST_CASE( "zero_extent_component", "[core]" )
     E_x.setComment("Datasets must contain dimensions.");
     REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {})),
                         Catch::Equals("Dataset extent must be at least 1D."));
+    REQUIRE_THROWS_WITH(E_x.makeEmpty<int>(0),
+                        Catch::Equals("Dataset extent must be at least 1D."));
     E_x.resetDataset(Dataset(Datatype::DOUBLE, {1}));
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -671,3 +671,14 @@ TEST_CASE( "empty_record_test", "[core]" )
     o.iterations[1].meshes["E"][RecordComponent::SCALAR].resetDataset(Dataset(Datatype::DOUBLE, {1}));
     o.flush();
 }
+
+TEST_CASE( "zero_extent_component", "[core]" )
+{
+    Series o = Series("./new_openpmd_output", AccessType::CREATE);
+
+    auto E_x = o.iterations[1].meshes["E"]["x"];
+    E_x.setComment("Datasets must contain dimensions.");
+    REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {})),
+                        Catch::Equals("Dataset extent must be at least 1D."));
+    E_x.resetDataset(Dataset(Datatype::DOUBLE, {1}));
+}

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -671,21 +671,3 @@ TEST_CASE( "empty_record_test", "[core]" )
     o.iterations[1].meshes["E"][RecordComponent::SCALAR].resetDataset(Dataset(Datatype::DOUBLE, {1}));
     o.flush();
 }
-
-TEST_CASE( "zero_extent_component", "[core]" )
-{
-    Series o = Series("./new_openpmd_output", AccessType::CREATE);
-
-    auto E_x = o.iterations[1].meshes["E"]["x"];
-    E_x.setComment("Datasets with zero extent in any dimension are not allowed.");
-    REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {0})),
-                        Catch::Equals("Dataset extent must not be zero in any dimension."));
-    REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {1, 0})),
-                        Catch::Equals("Dataset extent must not be zero in any dimension."));
-    REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {0, 1})),
-                        Catch::Equals("Dataset extent must not be zero in any dimension."));
-    E_x.setComment("Datasets must contain dimensions.");
-    REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {})),
-                        Catch::Equals("Dataset extent must be at least 1D."));
-    E_x.resetDataset(Dataset(Datatype::DOUBLE, {1}));
-}

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -97,7 +97,6 @@ TEST_CASE( "empty_dataset_test", "[serial]" )
 {
     for (auto const & t: backends)
     {
-        //if (std::get<0>(t) == "json")
         empty_dataset_test(std::get<0>(t));
     }
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -45,13 +45,13 @@ empty_dataset_test( std::string file_ending )
         Series series(
             "../samples/empty_datasets." + file_ending, AccessType::CREATE );
 
-        RecordComponent makeEmpty_dim_7_int =
+        auto makeEmpty_dim_7_int =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_dim_7_int" ];
-        RecordComponent makeEmpty_dim_7_long =
+        auto makeEmpty_dim_7_long =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_dim_7_bool" ];
-        RecordComponent makeEmpty_resetDataset_dim3 =
+        auto makeEmpty_resetDataset_dim3 =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_resetDataset_dim3" ];
-        RecordComponent makeEmpty_resetDataset_dim3_notallzero =
+        auto makeEmpty_resetDataset_dim3_notallzero =
             series.iterations[ 1 ]
                 .meshes[ "rho" ][ "makeEmpty_resetDataset_dim3_notallzero" ];
         makeEmpty_dim_7_int.makeEmpty< int >( 7 );
@@ -66,13 +66,13 @@ empty_dataset_test( std::string file_ending )
     {
         Series series(
             "../samples/empty_datasets." + file_ending, AccessType::READ_ONLY );
-        RecordComponent makeEmpty_dim_7_int =
+        auto makeEmpty_dim_7_int =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_dim_7_int" ];
-        RecordComponent makeEmpty_dim_7_long =
+        auto makeEmpty_dim_7_long =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_dim_7_bool" ];
-        RecordComponent makeEmpty_resetDataset_dim3 =
+        auto makeEmpty_resetDataset_dim3 =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_resetDataset_dim3" ];
-        RecordComponent makeEmpty_resetDataset_dim3_notallzero =
+        auto makeEmpty_resetDataset_dim3_notallzero =
             series.iterations[ 1 ]
                 .meshes[ "rho" ][ "makeEmpty_resetDataset_dim3_notallzero" ];
         REQUIRE(makeEmpty_dim_7_int.getDimensionality() == 7);

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -44,22 +44,7 @@ empty_dataset_test( std::string file_ending )
     {
         Series series(
             "../samples/empty_datasets." + file_ending, AccessType::CREATE );
-        
-        // The ADIOS1 backend prefers to have actual data written to it 
-        // as soon as possible
-        // related: https://github.com/openPMD/openPMD-api/issues/520
-        RecordComponent circumvent_ADIOS1_bug =
-                series.iterations[ 1 ]
-                    .meshes[ "rho" ][ "circumvent_ADIOS1_bug"];
-        circumvent_ADIOS1_bug.resetDataset(
-                Dataset(Datatype::INT, Extent{1}));
-        std::vector< int > data{ 1 };
-        circumvent_ADIOS1_bug.storeChunk(
-                data,
-                Offset{0},
-                Extent{1} );
-        series.flush();
-        
+
         RecordComponent makeEmpty_dim_7_int =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_dim_7_int" ];
         RecordComponent makeEmpty_dim_7_long =
@@ -267,9 +252,9 @@ TEST_CASE( "flush_without_position_positionOffset", "[serial]" )
             []( float * ptr ) { delete[] ptr; } ),
             { 0, 0 },
             { 2, 2 } );
-            
+
         s.flush();
-        
+
         for( auto const & key : { "position", "positionOffset" } )
         {
             for( auto const & dim : { "x", "y", "z" } )

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -92,19 +92,19 @@ empty_dataset_test( std::string file_ending )
                 .meshes[ "rho" ][ "makeEmpty_resetDataset_dim3_notallzero" ];
         REQUIRE(makeEmpty_dim_7_int.getDimensionality() == 7);
         REQUIRE(makeEmpty_dim_7_int.getExtent() == Extent(7, 0));
-        REQUIRE(makeEmpty_dim_7_int.getDatatype() == determineDatatype< int >());
+        REQUIRE(isSame(makeEmpty_dim_7_int.getDatatype(), determineDatatype< int >()));
 
         REQUIRE(makeEmpty_dim_7_long.getDimensionality() == 7);
         REQUIRE(makeEmpty_dim_7_long.getExtent() == Extent(7, 0));
-        REQUIRE(makeEmpty_dim_7_long.getDatatype() == determineDatatype< long >());
+        REQUIRE(isSame(makeEmpty_dim_7_long.getDatatype(), determineDatatype< long >()));
 
         REQUIRE(makeEmpty_resetDataset_dim3.getDimensionality() == 3);
         REQUIRE(makeEmpty_resetDataset_dim3.getExtent() == Extent(3, 0));
-        REQUIRE(makeEmpty_resetDataset_dim3.getDatatype() == Datatype::LONG);
-        
+        REQUIRE(isSame(makeEmpty_resetDataset_dim3.getDatatype(), Datatype::LONG));
+
         REQUIRE(makeEmpty_resetDataset_dim3_notallzero.getDimensionality() == 3);
         REQUIRE(makeEmpty_resetDataset_dim3_notallzero.getExtent() == Extent{1,2,0});
-        REQUIRE(makeEmpty_resetDataset_dim3_notallzero.getDatatype() == Datatype::LONG_DOUBLE);
+        REQUIRE(isSame(makeEmpty_resetDataset_dim3_notallzero.getDatatype(), Datatype::LONG_DOUBLE));
     }
 }
 


### PR DESCRIPTION
Close #514 and #516.
This PR adds the following member to the class `RecordComponent`:
```cpp
    template< typename T >
    RecordComponent& makeEmpty( uint8_t dimensions );
```
This lets the user explicitly create an empty dataset.
Upon detecting an empty dataset, the member `RecordComponent& resetDataset(Dataset);` will not fail any more, but also create an empty dataset.

Since backends do currently not expect empty datasets, I implemented this feature by using constant record components. Zero-dimensional datasets are still not allowed.