### PR TITLE
CMake: Generate pkg-config .pc file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Features
 - CMake:
 
   - build a shared library by default #506
-  - generate pkg-config .pc file #532
+  - generate pkg-config ``.pc`` file #532
 - Python:
 
   - manylinux2010 wheels for PyPI #523

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,10 @@ Features
 
 - ADIOS2: support added (v2.4.0+) #482 #513 #530
 - support empty datasets via ``RecordComponent::makeEmpty`` #528 #529
-- CMake: Build a shared library by default #506
+- CMake:
+
+  - build a shared library by default #506
+  - generate pkg-config .pc file #532
 - Python:
 
   - manylinux2010 wheels for PyPI #523

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,7 @@ endif()
 # own headers
 target_include_directories(openPMD PUBLIC
     $<BUILD_INTERFACE:${openPMD_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${openPMD_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -413,10 +414,6 @@ if(openPMD_HAVE_MPI)
     # MPI targets: CMake 3.9+
     # note: often the PUBLIC dependency to CXX is missing in C targets...
     target_link_libraries(openPMD PUBLIC MPI::MPI_C MPI::MPI_CXX)
-
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_MPI=1")
-else()
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_MPI=0")
 endif()
 
 # JSON Backend
@@ -424,9 +421,6 @@ if(openPMD_HAVE_JSON)
     #target_link_libraries(openPMD PRIVATE openPMD::thirdparty::nlohmann_json)
     target_include_directories(openPMD SYSTEM PRIVATE
         $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_JSON=1")
-else()
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_JSON=0")
 endif()
 
 # HDF5 Backend
@@ -434,9 +428,6 @@ if(openPMD_HAVE_HDF5)
     target_link_libraries(openPMD PRIVATE ${HDF5_LIBRARIES})
     target_include_directories(openPMD SYSTEM PRIVATE ${HDF5_INCLUDE_DIRS})
     target_compile_definitions(openPMD PRIVATE ${HDF5_DEFINITIONS})
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_HDF5=1")
-else()
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_HDF5=0")
 endif()
 
 # ADIOS1 Backend
@@ -457,9 +448,9 @@ if(openPMD_HAVE_ADIOS1)
     target_link_libraries(openPMD.ADIOS1.Parallel PUBLIC openPMD::thirdparty::mpark_variant)
 
     target_include_directories(openPMD.ADIOS1.Serial SYSTEM PRIVATE
-        ${openPMD_SOURCE_DIR}/include)
+        ${openPMD_SOURCE_DIR}/include ${openPMD_BINARY_DIR}/include)
     target_include_directories(openPMD.ADIOS1.Parallel SYSTEM PRIVATE
-        ${openPMD_SOURCE_DIR}/include)
+        ${openPMD_SOURCE_DIR}/include ${openPMD_BINARY_DIR}/include)
 
     if(openPMD_HAVE_MPI)
         target_link_libraries(openPMD.ADIOS1.Parallel PUBLIC MPI::MPI_C MPI::MPI_CXX)
@@ -530,19 +521,13 @@ if(openPMD_HAVE_ADIOS1)
         target_compile_definitions(openPMD.ADIOS1.Parallel PRIVATE "-DopenPMD_USE_VERIFY=0")
     endif()
 
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS1=1")
     target_link_libraries(openPMD PUBLIC openPMD.ADIOS1.Serial)
     target_link_libraries(openPMD PUBLIC openPMD.ADIOS1.Parallel)
-else()
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS1=0")
 endif()
 
 # ADIOS2 Backend
 if(openPMD_HAVE_ADIOS2)
     target_link_libraries(openPMD PUBLIC adios2::adios2)
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS2=1")
-else()
-    target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_ADIOS2=0")
 endif()
 
 # Runtime parameter and API status checks ("asserts")
@@ -665,27 +650,7 @@ if(BUILD_TESTING)
         add_executable(${testname}Tests test/${testname}Test.cpp)
 
         if(openPMD_USE_INVASIVE_TESTS)
-            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_USE_INVASIVE_TESTS=1")
-        endif()
-
-        if(openPMD_HAVE_MPI)
-            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_MPI=1")
-        endif()
-
-        if(openPMD_HAVE_JSON)
-            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_JSON=1")
-        endif()
-
-        if(openPMD_HAVE_HDF5)
-            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_HDF5=1")
-        endif()
-
-        if(openPMD_HAVE_ADIOS1)
-            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS1=1")
-        endif()
-
-        if(openPMD_HAVE_ADIOS2)
-            target_compile_definitions(${testname}Tests PUBLIC "-DopenPMD_HAVE_ADIOS2=1")
+            target_compile_definitions(${testname}Tests PRIVATE "-DopenPMD_USE_INVASIVE_TESTS=1")
         endif()
         target_link_libraries(${testname}Tests PRIVATE openPMD)
         if(${testname} MATCHES "Parallel.+$")
@@ -756,16 +721,17 @@ endif ()
 #
 # TODO configure a version.hpp
 configure_file(
+    ${openPMD_SOURCE_DIR}/include/openPMD/config.hpp.in
+    ${openPMD_BINARY_DIR}/include/openPMD/config.hpp
+    @ONLY
+)
+
+configure_file(
     ${openPMD_SOURCE_DIR}/openPMDConfig.cmake.in
     ${openPMD_BINARY_DIR}/openPMDConfig.cmake
     @ONLY
 )
 if(openPMD_HAVE_PKGCONFIG)
-    get_target_property(openPMD_PC_DEFINES openPMD INTERFACE_COMPILE_DEFINITIONS)
-    foreach(PC_DEF IN LISTS openPMD_PC_DEFINES)
-        set(openPMD_PC_PUBLIC_DEFINES "${openPMD_PC_PUBLIC_DEFINES} -D${PC_DEF}")
-    endforeach()
-
     CONFIGURE_FILE(
         ${openPMD_SOURCE_DIR}/openPMD.pc.in
         ${openPMD_BINARY_DIR}/openPMD.pc
@@ -804,6 +770,11 @@ if(openPMD_HAVE_PYTHON)
 endif()
 install(DIRECTORY "${openPMD_SOURCE_DIR}/include/openPMD"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
+)
+install(
+    FILES ${openPMD_BINARY_DIR}/include/openPMD/config.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openPMD
 )
 # install third-party libraries
 # TODO not needed with C++17 compiler

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ openpmd_option(ADIOS1         "ADIOS1 backend (.bp files)"                AUTO)
 openpmd_option(ADIOS2         "ADIOS2 backend (.bp files)"                 OFF)
 openpmd_option(PYTHON         "Enable Python bindings"                    AUTO)
 
+option(openPMD_HAVE_PKGCONFIG        "Generate a .pc file for pkg-config"   ON)
 option(openPMD_USE_INTERNAL_VARIANT  "Use internally shipped MPark.Variant" ON)
 option(openPMD_USE_INTERNAL_CATCH    "Use internally shipped Catch2"        ON)
 option(openPMD_USE_INTERNAL_PYBIND11 "Use internally shipped pybind11"      ON)
@@ -759,6 +760,18 @@ configure_file(
     ${openPMD_BINARY_DIR}/openPMDConfig.cmake
     @ONLY
 )
+if(openPMD_HAVE_PKGCONFIG)
+    get_target_property(openPMD_PC_DEFINES openPMD INTERFACE_COMPILE_DEFINITIONS)
+    foreach(PC_DEF IN LISTS openPMD_PC_DEFINES)
+        set(openPMD_PC_PUBLIC_DEFINES "${openPMD_PC_PUBLIC_DEFINES} -D${PC_DEF}")
+    endforeach()
+
+    CONFIGURE_FILE(
+        ${openPMD_SOURCE_DIR}/openPMD.pc.in
+        ${openPMD_BINARY_DIR}/openPMD.pc
+        @ONLY
+    )
+endif()
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("openPMDConfigVersion.cmake"
@@ -817,6 +830,16 @@ install(
         ${openPMD_SOURCE_DIR}/share/openPMD/cmake/FindADIOS.cmake
     DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules
 )
+# pkg-config .pc file for depending legacy projects
+#   This is for projects that do not use a build file generator, e.g.
+#   because they compile manually on the command line or write their
+#   Makefiles by hand.
+if(openPMD_HAVE_PKGCONFIG)
+    install(
+        FILES       ${openPMD_BINARY_DIR}/openPMD.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()
 
 
 # Tests #######################################################################

--- a/README.md
+++ b/README.md
@@ -290,5 +290,5 @@ pkg-config --libs openPMD
 # -L${HOME}/somepath/lib -lopenPMD
 
 pkg-config --cflags openPMD
-# -I${HOME}/somepath/include -DopenPMD_HAVE_MPI=1 -DopenPMD_HAVE_JSON=1 -D_FORTIFY_SOURCE=2 -DopenPMD_HAVE_HDF5=1 -DopenPMD_HAVE_ADIOS1=0 -DopenPMD_HAVE_ADIOS2=0
+# -I${HOME}/somepath/include
 ```

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The install will contain header files and libraries in the path set with `-DCMAK
 
 ### CMake
 
-If your project is using CMake for its build, one can conveniently use our provided `Config.cmake` package which is installed alongside the library.
+If your project is using CMake for its build, one can conveniently use our provided `openPMDConfig.cmake` package which is installed alongside the library.
 
 First set the following environment hint if openPMD-api was *not* installed in a system path:
 
@@ -271,4 +271,24 @@ endif()
 add_subdirectory("path/to/source/of/openPMD-api")
 
 target_link_libraries(YourTarget PRIVATE openPMD::openPMD)
+```
+
+### Manually
+
+If your (Linux/OSX) project is build by calling the compiler directly or uses a manually written `Makefile`, consider using our `openPMD.pc` helper file for `pkg-config` which are installed alongside the library.
+
+First set the following environment hint if openPMD-api was *not* installed in a system path:
+
+```bash
+# optional: only needed if installed outside of system paths
+export PKG_CONFIG_PATH=$HOME/somepath/lib/pkgconfig:$PKG_CONFIG_PATH
+```
+
+Additional linker and compiler flags for your project are available via:
+```bash
+pkg-config --libs openPMD
+# -L${HOME}/somepath/lib -lopenPMD
+
+pkg-config --cflags openPMD
+# -I${HOME}/somepath/include -DopenPMD_HAVE_MPI=1 -DopenPMD_HAVE_JSON=1 -D_FORTIFY_SOURCE=2 -DopenPMD_HAVE_HDF5=1 -DopenPMD_HAVE_ADIOS1=0 -DopenPMD_HAVE_ADIOS2=0
 ```

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #include <future>

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #if openPMD_HAVE_ADIOS1

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #include <future>

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #include <future>

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AccessType.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/IO/IOTask.hpp"

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -19,7 +19,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #pragma once
-    
+
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #if openPMD_HAVE_HDF5
 #   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 #   include <hdf5.h>

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #include <future>

--- a/include/openPMD/IO/JSON/JSONFilePosition.hpp
+++ b/include/openPMD/IO/JSON/JSONFilePosition.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractFilePosition.hpp"
 
 

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-
+#include "openPMD/config.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/config.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "openPMD/config.hpp"
 #if openPMD_HAVE_MPI
 
 

--- a/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
@@ -21,16 +21,17 @@
 
 #pragma once
 
+#include "openPMD/config.hpp"
 #if openPMD_HAVE_MPI
 
+#include "openPMD/Datatype.hpp"
+#include "openPMD/Series.hpp"
 
 #include <map>
 #include <tuple>
 #include <vector>
 #include <mpi.h>
 #include "string.h"
-#include "openPMD/Datatype.hpp"
-#include "openPMD/Series.hpp"
 
 
 namespace openPMD

--- a/include/openPMD/config.hpp.in
+++ b/include/openPMD/config.hpp.in
@@ -1,4 +1,4 @@
-/* Copyright 2017-2019 Fabian Koller
+/* Copyright 2019 Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -20,32 +20,22 @@
  */
 #pragma once
 
-#include "openPMD/config.hpp"
-#include "openPMD/IO/AbstractIOHandlerImpl.hpp"
-
-#if openPMD_HAVE_MPI
-#   include <mpi.h>
-#   if openPMD_HAVE_HDF5
-#       include "openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp"
-#   endif
+#ifndef openPMD_HAVE_MPI
+#   cmakedefine01 openPMD_HAVE_MPI
 #endif
 
-
-namespace openPMD
-{
-#if openPMD_HAVE_HDF5 && openPMD_HAVE_MPI
-    class ParallelHDF5IOHandlerImpl : public HDF5IOHandlerImpl
-    {
-    public:
-        ParallelHDF5IOHandlerImpl(AbstractIOHandler*, MPI_Comm);
-        virtual ~ParallelHDF5IOHandlerImpl();
-
-        MPI_Comm m_mpiComm;
-        MPI_Info m_mpiInfo;
-    }; // ParallelHDF5IOHandlerImpl
-#else
-    class ParallelHDF5IOHandlerImpl
-    {
-    }; // ParallelHDF5IOHandlerImpl
+#ifndef openPMD_HAVE_JSON
+#   cmakedefine01 openPMD_HAVE_JSON
 #endif
-} // openPMD
+
+#ifndef openPMD_HAVE_HDF5
+#   cmakedefine01 openPMD_HAVE_HDF5
+#endif
+
+#ifndef openPMD_HAVE_ADIOS1
+#   cmakedefine01 openPMD_HAVE_ADIOS1
+#endif
+
+#ifndef openPMD_HAVE_ADIOS2
+#   cmakedefine01 openPMD_HAVE_ADIOS2
+#endif

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -48,5 +48,6 @@
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 
+#include "openPMD/config.hpp"
 #include "openPMD/version.hpp"
 // IWYU pragma: end_exports

--- a/openPMD.pc.in
+++ b/openPMD.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: openPMD
+Description: C++ & Python API for Scientific I/O with openPMD.
+Version: @openPMD_VERSION@
+URL: https://openpmd-api.readthedocs.io
+
+Libs: -L${libdir} -lopenPMD @openPMD_PC_PUBLIC_LIBS@
+Libs.private: -L${libdir} @openPMD_PC_PRIVATE_LIBS@
+Cflags: -I${includedir} @openPMD_PC_PUBLIC_DEFINES@

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -351,5 +351,10 @@ ParallelADIOS1IOHandler::flush()
 {
     return std::future< void >();
 }
+
+void
+ParallelADIOS1IOHandler::enqueue(IOTask const&)
+{
+}
 #endif
 } // openPMD

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -18,15 +18,19 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+
+#include "openPMD/config.hpp"
+#include "openPMD/Series.hpp"
+
 #if openPMD_HAVE_MPI
 //  re-implemented signatures:
 //  include <mpi4py/mpi4py.h>
 #   include <mpi.h>
 #endif
 
-#include "openPMD/Series.hpp"
 #include <string>
 
 namespace py = pybind11;

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -21,6 +21,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "openPMD/config.hpp"
 #include "openPMD/version.hpp"
 
 #include <string>

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -3,6 +3,7 @@
 #   define OPENPMD_private public
 #   define OPENPMD_protected public
 #endif
+#include "openPMD/config.hpp"
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"


### PR DESCRIPTION
Generate `.pc` files for consumption via [`pkg-config`](https://people.freedesktop.org/~dbn/pkg-config-guide.html). This is useful for projects with legacy build environments that do not use a build system generator such as CMake and instead write `Makefile`s by hand or even compile manually by calling the compiler directly.

Example to update downstream: WarpX https://github.com/ECP-WarpX/WarpX/pull/80

Also removes the public defines for "variants" of the installed library from the build system and instead pulls them automatically in the facade headers via a `openPMD/config.hpp` file. Since the library "variant" cannot be changed after the fact anyway, this avoids having to set magic defines downstream.