### PR TITLE
CMake: HDF5 Linkage is Private

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,10 @@ Bug Fixes
 - Remove dummy dataset writing from ``RecordComponent::flush()`` #528
 - remove dummy dataset writing from ``PatchRecordComponent::flush`` #512
 - Allow flushing before defining position and positionOffset components of particle species #518 #519
-- CMake: make install paths cacheable on Windows #521
+- CMake:
+
+  - make install paths cacheable on Windows #521
+  - HDF5 linkage is private #533
 - warnings:
 
   - unused variable in JSON backend #507

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,9 +430,9 @@ endif()
 
 # HDF5 Backend
 if(openPMD_HAVE_HDF5)
-    target_link_libraries(openPMD PUBLIC ${HDF5_LIBRARIES})
-    target_include_directories(openPMD SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
-    target_compile_definitions(openPMD PUBLIC ${HDF5_DEFINITIONS})
+    target_link_libraries(openPMD PRIVATE ${HDF5_LIBRARIES})
+    target_include_directories(openPMD SYSTEM PRIVATE ${HDF5_INCLUDE_DIRS})
+    target_compile_definitions(openPMD PRIVATE ${HDF5_DEFINITIONS})
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_HDF5=1")
 else()
     target_compile_definitions(openPMD PUBLIC "-DopenPMD_HAVE_HDF5=0")


### PR DESCRIPTION
The HDF5 include dirs and libs should be linked as `PRIVATE` since we encapsulate them properly in `.cpp` files.