### PR TITLE
pkg-config: support static linking

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Features
 - CMake:
 
   - build a shared library by default #506
-  - generate pkg-config ``.pc`` file #532
+  - generate pkg-config ``.pc`` file #532 #535
 - Python:
 
   - manylinux2010 wheels for PyPI #523

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,8 +731,25 @@ configure_file(
     ${openPMD_BINARY_DIR}/openPMDConfig.cmake
     @ONLY
 )
+
+# get absolute paths to linked libraries
+function(openpmdreclibs tgtname outname)
+    get_target_property(PC_PRIVATE_LIBS_TGT ${tgtname} INTERFACE_LINK_LIBRARIES)
+    foreach(PC_LIB IN LISTS PC_PRIVATE_LIBS_TGT)
+       if(TARGET ${PC_LIB})
+           openpmdreclibs(${PC_LIB} ${outname})
+       else()
+           if(PC_LIB)
+               string(APPEND ${outname} " ${PC_LIB}")
+           endif()
+       endif()
+    endforeach()
+    set(${outname} ${${outname}} PARENT_SCOPE)
+endfunction()
+
 if(openPMD_HAVE_PKGCONFIG)
-    CONFIGURE_FILE(
+    openpmdreclibs(openPMD openPMD_PC_PRIVATE_LIBS)
+    configure_file(
         ${openPMD_SOURCE_DIR}/openPMD.pc.in
         ${openPMD_BINARY_DIR}/openPMD.pc
         @ONLY

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 C++ & Python API for Scientific I/O with openPMD
 ================================================
 
@@ -288,6 +289,10 @@ Additional linker and compiler flags for your project are available via:
 ```bash
 pkg-config --libs openPMD
 # -L${HOME}/somepath/lib -lopenPMD
+
+# if you build openPMD-api as static library with `-DBUILD_SHARED_LIBS=OFF`
+pkg-config --libs --static openPMD
+# -L/usr/local/lib -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lopenPMD -pthread /usr/lib/libmpi.so -pthread /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so /usr/lib/libmpi.so /usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so /usr/lib/x86_64-linux-gnu/libsz.so /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/x86_64-linux-gnu/libdl.so /usr/lib/x86_64-linux-gnu/libm.so -pthread /usr/lib/libmpi.so -pthread /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so /usr/lib/libmpi.so
 
 pkg-config --cflags openPMD
 # -I${HOME}/somepath/include


### PR DESCRIPTION
populate the `Libs.private` section of our `openPMD.pc` file for static linking with `pkg-config --libs --static openPMD`

Follow-up to #532 