### PR TITLE
Python Manifest: add .in files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Features
 - CMake:
 
   - build a shared library by default #506
-  - generate pkg-config ``.pc`` file #532 #535
+  - generate pkg-config ``.pc`` file #532 #535 #537
 - Python:
 
   - manylinux2010 wheels for PyPI #523

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include README.md COPYING COPYING.LESSER
 include pyproject.toml
 include requirements.txt
-global-include CMakeLists.txt *.cmake *.cmake.in
+global-include CMakeLists.txt *.cmake *.in
 recursive-include include *
 recursive-include src *
 recursive-include share *


### PR DESCRIPTION
add the newly created package config file `.pc` and `config.hpp.in` to source distribution.

Follow-up fix to #532 #535