### PR TITLE
Docs: Minor Typos & Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Additional linker and compiler flags for your project are available via:
 pkg-config --libs openPMD
 # -L${HOME}/somepath/lib -lopenPMD
 
-# if you build openPMD-api as static library with `-DBUILD_SHARED_LIBS=OFF`
+# if you build openPMD-api as static library with BUILD_SHARED_LIBS=OFF
 pkg-config --libs --static openPMD
 # -L/usr/local/lib -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lopenPMD -pthread /usr/lib/libmpi.so -pthread /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so /usr/lib/libmpi.so /usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so /usr/lib/x86_64-linux-gnu/libsz.so /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/x86_64-linux-gnu/libdl.so /usr/lib/x86_64-linux-gnu/libm.so -pthread /usr/lib/libmpi.so -pthread /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so /usr/lib/libmpi.so
 

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -45,7 +45,7 @@ They do come handy to test pre-releases quickly with power-users.
    #    e.g. `<v>.dev[N]`, `<v>a[N]`, `<v>b[N]`, `<v>rc[N]`, or `<v>`
 
    rm -rf dist/
-   setup.py clean --all
+   python setup.py clean --all
 
    # prepare source distribution
    python setup.py sdist

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,8 +40,8 @@ The supported version of the `openPMD standard <https://github.com/openPMD/openP
 ======================= ===================================
 openPMD-api version     supported openPMD standard versions
 ======================= ===================================
-``1.0.0+``              ``1.0.1-1.1.0`` (not released yet)
 ``2.0.0+``              ``2.0.0+``      (not released yet)
+``1.0.0+``              ``1.0.1-1.1.0`` (not released yet)
 ``0.1.0-0.9.0`` (alpha) ``1.0.0-1.1.0``
 ======================= ===================================
 


### PR DESCRIPTION
Fix a formatting issue with Doxygen pages in README. Also add a missing "python" prefix on the release clean command.