### PR TITLE
CMake: Skip Python Examples w/o HDF5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Bug Fixes
 """""""""
 
 - Clang: fix pybind11 compile on older releases, such as AppleClang 7.3-9.0, Clang 3.9 #543
+- Python: skip examples using HDF5 if backend is missing #544
 
 Other
 """""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -946,7 +946,8 @@ if(BUILD_EXAMPLES)
 endif()
 
 # Python Examples
-if(openPMD_HAVE_PYTHON)
+# Current examples all use HDF5, elaborate if other backends are used
+if(openPMD_HAVE_PYTHON AND openPMD_HAVE_HDF5)
     if(EXISTS "${openPMD_BINARY_DIR}/samples/git-sample/")
         execute_process(COMMAND ${PYTHON_EXECUTABLE}
             -m mpi4py


### PR DESCRIPTION
During testing, skip the python examples if the HDF5 backend, which all of them are currently using, is missing.