### PR TITLE
static constexpr: storage class first

### DIFF
--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -157,7 +157,7 @@ public:
     >::type
     storeChunk(T_ContiguousContainer &, Offset = {0u}, Extent = {-1u});
 
-    constexpr static char const * const SCALAR = "\vScalar";
+    static constexpr char const * const SCALAR = "\vScalar";
 
 OPENPMD_protected:
     RecordComponent();

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -251,8 +251,8 @@ OPENPMD_private:
     void readBase();
     void read();
 
-    constexpr static char const * const OPENPMD = "1.1.0";
-    constexpr static char const * const BASEPATH = "/data/%T/";
+    static constexpr char const * const OPENPMD = "1.1.0";
+    static constexpr char const * const BASEPATH = "/data/%T/";
 
     std::shared_ptr< IterationEncoding > m_iterationEncoding;
     std::shared_ptr< std::string > m_name;

--- a/include/openPMD/auxiliary/Filesystem.hpp
+++ b/include/openPMD/auxiliary/Filesystem.hpp
@@ -28,9 +28,9 @@ namespace openPMD
 namespace auxiliary
 {
 #ifdef _WIN32
-constexpr static char const directory_separator = '\\';
+static constexpr char const directory_separator = '\\';
 #else
-constexpr static char const directory_separator = '/';
+static constexpr char const directory_separator = '/';
 #endif
 
 /** Check if a directory exists at a give absolute or relative path.


### PR DESCRIPTION
Seen with PGI compiler for `static constexpr`:
```
warning: storage class is not first
```