### PR TITLE
SerialIOTest: Uniform Init -> Value Init

### DIFF
--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -247,7 +247,7 @@ TEST_CASE( "flush_without_position_positionOffset", "[serial]" )
         RecordComponent weighting = e[ "weighting" ][ RecordComponent::SCALAR ];
         weighting.resetDataset( Dataset( Datatype::FLOAT, Extent{ 2, 2 } ) );
         weighting.storeChunk( std::shared_ptr< float >(
-            new float[ 4 ]{},
+            new float[ 4 ](),
             []( float * ptr ) { delete[] ptr; } ),
             { 0, 0 },
             { 2, 2 } );
@@ -261,7 +261,7 @@ TEST_CASE( "flush_without_position_positionOffset", "[serial]" )
                 RecordComponent rc = e[ key ][ dim ];
                 rc.resetDataset( Dataset( Datatype::FLOAT , Extent{ 2, 2 } ) );
                 rc.storeChunk( std::shared_ptr< float >(
-                    new float[ 4 ]{},
+                    new float[ 4 ](),
                     []( float * ptr ) { delete[] ptr; } ),
                     { 0, 0 },
                     { 2, 2 } );


### PR DESCRIPTION
Replace the C++11 uniform initializer for a C-array with the C++98-style value initializer. The result is the same - an initialized array.

https://stackoverflow.com/questions/2204176/how-to-initialise-memory-with-new-operator-in-c

The XL compiler in version 16.1 has a problem with the newer expression when used inside the constructor of a `shared_ptr` (reported to upstream).

```C++
// $ xlC -std=c++11 main.cpp 
#include <memory>

int main() {

  auto x = std::shared_ptr< float >(
            new float[ 4 ]{},
            []( float * ptr ) { delete[] ptr; } );

  return 0;
} 
```
```
main.cpp:6:27: error: 1540-2991 The expression is not supported.
            new float[ 4 ]{}, 
```