### PR TITLE
ICC & PGI: Compiler ID Fix

### DIFF
--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -667,13 +667,7 @@ ReturnType switchType(
         },
         {
             Datatype::BOOL ,
-            &Action::OPENPMD_TEMPLATE_OPERATOR() < bool > },
-        {
-            Datatype::DATATYPE ,
-            &Action::OPENPMD_TEMPLATE_OPERATOR() < 1000 > },
-        {
-            Datatype::UNDEFINED ,
-            &Action::OPENPMD_TEMPLATE_OPERATOR() < 0 > }
+            &Action::OPENPMD_TEMPLATE_OPERATOR() < bool > }
     };
     auto it = funs.find( dt );
     if( it != funs.end( ) )

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -519,7 +519,7 @@ isSame( openPMD::Datatype const d, openPMD::Datatype const e )
     return false;
 }
 
-#if _MSC_VER && !__INTEL_COMPILER
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #define OPENPMD_TEMPLATE_OPERATOR operator
 #else
 #define OPENPMD_TEMPLATE_OPERATOR template operator
@@ -551,7 +551,7 @@ ReturnType switchType(
     Action action,
     Args && ...args
 ) {
-#if _MSC_VER && !__INTEL_COMPILER
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
     auto f = &Action::OPENPMD_TEMPLATE_OPERATOR() < int >;
     using fun = decltype(f);
 #else

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -81,14 +81,6 @@ struct DefaultValue
     {
         rc.makeConstant( T() );
     }
-
-    template< unsigned n, typename... Args >
-    void
-    operator()( Args &&... )
-    {
-        throw std::runtime_error(
-            "makeEmpty: Datatype not supported by openPMD." );
-    }
 };
 } // namespace detail
 } // namespace openPMD


### PR DESCRIPTION
The compiler identification macros are either defined or undefined, so we should transform those to a boolean.

ICC 19.0.0 and PGI 19.5 compilers do not compile. The reason is our "datatype"/"undefined" specialization attempt via a varied template signature, which does not work that way.