### PR TITLE
Clang-tidy 7 Warnings

### DIFF
--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -89,7 +89,7 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     if( !written )
     {
         /* create file */
-        Series* s = dynamic_cast<Series *>(parent->attributable->parent->attributable);
+        auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
         Parameter< Operation::CREATE_FILE > fCreate;
         fCreate.name = filename;
         IOHandler->enqueue(IOTask(s, fCreate));
@@ -105,7 +105,7 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     } else
     {
         /* open file */
-        Series* s = dynamic_cast<Series *>(parent->attributable->parent->attributable);
+        auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
         Parameter< Operation::OPEN_FILE > fOpen;
         fOpen.name = filename;
         IOHandler->enqueue(IOTask(s, fOpen));
@@ -153,7 +153,7 @@ Iteration::flush()
         Writable *w = this->parent;
         while( w->parent )
             w = w->parent;
-        Series* s = dynamic_cast<Series *>(w->attributable);
+        auto s = dynamic_cast< Series* >(w->attributable);
 
         if( !meshes.empty() || s->containsAttribute("meshesPath") )
         {
@@ -218,7 +218,7 @@ Iteration::read()
     Writable *w = getWritable(this);
     while( w->parent )
         w = w->parent;
-    Series* s = dynamic_cast<Series *>(w->attributable);
+    auto s = dynamic_cast< Series* >(w->attributable);
 
     Parameter< Operation::LIST_PATHS > pList;
     std::string version = s->openPMD();

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -78,7 +78,7 @@ list_directory(std::string const& path )
     if( hFind == INVALID_HANDLE_VALUE )
         throw std::system_error(std::error_code(errno, std::system_category()));
     do {
-        if( strcmp(data.cFileName, ".") && strcmp(data.cFileName, "..") )
+        if( strcmp(data.cFileName, ".") != 0 && strcmp(data.cFileName, "..") != 0 )
             ret.emplace_back(data.cFileName);
     } while (FindNextFile(hFind, &data) != 0);
     FindClose(hFind);
@@ -88,7 +88,7 @@ list_directory(std::string const& path )
         throw std::system_error(std::error_code(errno, std::system_category()));
     dirent* entry;
     while ((entry = readdir(directory)) != nullptr)
-        if( strcmp(entry->d_name, ".") && strcmp(entry->d_name, "..") )
+        if( strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0 )
             ret.emplace_back(entry->d_name);
     closedir(directory);
 #endif


### PR DESCRIPTION
Fix minor warnings from `clang-tidy-7`:
- strcmp: avoid implicit cast to bool: Detect by clang-tidy 7 via `bugprone-suspicious-string-compare`
- Series Variable: Avoid Type Name Dup: clang-tidy-7 warning: use auto when initializing with a cast to avoid duplicating the type name `[modernize-use-auto]`