### PR TITLE
gitignore: more build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ __pycache__
 cmake-build-*/
 .kdev?/
 *.kdev?
+spack-build*
+build/
 
 # File-based project format:
 *.iws


### PR DESCRIPTION
Ignore a typically used build dir `build/` and the `spack diy` build directory called `spack-build/` and its log files `spack-build-env.txt`/`spack-build-out.txt`.