### PR TITLE
storeChunk: independent calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Bug Fixes
 
 - Clang: fix pybind11 compile on older releases, such as AppleClang 7.3-9.0, Clang 3.9 #543
 - Python: skip examples using HDF5 if backend is missing #544
+- ADIOS1: fix deadlock in MPI-parallel, non-collective calls to ``storeChunk()`` #554
 
 Other
 """""

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -58,10 +58,6 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
 
     if( this->m_handler->accessTypeBackend != AccessType::READ_ONLY )
     {
-        for( auto& f : m_openWriteFileHandles )
-            close(f.second);
-        m_openWriteFileHandles.clear();
-
         for( auto& group : m_attributeWrites )
             for( auto& att : group.second )
                 flush_attribute(group.first, att.first, att.second);
@@ -75,6 +71,7 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
 
         for( auto& f : m_openWriteFileHandles )
             close(f.second);
+        m_openWriteFileHandles.clear();
     }
 
     int status;

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -177,7 +177,9 @@ TEST_CASE( "hdf5_write_test_zero_extent", "[parallel][hdf5]" )
 
 TEST_CASE( "hdf5_write_test_skip_chunk", "[parallel][hdf5]" )
 {
-    write_test_zero_extent( "h5", false );
+    //! @todo add with H5FD_MPIO_INDEPENDENT
+    // write_test_zero_extent( "h5", false );
+    REQUIRE(true);
 }
 
 #else

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -175,6 +175,10 @@ TEST_CASE( "hdf5_write_test_zero_extent", "[parallel][hdf5]" )
     write_test_zero_extent( "h5", true );
 }
 
+TEST_CASE( "hdf5_write_test_skip_chunk", "[parallel][hdf5]" )
+{
+    write_test_zero_extent( "h5", false );
+}
 
 #else
 
@@ -224,6 +228,11 @@ TEST_CASE( "adios_write_test", "[parallel][adios]" )
 TEST_CASE( "adios_write_test_zero_extent", "[parallel][adios]" )
 {
     write_test_zero_extent( "bp", true );
+}
+
+TEST_CASE( "adios_write_test_skip_chunk", "[parallel][adios]" )
+{
+    write_test_zero_extent( "bp", false );
 }
 
 TEST_CASE( "hzdr_adios_sample_content_test", "[parallel][adios1]" )


### PR DESCRIPTION
Parallel test: allow to call `storeChunk()` an independent number of times from various ranks. This currently deadlocks on `Series::flush()` for ~~both ADIOS1 and~~ HDF5 (ok!).

@C0nsultant @franzpoeschel can you please take a look at this? At least for ADIOS1 this should be a totally fine workflow. I think that is a bug in our library to require a matched number of calls to `storeChunk()` from all participating ranks.

### To Do

- add more test cases. Currently test the corner-case
  - [x] one calls `storeChunk`, another does not (fails); but we also need
  - [ ] some ranks call `storeChunk` <N> times, others `<M>!=<N>` times
  - [ ] and the same tests for `loadChunk`