### PR TITLE
Travis CI: Speedup Dependency Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -345,6 +345,7 @@ jobs:
       script: *script-cpp-unit
       before_install:
         - CXX=clang++ && CC=clang
+        - perl --version
     # Clang 10.0.0-apple + Python 3.7.2 @ OSX "mojave" with libc++
     - <<: *test-cpp-unit
       name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 +ADIOS1 libc++
@@ -358,6 +359,7 @@ jobs:
       script: *script-cpp-unit
       before_install:
         - CXX=clang++ && CC=clang
+        - perl --version
     # GCC 4.9.4
     - <<: *test-cpp-unit
       name: gcc@4.9.4 -MPI -PY +H5 +ADIOS1

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -1,4 +1,18 @@
 packages:
+  perl:
+    version: [5.14.0, 5.18.2, 5.22.4]
+    paths:
+      perl@5.14.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /usr
+      perl@5.14.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
+      perl@5.14.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /usr
+      perl@5.14.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /usr
+      perl@5.22.4%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
+      perl@5.22.4%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr
+      perl@5.22.4%clang@6.0.0 arch=linux-ubuntu16-x86_64: /usr
+      perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
+      perl@5.18.2%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
+      perl@5.18.2%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr
+    buildable: False
   cmake:
     version: [3.11.0]
     paths:
@@ -45,6 +59,16 @@ packages:
       python@3.7.2%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
       python@3.7.2%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
     buildable: False
+
+  # speed up builds of dependencies
+  ncurses:
+    variants: ~termlib          
+  gettext:
+    variants: ~curses ~libxml2 ~git ~tar ~bzip2 ~xz
+  py-numpy:
+    variants: ~blas ~lapack
+
+  # set MPI providers and compiler versions
   all:
     providers:
       mpi: [openmpi]


### PR DESCRIPTION
Improve build times for dependencies by using external perl and less feature-rich variants (spack).