### PR TITLE
clang-tidy: const correctness

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 # Future consideration: cppcoreguidelines-*,clang-analyzer-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,readability-*,-clang-diagnostic-unused-command-line-argument,-*-namespace-comment*,-*-braces-around-statements,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-readability-named-parameter
 # FIXME: all performance-* reports
 # FIXME: all cert-* reports
-Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*
+Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter
 HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -125,7 +125,7 @@ write2()
 
     // data is assumed to reside behind a pointer as a contiguous column-major array
     // shared data ownership during IO is indicated with a smart pointer
-    std::shared_ptr< double > partial_mesh(new double[5], [](double *p){ delete[] p; p = nullptr; });
+    std::shared_ptr< double > partial_mesh(new double[5], [](double const * p){ delete[] p; p = nullptr; });
 
     // before storing record data, you must specify the dataset once per component
     // this describes the datatype and shape of data as it should be written to disk
@@ -138,12 +138,12 @@ write2()
     ParticleSpecies& electrons = cur_it.particles["electrons"];
 
     Extent mpiDims{4};
-    std::shared_ptr< float > partial_particlePos(new float[2], [](float *p){ delete[] p; p = nullptr; });
+    std::shared_ptr< float > partial_particlePos(new float[2], [](float const * p){ delete[] p; p = nullptr; });
     dtype = determineDatatype(partial_particlePos);
     d = Dataset(dtype, mpiDims);
     electrons["position"]["x"].resetDataset(d);
 
-    std::shared_ptr< uint64_t > partial_particleOff(new uint64_t[2], [](uint64_t *p){ delete[] p; p = nullptr; });
+    std::shared_ptr< uint64_t > partial_particleOff(new uint64_t[2], [](uint64_t const * p){ delete[] p; p = nullptr; });
     dtype = determineDatatype(partial_particleOff);
     d = Dataset(dtype, mpiDims);
     electrons["positionOffset"]["x"].resetDataset(d);

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -51,7 +51,7 @@ void write_test_zero_extent( std::string file_ending, bool writeAllChunks )
     std::vector< double > position_global(num_cells);
     double pos{1.};
     std::generate(position_global.begin(), position_global.end(), [&pos]{ return pos++; });
-    std::shared_ptr< double > position_local(new double[rank], [](double *p) { delete[] p;});
+    std::shared_ptr< double > position_local(new double[rank], [](double const * p) { delete[] p;});
     uint64_t offset;
     if( rank != 0 )
         offset = ((rank-1)*(rank-1) + (rank-1))/2;
@@ -63,7 +63,7 @@ void write_test_zero_extent( std::string file_ending, bool writeAllChunks )
     std::vector< uint64_t > positionOffset_global(num_cells);
     uint64_t posOff{1};
     std::generate(positionOffset_global.begin(), positionOffset_global.end(), [&posOff]{ return posOff++; });
-    std::shared_ptr< uint64_t > positionOffset_local(new uint64_t[rank], [](uint64_t *p) { delete[] p;});
+    std::shared_ptr< uint64_t > positionOffset_local(new uint64_t[rank], [](uint64_t const * p) { delete[] p;});
 
     e["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local), {num_cells}));
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -130,7 +130,7 @@ void constant_scalar(std::string file_ending)
         E_x.makeConstant(static_cast< float >(13.37));
         auto E_y = s.iterations[1].meshes["E"]["y"];
         E_y.resetDataset(Dataset(Datatype::UINT, {1, 2, 3}));
-        std::shared_ptr< unsigned int > E(new unsigned int[6], [](unsigned int *p){ delete[] p; });
+        std::shared_ptr< unsigned int > E(new unsigned int[6], [](unsigned int const *p){ delete[] p; });
         unsigned int e{0};
         std::generate(E.get(), E.get() + 6, [&e]{ return e++; });
         E_y.storeChunk(E, {0, 0, 0}, {1, 2, 3});
@@ -161,7 +161,7 @@ void constant_scalar(std::string file_ending)
         vel_x.makeConstant(static_cast< short >(-1));
         auto vel_y = s.iterations[1].particles["e"]["velocity"]["y"];
         vel_y.resetDataset(Dataset(Datatype::ULONGLONG, {3, 2, 1}));
-        std::shared_ptr< unsigned long long > vel(new unsigned long long[6], [](unsigned long long *p){ delete[] p; });
+        std::shared_ptr< unsigned long long > vel(new unsigned long long[6], [](unsigned long long const *p){ delete[] p; });
         unsigned long long v{0};
         std::generate(vel.get(), vel.get() + 6, [&v]{ return v++; });
         vel_y.storeChunk(vel, {0, 0, 0}, {3, 2, 1});
@@ -248,7 +248,7 @@ TEST_CASE( "flush_without_position_positionOffset", "[serial]" )
         weighting.resetDataset( Dataset( Datatype::FLOAT, Extent{ 2, 2 } ) );
         weighting.storeChunk( std::shared_ptr< float >(
             new float[ 4 ](),
-            []( float * ptr ) { delete[] ptr; } ),
+            []( float const * ptr ) { delete[] ptr; } ),
             { 0, 0 },
             { 2, 2 } );
 
@@ -262,7 +262,7 @@ TEST_CASE( "flush_without_position_positionOffset", "[serial]" )
                 rc.resetDataset( Dataset( Datatype::FLOAT , Extent{ 2, 2 } ) );
                 rc.storeChunk( std::shared_ptr< float >(
                     new float[ 4 ](),
-                    []( float * ptr ) { delete[] ptr; } ),
+                    []( float const * ptr ) { delete[] ptr; } ),
                     { 0, 0 },
                     { 2, 2 } );
                     }


### PR DESCRIPTION
Add const-correctness checks to clang-tidy.
https://clang.llvm.org/extra/clang-tidy/checks/readability-non-const-parameter.html