### PR TITLE
ADIOS2: Infrastructure & Docs Update

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -114,6 +114,8 @@ install:
 
   # Configure the VM.
   - cmd: conda install -n root --quiet --yes numpy>=1.15 cmake hdf5
+  # ADIOS2 build only for 64bit Windows and Python 3.6+
+  - cmd: if "%TARGET_ARCH%"=="x64" if %CONDA_PY% GEQ 36 conda install -n root --quiet --yes adios2
 
 before_build:
   - cmd: cd C:\projects\openpmd-api
@@ -140,4 +142,4 @@ build_script:
 
 test_script:
   - cmd: ctest -V -C %CONFIGURATION%
-  - cmd: python -c "import openpmd_api; print(openpmd_api.__version__)"
+  - cmd: python -c "import openpmd_api; print(openpmd_api.__version__); print(openpmd_api.variants)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
       dist: xenial
       compiler: clang
     #   env:
-    #     - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+    #     - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON
     #   addons:
     #     apt:
     #       packages:
@@ -128,7 +128,7 @@ jobs:
     #         exit 1;
     #       fi
     # - <<: *static_code_cpp
-      name: clang-tidy@5.0.0 +MPI -PY +H5 +ADIOS1 +ADIOS2 +JSON
+      name: clang-tidy@5.0.0 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
       sudo: false
       env:
         - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON
@@ -189,7 +189,7 @@ jobs:
     # Clang 5.0.0
     - &test-cpp-unit
       stage: 'C++ Unit Tests'
-      name: clang@5.0.0 -MPI -PY +H5 -ADIOS1
+      name: clang@5.0.0 -MPI -PY +H5 +JSON -ADIOS1 -ADIOS2
       language: cpp
       dist: xenial
       env:
@@ -254,11 +254,11 @@ jobs:
         # - dpkg -i openPMD*.deb
         - ls -R $HOME/openPMD-test-install | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//--/g' -e 's/^/   /' -e 's/-/|/'
     - <<: *test-cpp-unit
-      name: clang@5.0.0 +MPI -PY +H5 +ADIOS1
+      name: clang@5.0.0 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:
@@ -272,11 +272,11 @@ jobs:
         - CXX=clang++-5.0 && CC=clang-5.0
     # Clang 6.0.0 + Python 3.6.3 @ Xenial
     - <<: *test-cpp-unit
-      name: clang@6.0.0 -MPI +PY@3.6 +H5 +ADIOS1 libc++
+      name: clang@6.0.0 -MPI +PY@3.6 +H5 +JSON +ADIOS1 +ADIOS2 libc++
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%clang@6.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%clang@6.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:
@@ -292,12 +292,12 @@ jobs:
         - CXX=clang++-6.0 && CC=clang-6.0 && CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -I/usr/include/libcxxabi/"
     # Clang 7.0.0 + Python 3.7.1 @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 +MPI +PY@3.7 +H5 +ADIOS1 +Release
+      name: clang@7.0.0 +MPI +PY@3.7 +H5 +JSON +ADIOS1 +ADIOS2 +Release
       dist: xenial
       language: python
       python: "3.7"
       env:
-        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON BUILD_TYPE="Release"
+        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON BUILD_TYPE="Release"
       compiler: clang
       addons:
         apt:
@@ -311,12 +311,12 @@ jobs:
         - CXX=clang++ && CC=clang
     # Clang 7.0.0 + Python 3.7.1 + Address Sanitizer + Undefined Behavior Sanitizer @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 +MPI +PY@3.7 +H5 -ADIOS1 +JSON +ASan +UBSan +STATIC
+      name: clang@7.0.0 +MPI +PY@3.7 +H5 +JSON -ADIOS1 +ADIOS2 +ASan +UBSan +STATIC
       dist: xenial
       language: python
       python: "3.7"
       env:
-        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=OFF USE_SHARED=OFF USE_JSON=ON USE_SAMPLES=ON
+        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SHARED=OFF USE_JSON=ON USE_SAMPLES=ON
         # sanitizer options: test as much as possible and suppress OpenMPI memory leaks
         - ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         - LSAN_OPTIONS=suppressions=${TRAVIS_BUILD_DIR}/.travis/sanitizer/clang/Leak.supp
@@ -334,7 +334,7 @@ jobs:
         # - find / -name libclang_rt*
     # Clang 9.1.0-apple + Python 3.7.2 @ OSX "highsierra"
     - <<: *test-cpp-unit
-      name: AppleClang@9.1.0 -MPI +PY@3.7 +H5 +ADIOS1
+      name: AppleClang@9.1.0 -MPI +PY@3.7 +H5 +JSON +ADIOS1 -ADIOS2
       os: osx
       osx_image: xcode9.4
       sudo: required
@@ -348,13 +348,13 @@ jobs:
         - perl --version
     # Clang 10.0.0-apple + Python 3.7.2 @ OSX "mojave" with libc++
     - <<: *test-cpp-unit
-      name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 +ADIOS1 libc++
+      name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 +JSON +ADIOS1 +ADIOS2 libc++
       os: osx
       osx_image: xcode10.1
       sudo: required
       language: generic
       env:
-        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
       before_install:
@@ -362,12 +362,12 @@ jobs:
         - perl --version
     # GCC 4.9.4
     - <<: *test-cpp-unit
-      name: gcc@4.9.4 -MPI -PY +H5 +ADIOS1
+      name: gcc@4.9.4 -MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@4.9.4" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=OFF
+        - CXXSPEC="%gcc@4.9.4" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=OFF
       compiler: gcc
       addons:
         apt:
@@ -381,12 +381,12 @@ jobs:
         - CXX=g++-4.9 && CC=gcc-4.9
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@4.9.4 +MPI -PY +H5 +ADIOS1
+      name: gcc@4.9.4 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@4.9.4" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%gcc@4.9.4" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -399,12 +399,12 @@ jobs:
       script: *script-cpp-unit
     # GCC 7.4.0
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 -MPI -PY +H5 +ADIOS1 -JSON
+      name: gcc@7.4.0 -MPI -PY +H5 -JSON +ADIOS1 +ADIOS2
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=OFF USE_PYTHON=OFF USE_JSON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=OFF USE_PYTHON=OFF USE_JSON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -418,12 +418,12 @@ jobs:
         - CXX=g++-7 && CC=gcc-7
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 +MPI -PY +H5 +ADIOS1
+      name: gcc@7.4.0 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2@2.4.0
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON ADIOS2_VERSION=@2.4.0 USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -436,7 +436,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 6.5.0 + Python 3.5
     - <<: *test-cpp-unit
-      name: gcc@6.5.0 -MPI +PY@3.5 +H5 +ADIOS@1.13.1
+      name: gcc@6.5.0 -MPI +PY@3.5 +H5 +JSON +ADIOS1@1.13.1 -ADIOS2
       dist: trusty
       language: python
       python: "3.5"
@@ -456,7 +456,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 8.1.0 + Python 3.7
     - <<: *test-cpp-unit
-      name: gcc@8.1.0 -MPI +PY@3.7 +H5 +ADIOS1 +STATIC
+      name: gcc@8.1.0 -MPI +PY@3.7 +H5 +JSON +ADIOS1 -ADIOS2 +STATIC
       language: python
       python: "3.7"
       sudo: required
@@ -477,7 +477,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 6.5.0 + Python 3.6
     - <<: *test-cpp-unit
-      name: gcc@6.5.0 -MPI +PY@3.6 +H5@1.8.13 -ADIOS1
+      name: gcc@6.5.0 -MPI +PY@3.6 +H5@1.8.13 +JSON -ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
@@ -493,7 +493,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 4.8.5 + Python 3.5.5
     - <<: *test-cpp-unit
-      name: gcc@4.8.5 -MPI +PY@3.5 +H5 -ADIOS1
+      name: gcc@4.8.5 -MPI +PY@3.5 +H5 +JSON -ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.5"
@@ -523,7 +523,7 @@ jobs:
       python: "3.6"
       compiler: gcc
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON
       addons:
         apt:
           <<: *apt_common_sources
@@ -578,10 +578,13 @@ jobs:
         - mkdir -p coverage
         - cd bin
         # TODO code coverage with mpirun
-        - for binary in *; do
-            if [ -f $binary ]; then
-              kcov --exclude-pattern=/usr/,share/openPMD/thirdParty,/test/ ../coverage/$binary $binary;
-            fi;
+        - for OPENPMD_BP_PROVIDER in "ADIOS1" "ADIOS2"; do
+            export OPENPMD_BP_PROVIDER;
+            for binary in *; do
+              if [ -f $binary ]; then
+                kcov --exclude-pattern=/usr/,share/openPMD/thirdParty,/test/ ../coverage/$binary $binary;
+              fi;
+            done
           done
       after_script:
         - kcov --merge --coveralls-id=$TRAVIS_JOB_ID ../coverage/merged ../coverage/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -244,7 +244,7 @@ jobs:
         - if [ "$USE_PYTHON" == "ON" ] && [ ! -z ${ASAN_OPTIONS+x} ]; then
             export LD_PRELOAD=/usr/local/clang-7.0.0/lib/clang/7.0.0/lib/linux/libclang_rt.asan-x86_64.so;
           fi
-        - CTEST_OUTPUT_ON_FAILURE=1 make test
+        - CTEST_OUTPUT_ON_FAILURE=1 travis_wait make test
         - if [ ! -z ${LD_PRELOAD+x} ]; then
             unset LD_PRELOAD;
           fi
@@ -348,13 +348,13 @@ jobs:
         - perl --version
     # Clang 10.0.0-apple + Python 3.7.2 @ OSX "mojave" with libc++
     - <<: *test-cpp-unit
-      name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 +JSON +ADIOS1 +ADIOS2 libc++
+      name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 +JSON -ADIOS1 +ADIOS2 libc++
       os: osx
       osx_image: xcode10.1
       sudo: required
       language: generic
       env:
-        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
+        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
       before_install:
@@ -381,12 +381,12 @@ jobs:
         - CXX=g++-4.9 && CC=gcc-4.9
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@4.9.4 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
+      name: gcc@4.9.4 +MPI -PY +H5 +JSON +ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@4.9.4" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
+        - CXXSPEC="%gcc@4.9.4" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -399,12 +399,12 @@ jobs:
       script: *script-cpp-unit
     # GCC 7.4.0
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 -MPI -PY +H5 -JSON +ADIOS1 +ADIOS2
+      name: gcc@7.4.0 -MPI -PY +H5 -JSON +ADIOS1 +ADIOS2@2.4.0
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=OFF USE_PYTHON=OFF USE_JSON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=OFF USE_PYTHON=OFF USE_JSON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON ADIOS2_VERSION=@2.4.0 USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -418,12 +418,12 @@ jobs:
         - CXX=g++-7 && CC=gcc-7
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2@2.4.0
+      name: gcc@7.4.0 +MPI -PY +H5 +JSON +ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON ADIOS2_VERSION=@2.4.0 USE_SAMPLES=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -517,13 +517,13 @@ jobs:
     ###########################################################################
     - &code_coverage
       stage: 'Code Coverage'
-      name: gcc@7.4.0 +coveralls
+      name: gcc@7.4.0 +MPI +PY +H5 +JSON +ADIOS1 -ADIOS2 +coveralls
       sudo: required
       language: python
       python: "3.6"
       compiler: gcc
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF
       addons:
         apt:
           <<: *apt_common_sources
@@ -578,7 +578,7 @@ jobs:
         - mkdir -p coverage
         - cd bin
         # TODO code coverage with mpirun
-        - for OPENPMD_BP_PROVIDER in "ADIOS1" "ADIOS2"; do
+        - for OPENPMD_BP_PROVIDER in "ADIOS1"; do
             export OPENPMD_BP_PROVIDER;
             for binary in *; do
               if [ -f $binary ]; then

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Changes to "0.9.0-alpha"
 Features
 """"""""
 
-- ADIOS2: support added (v2.4.0+) #482 #513 #530
+- ADIOS2: support added (v2.4.0+) #482 #513 #530 #568
 - Python: support empty datasets via ``Record_Component.make_empty`` #538
 
 Bug Fixes

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,6 +3,14 @@
 Upgrade Guide
 =============
 
+0.10.0-alpha
+------------
+
+We added support for ADIOS2 in this release.
+As soon as the ADIOS2 backend is enabled it will take precedence for ``.bp`` files over a potentially also enabled ADIOS1 backend.
+In order to prefer the legacy ADIOS1 backend in such a situation, set an environment variable: ``export OPENPMD_BP_BACKEND="ADIOS1"``.
+
+
 0.9.0-alpha
 -----------
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Choose *one* of the install methods below to get started:
 [![Spack Status](https://img.shields.io/badge/method-recommended-brightgreen.svg)](https://spack.readthedocs.io/en/latest/package_list.html#openpmd-api)
 
 ```bash
-# optional:               +python +adios1 -mpi
+# optional:               +python +adios1 +adios2 -mpi
 spack install openpmd-api
 spack load -r openpmd-api
 ```
@@ -156,7 +156,7 @@ conda install -c conda-forge openpmd-api
 [![PyPI Status](https://img.shields.io/badge/method-experimental-yellow.svg)](https://pypi.org/project/openPMD-api)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/openPMD-api.svg)](https://pypi.org/project/openPMD-api)
 
-Behind the scenes, this install method *compiles from source* against the found installations of HDF5, ADIOS and/or MPI (in system paths, from other package managers, or loaded via a module system, ...).
+Behind the scenes, this install method *compiles from source* against the found installations of HDF5, ADIOS1, ADIOS2, and/or MPI (in system paths, from other package managers, or loaded via a module system, ...).
 The current status for this install method is *experimental*.
 Please feel free to [report](https://github.com/openPMD/openPMD-api/issues/new/choose) how this works for you.
 
@@ -211,8 +211,8 @@ CMake controls options with prefixed `-D`, e.g. `-DopenPMD_USE_MPI=OFF`:
 | `openPMD_USE_MPI`            | **AUTO**/ON/OFF  | Parallel, Multi-Node I/O for clusters                                        |
 | `openPMD_USE_JSON`           | **AUTO**/ON/OFF  | JSON backend (`.json` files)                                                 |
 | `openPMD_USE_HDF5`           | **AUTO**/ON/OFF  | HDF5 backend (`.h5` files)                                                   |
-| `openPMD_USE_ADIOS1`         | **AUTO**/ON/OFF  | ADIOS1 backend (`.bp` files)                                                 |
-| `openPMD_USE_ADIOS2`         | **AUTO**/ON/OFF  | ADIOS2 backend (`.bp` files)                                                 |
+| `openPMD_USE_ADIOS1`         | **AUTO**/ON/OFF  | ADIOS1 backend (`.bp` files up to version BP3)                               |
+| `openPMD_USE_ADIOS2`         | **AUTO**/ON/OFF  | ADIOS2 backend (`.bp` files in BP3, BP4 or higher)                           |
 | `openPMD_USE_PYTHON`         | **AUTO**/ON/OFF  | Enable Python bindings                                                       |
 | `openPMD_USE_INVASIVE_TESTS` | ON/**OFF**       | Enable unit tests that modify source code <sup>1</sup>                       |
 | `openPMD_USE_VERIFY`         | **ON**/OFF       | Enable internal VERIFY (assert) macro independent of build type <sup>2</sup> |
@@ -300,7 +300,7 @@ pkg-config --cflags openPMD
 ## Author Contributions
 
 openPMD-api is developed by many people.
-It was initially started by [Computational Radiation Physics Group](https://hzdr.de/crp) at [HZDR](https://www.hzdr.de/) as successor to [libSplash](https://github.com/ComputationalRadiationPhysics/libSplash/), generalizing the [successful HDF5 & ADIOS1 implementations](https://arxiv.org/abs/1706.00522) in [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu).
+It was initially started by the [Computational Radiation Physics Group](https://hzdr.de/crp) at [HZDR](https://www.hzdr.de/) as successor to [libSplash](https://github.com/ComputationalRadiationPhysics/libSplash/), generalizing the [successful HDF5 & ADIOS1 implementations](https://arxiv.org/abs/1706.00522) in [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu).
 The following people and institutions [contributed](https://github.com/openPMD/openPMD-api/graphs/contributors) to openPMD-api:
 
 * [Axel Huebl (HZDR, now LBNL)](https://github.com/ax3l):

--- a/Singularity
+++ b/Singularity
@@ -7,7 +7,7 @@ From: debian:unstable
 Welcome to the openPMD-api container.
 This container contains a pre-installed openPMD-api library.
 This container provides serial I/O.
-Supported backends are HDF5 and ADIOS.
+Supported backends are HDF5 and ADIOS1.
 Supported frontends are C++11 and Python3.
 
 %setup
@@ -36,15 +36,18 @@ Supported frontends are C++11 and Python3.
     # libadios-openmpi-dev
     # libopenmpi-dev libhdf5-openmpi-dev
 
+    # libadios2-dev
+
     cd $(mktemp -d)
-    cmake /opt/openpmd-api \
-        -DopenPMD_USE_MPI=OFF \
-        -DopenPMD_USE_HDF5=ON \
-        -DopenPMD_USE_ADIOS1=ON \
+    cmake /opt/openpmd-api       \
+        -DopenPMD_USE_MPI=OFF    \
+        -DopenPMD_USE_HDF5=ON    \
+        -DopenPMD_USE_JSON=ON    \
+        -DopenPMD_USE_ADIOS1=ON  \
         -DopenPMD_USE_ADIOS2=OFF \
-        -DopenPMD_USE_PYTHON=ON \
+        -DopenPMD_USE_PYTHON=ON  \
         -DPYTHON_EXECUTABLE=$(which python3) \
-        -DBUILD_TESTING=OFF \
+        -DBUILD_TESTING=OFF      \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DCMAKE_INSTALL_PYTHONDIR=lib/python3.6/dist-packages
     make
@@ -60,6 +63,7 @@ Supported frontends are C++11 and Python3.
 %labels
     openPMD_HAVE_MPI OFF
     openPMD_HAVE_HDF5 ON
+    openPMD_HAVE_JSON ON
     openPMD_HAVE_ADIOS1 ON
     openPMD_HAVE_ADIOS2 OFF
     openPMD_HAVE_PYTHON ON

--- a/docs/source/backends/adios1.rst
+++ b/docs/source/backends/adios1.rst
@@ -23,15 +23,19 @@ Backend-Specific Controls
 The following environment variables control ADIOS1 I/O behavior at runtime.
 Fine-tuning these is especially useful when running at large scale.
 
-==================================== ======= =============================================================================
-environment variable                 default description
-==================================== ======= =============================================================================
-``OPENPMD_ADIOS_NUM_AGGREGATORS``    ``1``   Number of I/O aggregator nodes for ADIOS1 ``MPI_AGGREGATE`` transport method.
-``OPENPMD_ADIOS_NUM_OST``            ``0``   Number of I/O OSTs for ADIOS1 ``MPI_AGGREGATE`` transport method.
-``OPENPMD_ADIOS_HAVE_METADATA_FILE`` ``1``   Online creation of the adios journal file (``1``: yes, ``0``: no).
-==================================== ======= =============================================================================
+==================================== ========= ================================================================================
+environment variable                 default   description
+==================================== ========= ================================================================================
+``OPENPMD_ADIOS_NUM_AGGREGATORS``    ``1``     Number of I/O aggregator nodes for ADIOS1 ``MPI_AGGREGATE`` transport method.
+``OPENPMD_ADIOS_NUM_OST``            ``0``     Number of I/O OSTs for ADIOS1 ``MPI_AGGREGATE`` transport method.
+``OPENPMD_ADIOS_HAVE_METADATA_FILE`` ``1``     Online creation of the adios journal file (``1``: yes, ``0``: no).
+``OPENPMD_BP_BACKEND``              ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
+==================================== ========= ================================================================================
 
-Please refer to the `ADIOS1 manual, section 6.1.5 <https://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.13.1.pdf>`_ for details.
+Please refer to the `ADIOS1 manual, section 6.1.5 <https://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.13.1.pdf>`_ for details on I/O tuning.
+
+In case only the ADIOS1 backend is enabled but not the :ref:`ADIOS2 backend <backends-adios2>`, the default of ``OPENPMD_BP_BACKEND`` is automatically switched to ``ADIOS1``.
+Be advised that ADIOS1 only supports ``.bp`` files up to the internal version BP3, while ADIOS2 supports BP3, BP4 and later formats.
 
 
 Best Practice at Large Scale

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -23,15 +23,19 @@ Backend-Specific Controls
 The following environment variables control ADIOS2 I/O behavior at runtime.
 Fine-tuning these is especially useful when running at large scale.
 
-===================================== ======= ===================================================================
-environment variable                  default description
-===================================== ======= ===================================================================
-``OPENPMD_ADIOS2_HAVE_PROFILING``      ``1``   Turns on/off profiling information right after a run.
-``OPENPMD_ADIOS2_HAVE_METADATA_FILE``  ``1``   Online creation of the adios journal file (``1``: yes, ``0``: no).
-``OPENPMD_ADIOS2_NUM_SUBSTREAMS``      ``0``   Number of files to be created, 0 indicates maximum number possible.
-===================================== ======= ===================================================================
+===================================== ========= ================================================================================
+environment variable                  default   description
+===================================== ========= ================================================================================
+``OPENPMD_ADIOS2_HAVE_PROFILING``     ``1``     Turns on/off profiling information right after a run.
+``OPENPMD_ADIOS2_HAVE_METADATA_FILE`` ``1``     Online creation of the adios journal file (``1``: yes, ``0``: no).
+``OPENPMD_ADIOS2_NUM_SUBSTREAMS``     ``0``     Number of files to be created, 0 indicates maximum number possible.
+``OPENPMD_BP_BACKEND``               ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
+===================================== ========= ================================================================================
 
-Please refer to the `ADIOS2 manual, section 5.1 <https://media.readthedocs.org/pdf/adios2/latest/adios2.pdf>`_ for details.
+Please refer to the `ADIOS2 manual, section 5.1 <https://media.readthedocs.org/pdf/adios2/latest/adios2.pdf>`_ for details on I/O tuning.
+
+In case both the the :ref:`ADIOS1 backend <backends-adios1>` and ADIOS2 backend are enabled, set ``OPENPMD_BP_BACKEND`` to ``ADIOS1`` to enforce using ADIOS1.
+Be advised that ADIOS1 only supports ``.bp`` files up to the internal version BP3, while ADIOS2 supports BP3, BP4 and later formats.
 
 
 Best Practice at Large Scale

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -17,8 +17,8 @@ CMake Option                   Values          Description
 ``openPMD_USE_MPI``            **AUTO**/ON/OFF Parallel, Multi-Node I/O for clusters
 ``openPMD_USE_JSON``           **AUTO**/ON/OFF JSON backend (``.json`` files)
 ``openPMD_USE_HDF5``           **AUTO**/ON/OFF HDF5 backend (``.h5`` files)
-``openPMD_USE_ADIOS1``         **AUTO**/ON/OFF ADIOS1 backend (``.bp`` files)
-``openPMD_USE_ADIOS2``         **AUTO**/ON/OFF ADIOS2 backend (``.bp`` files)
+``openPMD_USE_ADIOS1``         **AUTO**/ON/OFF ADIOS1 backend (``.bp`` files up to version BP3)
+``openPMD_USE_ADIOS2``         **AUTO**/ON/OFF ADIOS2 backend (``.bp`` files in BP3, BP4 or higher)
 ``openPMD_USE_PYTHON``         **AUTO**/ON/OFF Enable Python bindings
 ``openPMD_USE_INVASIVE_TESTS`` ON/**OFF**      Enable unit tests that modify source code :sup:`1`
 ``openPMD_USE_VERIFY``         **ON**/OFF      Enable internal VERIFY (assert) macro independent of build type :sup:`2`

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -31,7 +31,7 @@ A package for openPMD-api is available on the `Spack <https://spack.io>`_ packag
 
 .. code-block:: bash
 
-   # optional:               +python +adios1 -mpi
+   # optional:               +python +adios1 +adios2 -mpi
    spack install openpmd-api
    spack load -r openpmd-api
 
@@ -63,7 +63,7 @@ Using the PyPI Package
 
 A package for openPMD-api is available on the Python Package Index (`PyPI <https://pypi.org>`_).
 
-Behind the scenes, this install method *compiles from source* against the found installations of HDF5, ADIOS and/or MPI (in system paths, from other package managers, or loaded via a module system, ...).
+Behind the scenes, this install method *compiles from source* against the found installations of HDF5, ADIOS1, ADIOS2, and/or MPI (in system paths, from other package managers, or loaded via a module system, ...).
 The current status for this install method is *experimental*.
 Please feel free to `report <https://github.com/openPMD/openPMD-api/issues/new/choose>`_ how this works for you.
 

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -28,7 +28,7 @@ int main(
     // given that you provide it with an appropriate DatasetFillerProvider
     // (template parameter of the Benchmark class).
     using type = long int;
-#if openPMD_HAVE_ADIOS1 || openPMD_HAVE_HDF5
+#if openPMD_HAVE_ADIOS1 || openPMD_HAVE_ADIOS2 || openPMD_HAVE_HDF5
     openPMD::Datatype dt = openPMD::determineDatatype<type>();
 #endif
 
@@ -89,7 +89,7 @@ int main(
     // * The datatype to use for this run.
     // * The number of iterations. Effectively, the benchmark will be repeated for this many
     //   times.
-#if openPMD_HAVE_ADIOS1
+#if openPMD_HAVE_ADIOS1 || openPMD_HAVE_ADIOS2
     benchmark.addConfiguration("", 0, "bp", dt, 10);
 #endif
 #if openPMD_HAVE_HDF5

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -337,7 +337,7 @@ namespace detail
                           const adios2::Dims & shape = adios2::Dims( ),
                           const adios2::Dims & start = adios2::Dims( ),
                           const adios2::Dims & count = adios2::Dims( ),
-                          bool constantDims = false );
+                          const bool constantDims = false );
 
         template < int n, typename... Params >
         void operator( )( adios2::IO & IO, Params &&... );

--- a/include/openPMD/auxiliary/Environment.hpp
+++ b/include/openPMD/auxiliary/Environment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2019 Franz Poeschel
+/* Copyright 2018-2019 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -19,17 +19,27 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <stdexcept>
+
 
 namespace openPMD
 {
 namespace auxiliary
 {
+    inline std::string getEnvString( std::string const & key, std::string const defaultValue )
+    {
+        char const * env = std::getenv( key.c_str( ) );
+        if ( env != nullptr )
+            return std::string{env};
+        else
+            return defaultValue;
+    }
 
     inline int getEnvNum( std::string const & key, int defaultValue )
     {

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -69,12 +69,12 @@ namespace openPMD
             case Format::HDF5:
                 return std::make_shared< HDF5IOHandler >(path, accessType);
             case Format::ADIOS1:
-#   if openPMD_HAVE_ADIOS1
+#if openPMD_HAVE_ADIOS1
                 return std::make_shared< ADIOS1IOHandler >(path, accessType);
-#   else
+#else
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
                 return std::make_shared< DummyIOHandler >(path, accessType);
-#   endif
+#endif
 #if openPMD_HAVE_ADIOS2
             case Format::ADIOS2:
                 return std::make_shared<ADIOS2IOHandler>(path, accessType);


### PR DESCRIPTION
Further updates now that we have ADIOS2 #482 taking off :rocket: :sparkles: 

- [x] update documentation further, including changes and upgrades
- [x] update CI to dominantly check ADIOS2 runtime
- [x] update `Dockerfile` for `manylinux2010` build https://github.com/ornladios/ADIOS2/issues/1810
- [x] update parallel benchmark example
- [x] make selected backend for ``.bp`` files a runtime option (currently via environment variable)
- [x] fix OSX `Extent` cast causing a build error

## Found bug during the process

ADIOS2 VariableDefiner: Fix OSX Cast Error
    
Add an explicit cast from `openPMD::Extent` (aka `std::vector< std::uint64_t >`) to `adios2::Dims` (aka `std::vector< std::size_t >`) to avoid a compile error on OSX:
    
```
    include/openPMD/Datatype.hpp:558:23: error: no matching member function for call to 'operator()'
            return action.OPENPMD_TEMPLATE_OPERATOR( )< char >(
                   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    
    include/openPMD/Datatype.hpp:532:44: note: expanded from macro 'OPENPMD_TEMPLATE_OPERATOR'
                                               ^
    
    src/IO/ADIOS/ADIOS2IOHandler.cpp:201:9: note: in instantiation of function template specialization 'openPMD::switchType<void, openPMD::detail::VariableDefiner, adios2::IO &, std::__1::basic_string<char> &, std::__1::unique_ptr<adios2::Operator, std::__1::default_delete<adios2::Operator> >, const std::__1::vector<unsigned long long, std::__1::allocator<unsigned long long> > &>' requested here
            switchType( parameters.dtype, detail::VariableDefiner( ),
            ^
    
    src/IO/ADIOS/ADIOS2IOHandler.cpp:794:5: note: candidate function not viable: no known conversion from 'const vector<unsigned long long, allocator<unsigned long long>>' to 'const vector<size_t, allocator<unsigned long>>' for 4th argument
        operator( )( adios2::IO & IO, const std::string & name,
        ^
    
    src/IO/ADIOS/ADIOS2IOHandler.cpp:804:27: note: candidate template ignored: invalid explicitly-specified argument for template parameter 'n'
        void VariableDefiner::operator( )( adios2::IO &, Params &&... )
```