### PR TITLE
Advanced backend configuration via JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ set(CORE_SOURCE
         src/version.cpp
         src/auxiliary/Date.cpp
         src/auxiliary/Filesystem.cpp
+        src/auxiliary/JSON.cpp
         src/backend/Attributable.cpp
         src/backend/BaseRecordComponent.cpp
         src/backend/MeshRecordComponent.cpp

--- a/docs/source/backends/json.rst
+++ b/docs/source/backends/json.rst
@@ -85,4 +85,5 @@ The example code in the :ref:`usage section <usage-serial>` will produce the fol
 when picking the JSON backend:
 
 .. literalinclude:: json_example.json
+   :language: json
 

--- a/docs/source/details/adios2.json
+++ b/docs/source/details/adios2.json
@@ -1,0 +1,19 @@
+{
+  "adios2": {
+    "engine": {
+      "type": "sst",
+      "parameters": {
+        "BufferGrowthFactor": "2.0",
+        "QueueLimit": "2"
+      }
+    },
+    "dataset": {
+      "operators": [ 
+        {
+          "type": "bzip2",
+          "parameters": {}
+        }
+      ]
+    }
+  }
+}

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -1,6 +1,6 @@
 .. _backendconfig
 
-Backend-Specific configuration
+Backend-Specific Configuration
 ==============================
 
 While the openPMD API intends to be a backend-*independent* implementation of the openPMD standard, it is sometimes useful to pass configuration parameters to the specific backend in use.
@@ -10,6 +10,7 @@ A JSON option always takes precedence over an environment variable.
 The fundamental structure of this JSON configuration string is given as follows:
 
 .. literalinclude:: config_layout.json
+   :language: json
 
 This structure allows keeping one configuration string for several backends at once, with the concrete backend configuration being chosen upon choosing the backend itself.
 
@@ -39,12 +40,17 @@ ADIOS2
 A full configuration of the ADIOS2 backend:
 
 .. literalinclude:: adios2.json
+   :language: json
 
-All keys found under ``adios2.dataset`` are applicable globally as well as per dataset, keys found under ``adios2.engine`` only globally. Explanation of the single keys:
+All keys found under ``adios2.dataset`` are applicable globally as well as per dataset, keys found under ``adios2.engine`` only globally.
+Explanation of the single keys:
 
-* ``adios2.engine.type``: A string that is passed directly to ``adios2::IO:::SetEngine`` for choosing the ADIOS2 engine to be used. Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for a list of available engines.
-* ``adios2.engine.type``: An associative array of string-formatted engine parameters, passed directly through to ``adios2::IO::SetParameters``. Please refer to the official ADIOS2 documentation for the allowable engine parameters.
-* ``adios2.dataset.operators``: (*currently unimplemented* – please use the ``openPMD::Dataset::compression`` for the meantime) This key contains a list of ADIOS2 `operators <https://adios2.readthedocs.io/en/latest/components/components.html#operator>`_, used to enable compression or dataset transformations. Each object in the list has three keys:
+* ``adios2.engine.type``: A string that is passed directly to ``adios2::IO:::SetEngine`` for choosing the ADIOS2 engine to be used.
+  Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for a list of available engines.
+* ``adios2.engine.type``: An associative array of string-formatted engine parameters, passed directly through to ``adios2::IO::SetParameters``.
+  Please refer to the official ADIOS2 documentation for the allowable engine parameters.
+* ``adios2.dataset.operators``: (*currently unimplemented* – please use the ``openPMD::Dataset::compression`` for the meantime) This key contains a list of ADIOS2 `operators <https://adios2.readthedocs.io/en/latest/components/components.html#operator>`_, used to enable compression or dataset transformations.
+  Each object in the list has three keys:
 
   * ``type`` supported ADIOS operator type, e.g. zfp, sz
   * ``parameters`` is an associative map of string parameters for the operator (e.g. compression levels)
@@ -52,4 +58,5 @@ All keys found under ``adios2.dataset`` are applicable globally as well as per d
 Other backends
 ^^^^^^^^^^^^^^
 
-Do currently not read the configuration string. Please refer to the respective backends' documentations for further information on their configuration.
+Do currently not read the configuration string.
+Please refer to the respective backends' documentations for further information on their configuration.

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -1,9 +1,11 @@
 .. _backendconfig
 
-Backend-specific configuration
+Backend-Specific configuration
 ==============================
 
-While the openPMD API intends to be a backend-*independent* implementation of the openPMD standard, it is often necessary to pass configuration parameters to the concrete backend in use. Some backends recognize a number of configuration options via environment variables (see the backends' documentations), the preferred way to do so, however, *– as far as it is implemented –* is via a JSON-formatted string.
+While the openPMD API intends to be a backend-*independent* implementation of the openPMD standard, it is sometimes useful to pass configuration parameters to the specific backend in use.
+:ref:`For each backend <backends-overview>`, configuration options can be passed via a JSON-formatted string or via environment variables.
+A JSON option always takes precedence over an environment variable.
 
 The fundamental structure of this JSON configuration string is given as follows:
 
@@ -11,18 +13,24 @@ The fundamental structure of this JSON configuration string is given as follows:
 
 This structure allows keeping one configuration string for several backends at once, with the concrete backend configuration being chosen upon choosing the backend itself.
 
-The configuration is currently read in a case-sensitive manner. Since this may change in the future, all parts of the configuration are given in *lower case*. Parameters that are directly passed through to an external library and not interpreted within the openPMD API (e.g. ``adios2.engine.parameters``) are unaffected by this and follow the respective library's conventions.
+The configuration is read in a case-sensitive manner.
+Generally, keys of the configuration are *lower case*.
+Parameters that are directly passed through to an external library and not interpreted within openPMD API (e.g. ``adios2.engine.parameters``) are unaffected by this and follow the respective library's conventions.
 
-The configuration string may refer to the complete ``openPMD::Series`` and additionally be specified per ``openPMD::Dataset``, passed in the respective constructors. *Configuration per dataset is currently not yet implemented.* This reflects the fact that certain backend-specific parameters may refer to the whole Series (such as storage engines and their parameters) and others refer to actual datasets (such as compression).
+The configuration string may refer to the complete ``openPMD::Series`` or may additionally be specified per ``openPMD::Dataset``, passed in the respective constructors.
+*A configuration per dataset is currently not yet implemented.*
+This reflects the fact that certain backend-specific parameters may refer to the whole Series (such as storage engines and their parameters) and others refer to actual datasets (such as compression).
 
 For a consistent user interface, backends shall follow the following rules:
 
 * The configuration structures for the Series and for each dataset should be defined equivalently.
 * Any setting referring to single datasets should also be applicable globally, affecting all datasets.
 * If a setting is defined globally, but also for a concrete dataset, the dataset-specific setting should override the global one.
-* If a setting is passed to a dataset that only makes sense globally (such as the storage engine), the setting should be ignored except for printing a warning. Backends should define clearly which keys are applicable to datasets and which are not.
+* If a setting is passed to a dataset that only makes sense globally (such as the storage engine), the setting should be ignored except for printing a warning.
+  Backends should define clearly which keys are applicable to datasets and which are not.
 
-Configuration structure per backend
+
+Configuration Structure per Backend
 -----------------------------------
 
 ADIOS2

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -1,0 +1,47 @@
+.. _backendconfig
+
+Backend-specific configuration
+==============================
+
+While the openPMD API intends to be a backend-*independent* implementation of the openPMD standard, it is often necessary to pass configuration parameters to the concrete backend in use. Some backends recognize a number of configuration options via environment variables (see the backends' documentations), the preferred way to do so, however, *– as far as it is implemented –* is via a JSON-formatted string.
+
+The fundamental structure of this JSON configuration string is given as follows:
+
+.. literalinclude:: config_layout.json
+
+This structure allows keeping one configuration string for several backends at once, with the concrete backend configuration being chosen upon choosing the backend itself.
+
+The configuration is currently read in a case-sensitive manner. Since this may change in the future, all parts of the configuration are given in *lower case*. Parameters that are directly passed through to an external library and not interpreted within the openPMD API (e.g. ``adios2.engine.parameters``) are unaffected by this and follow the respective library's conventions.
+
+The configuration string may refer to the complete ``openPMD::Series`` and additionally be specified per ``openPMD::Dataset``, passed in the respective constructors. *Configuration per dataset is currently not yet implemented.* This reflects the fact that certain backend-specific parameters may refer to the whole Series (such as storage engines and their parameters) and others refer to actual datasets (such as compression).
+
+For a consistent user interface, backends shall follow the following rules:
+
+* The configuration structures for the Series and for each dataset should be defined equivalently.
+* Any setting referring to single datasets should also be applicable globally, affecting all datasets.
+* If a setting is defined globally, but also for a concrete dataset, the dataset-specific setting should override the global one.
+* If a setting is passed to a dataset that only makes sense globally (such as the storage engine), the setting should be ignored except for printing a warning. Backends should define clearly which keys are applicable to datasets and which are not.
+
+Configuration structure per backend
+-----------------------------------
+
+ADIOS2
+^^^^^^
+
+A full configuration of the ADIOS2 backend:
+
+.. literalinclude:: adios2.json
+
+All keys found under ``adios2.dataset`` are applicable globally as well as per dataset, keys found under ``adios2.engine`` only globally. Explanation of the single keys:
+
+* ``adios2.engine.type``: A string that is passed directly to ``adios2::IO:::SetEngine`` for choosing the ADIOS2 engine to be used. Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for a list of available engines.
+* ``adios2.engine.type``: An associative array of string-formatted engine parameters, passed directly through to ``adios2::IO::SetParameters``. Please refer to the official ADIOS2 documentation for the allowable engine parameters.
+* ``adios2.dataset.operators``: (*currently unimplemented* – please use the ``openPMD::Dataset::compression`` for the meantime) This key contains a list of ADIOS2 `operators <https://adios2.readthedocs.io/en/latest/components/components.html#operator>`_, used to enable compression or dataset transformations. Each object in the list has three keys:
+
+  * ``type`` supported ADIOS operator type, e.g. zfp, sz
+  * ``parameters`` is an associative map of string parameters for the operator (e.g. compression levels)
+
+Other backends
+^^^^^^^^^^^^^^
+
+Do currently not read the configuration string. Please refer to the respective backends' documentations for further information on their configuration.

--- a/docs/source/details/config_layout.json
+++ b/docs/source/details/config_layout.json
@@ -1,5 +1,6 @@
 {
     "adios": "put ADIOS config here",
     "adios2": "put ADIOS2 config here",
-    "hdf5": "put HDF5 config here"
+    "hdf5": "put HDF5 config here",
+    "json": "put JSON config here"
 }

--- a/docs/source/details/config_layout.json
+++ b/docs/source/details/config_layout.json
@@ -1,0 +1,5 @@
+{
+    "adios": "put ADIOS config here",
+    "adios2": "put ADIOS2 config here",
+    "hdf5": "put HDF5 config here"
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,7 @@ API Details
    details/doxygen.rst
    details/python.rst
    details/mpi.rst
+   details/backendconfig.rst
 
 Utilities
 ---------

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -187,16 +187,16 @@ public:
 private:
     adios2::ADIOS m_ADIOS;
 
-#   if openPMD_HAVE_JSON
-    nlohmann::json m_config;
-    static nlohmann::json nullvalue;
+#    if openPMD_HAVE_JSON
+    auxiliary::TracingJSON m_config;
+    static auxiliary::TracingJSON nullvalue;
 
     void
     init( nlohmann::json config );
 
     template< typename Key >
-    nlohmann::json &
-    config( Key && key, nlohmann::json & cfg )
+    auxiliary::TracingJSON
+    config( Key && key, auxiliary::TracingJSON & cfg )
     {
         if( cfg.is_object() && cfg.contains( key ) )
         {
@@ -209,7 +209,7 @@ private:
     }
 
     template< typename Key >
-    nlohmann::json &
+    auxiliary::TracingJSON
     config( Key && key )
     {
         return config< Key >( std::forward< Key >( key ), m_config );

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -96,13 +96,24 @@ public:
 
 #if openPMD_HAVE_MPI
 
-    ADIOS2IOHandlerImpl( AbstractIOHandler *, MPI_Comm, nlohmann::json config );
+    ADIOS2IOHandlerImpl(
+        AbstractIOHandler *,
+        MPI_Comm
+#   if openPMD_HAVE_JSON
+        , nlohmann::json config
+#   endif
+    );
 
     MPI_Comm m_comm;
 
 #endif // openPMD_HAVE_MPI
 
-    explicit ADIOS2IOHandlerImpl( AbstractIOHandler *, nlohmann::json config );
+    explicit ADIOS2IOHandlerImpl(
+        AbstractIOHandler *
+#   if openPMD_HAVE_JSON
+        , nlohmann::json config
+#   endif
+    );
 
 
     ~ADIOS2IOHandlerImpl( ) override = default;
@@ -175,6 +186,8 @@ public:
 
 private:
     adios2::ADIOS m_ADIOS;
+
+#   if openPMD_HAVE_JSON
     nlohmann::json m_config;
     static nlohmann::json nullvalue;
 
@@ -201,7 +214,7 @@ private:
     {
         return config< Key >( std::forward< Key >( key ), m_config );
     }
-
+#   endif // openPMD_HAVE_JSON
     /*
      * We need to give names to IO objects. These names are irrelevant
      * within this application, since:
@@ -705,13 +718,21 @@ public:
     ADIOS2IOHandler(
         std::string path,
         AccessType,
-        MPI_Comm,
-        nlohmann::json options );
+        MPI_Comm
+#   if openPMD_HAVE_JSON
+        , nlohmann::json options
+#   endif
+    );
 
 #endif
 
-    ADIOS2IOHandler( std::string path, AccessType,
-        nlohmann::json options);
+    ADIOS2IOHandler(
+        std::string path,
+        AccessType
+#if openPMD_HAVE_JSON
+        , nlohmann::json options
+#endif
+    );
 
     std::string backendName() const override { return "ADIOS2"; }
 

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -287,16 +287,22 @@ private:
                                          std::string const & var );
 }; // ADIOS2IOHandlerImpl
 
+/*
+ * The following strings are used during parsing of the JSON configuration
+ * string for the ADIOS2 backend.
+ * Note that this struct's members additionally need to be defined at namespace
+ * scope up until C++17, see ADIOS2IOHandlerImpl.cpp
+ */
+struct ADIOS2Defaults
+{
+    using const_str = char const * const;
+    constexpr static const_str str_engine = "engine";
+    constexpr static const_str str_type = "type";
+    constexpr static const_str str_params = "parameters";
+};
+
 namespace detail
 {
-    /*
-     * The following strings are used during parsing of the JSON configuration
-     * string for the ADIOS2 backend.
-     */
-    constexpr char const * const str_engine = "engine";
-    constexpr char const * str_type = "type";
-    constexpr char const * str_params = "parameters";
-
     // Helper structs for calls to the switchType function
 
     struct DatasetReader

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -96,13 +96,7 @@ public:
 
 #if openPMD_HAVE_MPI
 
-    ADIOS2IOHandlerImpl(
-        AbstractIOHandler *,
-        MPI_Comm
-#   if openPMD_HAVE_JSON
-        , nlohmann::json config
-#   endif
-    );
+    ADIOS2IOHandlerImpl( AbstractIOHandler *, MPI_Comm, nlohmann::json config );
 
     MPI_Comm m_comm;
 
@@ -110,15 +104,14 @@ public:
 
     explicit ADIOS2IOHandlerImpl(
         AbstractIOHandler *
-#   if openPMD_HAVE_JSON
         , nlohmann::json config
-#   endif
     );
 
 
-    ~ADIOS2IOHandlerImpl( ) override = default;
+    ~ADIOS2IOHandlerImpl() override = default;
 
-    std::future< void > flush( ) override;
+    std::future< void >
+    flush() override;
 
     void createFile( Writable *,
                      Parameter< Operation::CREATE_FILE > const & ) override;
@@ -187,7 +180,6 @@ public:
 private:
     adios2::ADIOS m_ADIOS;
 
-#    if openPMD_HAVE_JSON
     auxiliary::TracingJSON m_config;
     static auxiliary::TracingJSON nullvalue;
 
@@ -214,7 +206,6 @@ private:
     {
         return config< Key >( std::forward< Key >( key ), m_config );
     }
-#   endif // openPMD_HAVE_JSON
     /*
      * We need to give names to IO objects. These names are irrelevant
      * within this application, since:
@@ -719,20 +710,12 @@ public:
         std::string path,
         AccessType,
         MPI_Comm
-#   if openPMD_HAVE_JSON
         , nlohmann::json options
-#   endif
     );
 
 #endif
 
-    ADIOS2IOHandler(
-        std::string path,
-        AccessType
-#if openPMD_HAVE_JSON
-        , nlohmann::json options
-#endif
-    );
+    ADIOS2IOHandler( std::string path, AccessType, nlohmann::json options );
 
     std::string backendName() const override { return "ADIOS2"; }
 

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -180,6 +180,14 @@ public:
 private:
     adios2::ADIOS m_ADIOS;
 
+    struct ParameterizedOperator
+    {
+        adios2::Operator const op;
+        adios2::Params const params;
+    };
+
+    std::vector< ParameterizedOperator > defaultOperators;
+
     auxiliary::TracingJSON m_config;
     static auxiliary::TracingJSON nullvalue;
 
@@ -206,6 +214,21 @@ private:
     {
         return config< Key >( std::forward< Key >( key ), m_config );
     }
+
+    /**
+     *
+     * @param config The top-level of the ADIOS2 configuration JSON object
+     * with operators to be found under dataset.operators
+     * @return first parameter: the operators, second parameters: whether
+     * operators have been configured
+     */
+    std::pair< std::vector< ParameterizedOperator >, bool >
+    getOperators( auxiliary::TracingJSON config );
+
+    // use m_config
+    std::pair< std::vector< ParameterizedOperator >, bool >
+    getOperators();
+
     /*
      * We need to give names to IO objects. These names are irrelevant
      * within this application, since:
@@ -516,7 +539,8 @@ namespace detail
         defineVariable(
             adios2::IO & IO,
             std::string const & name,
-            std::unique_ptr< adios2::Operator > compression,
+            std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator >
+                compressions,
             adios2::Dims const & shape = adios2::Dims(),
             adios2::Dims const & start = adios2::Dims(),
             adios2::Dims const & count = adios2::Dims(),

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "ADIOS2FilePosition.hpp"
+#include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 #include "openPMD/IO/AbstractIOHandlerImplCommon.hpp"
@@ -28,22 +29,6 @@
 #include "openPMD/IO/InvalidatableFile.hpp"
 #include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/backend/Writable.hpp"
-
-#include <array>
-#include <exception>
-#include <future>
-#include <iostream>
-#include <memory> // shared_ptr
-#include <string>
-#include <unordered_map>
-#include <utility> // pair
-#include <vector>
-
-#include <nlohmann/json.hpp>
-
-#include "openPMD/config.hpp"
-
-#include <nlohmann/json.hpp>
 
 #if openPMD_HAVE_ADIOS2
 #   include <adios2.h>
@@ -54,6 +39,17 @@
 #   include <mpi.h>
 #endif
 
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <exception>
+#include <future>
+#include <iostream>
+#include <memory> // shared_ptr
+#include <string>
+#include <unordered_map>
+#include <utility> // pair
+#include <vector>
 
 namespace openPMD
 {
@@ -111,10 +107,9 @@ public:
     );
 
 
-    ~ADIOS2IOHandlerImpl() override = default;
+    ~ADIOS2IOHandlerImpl( ) override = default;
 
-    std::future< void >
-    flush() override;
+    std::future< void > flush( ) override;
 
     void createFile( Writable *,
                      Parameter< Operation::CREATE_FILE > const & ) override;
@@ -316,8 +311,6 @@ private:
 /*
  * The following strings are used during parsing of the JSON configuration
  * string for the ADIOS2 backend.
- * Note that this struct's members additionally need to be defined at namespace
- * scope up until C++17, see ADIOS2IOHandlerImpl.cpp
  */
 namespace ADIOS2Defaults
 {
@@ -757,8 +750,8 @@ public:
     ADIOS2IOHandler(
         std::string path,
         AccessType,
-        MPI_Comm
-        , nlohmann::json options
+        MPI_Comm,
+        nlohmann::json options
     );
 
 #endif

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -316,13 +316,13 @@ private:
  * Note that this struct's members additionally need to be defined at namespace
  * scope up until C++17, see ADIOS2IOHandlerImpl.cpp
  */
-struct ADIOS2Defaults
+namespace ADIOS2Defaults
 {
     using const_str = char const * const;
-    constexpr static const_str str_engine = "engine";
-    constexpr static const_str str_type = "type";
-    constexpr static const_str str_params = "parameters";
-};
+    constexpr const_str str_engine = "engine";
+    constexpr const_str str_type = "type";
+    constexpr const_str str_params = "parameters";
+}
 
 namespace detail
 {

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -375,17 +375,13 @@ namespace detail
 
     struct VariableDefiner
     {
+        // Parameters such as DatasetHelper< T >::defineVariable
+        template < typename T, typename... Params >
+        void operator( )( Params &&... params );
 
-        template < typename T >
-        void operator( )( adios2::IO & IO, const std::string & name,
-                          std::unique_ptr< adios2::Operator > compression,
-                          const adios2::Dims & shape = adios2::Dims( ),
-                          const adios2::Dims & start = adios2::Dims( ),
-                          const adios2::Dims & count = adios2::Dims( ),
-                          const bool constantDims = false );
-
-        template < int n, typename... Params >
-        void operator( )( adios2::IO & IO, Params &&... );
+        template< int n, typename... Params >
+        void
+        operator()( Params &&... );
     };
 
 
@@ -517,10 +513,14 @@ namespace detail
                           std::string const & fileName );
 
         static void
-        defineVariable( adios2::IO & IO, const std::string & name,
-                        std::unique_ptr< adios2::Operator > compression,
-                        const adios2::Dims & shape, const adios2::Dims & start,
-                        const adios2::Dims & count, bool constantDims );
+        defineVariable(
+            adios2::IO & IO,
+            std::string const & name,
+            std::unique_ptr< adios2::Operator > compression,
+            adios2::Dims const & shape = adios2::Dims(),
+            adios2::Dims const & start = adios2::Dims(),
+            adios2::Dims const & count = adios2::Dims(),
+            bool const constantDims = false );
 
         void writeDataset( BufferedPut &, adios2::IO &, adios2::Engine & );
     };

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -26,6 +26,7 @@
 #include "openPMD/IO/AbstractIOHandlerImplCommon.hpp"
 #include "openPMD/IO/IOTask.hpp"
 #include "openPMD/IO/InvalidatableFile.hpp"
+#include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/backend/Writable.hpp"
 
 #include <array>
@@ -41,6 +42,8 @@
 #include <nlohmann/json.hpp>
 
 #include "openPMD/config.hpp"
+
+#include <nlohmann/json.hpp>
 
 #if openPMD_HAVE_ADIOS2
 #   include <adios2.h>
@@ -535,6 +538,21 @@ namespace detail
         void readDataset( BufferedGet &, adios2::IO &, adios2::Engine &,
                           std::string const & fileName );
 
+        /**
+         * @brief Define a Variable of type T within the passed IO.
+         * 
+         * @param IO The adios2::IO object within which to define the
+         *           variable. The variable can later be retrieved from
+         *           the IO using the passed name.
+         * @param name As in adios2::IO::DefineVariable
+         * @param compressions ADIOS2 operators, including an arbitrary
+         *                     number of parameters, to be added to the
+         *                     variable upon definition.
+         * @param shape As in adios2::IO::DefineVariable
+         * @param start As in adios2::IO::DefineVariable
+         * @param count As in adios2::IO::DefineVariable
+         * @param constantDims As in adios2::IO::DefineVariable
+         */
         static void
         defineVariable(
             adios2::IO & IO,

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -539,7 +539,7 @@ namespace detail
         defineVariable(
             adios2::IO & IO,
             std::string const & name,
-            std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator >
+            std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator > const &
                 compressions,
             adios2::Dims const & shape = adios2::Dims(),
             adios2::Dims const & start = adios2::Dims(),

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -198,7 +198,7 @@ private:
     auxiliary::TracingJSON
     config( Key && key, auxiliary::TracingJSON & cfg )
     {
-        if( cfg.is_object() && cfg.contains( key ) )
+        if( cfg.json().is_object() && cfg.json().contains( key ) )
         {
             return cfg[ key ];
         }

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -36,26 +36,28 @@ namespace openPMD
      * @param   comm        MPI communicator used for IO.
      * @return  Smart pointer to created IOHandler.
      */
-    std::shared_ptr< AbstractIOHandler >
-    createIOHandler(
-        std::string path,
-        AccessType accessType,
-        Format format,
-        MPI_Comm comm
-    );
+std::shared_ptr< AbstractIOHandler >
+createIOHandler(
+    std::string path,
+    AccessType accessType,
+    Format format,
+    MPI_Comm comm,
+    std::string const & options = "{}" );
 #endif
 
-    /** Construct an appropriate specific IOHandler for the desired IO mode.
-     *
-     * @param   path        Path to root folder for all operations associated with the desired handler.
-     * @param   accessType  AccessType describing desired operations and permissions of the desired handler.
-     * @param   format      Format describing the IO backend of the desired handler.
-     * @return  Smart pointer to created IOHandler.
-     */
-    std::shared_ptr< AbstractIOHandler >
-    createIOHandler(
-        std::string path,
-        AccessType accessType,
-        Format format
-    );
-} // openPMD
+/** Construct an appropriate specific IOHandler for the desired IO mode.
+ *
+ * @param   path        Path to root folder for all operations associated with
+ * the desired handler.
+ * @param   accessType  AccessType describing desired operations and permissions
+ * of the desired handler.
+ * @param   format      Format describing the IO backend of the desired handler.
+ * @return  Smart pointer to created IOHandler.
+ */
+std::shared_ptr< AbstractIOHandler >
+createIOHandler(
+    std::string path,
+    AccessType accessType,
+    Format format,
+    std::string const & options = "{}" );
+} // namespace openPMD

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -34,6 +34,8 @@ namespace openPMD
      * @param   accessType  AccessType describing desired operations and permissions of the desired handler.
      * @param   format      Format describing the IO backend of the desired handler.
      * @param   comm        MPI communicator used for IO.
+     * @param   options     JSON-formatted option string, to be interpreted by
+     *                      the backend.
      * @return  Smart pointer to created IOHandler.
      */
 std::shared_ptr< AbstractIOHandler >
@@ -52,6 +54,8 @@ createIOHandler(
  * @param   accessType  AccessType describing desired operations and permissions
  * of the desired handler.
  * @param   format      Format describing the IO backend of the desired handler.
+ * @param   options     JSON-formatted option string, to be interpreted by
+ *                      the backend.
  * @return  Smart pointer to created IOHandler.
  */
 std::shared_ptr< AbstractIOHandler >

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -58,12 +58,17 @@ class Series : public Attributable
 
 public:
 #if openPMD_HAVE_MPI
-    Series(std::string const& filepath,
-           AccessType at,
-           MPI_Comm comm);
+    Series(
+        std::string const & filepath,
+        AccessType at,
+        MPI_Comm comm,
+        std::string const & options = "{}" );
 #endif
-    Series(std::string const& filepath,
-           AccessType at);
+
+    Series(
+        std::string const & filepath,
+        AccessType at,
+        std::string const & options = "{}" );
     ~Series();
 
     /**

--- a/include/openPMD/auxiliary/JSON.hpp
+++ b/include/openPMD/auxiliary/JSON.hpp
@@ -1,10 +1,32 @@
+/* Copyright 2020 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
+
+#include "openPMD/config.hpp"
+
+#include <nlohmann/json.hpp>
 
 #include <memory>  // std::shared_ptr
 #include <utility> // std::forward
-
-#include "openPMD/config.hpp"
-#include <nlohmann/json.hpp>
 
 namespace openPMD
 {
@@ -69,14 +91,39 @@ namespace auxiliary
         declareFullyRead();
 
     private:
+        /**
+         * @brief The JSON object with which this class has been initialized.
+         *        Shared pointer shared between all instances returned by
+         *        operator[]() in order to avoid use-after-free situations.
+         *
+         */
         std::shared_ptr< nlohmann::json > m_originalJSON;
+        /**
+         * @brief A JSON object keeping track of all accessed indices within the
+         *        original JSON object. Initially an empty JSON object,
+         *        gradually filled by applying each operator[]() call also to
+         *        it.
+         *        Shared pointer shared between all instances returned by
+         *        operator[]() in order to avoid use-after-free situations.
+         *
+         */
         std::shared_ptr< nlohmann::json > m_shadow;
+        /**
+         * @brief The sub-expression within m_originalJSON corresponding with
+         *        the current instance.
+         *
+         */
         nlohmann::json * m_positionInOriginal;
+        /**
+         * @brief The sub-expression within m_positionInOriginal corresponding
+         *        with the current instance.
+         *
+         */
         nlohmann::json * m_positionInShadow;
         bool m_trace = true;
 
         void
-        invertShadow( nlohmann::json & result, nlohmann::json & shadow );
+        invertShadow( nlohmann::json & result, nlohmann::json const & shadow );
 
         TracingJSON(
             std::shared_ptr< nlohmann::json > originalJSON,

--- a/include/openPMD/auxiliary/JSON.hpp
+++ b/include/openPMD/auxiliary/JSON.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
+#include <memory>  // std::shared_ptr
+#include <utility> // std::forward
+
 #include "openPMD/config.hpp"
-
-#if openPMD_HAVE_JSON
-
-#    include <memory>  // std::shared_ptr
-#    include <utility> // std::forward
-
-#    include <nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace openPMD
 {
@@ -112,5 +109,3 @@ namespace auxiliary
     }
 } // namespace auxiliary
 } // namespace openPMD
-
-#endif // openPMD_HAVE_JSON

--- a/include/openPMD/auxiliary/JSON.hpp
+++ b/include/openPMD/auxiliary/JSON.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "openPMD/config.hpp"
+
+#if openPMD_HAVE_JSON
+
+#    include <memory>  // std::shared_ptr
+#    include <utility> // std::forward
+
+#    include <nlohmann/json.hpp>
+
+namespace openPMD
+{
+namespace auxiliary
+{
+    /**
+     * @brief Extend nlohmann::json with tracing of which keys have been
+     * accessed by operator[]().
+     * An access is only registered if the current JSON value is a JSON object
+     * (not an array) and if the accessed JSON value is a leaf, i.e. anything
+     * but an object. This means that objects contained in arrays will not be
+     * traced.
+     *
+     * Warning: The current implementation is inefficient because it will copy
+     * the accessed JSON value upon access. Currently not to be used for deeply
+     * nested / large JSON structures.
+     *
+     */
+    class TracingJSON : public nlohmann::json
+    {
+    public:
+        TracingJSON();
+        TracingJSON( nlohmann::json );
+
+        template< typename Key >
+        TracingJSON operator[]( Key && key );
+
+        /**
+         * @brief Get the "shadow", i.e. a copy of the original JSON value
+         * containing all accessed object keys.
+         *
+         * @return nlohmann::json const&
+         */
+        nlohmann::json const &
+        getShadow();
+
+        /**
+         * @brief Invert the "shadow", i.e. a copy of the original JSON value
+         * that contains exactly those values that have not been accessed yet.
+         *
+         * @return nlohmann::json
+         */
+        nlohmann::json
+        invertShadow();
+
+        /**
+         * @brief Declare all keys of the current object read.
+         *
+         */
+        void
+        declareFullyRead();
+
+    private:
+        std::shared_ptr< nlohmann::json > m_shadow;
+        nlohmann::json * m_position;
+        bool m_trace = true;
+
+        void
+        invertShadow( nlohmann::json & result, nlohmann::json & shadow );
+
+        TracingJSON(
+            nlohmann::json,
+            std::shared_ptr< nlohmann::json > shadow,
+            nlohmann::json * position,
+            bool trace );
+    };
+
+    template< typename Key >
+    TracingJSON TracingJSON::operator[]( Key && key )
+    {
+        nlohmann::json::const_reference res = nlohmann::json::operator[]( key );
+        // If accessing a leaf in the JSON tree from an object (not an array!)
+        // erase the corresponding key
+        static nlohmann::json nullvalue;
+        nlohmann::json * emplaced = &nullvalue;
+        if( m_trace && this->is_object() )
+        {
+            emplaced = &m_position->operator[]( key );
+        }
+        bool traceFurther = res.is_object();
+        return TracingJSON( res, m_shadow, emplaced, traceFurther );
+    }
+} // namespace auxiliary
+} // namespace openPMD
+
+#endif // openPMD_HAVE_JSON

--- a/include/openPMD/auxiliary/JSON.hpp
+++ b/include/openPMD/auxiliary/JSON.hpp
@@ -109,3 +109,4 @@ namespace auxiliary
     }
 } // namespace auxiliary
 } // namespace openPMD
+

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1183,16 +1183,18 @@ namespace detail
         // TODO if changing TracingJSON to return references upon operator[](),
         // change this to a reference
         auto engineConfig = impl.config( detail::str_engine );
-        if( !engineConfig.is_null() )
+        if( !engineConfig.json().is_null() )
         {
-            m_IO.SetEngine( impl.config( detail::str_type, engineConfig ) );
+            m_IO.SetEngine(
+                impl.config( detail::str_type, engineConfig ).json() );
             // TODO if changing TracingJSON to return references upon
             // operator[](), change this to a reference
             auto params = impl.config( detail::str_params, engineConfig );
             params.declareFullyRead();
-            if( params.is_object() )
+            if( params.json().is_object() )
             {
-                for( auto it = params.begin(); it != params.end(); it++ )
+                for( auto it = params.json().begin(); it != params.json().end();
+                     it++ )
                 {
                     m_IO.SetParameter( it.key(), it.value() );
                     alreadyConfigured.emplace( it.key() );

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -64,26 +64,36 @@ namespace openPMD
 
 ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(
     AbstractIOHandler * handler,
-    MPI_Comm communicator,
-    nlohmann::json cfg )
+    MPI_Comm communicator
+#       if openPMD_HAVE_JSON
+    , nlohmann::json cfg
+#       endif // openPMD_HAVE_JSON
+)
     : AbstractIOHandlerImplCommon( handler )
     , m_comm{ communicator }
     , m_ADIOS{ communicator, ADIOS2_DEBUG_MODE }
 {
+#       if openPMD_HAVE_JSON
     init( std::move( cfg ) );
+#       endif // openPMD_HAVE_JSON
 }
 
 #    endif // openPMD_HAVE_MPI
 
 ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(
-    AbstractIOHandler * handler,
-    nlohmann::json cfg )
+    AbstractIOHandler * handler
+#       if openPMD_HAVE_JSON
+    , nlohmann::json cfg
+#       endif // openPMD_HAVE_JSON
+)
     : AbstractIOHandlerImplCommon( handler ), m_ADIOS{ ADIOS2_DEBUG_MODE }
 {
+#       if openPMD_HAVE_JSON
     init( std::move( cfg ) );
+#       endif // openPMD_HAVE_JSON
 }
 
-
+#       if openPMD_HAVE_JSON
 void
 ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
 {
@@ -92,6 +102,7 @@ ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
         m_config = std::move( cfg[ "adios2" ] );
     }
 }
+#       endif // openPMD_HAVE_JSON
 
 std::future< void > ADIOS2IOHandlerImpl::flush( )
 {
@@ -531,7 +542,9 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2Accesstype( )
     }
 }
 
+#       if openPMD_HAVE_JSON
 nlohmann::json ADIOS2IOHandlerImpl::nullvalue = nlohmann::json();
+#       endif // openPMD_HAVE_JSON
 
 std::string ADIOS2IOHandlerImpl::filePositionToString(
     std::shared_ptr< ADIOS2FilePosition > filepos )
@@ -1155,7 +1168,9 @@ namespace detail
     void
     BufferedActions::configure_IO( ADIOS2IOHandlerImpl & impl )
     {
+        (void)impl;
         std::set< std::string > alreadyConfigured;
+#if openPMD_HAVE_JSON
         auto & engineConfig = impl.config( detail::str_engine );
         if( !engineConfig.is_null() )
         {
@@ -1171,7 +1186,7 @@ namespace detail
             }
             alreadyConfigured.emplace( "Engine" );
         }
-
+#endif // openPMD_HAVE_JSON
         auto notYetConfigured =
             [&alreadyConfigured]( std::string const & param ) {
                 auto it = alreadyConfigured.find( param );
@@ -1379,11 +1394,18 @@ namespace detail
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     openPMD::AccessType at,
-    MPI_Comm comm,
-    nlohmann::json options )
+    MPI_Comm comm
+#   if openPMD_HAVE_JSON
+    , nlohmann::json options
+#   endif
+)
     : AbstractIOHandler( std::move( path ), at, comm )
-    , m_impl{ this, comm, std::move( options )
-
+    , m_impl{
+        this,
+        comm
+#   if openPMD_HAVE_JSON
+        , std::move( options )
+#   endif
     }
 {
 }
@@ -1392,10 +1414,18 @@ ADIOS2IOHandler::ADIOS2IOHandler(
 
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
-    AccessType at,
-    nlohmann::json options )
+    AccessType at
+#   if openPMD_HAVE_JSON
+    , nlohmann::json options
+#   endif
+)
     : AbstractIOHandler( std::move( path ), at )
-    , m_impl{ this, std::move( options ) }
+    , m_impl{
+        this
+#   if openPMD_HAVE_JSON
+        , std::move( options )
+#   endif
+    }
 {
 }
 
@@ -1410,18 +1440,24 @@ std::future< void > ADIOS2IOHandler::flush( )
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     AccessType at,
-    MPI_Comm comm,
-    nlohmann::json )
+    MPI_Comm comm
+#   if openPMD_HAVE_JSON
+    , nlohmann::json
+#   endif
+)
     : AbstractIOHandler( std::move( path ), at, comm )
 {
 }
 
-#    endif
+#endif // openPMD_HAVE_MPI
 
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
-    AccessType at,
-    nlohmann::json )
+    AccessType at
+#if openPMD_HAVE_JSON
+    , nlohmann::json
+#endif
+)
     : AbstractIOHandler( std::move( path ), at )
 {
 }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -749,18 +749,6 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
     return var;
 }
 
-#    if __cplusplus < 201703L
-// https://en.cppreference.com/w/cpp/language/static:
-// If a static data member is declared constexpr, it is implicitly inline and
-// does not need to be redeclared at namespace scope. This redeclaration
-// without an initializer (formerly required as shown above)
-// is still permitted, but is deprecated. (since C++17)
-
-constexpr ADIOS2Defaults::const_str ADIOS2Defaults::str_engine;
-constexpr ADIOS2Defaults::const_str ADIOS2Defaults::str_type;
-constexpr ADIOS2Defaults::const_str ADIOS2Defaults::str_params;
-#    endif
-
 namespace detail
 {
     DatasetReader::DatasetReader( openPMD::ADIOS2IOHandlerImpl * impl )

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1236,15 +1236,11 @@ namespace detail
     {
         (void)impl;
         std::set< std::string > alreadyConfigured;
-        // TODO if changing TracingJSON to return references upon operator[](),
-        // change this to a reference
         auto engineConfig = impl.config( ADIOS2Defaults::str_engine );
         if( !engineConfig.json().is_null() )
         {
             m_IO.SetEngine(
                 impl.config( ADIOS2Defaults::str_type, engineConfig ).json() );
-            // TODO if changing TracingJSON to return references upon
-            // operator[](), change this to a reference
             auto params =
                 impl.config( ADIOS2Defaults::str_params, engineConfig );
             params.declareFullyRead();

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -834,21 +834,20 @@ namespace detail
         throw std::runtime_error( "[ADIOS2] WRITE_DATASET: Invalid datatype." );
     }
 
-    template < typename T >
+    template < typename T, typename... Params >
     void VariableDefiner::
-    operator( )( adios2::IO & IO, const std::string & name,
-                 std::unique_ptr< adios2::Operator > compression,
-                 const adios2::Dims & shape, const adios2::Dims & start,
-                 const adios2::Dims & count, const bool constantDims )
+    operator( )( Params &&... params )
     {
-        DatasetHelper< T >::defineVariable( IO, name, std::move( compression ),
-                                            shape, start, count, constantDims );
+        DatasetHelper< T >::defineVariable(
+            std::forward< Params >( params )... );
     }
 
-    template < int n, typename... Params >
-    void VariableDefiner::operator( )( adios2::IO &, Params &&... )
+    template< int n, typename... Params >
+    void
+    VariableDefiner::operator()( Params &&... )
     {
-        throw std::runtime_error( "[ADIOS2] Defining a variable with undefined type." );
+        throw std::runtime_error(
+            "[ADIOS2] Defining a variable with undefined type." );
     }
 
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -268,7 +268,6 @@ void ADIOS2IOHandlerImpl::createDataset(
 
         auto operators = defaultOperators;
 
-        std::unique_ptr< adios2::Operator > compression;
         if( !parameters.compression.empty() )
         {
             std::unique_ptr< adios2::Operator > adiosOperator =
@@ -1085,7 +1084,7 @@ namespace detail
         defineVariable(
             adios2::IO & IO,
             const std::string & name,
-            std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator >
+            std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator > const &
                 compressions,
             const adios2::Dims & shape,
             const adios2::Dims & start,
@@ -1099,15 +1098,11 @@ namespace detail
             throw std::runtime_error(
                 "[ADIOS2] Internal error: Could not create Variable '" + name + "'." );
         }
-        // check whether the unique_ptr has an element
-        // and whether the held operator is valid
         for( auto const & compression : compressions )
         {
             if( compression.op )
             {
-                var.AddOperation(
-                    std::move( compression.op ),
-                    std::move( compression.params ) );
+                var.AddOperation( compression.op, compression.params );
             }
         }
     }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -127,7 +127,7 @@ ADIOS2IOHandlerImpl::getOperators( auxiliary::TracingJSON cfg )
                  ++paramIterator )
             {
                 adiosParams[ paramIterator.key() ] =
-                    std::string( paramIterator.value() );
+                    paramIterator.value().get< std::string >();
             }
         }
         std::unique_ptr< adios2::Operator > adiosOperator =

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1471,8 +1471,8 @@ ADIOS2IOHandler::ADIOS2IOHandler(
     openPMD::AccessType at,
     MPI_Comm comm,
     nlohmann::json options )
-    : AbstractIOHandler( std::move( path ), at, comm )
-    , m_impl{ this, comm, std::move( options ) }
+    : AbstractIOHandler( std::move( path ), at, comm ),
+      m_impl{ this, comm, std::move( options ) }
 {
 }
 
@@ -1482,8 +1482,8 @@ ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     AccessType at,
     nlohmann::json options )
-    : AbstractIOHandler( std::move( path ), at )
-    , m_impl{ this, std::move( options ) }
+    : AbstractIOHandler( std::move( path ), at ),
+      m_impl{ this, std::move( options ) }
 {
 }
 
@@ -1499,8 +1499,8 @@ ADIOS2IOHandler::flush()
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     AccessType at,
-    MPI_Comm comm
-    , nlohmann::json
+    MPI_Comm comm,
+    nlohmann::json
 )
     : AbstractIOHandler( std::move( path ), at, comm )
 {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -95,6 +95,7 @@ ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
         std::cerr << "Warning: ADIOS2 is not configured in the JSON "
                      "configuration. Running with default settings."
                   << std::endl;
+        return;
     }
 }
 
@@ -684,6 +685,18 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
     return var;
 }
 
+#    if __cplusplus < 201703L
+// https://en.cppreference.com/w/cpp/language/static:
+// If a static data member is declared constexpr, it is implicitly inline and
+// does not need to be redeclared at namespace scope. This redeclaration
+// without an initializer (formerly required as shown above)
+// is still permitted, but is deprecated. (since C++17)
+
+constexpr ADIOS2Defaults::const_str ADIOS2Defaults::str_engine;
+constexpr ADIOS2Defaults::const_str ADIOS2Defaults::str_type;
+constexpr ADIOS2Defaults::const_str ADIOS2Defaults::str_params;
+#    endif
+
 namespace detail
 {
     DatasetReader::DatasetReader( openPMD::ADIOS2IOHandlerImpl * impl )
@@ -1166,14 +1179,15 @@ namespace detail
         std::set< std::string > alreadyConfigured;
         // TODO if changing TracingJSON to return references upon operator[](),
         // change this to a reference
-        auto engineConfig = impl.config( detail::str_engine );
+        auto engineConfig = impl.config( ADIOS2Defaults::str_engine );
         if( !engineConfig.json().is_null() )
         {
             m_IO.SetEngine(
-                impl.config( detail::str_type, engineConfig ).json() );
+                impl.config( ADIOS2Defaults::str_type, engineConfig ).json() );
             // TODO if changing TracingJSON to return references upon
             // operator[](), change this to a reference
-            auto params = impl.config( detail::str_params, engineConfig );
+            auto params =
+                impl.config( ADIOS2Defaults::str_params, engineConfig );
             params.declareFullyRead();
             if( params.json().is_object() )
             {
@@ -1395,7 +1409,7 @@ namespace detail
 
 } // namespace detail
 
-#if openPMD_HAVE_MPI
+#    if openPMD_HAVE_MPI
 
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -19,17 +19,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include "openPMD/IO/AbstractIOHandlerHelper.hpp"
-#include "openPMD/IO/DummyIOHandler.hpp"
+
 #include "openPMD/IO/ADIOS/ADIOS1IOHandler.hpp"
-#include "openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
+#include "openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp"
+#include "openPMD/IO/DummyIOHandler.hpp"
 #include "openPMD/IO/HDF5/HDF5IOHandler.hpp"
 #include "openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp"
 #include "openPMD/IO/JSON/JSONIOHandler.hpp"
-
-#if openPMD_HAVE_JSON
-#   include <nlohmann/json.hpp>
-#endif
+#include <nlohmann/json.hpp>
 
 namespace openPMD
 {
@@ -42,12 +40,7 @@ namespace openPMD
         MPI_Comm comm,
         std::string const & options )
     {
-#   if openPMD_HAVE_JSON
         nlohmann::json optionsJson = nlohmann::json::parse( options );
-#   else
-        if( options.size() > 0u && options != "{}" )
-            throw std::runtime_error("openPMD-api built without JSON support which is required for runtime options!");
-#   endif
         switch( format )
         {
             case Format::HDF5:
@@ -59,16 +52,11 @@ namespace openPMD
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #   endif
             case Format::ADIOS2:
-                return std::make_shared<ADIOS2IOHandler>(
-                    path,
-                    accessTypeBackend,
-                    comm
-#   if openPMD_HAVE_JSON
-                    , std::move(optionsJson)
-#   endif
-                );
+                return std::make_shared< ADIOS2IOHandler >(
+                    path, accessTypeBackend, comm, std::move( optionsJson ) );
             default:
-                throw std::runtime_error("Unknown file format! Did you specify a file ending?" );
+                throw std::runtime_error(
+                    "Unknown file format! Did you specify a file ending?" );
         }
     }
 #endif
@@ -79,12 +67,7 @@ namespace openPMD
         Format format,
         std::string const & options )
     {
-#if openPMD_HAVE_JSON
         nlohmann::json optionsJson = nlohmann::json::parse( options );
-#else
-        if( options.size() > 0u && options != "{}" )
-            throw std::runtime_error("openPMD-api built without JSON support which is required for runtime options!");
-#endif
         switch( format )
         {
             case Format::HDF5:
@@ -96,19 +79,15 @@ namespace openPMD
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #endif
 #if openPMD_HAVE_ADIOS2
-        case Format::ADIOS2:
-            return std::make_shared< ADIOS2IOHandler >(
-                path,
-                accessType
-#   if openPMD_HAVE_JSON
-                , std::move( optionsJson )
-#   endif // openPMD_HAVE_JSON
-            );
+            case Format::ADIOS2:
+                return std::make_shared< ADIOS2IOHandler >(
+                    path, accessType, std::move( optionsJson ) );
 #endif // openPMD_HAVE_ADIOS2
             case Format::JSON:
-                return std::make_shared< JSONIOHandler >(path, accessType);
+                return std::make_shared< JSONIOHandler >( path, accessType );
             default:
-                throw std::runtime_error("Unknown file format! Did you specify a file ending?" );
+                throw std::runtime_error(
+                    "Unknown file format! Did you specify a file ending?" );
         }
     }
-} // openPMD
+    } // namespace openPMD

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -27,6 +27,7 @@
 #include "openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp"
 #include "openPMD/IO/JSON/JSONIOHandler.hpp"
 
+#include <nlohmann/json.hpp>
 
 namespace openPMD
 {
@@ -36,9 +37,10 @@ namespace openPMD
         std::string path,
         AccessType accessTypeBackend,
         Format format,
-        MPI_Comm comm
-    )
+        MPI_Comm comm,
+        std::string const & options )
     {
+        nlohmann::json optionsJson = nlohmann::json::parse( options );
         switch( format )
         {
             case Format::HDF5:
@@ -60,9 +62,10 @@ namespace openPMD
     createIOHandler(
         std::string path,
         AccessType accessType,
-        Format format
-    )
+        Format format,
+        std::string const & options )
     {
+        nlohmann::json optionsJson = nlohmann::json::parse( options );
         switch( format )
         {
             case Format::HDF5:

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -52,7 +52,7 @@ namespace openPMD
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #   endif
             case Format::ADIOS2:
-                return std::make_shared<ADIOS2IOHandler>(path, accessTypeBackend, comm);
+                return std::make_shared<ADIOS2IOHandler>(path, accessTypeBackend, comm, std::move(optionsJson));
             default:
                 throw std::runtime_error("Unknown file format! Did you specify a file ending?" );
         }
@@ -77,8 +77,9 @@ namespace openPMD
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #endif
 #if openPMD_HAVE_ADIOS2
-            case Format::ADIOS2:
-                return std::make_shared<ADIOS2IOHandler>(path, accessType);
+        case Format::ADIOS2:
+            return std::make_shared< ADIOS2IOHandler >(
+                path, accessType, std::move( optionsJson ) );
 #endif
             case Format::JSON:
                 return std::make_shared< JSONIOHandler >(path, accessType);

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -81,25 +81,30 @@ struct Series::ParsedInput
 };  //ParsedInput
 
 #if openPMD_HAVE_MPI
-Series::Series(std::string const& filepath,
-               AccessType at,
-               MPI_Comm comm)
-        : iterations{Container< Iteration, uint64_t >()},
-          m_iterationEncoding{std::make_shared< IterationEncoding >()}
+Series::Series(
+    std::string const & filepath,
+    AccessType at,
+    MPI_Comm comm,
+    std::string const & options )
+    : iterations{ Container< Iteration, uint64_t >() }
+    , m_iterationEncoding{ std::make_shared< IterationEncoding >() }
 {
-    auto input = parseInput(filepath);
-    auto handler = createIOHandler(input->path, at, input->format, comm);
-    init(handler, std::move(input));
+    auto input = parseInput( filepath );
+    auto handler =
+        createIOHandler( input->path, at, input->format, comm, options );
+    init( handler, std::move( input ) );
 }
 #endif
 
-Series::Series(std::string const& filepath,
-               AccessType at)
-        : iterations{Container< Iteration, uint64_t >()},
-          m_iterationEncoding{std::make_shared< IterationEncoding >()}
+Series::Series(
+    std::string const & filepath,
+    AccessType at,
+    std::string const & options )
+    : iterations{ Container< Iteration, uint64_t >() }
+    , m_iterationEncoding{ std::make_shared< IterationEncoding >() }
 {
-    auto input = parseInput(filepath);
-    auto handler = createIOHandler(input->path, at, input->format);
+    auto input = parseInput( filepath );
+    auto handler = createIOHandler( input->path, at, input->format, options );
     init(handler, std::move(input));
 }
 

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -13,23 +13,25 @@ namespace auxiliary
     }
 
     TracingJSON::TracingJSON( nlohmann::json json )
-        : nlohmann::json( std::move( json ) )
+        : m_originalJSON(
+              std::make_shared< nlohmann::json >( std::move( json ) ) )
         , m_shadow( std::make_shared< nlohmann::json >() )
-        , m_position( &*m_shadow )
+        , m_positionInOriginal( &*m_originalJSON )
+        , m_positionInShadow( &*m_shadow )
     {
     }
 
     nlohmann::json const &
     TracingJSON::getShadow()
     {
-        return *m_position;
+        return *m_positionInShadow;
     }
 
     nlohmann::json
     TracingJSON::invertShadow()
     {
-        nlohmann::json inverted = *this;
-        invertShadow( inverted, *m_position );
+        nlohmann::json inverted = *m_positionInOriginal;
+        invertShadow( inverted, *m_positionInShadow );
         return inverted;
     }
 
@@ -70,18 +72,21 @@ namespace auxiliary
     {
         if( m_trace )
         {
-            *m_position = *this;
+            // copy over
+            *m_positionInShadow = *m_positionInOriginal;
         }
     }
 
     TracingJSON::TracingJSON(
-        nlohmann::json json,
+        std::shared_ptr< nlohmann::json > originalJSON,
         std::shared_ptr< nlohmann::json > shadow,
-        nlohmann::json * position,
+        nlohmann::json * positionInOriginal,
+        nlohmann::json * positionInShadow,
         bool trace )
-        : nlohmann::json( json )
+        : m_originalJSON( std::move( originalJSON ) )
         , m_shadow( std::move( shadow ) )
-        , m_position( position )
+        , m_positionInOriginal( positionInOriginal )
+        , m_positionInShadow( positionInShadow )
         , m_trace( trace )
     {
     }

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -12,9 +12,9 @@ namespace auxiliary
     {
     }
 
-    TracingJSON::TracingJSON( nlohmann::json json )
+    TracingJSON::TracingJSON( nlohmann::json originalJSON )
         : m_originalJSON(
-              std::make_shared< nlohmann::json >( std::move( json ) ) )
+              std::make_shared< nlohmann::json >( std::move( originalJSON ) ) )
         , m_shadow( std::make_shared< nlohmann::json >() )
         , m_positionInOriginal( &*m_originalJSON )
         , m_positionInShadow( &*m_shadow )

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -1,0 +1,91 @@
+#include "openPMD/config.hpp"
+#if openPMD_HAVE_JSON
+#    include <vector>
+
+#    include "openPMD/auxiliary/JSON.hpp"
+
+namespace openPMD
+{
+namespace auxiliary
+{
+    TracingJSON::TracingJSON() : TracingJSON( nlohmann::json() )
+    {
+    }
+
+    TracingJSON::TracingJSON( nlohmann::json json )
+        : nlohmann::json( std::move( json ) )
+        , m_shadow( std::make_shared< nlohmann::json >() )
+        , m_position( &*m_shadow )
+    {
+    }
+
+    nlohmann::json const &
+    TracingJSON::getShadow()
+    {
+        return *m_position;
+    }
+
+    nlohmann::json
+    TracingJSON::invertShadow()
+    {
+        nlohmann::json inverted = *this;
+        invertShadow( inverted, *m_position );
+        return inverted;
+    }
+
+    void
+    TracingJSON::invertShadow(
+        nlohmann::json & result,
+        nlohmann::json & shadow )
+    {
+        if( !shadow.is_object() )
+        {
+            return;
+        }
+        std::vector< std::string > toRemove;
+        for( auto it = shadow.begin(); it != shadow.end(); ++it )
+        {
+            nlohmann::json & partialResult = result[ it.key() ];
+            if( partialResult.is_object() )
+            {
+                invertShadow( partialResult, it.value() );
+                if( partialResult.size() == 0 )
+                {
+                    toRemove.emplace_back( it.key() );
+                }
+            }
+            else
+            {
+                toRemove.emplace_back( it.key() );
+            }
+        }
+        for( auto const & key : toRemove )
+        {
+            result.erase( key );
+        }
+    }
+
+    void
+    TracingJSON::declareFullyRead()
+    {
+        if( m_trace )
+        {
+            *m_position = *this;
+        }
+    }
+
+    TracingJSON::TracingJSON(
+        nlohmann::json json,
+        std::shared_ptr< nlohmann::json > shadow,
+        nlohmann::json * position,
+        bool trace )
+        : nlohmann::json( json )
+        , m_shadow( std::move( shadow ) )
+        , m_position( position )
+        , m_trace( trace )
+    {
+    }
+} // namespace auxiliary
+} // namespace openPMD
+
+#endif

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -1,8 +1,8 @@
-#include "openPMD/config.hpp"
-#if openPMD_HAVE_JSON
-#    include <vector>
+#include "openPMD/auxiliary/JSON.hpp"
 
-#    include "openPMD/auxiliary/JSON.hpp"
+#include <vector>
+
+#include "openPMD/config.hpp"
 
 namespace openPMD
 {
@@ -92,5 +92,3 @@ namespace auxiliary
     }
 } // namespace auxiliary
 } // namespace openPMD
-
-#endif

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -1,8 +1,29 @@
+/* Copyright 2020 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "openPMD/auxiliary/JSON.hpp"
 
-#include <vector>
-
 #include "openPMD/config.hpp"
+
+#include <vector>
 
 namespace openPMD
 {
@@ -14,10 +35,10 @@ namespace auxiliary
 
     TracingJSON::TracingJSON( nlohmann::json originalJSON )
         : m_originalJSON(
-              std::make_shared< nlohmann::json >( std::move( originalJSON ) ) )
-        , m_shadow( std::make_shared< nlohmann::json >() )
-        , m_positionInOriginal( &*m_originalJSON )
-        , m_positionInShadow( &*m_shadow )
+              std::make_shared< nlohmann::json >( std::move( originalJSON ) ) ),
+          m_shadow( std::make_shared< nlohmann::json >() ),
+          m_positionInOriginal( &*m_originalJSON ),
+          m_positionInShadow( &*m_shadow )
     {
     }
 
@@ -38,7 +59,7 @@ namespace auxiliary
     void
     TracingJSON::invertShadow(
         nlohmann::json & result,
-        nlohmann::json & shadow )
+        nlohmann::json const & shadow )
     {
         if( !shadow.is_object() )
         {
@@ -83,11 +104,11 @@ namespace auxiliary
         nlohmann::json * positionInOriginal,
         nlohmann::json * positionInShadow,
         bool trace )
-        : m_originalJSON( std::move( originalJSON ) )
-        , m_shadow( std::move( shadow ) )
-        , m_positionInOriginal( positionInOriginal )
-        , m_positionInShadow( positionInShadow )
-        , m_trace( trace )
+        : m_originalJSON( std::move( originalJSON ) ),
+          m_shadow( std::move( shadow ) ),
+          m_positionInOriginal( positionInOriginal ),
+          m_positionInShadow( positionInShadow ),
+          m_trace( trace )
     {
     }
 } // namespace auxiliary

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -57,10 +57,14 @@ using namespace openPMD;
 void init_Series(py::module &m) {
     py::class_<Series, Attributable>(m, "Series")
 
-        .def(py::init<std::string const&, AccessType>(),
-            py::arg("filepath"), py::arg("access_type"))
+        .def(py::init<std::string const&, AccessType, std::string const &>(),
+            py::arg("filepath"), py::arg("access_type"), py::arg("options") = "{}")
 #if openPMD_HAVE_MPI
-        .def(py::init([](std::string const& filepath, AccessType at, py::object &comm){
+        .def(py::init([](
+                std::string const& filepath,
+                AccessType at,
+                py::object &comm,
+                std::string const& options){
             //! @todo perform mpi4py import test and check min-version
             //!       careful: double MPI_Init risk? only import mpi4py.MPI?
             //!       required C-API init? probably just checks:
@@ -106,9 +110,12 @@ void init_Series(py::module &m) {
                                          "(Mismatched MPI at compile vs. runtime?)");
             }
 
-            return new Series(filepath, at, *mpiCommPtr);
+            return new Series(filepath, at, *mpiCommPtr, options);
         }),
-            py::arg("filepath"), py::arg("access_type"), py::arg("mpi_communicator")
+            py::arg("filepath"),
+            py::arg("access_type"),
+            py::arg("mpi_communicator"),
+            py::arg("options") = "{}"
         )
 #endif
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3,23 +3,23 @@
 #   define OPENPMD_private public
 #   define OPENPMD_protected public
 #endif
-#include "openPMD/openPMD.hpp"
-#include "openPMD/auxiliary/Filesystem.hpp"
-
-#include <catch2/catch.hpp>
-
-#include <iostream>
 #include <algorithm>
-#include <sstream>
-#include <string>
-#include <vector>
 #include <array>
 #include <cmath>
-#include <memory>
+#include <iostream>
 #include <limits>
 #include <list>
+#include <memory>
 #include <numeric>
+#include <sstream>
+#include <string>
 #include <tuple>
+#include <vector>
+
+#include "openPMD/auxiliary/Filesystem.hpp"
+#include "openPMD/auxiliary/Environment.hpp"
+#include "openPMD/openPMD.hpp"
+#include <catch2/catch.hpp>
 
 using namespace openPMD;
 
@@ -2323,6 +2323,11 @@ TEST_CASE( "no_serial_adios1", "[serial][adios]")
 #if openPMD_HAVE_ADIOS2
 TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
 {
+    if( auxiliary::getEnvString( "OPENPMD_BP_BACKEND", "NOT_SET" ) == "ADIOS1" )
+    {
+        // run this test for ADIOS2 only
+        return;
+    }
     std::string writeConfigBP3 = R"END(
 {
   "adios2": {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3,6 +3,13 @@
 #   define OPENPMD_private public
 #   define OPENPMD_protected public
 #endif
+
+#include "openPMD/auxiliary/Environment.hpp"
+#include "openPMD/auxiliary/Filesystem.hpp"
+#include "openPMD/openPMD.hpp"
+
+#include <catch2/catch.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -15,11 +22,6 @@
 #include <string>
 #include <tuple>
 #include <vector>
-
-#include "openPMD/auxiliary/Filesystem.hpp"
-#include "openPMD/auxiliary/Environment.hpp"
-#include "openPMD/openPMD.hpp"
-#include <catch2/catch.hpp>
 
 using namespace openPMD;
 
@@ -2380,7 +2382,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
   }
 }
 )END";
-    auto write = []( std::string const & filename,
+    auto const write = []( std::string const & filename,
                      std::string const & config ) {
         openPMD::Series series( filename, openPMD::AccessType::CREATE, config );
         auto E_x = series.iterations[ 0 ].meshes[ "E" ][ "x" ];
@@ -2419,7 +2421,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
   }
 }
 )END";
-    auto read = []( std::string const & filename, std::string const & config ) {
+    auto const read = []( std::string const & filename, std::string const & config ) {
         openPMD::Series series(
             filename, openPMD::AccessType::READ_ONLY, config );
         auto E_x = series.iterations[ 0 ].meshes[ "E" ][ "x" ];

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2337,7 +2337,13 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
     "unused": "as well",
     "dataset": {
       "operators": [
-        { "type": "BZip2" }
+        {
+          "type": "blosc",
+          "parameters": {
+              "clevel": "1",
+              "doshuffle": "BLOSC_BITSHUFFLE"
+          }
+        }
       ]
     }
   }
@@ -2357,7 +2363,13 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
     "unused": "as well",
     "dataset": {
       "operators": [
-        { "type": "BZip2" }
+        {
+          "type": "blosc",
+          "parameters": {
+              "clevel": "1",
+              "doshuffle": "BLOSC_BITSHUFFLE"
+          }
+        }
       ]
     }
   }


### PR DESCRIPTION
This PR adds backend-specific configuration options. Close #150. The configuration is passed as an optional string parameter in JSON format to the constructor of `openPMD::Series`.
The top-level JSON maps backends to the corresponding backend's configuration. This allows to configure several backends at once.

At the moment, only the ADIOS2 backend has been made aware of this. A possible configuration looks like this:
```cpp
std::string options = R"(
{
  "adios2": {
    "engine": {
      "type": "sst",
      "parameters": ["BufferGrowthFactor": "2.0", "QueueLimit": "2"]
    }
  }
}
)";
```
TODO:


- [x] Safety measure: Warn upon reading an unexpected key.
- [x] Add Python bindings
- [x] Code cleanup
- [x] Add user documentation, e.g. in `docs/source/backends/adios2.rst`

Probably follow-up for a later PR:

- [ ] Implement the suggestions in issue #688 
- [ ] Further configuration options in ADIOS2, e.g. switching on and off debug mode at runtime.
- [ ] Implement option reading in other backends
- [ ] What about case insensitivity? Should the JSON keys that are read by the openPMD API and not directly passed through to the backend (such as the ADIOS2 "parameters" list) be made case insensitive?
- [ ] Override choice of backend from JSON. Choosing the backend by filename extension is simple, yet inflexible if one backend has several possible extensions (ADIOS2) or two backens share an extension (ADIOS in versions 1 and 2). Just overwrite setting introduced in #568