### PR TITLE
CLI Tools: openpmd-ls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Features
 - ``Series::setSoftware()`` add second argument for version #657
 - free standing functions to query the API version and feature variants at runtime #665
 - expose ``determineFormat`` and ``suffix`` functions #684
+- CLI: add ``openpmd-ls`` tool #574
 
 Bug Fixes
 """""""""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,8 @@ mark_as_advanced(BUILD_SHARED_LIBS)
 include(CTest)
 # automatically defines: BUILD_TESTING, default is ON
 
-option(BUILD_EXAMPLES "Build the examples" ON)
+option(BUILD_CLI_TOOLS "Build the command line tools" ON)
+option(BUILD_EXAMPLES  "Build the examples" ON)
 
 
 # Dependencies ################################################################
@@ -312,7 +313,8 @@ set(CORE_SOURCE
         src/backend/PatchRecord.cpp
         src/backend/PatchRecordComponent.cpp
         src/backend/Writable.cpp
-        src/benchmark/mpi/OneDimensionalBlockSlicer.cpp)
+        src/benchmark/mpi/OneDimensionalBlockSlicer.cpp
+        src/helper/list_series.cpp)
 set(IO_SOURCE
         src/IO/AbstractIOHandlerHelper.cpp
         src/IO/DummyIOHandler.cpp
@@ -525,6 +527,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/Container.cpp
         src/binding/python/Dataset.cpp
         src/binding/python/Datatype.cpp
+        src/binding/python/Helper.cpp
         src/binding/python/Iteration.cpp
         src/binding/python/IterationEncoding.cpp
         src/binding/python/Mesh.cpp
@@ -588,6 +591,10 @@ set(openPMD_TEST_NAMES
     SerialIO
     ParallelIO
 )
+# command line tools
+set(openPMD_CLI_TOOL_NAMES
+    ls
+)
 # examples
 set(openPMD_EXAMPLE_NAMES
     1_structure
@@ -650,6 +657,13 @@ if(BUILD_TESTING)
         else()
             target_link_libraries(${testname}Tests PRIVATE CatchMain)
         endif()
+    endforeach()
+endif()
+
+if(BUILD_CLI_TOOLS)
+    foreach(toolname ${openPMD_CLI_TOOL_NAMES})
+        add_executable(openpmd-${toolname} src/cli/${toolname}.cpp)
+        target_link_libraries(openpmd-${toolname} PRIVATE openPMD)
     endforeach()
 endif()
 
@@ -759,6 +773,12 @@ set(openPMD_INSTALL_TARGET_NAMES openPMD)
 if(openPMD_HAVE_ADIOS1)
     list(APPEND openPMD_INSTALL_TARGET_NAMES
         openPMD.ADIOS1.Serial openPMD.ADIOS1.Parallel)
+endif()
+
+if(BUILD_CLI_TOOLS)
+    foreach(toolname ${openPMD_CLI_TOOL_NAMES})
+        list(APPEND openPMD_INSTALL_TARGET_NAMES openpmd-${toolname})
+    endforeach()
 endif()
 
 install(TARGETS ${openPMD_INSTALL_TARGET_NAMES}
@@ -916,6 +936,25 @@ if(BUILD_EXAMPLES)
         else()
             message(STATUS "Note: Skipping C++ example tests (missing example files)")
         endif()
+    endif()
+endif()
+
+# Command Line Tools ##################################################
+#
+if(BUILD_CLI_TOOLS)
+    # all tools must provide a "--help"
+    foreach(toolname ${openPMD_CLI_TOOL_NAMES})
+        list(APPEND openPMD_INSTALL_TARGET_NAMES openpmd-${toolname})
+        add_test(NAME CLI.help.${toolname}
+            COMMAND openpmd-${toolname} --help
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
+    endforeach()
+    if(openPMD_HAVE_HDF5 AND EXISTS "${openPMD_BINARY_DIR}/samples/git-sample/")
+        add_test(NAME CLI.ls
+            COMMAND openpmd-ls ../samples/git-sample/data%08T.h5
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
     endif()
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,6 +139,7 @@ RUN        ls -hal /usr/local/lib/python3.7/dist-packages/
 # RUN        objdump -x /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so | grep RPATH
 RUN        ldd /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so
 RUN        python3 -c "import openpmd_api as api; print(api.__version__); print(api.variants)"
+#RUN        openpmd-ls --help
 #RUN        echo "* soft core 100000" >> /etc/security/limits.conf && \
 #           python3 -c "import openpmd_api as api;"; \
 #           gdb -ex bt -c core
@@ -167,6 +168,7 @@ RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp36-cp36m-manylinux2010_x86_64.whl
 RUN        python3 -c "import openpmd_api as api; print(api.__version__); print(api.variants)"
+#RUN        openpmd-ls --help
 
 # test in fresh env: Debian:Stretch + Python 3.5
 FROM       debian:stretch
@@ -179,6 +181,7 @@ RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp35-cp35m-manylinux2010_x86_64.whl
 RUN        python3 -c "import openpmd_api as api; print(api.__version__); print(api.variants)"
+#RUN        openpmd-ls --help
 
 
 # copy binary artifacts (wheels)

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ You can only build a static or a shared library at a time.
 By default, the `Release` version is built.
 In order to build with debug symbols, pass `-DCMAKE_BUILD_TYPE=Debug` to your `cmake` command.
 
-By default, tests and examples are built.
-In order to skip building those, pass `-DBUILD_TESTING=OFF` or `-DBUILD_EXAMPLES=OFF` to your `cmake` command.
+By default, tests, examples and command line tools are built.
+In order to skip building those, pass `-DBUILD_TESTING=OFF`, `-DBUILD_EXAMPLES=OFF`, or `-DBUILD_CLI_TOOLS=OFF` to your `cmake` command.
 
 ## Linking to your project
 

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -75,8 +75,8 @@ CMake Option                      Values      Installs Library       Version
 ================================= =========== ======== ============= ========
 
 
-Tests
------
+Tests, Examples and Command Line Tools
+--------------------------------------
 
-By default, tests and examples are built.
-In order to skip building those, pass ``-DBUILD_TESTING=OFF`` or ``-DBUILD_EXAMPLES=OFF`` to your ``cmake`` command.
+By default, tests, examples and command line tools are built.
+In order to skip building those, pass ``-DBUILD_TESTING=OFF``, ``-DBUILD_EXAMPLES=OFF``, or ``-DBUILD_CLI_TOOLS=OFF`` to your ``cmake`` command.

--- a/docs/source/dev/repostructure.rst
+++ b/docs/source/dev/repostructure.rst
@@ -19,9 +19,21 @@ Directory Structure
   * set ``-I`` here
   * prefixed with project name
 
+  * ``auxiliary/``
+
+    * internal auxiliary functionality
+
+  * ``helper/``, ``benchmark/``
+
+    * user-facing helper functionality
+
 * ``src/``
 
   * C++ source files
+
+  * ``cli/``
+
+    * user-facing command line tools
 
 * ``lib/``
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,7 +91,8 @@ Utilities
    :maxdepth: 1
    :hidden:
 
-   utilities/benchmark.rst
+   utilities/cli
+   utilities/benchmark
 
 Backends
 --------

--- a/docs/source/utilities/cli.rst
+++ b/docs/source/utilities/cli.rst
@@ -1,0 +1,14 @@
+.. _utilities-cli:
+
+Command Line Tools
+==================
+
+openPMD-api installs command line tools alongside the main library.
+These terminal-focused tools help to quickly explore, manage or manipulate openPMD data series.
+
+``openpmd-ls``
+--------------
+
+List information about an openPMD data series.
+See ``openpmd-ls --help`` for help.
+

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -227,9 +227,10 @@ public:
     Series& setIterationFormat(std::string const& iterationFormat);
 
     /**
-     * @return  String of a pattern for file names.
+     * @return String of a pattern for file names.
      */
     std::string name() const;
+
     /** Set the pattern for file names.
      *
      * @param   name    String of the pattern for file names. Must include iteration regex <CODE>\%T</CODE> for fileBased data.
@@ -237,7 +238,12 @@ public:
      */
     Series& setName(std::string const& name);
 
-    /** The currently used backend */
+    /** The currently used backend
+     *
+     * @see AbstractIOHandler::backendName()
+     *
+     * @return String of a pattern for data backend.
+     */
     std::string backend() const;
 
     /** Execute all required remaining IO operations to write or read data.

--- a/include/openPMD/helper/list_series.hpp
+++ b/include/openPMD/helper/list_series.hpp
@@ -1,0 +1,47 @@
+/* Copyright 2019-2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "openPMD/Series.hpp"
+
+#include <ostream>
+#include <iostream>
+
+
+namespace openPMD
+{
+namespace helper
+{
+    /** List information about an openPMD data series
+     *
+     * @param series a openPMD data path as in Series::Series
+     * @param longer write more information
+     * @param out    an output stream to write textual information to
+     * @return reference to out as output stream, e.g. to pass the stream on via `operator<<`
+     */
+    std::ostream &
+    listSeries(
+        Series const & series,
+        bool const longer = false,
+        std::ostream & out = std::cout
+    );
+} // helper
+} // openPMD

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -56,6 +56,8 @@ namespace openPMD {}
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 
+#include "openPMD/helper/list_series.hpp"
+
 #include "openPMD/config.hpp"
 #include "openPMD/version.hpp"
 // IWYU pragma: end_exports

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ class CMakeBuild(build_ext):
 
         cmake_args = [
             '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+            # '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=' + extdir,
+            '-DBUILD_CLI_TOOLS:BOOL=OFF',  # TODO: how to install properly?
             '-DCMAKE_PYTHON_OUTPUT_DIRECTORY=' + extdir,
             '-DPYTHON_EXECUTABLE=' + sys.executable,
             # variants
@@ -80,6 +82,11 @@ class CMakeBuild(build_ext):
                     cfg.upper(),
                     extdir
                 )
+                # TODO: how to install properly?
+                # '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{}={}'.format(
+                #     cfg.upper(),
+                #     extdir
+                # )
             ]
             if sys.maxsize > 2**32:
                 cmake_args += ['-A', 'x64']
@@ -156,6 +163,7 @@ setup(
     },
     ext_modules=[CMakeExtension('openpmd_api')],
     cmdclass=dict(build_ext=CMakeBuild),
+    # scripts=['openpmd-ls'],
     zip_safe=False,
     python_requires='>=3.5, <3.9',
     # tests_require=['pytest'],

--- a/src/binding/python/Helper.cpp
+++ b/src/binding/python/Helper.cpp
@@ -1,0 +1,44 @@
+/* Copyright 2019-2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "openPMD/helper/list_series.hpp"
+#include "openPMD/Series.hpp"
+
+#include <sstream>
+
+
+namespace py = pybind11;
+using namespace openPMD;
+
+void init_Helper(py::module &m) {
+    m.def("list_series",
+        [](Series const & series, bool const longer) {
+            std::stringstream s;
+            helper::listSeries( series, longer, s );
+            py::print(s.str());
+        },
+        py::arg("series"),
+        py::arg_v("longer", false, "Print more verbose output."),
+        "List information about an openPMD data series"
+    );
+}

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -39,6 +39,7 @@ void init_BaseRecordComponent(py::module &);
 void init_Container(py::module &);
 void init_Dataset(py::module &);
 void init_Datatype(py::module &);
+void init_Helper(py::module &);
 void init_Iteration(py::module &);
 void init_IterationEncoding(py::module &);
 void init_Mesh(py::module &);
@@ -54,7 +55,33 @@ void init_UnitDimension(py::module &);
 
 
 PYBIND11_MODULE(openpmd_api, m) {
-    // m.doc() = ...;
+    m.doc() = R"pbdoc(
+            openPMD-api
+            -----------
+            .. currentmodule:: openpmd_api
+
+            .. autosummary::
+               :toctree: _generate
+               Access_Type
+               Attributable
+               Container
+               Dataset
+               Datatype
+               determine_datatype
+               Iteration
+               Iteration_Encoding
+               Mesh
+               Base_Record_Component
+               Record_Component
+               Mesh_Record_Component
+               Particle_Patches
+               Patch_Record
+               Patch_Record_Component
+               Particle_Species
+               Record
+               Series
+               list_series
+    )pbdoc";
 
     // note: order from parent to child classes
     init_AccessType(m);
@@ -64,6 +91,7 @@ PYBIND11_MODULE(openpmd_api, m) {
     init_BaseRecord(m);
     init_Dataset(m);
     init_Datatype(m);
+    init_Helper(m);
     init_Iteration(m);
     init_IterationEncoding(m);
     init_Mesh(m);

--- a/src/cli/ls.cpp
+++ b/src/cli/ls.cpp
@@ -1,0 +1,82 @@
+/* Copyright 2019-2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openPMD/openPMD.hpp"
+
+#include <iostream>
+#include <string>
+#include <exception>
+
+
+inline void
+print_help( std::string const program_name )
+{
+    std::cout << "Usage: " << program_name << " openPMD-series\n";
+    std::cout << "List information about an openPMD data series.\n\n";
+    std::cout << "Options:\n    -h, --help    display this help and exit\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "    " << program_name << " ./samples/git-sample/data%T.h5\n";
+    std::cout << "    " << program_name << " ./samples/git-sample/data%08T.h5\n";
+    std::cout << "    " << program_name << " ./samples/serial_write.json\n";
+    std::cout << "    " << program_name << " ./samples/serial_patch.bp\n";
+}
+
+int main(
+    int argc,
+    char * argv[]
+)
+{
+    using namespace openPMD;
+
+    if( argc < 2 )
+    {
+        print_help( argv[0] );
+        return 0;
+    }
+    if( std::string("--help") == argv[1] || std::string("-h") == argv[1] )
+    {
+        print_help( argv[0] );
+        return 0;
+    }
+    if( argc > 2 )
+    {
+        std::cerr << "Too many arguments! See: " << argv[0] << " --help\n";
+        return 1;
+    }
+
+    try
+    {
+        auto s = Series(
+                argv[1],
+                AccessType::READ_ONLY
+        );
+
+        helper::listSeries(s, true, std::cout);
+    }
+    catch( std::exception const  & e )
+    {
+        std::cerr << "An error occurred while opening the specified openPMD series!\n";
+        std::cerr << e.what() << std::endl;
+        return 2;
+    }
+
+    return 0;
+}

--- a/src/helper/list_series.cpp
+++ b/src/helper/list_series.cpp
@@ -1,0 +1,126 @@
+/* Copyright 2019-2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openPMD/helper/list_series.hpp"
+
+#include "openPMD/Iteration.hpp"
+#include "openPMD/Mesh.hpp"
+#include "openPMD/ParticleSpecies.hpp"
+
+#include <utility>
+#include <iterator>
+#include <set>
+#include <string>
+
+
+namespace openPMD
+{
+namespace helper
+{
+    std::ostream &
+    listSeries(
+        Series const & series,
+        bool const longer,
+        std::ostream & out
+    )
+    {
+        out << "openPMD series: " << series.name() << "\n";
+        out << "openPMD standard: " << series.openPMD() << "\n";
+        out << "openPMD extensions: " << series.openPMDextension() << "\n\n";  //! @todo improve listing of extensions
+
+        if( longer )
+        {
+            out << "data author: ";
+            try{ out << series.author() << "\n"; } catch( no_such_attribute_error const & e ) { out << "unknown\n"; }
+            out << "data created: ";
+            try{ out << series.date() << "\n"; } catch( no_such_attribute_error const & e ) { out << "unknown\n"; }
+            out << "data backend: " << series.backend() << "\n";
+            out << "generating machine: ";
+            try{ out << series.machine() << "\n"; } catch( no_such_attribute_error const & e ) { out << "unknown\n"; }
+            out << "generating software: ";
+            try{ out << series.software(); } catch( no_such_attribute_error const & e ) { out << "unknown"; }
+            out <<  " (version: ";
+            try{ out << series.softwareVersion() << ")\n"; } catch( no_such_attribute_error const & e ) { out << "unknown)\n"; }
+            out << "generating software dependencies: ";
+            try{ out << series.softwareDependencies() << "\n"; } catch( no_such_attribute_error const & e ) { out << "unknown\n"; }
+
+            out << "\n";
+        }
+
+        std::set< std::string > meshes;     //! unique mesh names in all iterations
+        std::set< std::string > particles;  //! unique particle species names in all iterations
+
+        out << "number of iterations: " << series.iterations.size();
+        if( longer )
+            out << " (" << series.iterationEncoding() << ")";
+        out << "\n";
+        if( series.iterations.size() > 0u  )
+        {
+            if( longer )
+                out << "  all iterations: ";
+
+            for( auto const& i : series.iterations ) {
+                if( longer )
+                    out << i.first << " ";
+
+                // find unique record names
+                std::transform(
+                    i.second.meshes.begin(),
+                    i.second.meshes.end(),
+                    std::inserter( meshes, meshes.end() ),
+                    []( std::pair< std::string, Mesh > const & p )
+                        { return p.first; }
+                );
+                std::transform(
+                    i.second.particles.begin(),
+                    i.second.particles.end(),
+                    std::inserter( particles, particles.end() ),
+                    []( std::pair< std::string, ParticleSpecies > const & p )
+                        { return p.first; }
+                );
+            }
+
+            if( longer )
+                out << "\n";
+        }
+
+        out << "\n";
+        out << "number of meshes: " << meshes.size() << "\n";
+        if( longer && meshes.size() > 0u )
+        {
+            out << "  all meshes:\n";
+            for( auto const& m : meshes )
+                out << "    " << m << "\n";
+        }
+
+        out << "\n";
+        out << "number of particle species: " << particles.size() << "\n";
+        if( longer && particles.size() > 0u )
+        {
+            out << "  all particle species:\n";
+            for( auto const& p : particles )
+                out << "    " << p << "\n";
+        }
+
+        return out;
+    }
+} // helper
+} // openPMD

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -526,13 +526,25 @@ class APITest(unittest.TestCase):
             )
 
     def testLoadSeries(self):
-        """ Test loading a pmd series from hdf5."""
+        """ Test loading an openPMD series from hdf5."""
 
         # Get series.
         series = self.__series
         self.assertIsInstance(series, api.Series)
 
         self.assertEqual(series.openPMD, "1.1.0")
+
+    def testListSeries(self):
+        """ Test print()-ing and openPMD series from hdf5."""
+
+        # Get series.
+        series = self.__series
+        self.assertRaises(TypeError, api.list_series)
+        api.list_series(series)
+        api.list_series(series, False)
+        api.list_series(series, True)
+
+        print(api.list_series.__doc__)
 
     def testSliceRead(self):
         """ Testing sliced read on record components. """


### PR DESCRIPTION
Start adding command line interface (CLI) tools.

The first tool is `openpmd-ls`, which has the same function as `ls` but specific for querying an openPMD data series. Close #571

CLI argument parsing and tool functionality will be improved in the future with auxiliary libraries such as [these](https://gist.github.com/ax3l/b4ae0d439c8503cfc08b9c04d65f1327#cli).

### Usage so far

```command
$ bin/openpmd-ls ./samples/git-sample/data%08T.h5
openPMD series: data%08T
openPMD standard: 1.1.0
openPMD extensions: 1

data author: unknown
data created: 2018-02-06 09:52:07 -0800
data backend: HDF5
generating machine: unknown
generating software: warp (version: 4)
generating software dependencies: unknown

number of iterations: 5 (fileBased)
  all iterations: 100 200 300 400 500 

number of meshes: 2
  all meshes:
    rho
    E

number of particle species: 1
  all particle species:
    electrons
```
and
```
$ openpmd-ls --help
Usage: openpmd-ls openPMD-series
List information about an openPMD data series.

Options:
    -h, --help    display this help and exit

Examples:
    openpmd-ls ./samples/git-sample/data%T.h5
    openpmd-ls ./samples/git-sample/data%08T.h5
    openpmd-ls ./samples/serial_write.json
    openpmd-ls ./samples/serial_patch.bp
```

### To Do

- [ ] update `setup.py` install logic #585