### PR TITLE
Python 3.8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -290,12 +290,12 @@ jobs:
       before_install: &clang_init
         # FIXME: extra include needed https://bugs.launchpad.net/ubuntu/+source/libc++/+bug/1812133
         - CXX=clang++-6.0 && CC=clang-6.0 && CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -I/usr/include/libcxxabi/"
-    # Clang 7.0.0 + Python 3.7.1 @ Xenial
+    # Clang 7.0.0 + Python 3.8.0 @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 +MPI +PY@3.7 +H5 +JSON +ADIOS1 +ADIOS2 +Release
+      name: clang@7.0.0 +MPI +PY@3.8 +H5 +JSON +ADIOS1 +ADIOS2 +Release
       dist: xenial
       language: python
-      python: "3.7"
+      python: "3.8"
       env:
         - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON BUILD_TYPE="Release"
       compiler: clang

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -45,8 +45,9 @@ packages:
   adios2:
     variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc
   python:
-    version: [3.5.5, 3.6.3, 3.7.1, 3.7.2]
+    version: [3.5.5, 3.6.3, 3.7.1, 3.7.2, 3.8.0]
     paths:
+      python@3.8.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.8
       python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@3.6.3%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6
       python@3.6.3%clang@5.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,10 @@ Features
 
 - ADIOS2: support added (v2.4.0+) #482 #513 #530 #568
 - HDF5: add ``OPENPMD_HDF5_INDEPENDENT`` for non-collective parallel I/O #576
-- Python: support empty datasets via ``Record_Component.make_empty`` #538
+- Python:
+
+  - Python 3.8 support #581
+  - support empty datasets via ``Record_Component.make_empty`` #538
 - pkg-config: add ``static`` variable (``true``/``false``) to ``openPMD.pc`` package #580
 
 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.5 - 3.7
+  * Python 3.5 - 3.8
   * pybind 2.3.0+
   * numpy 1.15+
   * mpi4py 2.1+

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -41,7 +41,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.5 - 3.7
+  * Python 3.5 - 3.8
   * pybind11 2.3.0+
   * numpy 1.15+
   * mpi4py 2.1+

--- a/setup.py
+++ b/setup.py
@@ -130,9 +130,9 @@ setup(
     # note PEP-440 syntax: x.y.zaN but x.y.z.devN
     version='0.10.0.dev',
     author='Fabian Koller, Franz Poeschel, Axel Huebl',
-    author_email='f.koller@hzdr.de, f.poeschel@hzdr.de, a.huebl@hzdr.de',
+    author_email='f.koller@hzdr.de, f.poeschel@hzdr.de, axelhuebl@lbl.gov',
     maintainer='Axel Huebl',
-    maintainer_email='a.huebl@hzdr.de',
+    maintainer_email='axelhuebl@lbl.gov',
     description='C++ & Python API for Scientific I/O with openPMD',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -149,7 +149,7 @@ setup(
     ext_modules=[CMakeExtension('openpmd_api')],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
-    python_requires='>=3.5, <3.8',
+    python_requires='>=3.5, <3.9',
     # tests_require=['pytest'],
     install_requires=install_requires,
     # we would like to use this mechanism, but pip / setuptools do not
@@ -174,6 +174,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         ('License :: OSI Approved :: '
          'GNU Lesser General Public License v3 or later (LGPLv3+)'),
     ],


### PR DESCRIPTION
Add Python 3.8 support to docs, `setup.py`, and CI (Linux).

Related to #577