### PR TITLE
Python: Fix Shadowing a Variable in Mesh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -635,9 +635,11 @@ install:
   - cp $TRAVIS_BUILD_DIR/.travis/spack/*.yaml
        $SPACK_ROOT/etc/spack/
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      travis_wait 20 brew upgrade;
-      travis_wait 20 brew upgrade &&
-      travis_wait 20 brew install python3 &&
+      export HOMEBREW_NO_AUTO_UPDATE=1 &&
+      travis_wait 20 brew update;
+      travis_wait 20 brew install python3;
+      travis_wait 20 brew install numpy;
+      travis_wait 20 brew upgrade numpy;
       travis_wait 20 brew install modules &&
       brew info modules &&
       source /usr/local/opt/modules/init/bash &&
@@ -727,3 +729,7 @@ install:
       spack load adios2$ADIOS2_VERSION $SPACK_VAR_MPI $CXXSPEC;
     fi
   - spack clean -a
+
+before_cache:
+  # https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,10 @@ Bug Fixes
 """""""""
 
 - Clang: fix pybind11 compile on older releases, such as AppleClang 7.3-9.0, Clang 3.9 #543
-- Python: skip examples using HDF5 if backend is missing #544
+- Python:
+
+  - skip examples using HDF5 if backend is missing #544
+  - fix a variable shadowing in ``Mesh`` #582
 - ADIOS1: fix deadlock in MPI-parallel, non-collective calls to ``storeChunk()`` #554
 
 Other

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,7 @@ endif()
 
 # python bindings
 if(openPMD_HAVE_PYTHON)
-    pybind11_add_module(openPMD.py MODULE
+    pybind11_add_module(openPMD.py MODULE SYSTEM
         src/binding/python/openPMD.cpp
         src/binding/python/AccessType.cpp
         src/binding/python/Attributable.cpp
@@ -706,18 +706,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # at runtime when used with symbol-hidden code (e.g. pybind11 module)
 
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
-    # pybind11 does not fix -Wshadow https://github.com/pybind/pybind11/issues/1267
-    if(NOT openPMD_HAVE_PYTHON)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
-    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-    # pybind11 does not fix -Wshadow https://github.com/pybind/pybind11/issues/1267
-    # pybind11 does not fix -Wpedantic https://github.com/pybind/pybind11/issues/1417
-    if(NOT openPMD_HAVE_PYTHON)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow -Wpedantic")
-    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Warning C4503: "decorated name length exceeded, name was truncated"
     # Symbols longer than 4096 chars are truncated (and hashed instead)

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -36,8 +36,8 @@ void init_Mesh(py::module &m) {
         .def(py::init<Mesh const &>())
 
         .def("__repr__",
-            [](Mesh const & m) {
-                return "<openPMD.Mesh record with '" + std::to_string(m.size()) + "' record components>";
+            [](Mesh const & mesh) {
+                return "<openPMD.Mesh record with '" + std::to_string(mesh.size()) + "' record components>";
             }
         )
 


### PR DESCRIPTION
Test for `-Wshadow` warnings even when building with pybind11. We introduced a `SYSTEM` option to link pybind11 headers and CPython headers https://github.com/pybind/pybind11/pull/1416, which we can now use since we depend on pybind11 2.3.0+ (#525) :)

