### PR TITLE
JSON: Always Enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - PATH: $PATH:$HOME/.cache/spack/bin
     - BUILD_TYPE: "Debug"
     - PYBIND11_VERSION=@2.3.0
-    - USE_JSON: ON
     - USE_SHARED: ON
 
 addons:
@@ -112,7 +111,6 @@ jobs:
     #         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     #         -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
     #         -DopenPMD_USE_MPI=$USE_MPI
-    #         -DopenPMD_USE_JSON=$USE_JSON
     #         -DopenPMD_USE_HDF5=$USE_HDF5
     #         -DopenPMD_USE_ADIOS1=$USE_ADIOS1
     #         -DopenPMD_USE_ADIOS2=$USE_ADIOS2
@@ -128,7 +126,7 @@ jobs:
     #         exit 1;
     #       fi
     # - <<: *static_code_cpp
-      name: clang-tidy@5.0.0 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
+      name: clang-tidy@5.0.0 +MPI -PY +H5 +ADIOS1 +ADIOS2
       sudo: false
       env:
         - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON
@@ -151,7 +149,6 @@ jobs:
             -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy-5.0);-system-headers=0"
             -DCMAKE_BUILD_TYPE=Release
             -DopenPMD_USE_MPI=$USE_MPI
-            -DopenPMD_USE_JSON=$USE_JSON
             -DopenPMD_USE_HDF5=$USE_HDF5
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
@@ -189,7 +186,7 @@ jobs:
     # Clang 5.0.0
     - &test-cpp-unit
       stage: 'C++ Unit Tests'
-      name: clang@5.0.0 -MPI -PY +H5 +JSON -ADIOS1 -ADIOS2
+      name: clang@5.0.0 -MPI -PY +H5 -ADIOS1 -ADIOS2
       language: cpp
       dist: xenial
       env:
@@ -226,7 +223,6 @@ jobs:
           cmake
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
             -DopenPMD_USE_MPI=$USE_MPI
-            -DopenPMD_USE_JSON=$USE_JSON
             -DopenPMD_USE_HDF5=$USE_HDF5
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2
@@ -254,7 +250,7 @@ jobs:
         # - dpkg -i openPMD*.deb
         - ls -R $HOME/openPMD-test-install | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//--/g' -e 's/^/   /' -e 's/-/|/'
     - <<: *test-cpp-unit
-      name: clang@5.0.0 +MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
+      name: clang@5.0.0 +MPI -PY +H5 +ADIOS1 +ADIOS2
       language: python
       python: "3.6"
       env:
@@ -272,7 +268,7 @@ jobs:
         - CXX=clang++-5.0 && CC=clang-5.0
     # Clang 6.0.0 + Python 3.6.3 @ Xenial
     - <<: *test-cpp-unit
-      name: clang@6.0.0 -MPI +PY@3.6 +H5 +JSON +ADIOS1 +ADIOS2 libc++
+      name: clang@6.0.0 -MPI +PY@3.6 +H5 +ADIOS1 +ADIOS2 libc++
       language: python
       python: "3.6"
       env:
@@ -292,7 +288,7 @@ jobs:
         - CXX=clang++-6.0 && CC=clang-6.0 && CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -I/usr/include/libcxxabi/"
     # Clang 7.0.0 + Python 3.8.0 @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 +MPI +PY@3.8 +H5 +JSON +ADIOS1 +ADIOS2 +Release
+      name: clang@7.0.0 +MPI +PY@3.8 +H5 +ADIOS1 +ADIOS2 +Release
       dist: xenial
       language: python
       python: "3.8"
@@ -311,12 +307,12 @@ jobs:
         - CXX=clang++ && CC=clang
     # Clang 7.0.0 + Python 3.7.1 + Address Sanitizer + Undefined Behavior Sanitizer @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 +MPI +PY@3.7 +H5 +JSON -ADIOS1 +ADIOS2 +ASan +UBSan +STATIC
+      name: clang@7.0.0 +MPI +PY@3.7 +H5 -ADIOS1 +ADIOS2 +ASan +UBSan +STATIC
       dist: xenial
       language: python
       python: "3.7"
       env:
-        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SHARED=OFF USE_JSON=ON USE_SAMPLES=ON
+        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SHARED=OFF USE_SAMPLES=ON
         # sanitizer options: test as much as possible and suppress OpenMPI memory leaks
         - ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         - LSAN_OPTIONS=suppressions=${TRAVIS_BUILD_DIR}/.travis/sanitizer/clang/Leak.supp
@@ -334,7 +330,7 @@ jobs:
         # - find / -name libclang_rt*
     # Clang 9.1.0-apple + Python 3.7.2 @ OSX "highsierra"
     - <<: *test-cpp-unit
-      name: AppleClang@9.1.0 -MPI +PY@3.7 +H5 +JSON +ADIOS1 -ADIOS2
+      name: AppleClang@9.1.0 -MPI +PY@3.7 +H5 +ADIOS1 -ADIOS2
       os: osx
       osx_image: xcode9.4
       sudo: required
@@ -348,7 +344,7 @@ jobs:
         - perl --version
     # Clang 10.0.0-apple + Python 3.7.2 @ OSX "mojave" with libc++
     - <<: *test-cpp-unit
-      name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 +JSON -ADIOS1 +ADIOS2 libc++
+      name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 -ADIOS1 +ADIOS2 libc++
       os: osx
       osx_image: xcode10.1
       sudo: required
@@ -362,7 +358,7 @@ jobs:
         - perl --version
     # GCC 4.9.4
     - <<: *test-cpp-unit
-      name: gcc@4.9.4 -MPI -PY +H5 +JSON +ADIOS1 +ADIOS2
+      name: gcc@4.9.4 -MPI -PY +H5 +ADIOS1 +ADIOS2
       dist: trusty
       language: python
       python: "3.6"
@@ -381,7 +377,7 @@ jobs:
         - CXX=g++-4.9 && CC=gcc-4.9
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@4.9.4 +MPI -PY +H5 +JSON +ADIOS1 -ADIOS2
+      name: gcc@4.9.4 +MPI -PY +H5 +ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
@@ -399,12 +395,12 @@ jobs:
       script: *script-cpp-unit
     # GCC 7.4.0
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 -MPI -PY +H5 -JSON +ADIOS1 +ADIOS2@2.4.0
+      name: gcc@7.4.0 -MPI -PY +H5 +ADIOS1 +ADIOS2@2.4.0
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=OFF USE_PYTHON=OFF USE_JSON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON ADIOS2_VERSION=@2.4.0 USE_SAMPLES=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON ADIOS2_VERSION=@2.4.0 USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
@@ -418,7 +414,7 @@ jobs:
         - CXX=g++-7 && CC=gcc-7
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 +MPI -PY +H5 +JSON +ADIOS1 -ADIOS2
+      name: gcc@7.4.0 +MPI -PY +H5 +ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
@@ -436,7 +432,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 6.5.0 + Python 3.5
     - <<: *test-cpp-unit
-      name: gcc@6.5.0 -MPI +PY@3.5 +H5 +JSON +ADIOS1@1.13.1 -ADIOS2
+      name: gcc@6.5.0 -MPI +PY@3.5 +H5 +ADIOS1@1.13.1 -ADIOS2
       dist: trusty
       language: python
       python: "3.5"
@@ -456,7 +452,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 8.1.0 + Python 3.7
     - <<: *test-cpp-unit
-      name: gcc@8.1.0 -MPI +PY@3.7 +H5 +JSON +ADIOS1 -ADIOS2 +STATIC
+      name: gcc@8.1.0 -MPI +PY@3.7 +H5 +ADIOS1 -ADIOS2 +STATIC
       language: python
       python: "3.7"
       sudo: required
@@ -477,7 +473,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 6.5.0 + Python 3.6
     - <<: *test-cpp-unit
-      name: gcc@6.5.0 -MPI +PY@3.6 +H5@1.8.13 +JSON -ADIOS1 -ADIOS2
+      name: gcc@6.5.0 -MPI +PY@3.6 +H5@1.8.13 -ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
@@ -493,7 +489,7 @@ jobs:
       script: *script-cpp-unit
     # GCC 4.8.5 + Python 3.5.5
     - <<: *test-cpp-unit
-      name: gcc@4.8.5 -MPI +PY@3.5 +H5 +JSON -ADIOS1 -ADIOS2
+      name: gcc@4.8.5 -MPI +PY@3.5 +H5 -ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.5"
@@ -517,7 +513,7 @@ jobs:
     ###########################################################################
     - &code_coverage
       stage: 'Code Coverage'
-      name: gcc@7.4.0 +MPI +PY +H5 +JSON +ADIOS1 -ADIOS2 +coveralls
+      name: gcc@7.4.0 +MPI +PY +H5 +ADIOS1 -ADIOS2 +coveralls
       sudo: required
       language: python
       python: "3.6"
@@ -565,7 +561,6 @@ jobs:
           cmake
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
             -DopenPMD_USE_MPI=$USE_MPI
-            -DopenPMD_USE_JSON=$USE_JSON
             -DopenPMD_USE_HDF5=$USE_HDF5
             -DopenPMD_USE_ADIOS1=$USE_ADIOS1
             -DopenPMD_USE_ADIOS2=$USE_ADIOS2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,10 @@ Bug Fixes
 Other
 """""
 
-- NLohmann-JSON: updated to 3.7.0+ #556
+- JSON:
+
+  - the backend is now always enabled #587
+  - NLohmann-JSON dependency updated to 3.7.0+ #556
 
 
 0.9.0-alpha

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ function(openpmd_option name description default)
 endfunction()
 
 openpmd_option(MPI            "Parallel, Multi-Node I/O for clusters"     AUTO)
-openpmd_option(JSON           "JSON backend (.json files)"                AUTO)
 openpmd_option(HDF5           "HDF5 backend (.h5 files)"                  AUTO)
 openpmd_option(ADIOS1         "ADIOS1 backend (.bp files)"                AUTO)
 openpmd_option(ADIOS2         "ADIOS2 backend (.bp files)"                AUTO)
@@ -112,43 +111,20 @@ else()
     set(openPMD_HAVE_MPI FALSE)
 endif()
 
-# external library: nlohmann-json (optional)
-if(openPMD_USE_JSON STREQUAL AUTO)
-    if(openPMD_USE_INTERNAL_JSON)
-        set(JSON_BuildTests OFF CACHE INTERNAL "")
-        set(JSON_Install OFF CACHE INTERNAL "")  # only used PRIVATE
-        add_subdirectory("${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/json")
-        set(openPMD_HAVE_JSON TRUE)
-        message(STATUS "nlohmann-json: Using INTERNAL version 3.7.0")
-    else()
-        find_package(nlohmann_json 3.7.0 CONFIG)
-        if(nlohmann_json_FOUND)
-            set(openPMD_HAVE_JSON TRUE)
-            message(STATUS "nlohmann-json: Found version ${nlohmann_json_VERSION}")
-        else()
-            set(openPMD_HAVE_JSON FALSE)
-        endif()
-    endif()
-elseif(openPMD_USE_JSON)
-    if(openPMD_USE_INTERNAL_JSON)
-        set(JSON_BuildTests OFF CACHE INTERNAL "")
-        set(JSON_Install OFF CACHE INTERNAL "")  # only used PRIVATE
-        add_subdirectory("${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/json")
-        set(openPMD_HAVE_JSON TRUE)
-        message(STATUS "nlohmann-json: Using INTERNAL version 3.7.0")
-    else()
-        find_package(nlohmann_json 3.7.0 CONFIG REQUIRED)
-        set(openPMD_HAVE_JSON TRUE)
-        message(STATUS "nlohmann-json: Found version ${nlohmann_json_VERSION}")
-    endif()
+# external library: nlohmann-json (required)
+if(openPMD_USE_INTERNAL_JSON)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    set(JSON_Install OFF CACHE INTERNAL "")  # only used PRIVATE
+    add_subdirectory("${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/json")
+    message(STATUS "nlohmann-json: Using INTERNAL version 3.7.0")
 else()
-    set(openPMD_HAVE_JSON FALSE)
+    find_package(nlohmann_json 3.7.0 CONFIG REQUIRED)
+    message(STATUS "nlohmann-json: Found version ${nlohmann_json_VERSION}")
 endif()
-if(openPMD_HAVE_JSON)
-    add_library(openPMD::thirdparty::nlohmann_json INTERFACE IMPORTED)
-    target_link_libraries(openPMD::thirdparty::nlohmann_json
-        INTERFACE nlohmann_json::nlohmann_json)
-endif()
+add_library(openPMD::thirdparty::nlohmann_json INTERFACE IMPORTED)
+target_link_libraries(openPMD::thirdparty::nlohmann_json
+    INTERFACE nlohmann_json::nlohmann_json)
+
 
 # external library: HDF5 (optional)
 if(openPMD_USE_HDF5 STREQUAL AUTO)
@@ -415,12 +391,10 @@ if(openPMD_HAVE_MPI)
     target_link_libraries(openPMD PUBLIC MPI::MPI_C MPI::MPI_CXX)
 endif()
 
-# JSON Backend
-if(openPMD_HAVE_JSON)
-    #target_link_libraries(openPMD PRIVATE openPMD::thirdparty::nlohmann_json)
-    target_include_directories(openPMD SYSTEM PRIVATE
-        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
-endif()
+# JSON Backend and User-Facing Runtime Options
+#target_link_libraries(openPMD PRIVATE openPMD::thirdparty::nlohmann_json)
+target_include_directories(openPMD SYSTEM PRIVATE
+    $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # HDF5 Backend
 if(openPMD_HAVE_HDF5)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -10,6 +10,8 @@ We added support for ADIOS2 in this release.
 As soon as the ADIOS2 backend is enabled it will take precedence for ``.bp`` files over a potentially also enabled ADIOS1 backend.
 In order to prefer the legacy ADIOS1 backend in such a situation, set an environment variable: ``export OPENPMD_BP_BACKEND="ADIOS1"``.
 
+The JSON backend is now always enabled.
+The CMake option ``-DopenPMD_USE_JSON`` has been removed (as it is always ``ON`` now).
 
 0.9.0-alpha
 -----------

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ Shipped internally in `share/openPMD/thirdParty/`:
 * [pybind11](https://github.com/pybind/pybind11) 2.3.0+ ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
 * [NLohmann-JSON](https://github.com/nlohmann/json) 3.7.0+ ([MIT](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT))
 
-Optional I/O backends:
+I/O backends:
 * [JSON](https://en.wikipedia.org/wiki/JSON)
-* [HDF5](https://support.hdfgroup.org/HDF5) 1.8.13+
-* [ADIOS1](https://www.olcf.ornl.gov/center-projects/adios) 1.13.1+
-* [ADIOS2](https://github.com/ornladios/ADIOS2) 2.4.0+
+* [HDF5](https://support.hdfgroup.org/HDF5) 1.8.13+ (optional)
+* [ADIOS1](https://www.olcf.ornl.gov/center-projects/adios) 1.13.1+ (optional)
+* [ADIOS2](https://github.com/ornladios/ADIOS2) 2.4.0+ (optional)
 
 while those can be built either with or without:
 * MPI 2.1+, e.g. OpenMPI 1.6.5+ or MPICH2
@@ -132,7 +132,7 @@ Choose *one* of the install methods below to get started:
 [![Spack Status](https://img.shields.io/badge/method-recommended-brightgreen.svg)](https://spack.readthedocs.io/en/latest/package_list.html#openpmd-api)
 
 ```bash
-# optional:               +python +adios1 +adios2 -mpi
+# optional:               +python +adios1 +adios2 -hdf5 -mpi
 spack install openpmd-api
 spack load -r openpmd-api
 ```
@@ -209,7 +209,6 @@ CMake controls options with prefixed `-D`, e.g. `-DopenPMD_USE_MPI=OFF`:
 | CMake Option                 | Values           | Description                                                                  |
 |------------------------------|------------------|------------------------------------------------------------------------------|
 | `openPMD_USE_MPI`            | **AUTO**/ON/OFF  | Parallel, Multi-Node I/O for clusters                                        |
-| `openPMD_USE_JSON`           | **AUTO**/ON/OFF  | JSON backend (`.json` files)                                                 |
 | `openPMD_USE_HDF5`           | **AUTO**/ON/OFF  | HDF5 backend (`.h5` files)                                                   |
 | `openPMD_USE_ADIOS1`         | **AUTO**/ON/OFF  | ADIOS1 backend (`.bp` files up to version BP3)                               |
 | `openPMD_USE_ADIOS2`         | **AUTO**/ON/OFF  | ADIOS2 backend (`.bp` files in BP3, BP4 or higher)                           |
@@ -258,7 +257,7 @@ export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
 
 Use the following lines in your project's `CMakeLists.txt`:
 ```cmake
-# supports:                       COMPONENTS MPI NOMPI JSON HDF5 ADIOS1 ADIOS2
+# supports:                       COMPONENTS MPI NOMPI HDF5 ADIOS1 ADIOS2
 find_package(openPMD 0.9.0 CONFIG)
 
 if(openPMD_FOUND)

--- a/Singularity
+++ b/Singularity
@@ -42,7 +42,6 @@ Supported frontends are C++11 and Python3.
     cmake /opt/openpmd-api       \
         -DopenPMD_USE_MPI=OFF    \
         -DopenPMD_USE_HDF5=ON    \
-        -DopenPMD_USE_JSON=ON    \
         -DopenPMD_USE_ADIOS1=ON  \
         -DopenPMD_USE_ADIOS2=OFF \
         -DopenPMD_USE_PYTHON=ON  \
@@ -63,7 +62,6 @@ Supported frontends are C++11 and Python3.
 %labels
     openPMD_HAVE_MPI OFF
     openPMD_HAVE_HDF5 ON
-    openPMD_HAVE_JSON ON
     openPMD_HAVE_ADIOS1 ON
     openPMD_HAVE_ADIOS2 OFF
     openPMD_HAVE_PYTHON ON

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -15,7 +15,6 @@ USE_MDFILE_AS_MAINPAGE = README.md
 
 # "enable" all frontends and backends
 PREDEFINED        = openPMD_HAVE_MPI=1 \
-                    openPMD_HAVE_JSON=1 \
                     openPMD_HAVE_HDF5=1 \
                     openPMD_HAVE_ADIOS1=1 \
                     openPMD_HAVE_ADIOS2=1 \

--- a/docs/source/backends/json.rst
+++ b/docs/source/backends/json.rst
@@ -4,10 +4,7 @@ JSON Backend
 ============
 
 openPMD supports writing to and reading from JSON files.
-For this, the installed copy of openPMD must have been built with support for the JSON backend.
-To build openPMD with support for JSON, use the CMake option ``-DopenPMD_USE_JSON=ON``.
-For further information, check out the :ref:`installation guide <install>`,
-:ref:`build dependencies <development-dependencies>` and the :ref:`build options <development-buildoptions>`.
+The JSON backend is always available.
 
 
 JSON File Format

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -15,7 +15,6 @@ CMake controls options with prefixed ``-D``, e.g. ``-DopenPMD_USE_MPI=OFF``:
 CMake Option                   Values          Description
 ============================== =============== ========================================================================
 ``openPMD_USE_MPI``            **AUTO**/ON/OFF Parallel, Multi-Node I/O for clusters
-``openPMD_USE_JSON``           **AUTO**/ON/OFF JSON backend (``.json`` files)
 ``openPMD_USE_HDF5``           **AUTO**/ON/OFF HDF5 backend (``.h5`` files)
 ``openPMD_USE_ADIOS1``         **AUTO**/ON/OFF ADIOS1 backend (``.bp`` files up to version BP3)
 ``openPMD_USE_ADIOS2``         **AUTO**/ON/OFF ADIOS2 backend (``.bp`` files in BP3, BP4 or higher)

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -31,7 +31,7 @@ A package for openPMD-api is available on the `Spack <https://spack.io>`_ packag
 
 .. code-block:: bash
 
-   # optional:               +python +adios1 +adios2 -mpi
+   # optional:               +python +adios1 +adios2 -hdf5 -mpi
    spack install openpmd-api
    spack load -r openpmd-api
 

--- a/include/openPMD/IO/Format.hpp
+++ b/include/openPMD/IO/Format.hpp
@@ -23,14 +23,14 @@
 
 namespace openPMD
 {
-/** File format to use during IO.
- */
-enum class Format
-{
-    HDF5,
-    ADIOS1,
-    ADIOS2,
-    JSON,
-    DUMMY
-};  //Format
+    /** File format to use during IO.
+     */
+    enum class Format
+    {
+        HDF5,
+        ADIOS1,
+        ADIOS2,
+        JSON,
+        DUMMY
+    };
 } // openPMD

--- a/include/openPMD/IO/JSON/JSONFilePosition.hpp
+++ b/include/openPMD/IO/JSON/JSONFilePosition.hpp
@@ -24,26 +24,17 @@
 #include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractFilePosition.hpp"
 
-
-#if openPMD_HAVE_JSON
 #include <nlohmann/json.hpp>
-#endif
+
 
 namespace openPMD
 {
-
-
     struct JSONFilePosition :
         public AbstractFilePosition
-#if openPMD_HAVE_JSON
     {
         using json = nlohmann::json;
         json::json_pointer id;
 
         JSONFilePosition( json::json_pointer ptr = json::json_pointer( ) );
     };
-#else
-    {};
-#endif
-
 } // openPMD

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -28,6 +28,8 @@
 #include "openPMD/IO/AccessType.hpp"
 #include "openPMD/IO/JSON/JSONFilePosition.hpp"
 
+#include <nlohmann/json.hpp>
+
 #include <fstream>
 #include <memory>
 #include <tuple>
@@ -35,15 +37,6 @@
 #include <unordered_set>
 #include <vector>
 #include <stdexcept>
-
-
-#if openPMD_HAVE_JSON
-
-
-#include <nlohmann/json.hpp>
-
-
-#endif
 
 
 namespace openPMD
@@ -156,8 +149,6 @@ namespace std
 
 namespace openPMD
 {
-#if openPMD_HAVE_JSON
-
     class JSONIOHandlerImpl :
         public AbstractIOHandlerImpl
     {
@@ -551,29 +542,5 @@ namespace openPMD
             T operator()( nlohmann::json const & );
         };
     };
-
-#else
-
-    class JSONIOHandlerImpl
-    {
-    public:
-        JSONIOHandlerImpl( openPMD::AbstractIOHandler * )
-        {
-            throw std::runtime_error("openPMD-api built without JSON support");
-        };
-
-
-        ~JSONIOHandlerImpl( )
-        {};
-
-
-        std::future< void > flush( )
-        {
-            return std::future< void >( );
-        }
-    };
-
-#endif
-
 
 } // openPMD

--- a/include/openPMD/config.hpp.in
+++ b/include/openPMD/config.hpp.in
@@ -24,9 +24,7 @@
 #   cmakedefine01 openPMD_HAVE_MPI
 #endif
 
-#ifndef openPMD_HAVE_JSON
-#   cmakedefine01 openPMD_HAVE_JSON
-#endif
+#define openPMD_HAVE_JSON 1
 
 #ifndef openPMD_HAVE_HDF5
 #   cmakedefine01 openPMD_HAVE_HDF5

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -31,9 +31,6 @@ else()
 endif()
 set(openPMD_MPI_FOUND ${openPMD_HAVE_MPI})
 
-set(openPMD_HAVE_JSON @openPMD_HAVE_JSON@)
-set(openPMD_JSON_FOUND ${openPMD_HAVE_JSON})
-
 set(openPMD_HAVE_HDF5 @openPMD_HAVE_HDF5@)
 if(openPMD_HAVE_HDF5)
     find_dependency(HDF5)

--- a/src/IO/JSON/JSONFilePosition.cpp
+++ b/src/IO/JSON/JSONFilePosition.cpp
@@ -1,11 +1,9 @@
 #include "openPMD/IO/JSON/JSONFilePosition.hpp"
 
 
-namespace openPMD {
-
-#if openPMD_HAVE_JSON
+namespace openPMD
+{
     JSONFilePosition::JSONFilePosition( json::json_pointer ptr):
         id( ptr )
     {}
-#endif
 }

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -37,8 +37,6 @@ namespace openPMD
 
 #define VERIFY_ALWAYS( CONDITION, TEXT ) { if(!(CONDITION)) throw std::runtime_error((TEXT)); }
 
-#if openPMD_HAVE_JSON
-
 
     JSONIOHandlerImpl::JSONIOHandlerImpl( AbstractIOHandler * handler ) :
         AbstractIOHandlerImpl( handler )
@@ -1543,17 +1541,12 @@ namespace openPMD
                 T
             >::value
         >::type
-    >::operator()( nlohmann::json const & j )
-    {
-        try
-        {
-            return j.get< T >( );
-        } catch( ... )
-        {
-            return std::numeric_limits< T >::quiet_NaN( );
+    >::operator()( nlohmann::json const & j ) {
+        try {
+            return j.get<T>();
+        } catch (...) {
+            return std::numeric_limits<T>::quiet_NaN();
         }
     }
-
-#endif
 
 } // namespace openPMD

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -87,7 +87,7 @@ PYBIND11_MODULE(openpmd_api, m) {
     // feature variants
     m.attr("variants") = std::map<std::string, bool>{
         {"mpi", bool(openPMD_HAVE_MPI)},
-        {"json", bool(openPMD_HAVE_JSON)},
+        {"json", true},
         {"hdf5", bool(openPMD_HAVE_HDF5)},
         {"adios1", bool(openPMD_HAVE_ADIOS1)},
         {"adios2", bool(openPMD_HAVE_ADIOS2)}

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -23,9 +23,7 @@ std::vector<std::tuple<std::string, bool>> getBackends() {
     // first component: backend file ending
     // second component: whether to test 128 bit values
     std::vector<std::tuple<std::string, bool>> res;
-#if openPMD_HAVE_JSON
     res.emplace_back("json", false);
-#endif
 #if openPMD_HAVE_ADIOS1 || openPMD_HAVE_ADIOS2
     res.emplace_back("bp", true);
 #endif


### PR DESCRIPTION
Since we ship the dependencies for the private JSON backend with our source code and the dependency is of very hight quality and very portable, we can just compile it by default.

This is very similar to previous behavior, in the sense that it was `-DopenPMD_USE_JSON=AUTO` (internal) activated unless explicitly deactivated during compile.

Enabling JSON by default and making it a required dependency enables us to use it for further internal tasks, such as runtime option parsing of user parameters for all backends #569 .