### PR TITLE
Doc: Improve Pip Install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Bug Fixes
 Other
 """""
 
+- Python: improve ``pip`` install instructions #594
 - JSON:
 
   - the backend is now always enabled #587

--- a/README.md
+++ b/README.md
@@ -161,14 +161,21 @@ The current status for this install method is *experimental*.
 Please feel free to [report](https://github.com/openPMD/openPMD-api/issues/new/choose) how this works for you.
 
 ```bash
-# optional:             --user
-pip install openpmd-api
+# we need pip 19 or newer
+# optional:                   --user
+python3 -m pip install -U pip
+
+# optional:                        --user
+python3 -m pip install openpmd-api
 ```
 
 or with MPI support:
 ```bash
-# optional:                                                  --user
-openPMD_USE_MPI=ON pip install openpmd-api --no-binary :all:
+# optional:                   --user
+python3 -m pip install -U pip
+
+# optional:                                                                   --user
+openPMD_USE_MPI=ON python3 -m pip install openpmd-api --no-binary openpmd-api
 ```
 
 ### From Source

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -37,7 +37,7 @@ The following requirements need to be installed (once) to build our documentatio
     sudo apt-get install doxygen
 
     # python tools & style theme
-    pip install -r requirements.txt # --user
+    python -m pip install -r requirements.txt # --user
 
 
 With all documentation-related software successfully installed, just run the following commands to build your docs locally.

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -69,15 +69,22 @@ Please feel free to `report <https://github.com/openPMD/openPMD-api/issues/new/c
 
 .. code-block:: bash
 
-   # optional:             --user
-   pip install openpmd-api
+   # we need pip 19 or newer
+   # optional:                   --user
+   python3 -m pip install -U pip
+
+   # optional:                        --user
+   python3 -m pip install openpmd-api
 
 or with MPI support:
 
 .. code-block:: bash
 
-   # optional:                                                  --user
-   openPMD_USE_MPI=ON pip install openpmd-api --no-binary :all:
+   # optional:                   --user
+   python3 -m pip install -U pip
+
+   # optional:                                                                   --user
+   openPMD_USE_MPI=ON python3 -m pip install openpmd-api --no-binary openpmd-api
 
 .. _install-cmake:
 


### PR DESCRIPTION
- general: update pip first, so we definitely have pip version 19+
- MPI build: only build itself from source
- syntax: use pip as python(3) module