### PR TITLE
Fix OSX setup.py: @loader_path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Bug Fixes
 - Clang: fix pybind11 compile on older releases, such as AppleClang 7.3-9.0, Clang 3.9 #543
 - Python:
 
+  - OSX: fix ``dlopen`` issues due to missing ``@loader_path`` with ``pip``/``setup.py`` #595
   - skip examples using HDF5 if backend is missing #544
   - fix a variable shadowing in ``Mesh`` #582
 - ADIOS1: fix deadlock in MPI-parallel, non-collective calls to ``storeChunk()`` #554

--- a/setup.py
+++ b/setup.py
@@ -57,11 +57,14 @@ class CMakeBuild(build_ext):
             '-DHDF5_USE_STATIC_LIBRARIES:BOOL=' + HDF5_USE_STATIC_LIBRARIES,
             '-DADIOS_USE_STATIC_LIBS:BOOL=' + ADIOS_USE_STATIC_LIBS,
             # Unix: rpath to current dir when packaged
-            '-DCMAKE_INSTALL_RPATH=$ORIGIN',
             '-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON',
             '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF',
             # Windows: will already have %PATH% in package dir
         ]
+        if sys.platform == "darwin":
+            cmake_args.append('-DCMAKE_INSTALL_RPATH=@loader_path')
+        else:  # values: linux*, aix, freebsd, ... just as well win32 & cygwin
+            cmake_args.append('-DCMAKE_INSTALL_RPATH=$ORIGIN')
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]


### PR DESCRIPTION
On OSX, `$ORIGIN` is not a known concept for relative RPATHs. Instead, `@loader_path/` should be the right path (contrary to `@rpath/`) to find relative dependencies of a shared library.

Refs.:

- https://github.com/openPMD/openPMD-api/issues/593#issuecomment-552690470
- https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
- https://cmake.org/pipermail/cmake/2014-May/057654.html
- https://docs.python.org/3.8/library/sys.html#platform