### PR TITLE
Fix mpi4py Examples: import first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Bug Fixes
 - Python:
 
   - OSX: fix ``dlopen`` issues due to missing ``@loader_path`` with ``pip``/``setup.py`` #595
+  - import ``mpi4py`` first (MPICH on OSX issue) #596
   - skip examples using HDF5 if backend is missing #544
   - fix a variable shadowing in ``Mesh`` #582
 - ADIOS1: fix deadlock in MPI-parallel, non-collective calls to ``storeChunk()`` #554

--- a/examples/4_read_parallel.py
+++ b/examples/4_read_parallel.py
@@ -6,12 +6,13 @@ Copyright 2019 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-import openpmd_api
-
+# IMPORTANT: include mpi4py FIRST
 # https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html
 # on import: calls MPI_Init_thread()
 # exit hook: calls MPI_Finalize()
 from mpi4py import MPI
+
+import openpmd_api
 
 
 if __name__ == "__main__":

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -6,13 +6,14 @@ Copyright 2019 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-import openpmd_api
-import numpy as np
-
+# IMPORTANT: include mpi4py FIRST
 # https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html
 # on import: calls MPI_Init_thread()
 # exit hook: calls MPI_Finalize()
 from mpi4py import MPI
+
+import openpmd_api
+import numpy as np
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
At least on OSX and at least with MPICH, `mpi4py` must be included first in order to avoid an error of the kind:
```
Attempting to use an MPI routine before initializing MPICH
```
and in Jupyter
```
The kernel appears to have died. It will restart automatically.
```

First seen by @LDAmorim :sparkles: :muscle: 