### PR TITLE
[WIP] CMake: Enable IPO/LTO

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -266,6 +266,7 @@ Features
   - Python 3.8 support #581
   - support empty datasets via ``Record_Component.make_empty`` #538
 - pkg-config: add ``static`` variable (``true``/``false``) to ``openPMD.pc`` package #580
+- CMake: interprocedural/link-time optimization #597
 
 Bug Fixes
 """""""""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ openpmd_option(HDF5           "HDF5 backend (.h5 files)"                  AUTO)
 openpmd_option(ADIOS1         "ADIOS1 backend (.bp files)"                AUTO)
 openpmd_option(ADIOS2         "ADIOS2 backend (.bp files)"                AUTO)
 openpmd_option(PYTHON         "Enable Python bindings"                    AUTO)
+openpmd_option(IPO       "Enable interprocedural/link-time optimization"  AUTO)
 
 option(openPMD_INSTALL               "Add installation targets"             ON)
 option(openPMD_HAVE_PKGCONFIG        "Generate a .pc file for pkg-config"   ON)
@@ -102,6 +103,39 @@ include(CTest)
 
 option(BUILD_CLI_TOOLS "Build the command line tools" ON)
 option(BUILD_EXAMPLES  "Build the examples" ON)
+
+
+# LTO / IPO ###################################################################
+#
+# Optional link-time optimization (LTO) / interprocedural optimization (IPO).
+# Do not use IPO if it's not supported by compiler.
+include(CheckIPOSupported)
+check_ipo_supported(
+    RESULT IPO_CHECK_RESULT
+    OUTPUT IPO_CHECK_OUTPUT
+#    LANGUAGES CXX
+)
+if(openPMD_USE_IPO STREQUAL AUTO)
+    if(IPO_CHECK_RESULT)
+        set(openPMD_HAVE_IPO TRUE)
+    else()
+        set(openPMD_HAVE_IPO FALSE)
+        message(STATUS "IPO/LTO is NOT supported: ${IPO_CHECK_OUTPUT}")
+    endif()
+elseif(openPMD_USE_IPO)
+    if(IPO_CHECK_RESULT)
+        set(openPMD_HAVE_IPO TRUE)
+    else()
+        set(openPMD_HAVE_IPO FALSE)
+        message(FATAL_ERROR "IPO/LTO is NOT supported: ${IPO_CHECK_OUTPUT}")
+    endif()
+else()
+    set(openPMD_HAVE_IPO FALSE)
+endif()
+
+if(openPMD_HAVE_IPO)
+    message(STATUS "IPO/LTO is supported")
+endif()
 
 
 # Dependencies ################################################################
@@ -357,6 +391,7 @@ set_target_properties(openPMD PROPERTIES
     CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
     WINDOWS_EXPORT_ALL_SYMBOLS ON
+    INTERPROCEDURAL_OPTIMIZATION ${openPMD_HAVE_IPO}
 )
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_compile_options(openPMD PUBLIC "/bigobj")
@@ -453,7 +488,8 @@ if(openPMD_HAVE_ADIOS1)
         CXX_STANDARD_REQUIRED ON
         POSITION_INDEPENDENT_CODE ON
         CXX_VISIBILITY_PRESET hidden
-        VISIBILITY_INLINES_HIDDEN ON
+        VISIBILITY_INLINES_HIDDEN 1
+        INTERPROCEDURAL_OPTIMIZATION ${openPMD_HAVE_IPO}
     )
     if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
         set_target_properties(openPMD.ADIOS1.Serial PROPERTIES
@@ -481,6 +517,7 @@ if(openPMD_HAVE_ADIOS1)
             POSITION_INDEPENDENT_CODE ON
             CXX_VISIBILITY_PRESET hidden
             VISIBILITY_INLINES_HIDDEN 1
+            INTERPROCEDURAL_OPTIMIZATION ${openPMD_HAVE_IPO}
         )
         if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
             set_target_properties(openPMD.ADIOS1.Parallel PROPERTIES
@@ -653,6 +690,7 @@ if(BUILD_TESTING)
         CXX_STANDARD_REQUIRED ON
         POSITION_INDEPENDENT_CODE ON
         WINDOWS_EXPORT_ALL_SYMBOLS ON
+        # INTERPROCEDURAL_OPTIMIZATION ${openPMD_HAVE_IPO}
     )
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         target_compile_options(CatchRunner PUBLIC "/bigobj")
@@ -1013,7 +1051,7 @@ if(BUILD_TESTING)
                 RESULT_VARIABLE MPI4PY_RETURN)
 
             if(NOT MPI4PY_RETURN EQUAL 0)
-                message(STATUS "Note: mpi4py not found. "
+                message(STATUS "Note: mpi4py NOT found. "
                                "Skipping MPI-parallel Python examples.")
             endif()
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ CMake controls options with prefixed `-D`, e.g. `-DopenPMD_USE_MPI=OFF`:
 | `openPMD_USE_ADIOS1`         | **AUTO**/ON/OFF  | ADIOS1 backend (`.bp` files up to version BP3)                               |
 | `openPMD_USE_ADIOS2`         | **AUTO**/ON/OFF  | ADIOS2 backend (`.bp` files in BP3, BP4 or higher)                           |
 | `openPMD_USE_PYTHON`         | **AUTO**/ON/OFF  | Enable Python bindings                                                       |
+| `openPMD_USE_IPO`            | **AUTO**/ON/OFF  | Enable interprocedural/link-time optimization                                |
 | `openPMD_USE_INVASIVE_TESTS` | ON/**OFF**       | Enable unit tests that modify source code <sup>1</sup>                       |
 | `openPMD_USE_VERIFY`         | **ON**/OFF       | Enable internal VERIFY (assert) macro independent of build type <sup>2</sup> |
 | `openPMD_INSTALL`            | **ON**/OFF       | Add installation targets                                                     |

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -17,6 +17,7 @@ CMake Option                   Values          Description
 ``openPMD_USE_ADIOS1``         **AUTO**/ON/OFF ADIOS1 backend (``.bp`` files up to version BP3)
 ``openPMD_USE_ADIOS2``         **AUTO**/ON/OFF ADIOS2 backend (``.bp`` files in BP3, BP4 or higher)
 ``openPMD_USE_PYTHON``         **AUTO**/ON/OFF Enable Python bindings
+``openPMD_USE_IPO``            **AUTO**/ON/OFF Enable interprocedural/link-time optimization
 ``openPMD_USE_INVASIVE_TESTS`` ON/**OFF**      Enable unit tests that modify source code :sup:`1`
 ``openPMD_USE_VERIFY``         **ON**/OFF      Enable internal VERIFY (assert) macro independent of build type :sup:`2`
 ``openPMD_INSTALL``            **ON**/OFF      Add installation targets


### PR DESCRIPTION
[Interprocedural optimization (IPO) also known as link-time optimization (LTO)](https://en.wikipedia.org/wiki/Interprocedural_optimization) is a great feature to reduce binary size and to improve code performance, e.g. through extended inlining.

This feature is specifically useful for modern C++ code, which is also the reason pybind11 enables it automatically for our python bindings as soon as it is detected.

We now expose this feature for the rest of the library build as well and auto-enable it when supported by the compiler.

Binary size before:
```
$ du -hs lib/*
1.0M    lib/libCatchMain.so
1.0M    lib/libCatchRunner.so
1.3M    lib/libopenPMD.ADIOS1.Parallel.so
1.1M    lib/libopenPMD.ADIOS1.Serial.so
2.2M    lib/libopenPMD.so
968K    lib/python3.6
```
and with IPO/LTO enabled (new default):
```
$ du -hs lib/*
876K    lib/libCatchMain.so
876K    lib/libCatchRunner.so
1.2M    lib/libopenPMD.ADIOS1.Parallel.so
1.1M    lib/libopenPMD.ADIOS1.Serial.so
1.5M    lib/libopenPMD.so
968K    lib/python3.6
```