### PR TITLE
Python3 in docs cmake instructions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ cd openPMD-api-build
 # for options append:
 #   -DopenPMD_USE_...=...
 # e.g. for python support add:
-#   -DopenPMD_USE_PYTHON=ON -DPYTHON_EXECUTABLE=$(which python)
+#   -DopenPMD_USE_PYTHON=ON -DPYTHON_EXECUTABLE=$(which python3)
 cmake ../openPMD-api
 
 cmake --build .

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -117,7 +117,7 @@ Linux & OSX
    # for options append:
    #   -DopenPMD_USE_...=...
    # e.g. for python support add:
-   #   -DopenPMD_USE_PYTHON=ON -DPYTHON_EXECUTABLE=$(which python)
+   #   -DopenPMD_USE_PYTHON=ON -DPYTHON_EXECUTABLE=$(which python3)
    cmake ../openPMD-api
 
    cmake --build .


### PR DESCRIPTION
The installation in MacOS Mojave is successful with the command that is in [https://openpmd-api.readthedocs.io/en/latest/install/install.html](https://openpmd-api.readthedocs.io/en/latest/install/install.html):
```cmake ../openPMD-api -DCMALE_INSTALL_PREFIX=(...)/openPMD-api-install -DopenPMD_USE_PYTHON=ON -DPYTHON_EXECUTABLE=$(which python3)```

But can cause the error message below if both python2 and python3 versions are installed in that machine and `$(which python)` is used instead.

```bash
CMake Error at CMakeLists.txt:275 (message):
 python: Found version 2.7 is NOT supported.  Set for example
 -DPYTHON_EXECUTABLE=$(which python3) to use 3.5+.
-- Configuring incomplete, errors occurred!
```

- Changed `$(which python)` to `$(which python3)` in docs to prevent error of competing python < 3.5 versions.