### PR TITLE
ADIOS1: Keep Default for Now

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,9 +6,10 @@ Upgrade Guide
 0.10.0-alpha
 ------------
 
-We added support for ADIOS2 in this release.
-As soon as the ADIOS2 backend is enabled it will take precedence for ``.bp`` files over a potentially also enabled ADIOS1 backend.
-In order to prefer the legacy ADIOS1 backend in such a situation, set an environment variable: ``export OPENPMD_BP_BACKEND="ADIOS1"``.
+We added preliminary support for ADIOS2 in this release.
+As long as also the ADIOS1 backend is enabled it will take precedence for ``.bp`` files over the newer ADIOS2 backend.
+In order to enforce using the new ADIOS2 backend in such a situation, set an environment variable: ``export OPENPMD_BP_BACKEND="ADIOS2"``.
+We will change this default in upcoming releases to prefer ADIOS2.
 
 The JSON backend is now always enabled.
 The CMake option ``-DopenPMD_USE_JSON`` has been removed (as it is always ``ON`` now).

--- a/docs/source/backends/adios1.rst
+++ b/docs/source/backends/adios1.rst
@@ -29,12 +29,12 @@ environment variable                 default    description
 ``OPENPMD_ADIOS_NUM_AGGREGATORS``    ``1``      Number of I/O aggregator nodes for ADIOS1 ``MPI_AGGREGATE`` transport method.
 ``OPENPMD_ADIOS_NUM_OST``            ``0``      Number of I/O OSTs for ADIOS1 ``MPI_AGGREGATE`` transport method.
 ``OPENPMD_ADIOS_HAVE_METADATA_FILE`` ``1``      Online creation of the adios journal file (``1``: yes, ``0``: no).
-``OPENPMD_BP_BACKEND``               ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
+``OPENPMD_BP_BACKEND``               ``ADIOS1`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ==================================== ========== ================================================================================
 
 Please refer to the `ADIOS1 manual, section 6.1.5 <https://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.13.1.pdf>`_ for details on I/O tuning.
 
-In case only the ADIOS1 backend is enabled but not the :ref:`ADIOS2 backend <backends-adios2>`, the default of ``OPENPMD_BP_BACKEND`` is automatically switched to ``ADIOS1``.
+In case both the ADIOS1 backend and the :ref:`ADIOS2 backend <backends-adios2>` are enabled, set ``OPENPMD_BP_BACKEND`` to ``ADIOS2`` to enforce using ADIOS2.
 Be advised that ADIOS1 only supports ``.bp`` files up to the internal version BP3, while ADIOS2 supports BP3, BP4 and later formats.
 
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -9,6 +9,11 @@ To build openPMD with support for ADIOS2, use the CMake option ``-DopenPMD_USE_A
 For further information, check out the :ref:`installation guide <install>`,
 :ref:`build dependencies <development-dependencies>` and the :ref:`build options <development-buildoptions>`.
 
+.. note::
+
+   The ADIOS2 backend in a preview in this release!
+   Its data representation, such as choice of attributes and variables in ``.bp`` files, might change without further notice in the upcoming releases.
+
 
 I/O Method
 ----------
@@ -29,12 +34,12 @@ environment variable                  default    description
 ``OPENPMD_ADIOS2_HAVE_PROFILING``     ``1``      Turns on/off profiling information right after a run.
 ``OPENPMD_ADIOS2_HAVE_METADATA_FILE`` ``1``      Online creation of the adios journal file (``1``: yes, ``0``: no).
 ``OPENPMD_ADIOS2_NUM_SUBSTREAMS``     ``0``      Number of files to be created, 0 indicates maximum number possible.
-``OPENPMD_BP_BACKEND``                ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
+``OPENPMD_BP_BACKEND``                ``ADIOS1`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ===================================== ========== ================================================================================
 
 Please refer to the `ADIOS2 manual, section 5.1 <https://media.readthedocs.org/pdf/adios2/latest/adios2.pdf>`_ for details on I/O tuning.
 
-In case both the the :ref:`ADIOS1 backend <backends-adios1>` and ADIOS2 backend are enabled, set ``OPENPMD_BP_BACKEND`` to ``ADIOS1`` to enforce using ADIOS1.
+In case only the ADIOS2 backend is enabled but not the :ref:`ADIOS1 backend <backends-adios1>`, the default of ``OPENPMD_BP_BACKEND`` is automatically switched to ``ADIOS2``.
 Be advised that ADIOS1 only supports ``.bp`` files up to the internal version BP3, while ADIOS2 supports BP3, BP4 and later formats.
 
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -869,7 +869,9 @@ determineFormat(std::string const& filename)
     {
         auto const bp_backend = auxiliary::getEnvString(
             "OPENPMD_BP_BACKEND",
-#if openPMD_HAVE_ADIOS2
+#if openPMD_HAVE_ADIOS1
+            "ADIOS1"
+#elif openPMD_HAVE_ADIOS2
             "ADIOS2"
 #else
             "ADIOS1"


### PR DESCRIPTION
Since we are planning to add more refactoring in the internal (variables vs. attributes) representation of ADIOS2, let's not make this default over ADIOS1 yet to avoid writing files that soon cannot be read again.

Delay this just for a little for this upcoming release, so we can draft a new version without changing defaults yet. (I want to release a new version very soon to fix some installation issues and other updates that we accumulated.)

Delays the new defaults to ADIOS2 in #568 for a later release.