### PR TITLE
ADIOS1: Fix _FOUND False Positive (Version)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ Bug Fixes
 - ADIOS1: fix deadlock in MPI-parallel, non-collective calls to ``storeChunk()`` #554
 - xlC 16.1: work-around C-array initializer parsing issue #547
 - icc 19.0.0 and PGI 19.5: fix compiler ID identification #548
+- CMake: fix false-positives in ``FindADIOS.cmake`` module #609
 
 Other
 """""

--- a/share/openPMD/cmake/FindADIOS.cmake
+++ b/share/openPMD/cmake/FindADIOS.cmake
@@ -88,7 +88,7 @@
 # Required cmake version
 ###############################################################################
 
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 2.8.11)
 
 
 ###############################################################################
@@ -305,6 +305,7 @@ endif()
 # handles the REQUIRED, QUIET and version-related arguments for find_package
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ADIOS
+    FOUND_VAR ADIOS_FOUND
     REQUIRED_VARS ADIOS_LIBRARIES ADIOS_INCLUDE_DIRS
     VERSION_VAR ADIOS_VERSION
 )


### PR DESCRIPTION
This fixes a false positive on `ADIOS_FOUND` when the found version
of ADIOS1 is older than the requirement.

See https://github.com/ComputationalRadiationPhysics/cmake-modules/pull/14