### PR TITLE
Series: Throw on Dummy Handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Bug Fixes
 - xlC 16.1: work-around C-array initializer parsing issue #547
 - icc 19.0.0 and PGI 19.5: fix compiler ID identification #548
 - CMake: fix false-positives in ``FindADIOS.cmake`` module #609
+- Series: throws an error message if no file ending is specified #610
 
 Other
 """""

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -14,6 +14,10 @@ We will change this default in upcoming releases to prefer ADIOS2.
 The JSON backend is now always enabled.
 The CMake option ``-DopenPMD_USE_JSON`` has been removed (as it is always ``ON`` now).
 
+Previously, omitting a file ending in the ``Series`` constructor chose a "dummy" no-operation file backend.
+This was confusing and instead a runtime error is now thrown.
+
+
 0.9.0-alpha
 -----------
 

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -53,6 +53,7 @@ namespace openPMD
             case Format::ADIOS2:
                 return std::make_shared<ADIOS2IOHandler>(path, accessTypeBackend, comm);
             default:
+                throw std::runtime_error("Unknown file format! Did you specify a file ending?" );
                 return std::make_shared< DummyIOHandler >(path, accessTypeBackend);
         }
     }
@@ -82,6 +83,7 @@ namespace openPMD
             case Format::JSON:
                 return std::make_shared< JSONIOHandler >(path, accessType);
             default:
+                throw std::runtime_error("Unknown file format! Did you specify a file ending?" );
                 return std::make_shared< DummyIOHandler >(path, accessType);
         }
     }

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -33,7 +33,7 @@ struct TestHelper : public Attributable
 {
     TestHelper()
     {
-        m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
+        m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
         IOHandler = m_writable->IOHandler.get();
     }
 };
@@ -108,7 +108,7 @@ TEST_CASE( "container_default_test", "[auxiliary]")
 {
 #if openPMD_USE_INVASIVE_TESTS
     Container< openPMD::test::S > c = Container< openPMD::test::S >();
-    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
+    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
     c.IOHandler = c.m_writable->IOHandler.get();
 
     REQUIRE(c.empty());
@@ -143,7 +143,7 @@ TEST_CASE( "container_retrieve_test", "[auxiliary]" )
 #if openPMD_USE_INVASIVE_TESTS
     using structure = openPMD::test::structure;
     Container< structure > c = Container< structure >();
-    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
+    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
     c.IOHandler = c.m_writable->IOHandler.get();
 
     structure s;
@@ -220,7 +220,7 @@ TEST_CASE( "container_access_test", "[auxiliary]" )
 #if openPMD_USE_INVASIVE_TESTS
     using Widget = openPMD::test::Widget;
     Container< Widget > c = Container< Widget >();
-    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::DUMMY);
+    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
     c.IOHandler = c.m_writable->IOHandler.get();
 
     c["firstWidget"] = Widget(0);


### PR DESCRIPTION
Users can quickly forget to add a file ending. Instead of performing seamingly working, but zero-writing no-operations, let's throw a clean message.

Thanks to @rfbird for the report! :sparkles: