### PR TITLE
Python: Get Unit Dimension

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Bug Fixes
   - import ``mpi4py`` first (MPICH on OSX issue) #596
   - skip examples using HDF5 if backend is missing #544
   - fix a variable shadowing in ``Mesh`` #582
+  - add missing ``.unit_dimension`` for records #611
 - ADIOS1: fix deadlock in MPI-parallel, non-collective calls to ``storeChunk()`` #554
 - xlC 16.1: work-around C-array initializer parsing issue #547
 - icc 19.0.0 and PGI 19.5: fix compiler ID identification #548

--- a/src/binding/python/BaseRecord.cpp
+++ b/src/binding/python/BaseRecord.cpp
@@ -34,10 +34,14 @@ using namespace openPMD;
 
 
 void init_BaseRecord(py::module &m) {
-    py::class_<BaseRecord< RecordComponent >, Container< RecordComponent > >(m, "Base_Record_Record_Component");
-    py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Base_Record_Mesh_Record_Component");
-    py::class_<BaseRecord< BaseRecordComponent >, Container< BaseRecordComponent > >(m, "Base_Record_Base_Record_Component");
-    py::class_<BaseRecord< PatchRecordComponent >, Container< PatchRecordComponent > >(m, "Base_Record_Patch_Record_Component");
+    py::class_<BaseRecord< RecordComponent >, Container< RecordComponent > >(m, "Base_Record_Record_Component")
+        .def_property_readonly("unit_dimension", &BaseRecord< RecordComponent >::unitDimension);
+    py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Base_Record_Mesh_Record_Component")
+        .def_property_readonly("unit_dimension", &BaseRecord< MeshRecordComponent >::unitDimension);
+    py::class_<BaseRecord< BaseRecordComponent >, Container< BaseRecordComponent > >(m, "Base_Record_Base_Record_Component")
+        .def_property_readonly("unit_dimension", &BaseRecord< BaseRecordComponent >::unitDimension);
+    py::class_<BaseRecord< PatchRecordComponent >, Container< PatchRecordComponent > >(m, "Base_Record_Patch_Record_Component")
+        .def_property_readonly("unit_dimension", &BaseRecord< PatchRecordComponent >::unitDimension);
 
     py::enum_<UnitDimension>(m, "Unit_Dimension")
         .value("L", UnitDimension::L)

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -489,6 +489,11 @@ class APITest(unittest.TestCase):
         E_x = E["x"]
         shape = E_x.shape
 
+        if found_numpy:
+            np.testing.assert_allclose(E.unit_dimension,
+                                       [1., 1., -3., -1., 0., 0., 0.])
+        self.assertAlmostEqual(E_x.unit_SI, 1.0)
+
         self.assertSequenceEqual(shape, [26, 26, 201])
         if found_numpy:
             self.assertEqual(E_x.dtype, np.float64)
@@ -539,6 +544,11 @@ class APITest(unittest.TestCase):
         E_x = E["x"]
         pos_y = electrons["position"]["y"]
         w = electrons["weighting"][api.Record_Component.SCALAR]
+
+        if found_numpy:
+            np.testing.assert_allclose(electrons["position"].unit_dimension,
+                                       [1., 0., 0., 0., 0., 0., 0.])
+        self.assertAlmostEqual(pos_y.unit_SI, 1.0)
 
         offset = [4, 5, 9]
         extent = [4, 2, 3]


### PR DESCRIPTION
Expose access to a `.unit_dimension` member in records, just as in `.unit_SI`. Avoids having to query this openPMD required member by attribute.

Thanks to @LDAmorim for spotting!