### PR TITLE
ADIOS2: Fix C++17 Build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Features
 Bug Fixes
 """""""""
 
+- ADIOS2: fix C++17 build #614
+
 Other
 """""
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -699,10 +699,11 @@ namespace detail
          * that would otherwise be lost. Check whether this has been done.
          */
         using rep = AttributeTypes<bool>::rep;
+        if
 #if __cplusplus > 201402L
         constexpr
 #endif
-        if( std::is_same< T, rep >::value )
+        ( std::is_same< T, rep >::value )
         {
             std::string metaAttr = "__is_boolean__" + name;
             auto type = attributeInfo( IO, "__is_boolean__" + name );


### PR DESCRIPTION
Fix `if constexpr` syntax in C++17 build with ADIOS2.