### PR TITLE
NVCC: No Visibility Attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Bug Fixes
 """""""""
 
 - ADIOS2: fix C++17 build #614
+- nvcc:
+
+  - ignore export of ``enum class Operation`` #617
 
 Other
 """""

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -30,8 +30,10 @@
 #   include <queue>
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #   define EXPORT __declspec( dllexport )
+#elif defined(__NVCC__)
+#   define EXPORT
 #else
 #   define EXPORT __attribute__((visibility("default")))
 #endif

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -36,8 +36,10 @@
 #   include <unordered_set>
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #   define EXPORT __declspec( dllexport )
+#elif defined(__NVCC__)
+#   define EXPORT
 #else
 #   define EXPORT __attribute__((visibility("default")))
 #endif

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -30,8 +30,10 @@
 #   include <queue>
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #   define EXPORT __declspec( dllexport )
+#elif defined(__NVCC__)
+#   define EXPORT
 #else
 #   define EXPORT __attribute__((visibility("default")))
 #endif

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -37,8 +37,10 @@
 #   include <unordered_set>
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #   define EXPORT __declspec( dllexport )
+#elif defined(__NVCC__)
+#   define EXPORT
 #else
 #   define EXPORT __attribute__((visibility("default")))
 #endif

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -30,8 +30,10 @@
 #include <string>
 #include <utility>
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #   define EXPORT __declspec( dllexport )
+#elif defined(__NVCC__)
+#   define EXPORT
 #else
 #   define EXPORT __attribute__((visibility("default")))
 #endif


### PR DESCRIPTION
This project is provides host-side APIs [1]. Some downstream projects are unable to split their translation units properly in host+device and host-only, and just pass all code through `nvcc`. Doing so is not appreciated (by me) but tolerated (by me).

Unfortunately, `nvcc` is a bit behind in supporting visibility attributes (Nvidia bug report: 2767443 as of v10.2). Assuming that openPMD-api itself is built with a proper host-compiler instead of `nvcc`, we can live with defining our `EXPORT` macro to nothing during downstream consumption.

The previous implementation caused a compile error when build with GCC <6 and a warning with newer GCC in `include/openPMD/IO/IOTask.hpp` for `enum class Operation`.

[1] Note: We might support passing device-side pointers in the future, though. If HDF5 or ADIOS2 start to support consuming those...