### PR TITLE
MPark.Variant: Hotfix NVCC C++14

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Bug Fixes
 - nvcc:
 
   - ignore export of ``enum class Operation`` #617
+  - fix C++14 build #618
 
 Other
 """""

--- a/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
+++ b/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
@@ -2655,7 +2655,7 @@ namespace mpark {
     return false;
   }
 
-#ifdef MPARK_CPP14_CONSTEXPR
+#if defined(MPARK_CPP14_CONSTEXPR) && !defined(__NVCC__)
   namespace detail {
 
     inline constexpr bool all(std::initializer_list<bool> bs) {


### PR DESCRIPTION
Apply a hotfix for C++14 builds with NVCC in downstream projects.

Refs:
- https://github.com/mpark/variant/issues/70
- https://github.com/mpark/variant/pull/71