### PR TITLE
Add Container::contains

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Changes to "0.10.0-alpha"
 Features
 """"""""
 
+- C++: add ``Container::contains`` method #622
+
 Bug Fixes
 """""""""
 

--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -177,6 +177,10 @@ Python
    # record components
    E_x = E["x"]
 
+.. tip::
+
+   You can check via ``i.meshes.contains("E")`` (`C++ <https://www.openpmd.org/openPMD-api/classopen_p_m_d_1_1_container.html>`_) or ``"E" in i.meshes`` (Python) if an entry exists.
+
 Units
 -----
 

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -188,10 +188,22 @@ public:
         }
     }
 
-    size_type count(key_type const& key) const { return m_container->count(key); }
-
     iterator find(key_type const& key) { return m_container->find(key); }
     const_iterator find(key_type const& key) const { return m_container->find(key); }
+
+    /** This returns either 1 if the key is found in the container of 0 if not.
+     *
+     * @param key key value of the element to count
+     * @return since keys are unique in this container, returns 0 or 1
+     */
+    size_type count(key_type const& key) const { return m_container->count(key); }
+
+    /** Checks if there is an element with a key equivalent to an exiting key in the container.
+     *
+     * @param key key value of the element to search for
+     * @return true of key is found, else false
+     */
+    bool contains(key_type const& key) const { return m_container->find(key) != m_container->end(); }
 
     /** Remove a single element from the container and (if written) from disk.
      *

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -64,6 +64,14 @@ empty_dataset_test( std::string file_ending )
     {
         Series series(
             "../samples/empty_datasets." + file_ending, AccessType::READ_ONLY );
+
+        REQUIRE(series.iterations.contains(1));
+        REQUIRE(series.iterations.count(1) == 1);
+        REQUIRE(series.iterations.count(123456) == 0);
+
+        REQUIRE(series.iterations[1].meshes.contains("rho"));
+        REQUIRE(series.iterations[1].meshes["rho"].contains("makeEmpty_dim_7_int"));
+
         auto makeEmpty_dim_7_int =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_dim_7_int" ];
         auto makeEmpty_dim_7_long =

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -536,6 +536,12 @@ class APITest(unittest.TestCase):
         series = self.__series
         i = series.iterations[400]
 
+        # Test some entries exist
+        self.assertTrue("E" in i.meshes)
+        self.assertFalse("yolo" in i.meshes)
+        self.assertTrue("electrons" in i.particles)
+        self.assertFalse("graviton" in i.particles)
+
         # Get a mesh record and a particle species.
         E = i.meshes["E"]
         electrons = i.particles["electrons"]


### PR DESCRIPTION
Add a [`contains` method](https://en.cppreference.com/w/cpp/container/map/contains) as in C++20 to our `openPMD::Container`. This allows to check the existence of keys in iterations, records, etc. without having to use the exception system.

Suggested by @LDAmorim, thank you! :)