### PR TITLE
Rule of Three: Add Missing Assignment Ops

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Features
 Bug Fixes
 """""""""
 
+- Implement assignment operators for: ``IOTask``, ``Mesh``, ``Iteration``, ``BaseRecord``, ``Record`` #628
+
 Other
 """""
 

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -496,6 +496,14 @@ public:
         parameter{other.parameter}
     {}
 
+    IOTask& operator=(IOTask const & other)
+    {
+        writable = other.writable;
+        operation = other.operation;
+        parameter = other.parameter;
+        return *this;
+    }
+
     Writable* writable;
     Operation operation;
     std::shared_ptr< AbstractParameter > parameter;

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -44,6 +44,7 @@ class Iteration : public Attributable
 
 public:
     Iteration(Iteration const&);
+    Iteration& operator=(Iteration const&);
 
     /**
      * @tparam  T   Floating point type of user-selected precision (e.g. float, double).

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -42,6 +42,7 @@ class Mesh : public BaseRecord< MeshRecordComponent >
 
 public:
     Mesh(Mesh const&) = default;
+    Mesh& operator=(Mesh const&) = default;
 
     /** @brief Enumerated datatype for the geometry of the mesh.
      *

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -38,6 +38,7 @@ class Record : public BaseRecord< RecordComponent >
 
 public:
     Record(Record const&);
+    Record& operator=(Record const&);
     ~Record() override;
 
     Record& setUnitDimension(std::map< UnitDimension, double > const&);

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -56,6 +56,7 @@ public:
     using const_iterator = typename Container< T_elem >::const_iterator;
 
     BaseRecord(BaseRecord const& b);
+    BaseRecord& operator=(BaseRecord const& b);
     ~BaseRecord() override { }
 
     mapped_type& operator[](key_type const& key) override;
@@ -83,6 +84,13 @@ BaseRecord< T_elem >::BaseRecord(BaseRecord const& b)
         : Container< T_elem >(b),
           m_containsScalar{b.m_containsScalar}
 { }
+
+template< typename T_elem >
+BaseRecord< T_elem >& BaseRecord< T_elem >::operator=(openPMD::BaseRecord<T_elem> const& b) {
+    Container< T_elem >::operator=( b );
+    m_containsScalar = b.m_containsScalar;
+    return *this;
+}
 
 template< typename T_elem >
 BaseRecord< T_elem >::BaseRecord()

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -50,6 +50,20 @@ Iteration::Iteration(Iteration const& i)
     particles.parent = this->m_writable.get();
 }
 
+Iteration& Iteration::operator=(Iteration const& i)
+{
+    Attributable::operator=( i );
+    meshes = i.meshes;
+    particles = i.particles;
+    IOHandler = i.IOHandler;
+    parent = i.parent;
+    meshes.IOHandler = IOHandler;
+    meshes.parent = this->m_writable.get();
+    particles.IOHandler = IOHandler;
+    particles.parent = this->m_writable.get();
+    return *this;
+}
+
 template< typename T >
 Iteration&
 Iteration::setTime(T newTime)

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -31,6 +31,7 @@ Record::Record()
 }
 
 Record::Record(Record const&) = default;
+Record& Record::operator=(Record const&) = default;
 Record::~Record() = default;
 
 Record&


### PR DESCRIPTION
Add missing assignment operators to `IOTask`, `Mesh`, `BaseRecord`, `Record`, and `Iteration` classes that matches the already existing copy constructor ("rule of two/three").

This classes look self-assign safe without further handling.

Fix warnings from LGTM.