### PR TITLE
Spack: No microarch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -649,6 +649,7 @@ install:
       travis_wait 20 brew install python3;
       travis_wait 20 brew install numpy;
       travis_wait 20 brew upgrade numpy;
+      travis_wait 20 brew install jq;
       travis_wait 20 brew install modules &&
       brew info modules &&
       source /usr/local/opt/modules/init/bash &&
@@ -656,11 +657,12 @@ install:
       export TRAVIS_PYTHON_VERSION=3.7.2;
     fi
   - source $SPACK_ROOT/share/spack/setup-env.sh
-  - export SPACK_ARCH=$(spack spec --json cmake $CXXSPEC | jq -r '.spec[0].cmake.arch| (.platform + "-" + .platform_os + "-" + .target.name)')
+  - export SPACK_ARCH=$(spack spec --json cmake $CXXSPEC | jq -r '.spec[0].cmake.arch| (.platform + "-" + .platform_os + "-x86_64")')
   # fresh (cache-cleaned) travis runs seem to not properly init environment-modules
   - echo $MODULEPATH
   - if [[ ! $MODULEPATH = *"spack"* ]]; then
-      export MODULEPATH=$SPACK_ROOT/share/spack/modules/$(spack arch):$MODULEPATH;
+      export MODULEPATH=$SPACK_ROOT/share/spack/modules/${SPACK_ARCH}:$MODULEPATH;
+      echo ${MODULEPATH};
     fi
   # required dependencies - CMake 3.11.0
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -680,7 +682,7 @@ install:
       fi;
       spack install cmake@3.11.0 $CXXSPEC;
     fi
-  - spack load cmake@3.11.0 $CXXSPEC arch=${SPACK_ARCH}
+  - spack load cmake@3.11.0 $CXXSPEC
   # diagnostics: modules created and visible?
   - module av
   - module li
@@ -690,29 +692,29 @@ install:
       travis_wait spack install
         openmpi
         $CXXSPEC &&
-      spack load openmpi $CXXSPEC arch=${SPACK_ARCH};
+      spack load openmpi $CXXSPEC;
       SPACK_VAR_MPI="+mpi";
     fi
   - if [ $USE_PYTHON == "ON" ]; then
       travis_wait spack install
         python@$TRAVIS_PYTHON_VERSION
         $CXXSPEC &&
-      spack load python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
+      spack load python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
       if [ "$USE_INTERNAL_PYBIND11" == "OFF" ]; then
         travis_wait spack install
           py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION
           $CXXSPEC &&
-        spack load py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
+        spack load py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
       fi;
       travis_wait spack install
         py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION
         $CXXSPEC &&
-      spack load py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
+      spack load py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
       if [ $USE_MPI == "ON" ]; then
         travis_wait spack install
           py-mpi4py ^python@$TRAVIS_PYTHON_VERSION
           $CXXSPEC &&
-        spack load py-mpi4py ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
+        spack load py-mpi4py ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
       fi;
     fi
   - if [ $USE_HDF5 == "ON" ]; then
@@ -720,14 +722,14 @@ install:
         hdf5$HDF5_VERSION
         $SPACK_VAR_MPI
         $CXXSPEC &&
-      spack load hdf5$HDF5_VERSION $SPACK_VAR_MPI $CXXSPEC arch=${SPACK_ARCH};
+      spack load hdf5$HDF5_VERSION $SPACK_VAR_MPI $CXXSPEC;
     fi
   - if [ $USE_ADIOS1 == "ON" ]; then
       travis_wait 30 spack install
         adios$ADIOS1_VERSION
         $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION
         $CXXSPEC &&
-      spack load adios$ADIOS1_VERSION $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
+      spack load adios$ADIOS1_VERSION $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC;
     fi
   - if [ $USE_ADIOS2 == "ON" ]; then
       echo "adios2$ADIOS2_VERSION $SPACK_VAR_MPI $CXXSPEC";
@@ -736,7 +738,7 @@ install:
         adios2$ADIOS2_VERSION
         $SPACK_VAR_MPI
         $CXXSPEC &&
-      spack load adios2$ADIOS2_VERSION $SPACK_VAR_MPI $CXXSPEC arch=${SPACK_ARCH};
+      spack load adios2$ADIOS2_VERSION $SPACK_VAR_MPI $CXXSPEC;
     fi
   - spack clean -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -656,6 +656,7 @@ install:
       export TRAVIS_PYTHON_VERSION=3.7.2;
     fi
   - source $SPACK_ROOT/share/spack/setup-env.sh
+  - export SPACK_ARCH=$(spack spec --json cmake $CXXSPEC | jq -r '.spec[0].cmake.arch| (.platform + "-" + .platform_os + "-" + .target.name)')
   # fresh (cache-cleaned) travis runs seem to not properly init environment-modules
   - echo $MODULEPATH
   - if [[ ! $MODULEPATH = *"spack"* ]]; then
@@ -679,7 +680,7 @@ install:
       fi;
       spack install cmake@3.11.0 $CXXSPEC;
     fi
-  - spack load cmake@3.11.0 $CXXSPEC arch=$(spack arch)
+  - spack load cmake@3.11.0 $CXXSPEC arch=${SPACK_ARCH}
   # diagnostics: modules created and visible?
   - module av
   - module li
@@ -689,29 +690,29 @@ install:
       travis_wait spack install
         openmpi
         $CXXSPEC &&
-      spack load openmpi $CXXSPEC arch=$(spack arch);
+      spack load openmpi $CXXSPEC arch=${SPACK_ARCH};
       SPACK_VAR_MPI="+mpi";
     fi
   - if [ $USE_PYTHON == "ON" ]; then
       travis_wait spack install
         python@$TRAVIS_PYTHON_VERSION
         $CXXSPEC &&
-      spack load python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=$(spack arch);
+      spack load python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
       if [ "$USE_INTERNAL_PYBIND11" == "OFF" ]; then
         travis_wait spack install
           py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION
           $CXXSPEC &&
-        spack load py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=$(spack arch);
+        spack load py-pybind11$PYBIND11_VERSION ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
       fi;
       travis_wait spack install
         py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION
         $CXXSPEC &&
-      spack load py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=$(spack arch);
+      spack load py-numpy ~blas ~lapack ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
       if [ $USE_MPI == "ON" ]; then
         travis_wait spack install
           py-mpi4py ^python@$TRAVIS_PYTHON_VERSION
           $CXXSPEC &&
-        spack load py-mpi4py ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=$(spack arch);
+        spack load py-mpi4py ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
       fi;
     fi
   - if [ $USE_HDF5 == "ON" ]; then
@@ -719,14 +720,14 @@ install:
         hdf5$HDF5_VERSION
         $SPACK_VAR_MPI
         $CXXSPEC &&
-      spack load hdf5$HDF5_VERSION $SPACK_VAR_MPI $CXXSPEC arch=$(spack arch);
+      spack load hdf5$HDF5_VERSION $SPACK_VAR_MPI $CXXSPEC arch=${SPACK_ARCH};
     fi
   - if [ $USE_ADIOS1 == "ON" ]; then
       travis_wait 30 spack install
         adios$ADIOS1_VERSION
         $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION
         $CXXSPEC &&
-      spack load adios$ADIOS1_VERSION $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=$(spack arch);
+      spack load adios$ADIOS1_VERSION $SPACK_VAR_MPI ^python@$TRAVIS_PYTHON_VERSION $CXXSPEC arch=${SPACK_ARCH};
     fi
   - if [ $USE_ADIOS2 == "ON" ]; then
       echo "adios2$ADIOS2_VERSION $SPACK_VAR_MPI $CXXSPEC";
@@ -735,7 +736,7 @@ install:
         adios2$ADIOS2_VERSION
         $SPACK_VAR_MPI
         $CXXSPEC &&
-      spack load adios2$ADIOS2_VERSION $SPACK_VAR_MPI $CXXSPEC arch=$(spack arch);
+      spack load adios2$ADIOS2_VERSION $SPACK_VAR_MPI $CXXSPEC arch=${SPACK_ARCH};
     fi
   - spack clean -a
 

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -72,8 +72,9 @@ packages:
   py-numpy:
     variants: ~blas ~lapack
 
-  # set MPI providers and compiler versions
+  # set generic binary generation, mpi providers and compiler versions
   all:
+    target: ['x86_64']
     providers:
       mpi: [openmpi]
     compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@9.1.0, clang@10.0.0, clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0]


### PR DESCRIPTION
Some compilers fall back to an older compatible micro-architecture
such as:
```
$ spack install cmake@3.11.0 $CXXSPEC
==> Warning: clang@5.0.0 cannot build optimized binaries for "cascadelake". Using best target possible: "skylake_avx512"
==> cmake@3.11.0 : externally installed in /home/travis/.cache/cmake-3.11.0
==> cmake@3.11.0 : generating module file
==> cmake@3.11.0 : registering into DB
```
.
When loading this with
```
$ spack load cmake@3.11.0 $CXXSPEC arch=$(spack arch)
```
the fallback is unknown to `spack arch`:
```
==> Error: the constraint '['cmake@3.11.0', '%clang@5.0.0', 'arch=linux-ubuntu16.04-cascadelake']' matches no package
```

Therefore, query the chosen fallback micro-arch from `spack spec` now. 

Update: just take the generic x86_64 target.