### PR TITLE
LGTM: Add ADIOS1 and HDF5 Deps

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,11 @@
+extraction: 
+  cpp:
+    prepare:
+      packages:
+        # MPI-enabled ADIOS missing on cosmic (but is available on disco+)
+        #- libhdf5-mpich-dev
+        #- libadios-mpich-dev
+        #- mpich
+        #- libmpich-dev
+        - libhdf5-dev
+        - libadios-dev


### PR DESCRIPTION
Cover more code by providing ADIOS1 and HDF5.
(MPI-enabled ADIOS packages are missing on Ubuntu cosmic, but are available on newer releases of Ubuntu (disco+) ...)