### PR TITLE
Add Missing Virtual Destructors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 # Future consideration: cppcoreguidelines-*,clang-analyzer-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,readability-*,-clang-diagnostic-unused-command-line-argument,-*-namespace-comment*,-*-braces-around-statements,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-readability-named-parameter
 # FIXME: all performance-* reports
 # FIXME: all cert-* reports
-Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter
+Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,modernize-use-override
 HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 # Future consideration: cppcoreguidelines-*,clang-analyzer-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,readability-*,-clang-diagnostic-unused-command-line-argument,-*-namespace-comment*,-*-braces-around-statements,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-readability-named-parameter
 # FIXME: all performance-* reports
 # FIXME: all cert-* reports
-Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,modernize-use-override
+Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,modernize-use-override,modernize-use-equals-default
 HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -342,7 +342,7 @@ jobs:
       before_install:
         - CXX=clang++ && CC=clang
         - perl --version
-    # Clang 10.0.0-apple + Python 3.7.2 @ OSX "mojave" with libc++
+    # Clang 10.0.0-apple + Python 3.7.2 @ OSX "highsierra" with libc++
     - <<: *test-cpp-unit
       name: AppleClang@10.0.0 -MPI +PY@3.7 +H5 -ADIOS1 +ADIOS2 libc++
       os: osx
@@ -351,6 +351,20 @@ jobs:
       language: generic
       env:
         - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SAMPLES=ON
+      compiler: clang
+      script: *script-cpp-unit
+      before_install:
+        - CXX=clang++ && CC=clang
+        - perl --version
+    # Clang 11.0.0-apple + Python 3.7.2 @ OSX "mojave"
+    - <<: *test-cpp-unit
+      name: AppleClang@11.0.0 -MPI -PY +H5 +ADIOS1 +ADIOS2
+      os: osx
+      osx_image: xcode11.2
+      sudo: required
+      language: generic
+      env:
+        - CXXSPEC="%clang@11.0.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
       before_install:

--- a/.travis/spack/compilers.yaml
+++ b/.travis/spack/compilers.yaml
@@ -32,6 +32,19 @@ compilers:
     extra_rpaths: []
     flags: {}
     modules: []
+    operating_system: mojave
+    paths:
+      cc: /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: null
+      fc: null
+    spec: clang@11.0.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
     operating_system: ubuntu16.04
     paths:
       cc: /usr/lib/llvm-5.0/bin/clang

--- a/.travis/spack/packages.yaml
+++ b/.travis/spack/packages.yaml
@@ -12,6 +12,7 @@ packages:
       perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.18.2%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
       perl@5.18.2%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr
+      perl@5.18.2%clang@11.0.0 arch=darwin-mojave-x86_64: /usr
     buildable: False
   cmake:
     version: [3.11.0]
@@ -26,6 +27,7 @@ packages:
       cmake@3.11.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
       cmake@3.11.0%clang@10.0.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.11.0%clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
     version: [1.6.5, 1.10.2]
@@ -59,6 +61,7 @@ packages:
       python@3.7.1%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@3.7.2%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
       python@3.7.2%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
+      python@3.7.2%clang@11.0.0 arch=darwin-mojave-x86_64: /usr/local/opt/python
     buildable: False
 
   # speed up builds of dependencies
@@ -73,4 +76,4 @@ packages:
   all:
     providers:
       mpi: [openmpi]
-    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@9.1.0, clang@10.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0]
+    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@9.1.0, clang@10.0.0, clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Bug Fixes
 """""""""
 
 - Implement assignment operators for: ``IOTask``, ``Mesh``, ``Iteration``, ``BaseRecord``, ``Record`` #628
+- Missing ``virtual`` destructors added #632
 
 Other
 """""

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -102,7 +102,7 @@ public:
     explicit ADIOS2IOHandlerImpl( AbstractIOHandler * );
 
 
-    ~ADIOS2IOHandlerImpl( ) override;
+    ~ADIOS2IOHandlerImpl( ) override = default;
 
     std::future< void > flush( ) override;
 
@@ -641,7 +641,10 @@ private:
     ADIOS2IOHandlerImpl m_impl;
 
 public:
-    ~ADIOS2IOHandler( ) override;
+    ~ADIOS2IOHandler( ) override
+    {
+        this->flush( );
+    }
 
 #else
 public:

--- a/include/openPMD/IO/AbstractFilePosition.hpp
+++ b/include/openPMD/IO/AbstractFilePosition.hpp
@@ -26,6 +26,6 @@ namespace openPMD
 class AbstractFilePosition
 {
 public:
-    virtual ~AbstractFilePosition() { }
+    virtual ~AbstractFilePosition() = default;
 }; // AbstractFilePosition
 } // openPMD

--- a/include/openPMD/IO/DummyIOHandler.hpp
+++ b/include/openPMD/IO/DummyIOHandler.hpp
@@ -36,7 +36,7 @@ namespace openPMD
     {
     public:
         DummyIOHandler(std::string, AccessType);
-        ~DummyIOHandler();
+        ~DummyIOHandler() override = default;
 
         /** No-op consistent with the IOHandler interface to enable library use without IO.
         */

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -36,7 +36,7 @@ namespace openPMD
     {
     public:
         HDF5IOHandlerImpl(AbstractIOHandler*);
-        virtual ~HDF5IOHandlerImpl();
+        ~HDF5IOHandlerImpl() override;
 
         void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) override;
         void createPath(Writable*, Parameter< Operation::CREATE_PATH > const&) override;

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
@@ -38,7 +38,7 @@ namespace openPMD
     {
     public:
         ParallelHDF5IOHandlerImpl(AbstractIOHandler*, MPI_Comm);
-        virtual ~ParallelHDF5IOHandlerImpl();
+        ~ParallelHDF5IOHandlerImpl() override;
 
         MPI_Comm m_mpiComm;
         MPI_Info m_mpiInfo;

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -90,6 +90,7 @@ public:
     Container< Mesh > meshes;
     Container< ParticleSpecies > particles; //particleSpecies?
 
+    virtual ~Iteration() = default;
 private:
     Iteration();
 

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -43,6 +43,7 @@ class Mesh : public BaseRecord< MeshRecordComponent >
 public:
     Mesh(Mesh const&) = default;
     Mesh& operator=(Mesh const&) = default;
+    ~Mesh() override = default;
 
     /** @brief Enumerated datatype for the geometry of the mesh.
      *

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -37,9 +37,10 @@ namespace openPMD
 
     public:
         size_t numPatches() const;
+        ~ParticlePatches() override = default;
 
     private:
-        ParticlePatches();
+        ParticlePatches() = default;
         void read();
     }; // ParticlePatches
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -41,7 +41,7 @@ public:
     ParticlePatches particlePatches;
 
 private:
-    ParticleSpecies();
+    ParticleSpecies() = default;
 
     void read();
     void flush(std::string const &) override;

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -37,9 +37,9 @@ class Record : public BaseRecord< RecordComponent >
     friend class ParticleSpecies;
 
 public:
-    Record(Record const&);
-    Record& operator=(Record const&);
-    ~Record() override;
+    Record(Record const&) = default;
+    Record& operator=(Record const&) = default;
+    ~Record() override = default;
 
     Record& setUnitDimension(std::map< UnitDimension, double > const&);
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -159,6 +159,8 @@ public:
 
     static constexpr char const * const SCALAR = "\vScalar";
 
+    virtual ~RecordComponent() = default;
+
 OPENPMD_protected:
     RecordComponent();
 

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -67,13 +67,12 @@ public:
 
 protected:
     BaseRecord();
-
     void readBase();
 
     std::shared_ptr< bool > m_containsScalar;
 
 private:
-    virtual void flush(std::string const&) final;
+    void flush(std::string const&) final;
     virtual void flush_impl(std::string const&) = 0;
     virtual void read() = 0;
 };  //BaseRecord

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -57,7 +57,7 @@ public:
 
     BaseRecord(BaseRecord const& b);
     BaseRecord& operator=(BaseRecord const& b);
-    ~BaseRecord() override { }
+    virtual ~BaseRecord() = default;
 
     mapped_type& operator[](key_type const& key) override;
     mapped_type& operator[](key_type&& key) override;

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -46,8 +46,7 @@ class BaseRecordComponent : public Attributable
     class Container;
 
 public:
-    virtual ~BaseRecordComponent()
-    { }
+    ~BaseRecordComponent() override = default;
 
     double unitSI() const;
 

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -91,7 +91,7 @@ public:
     using const_iterator = typename InternalContainer::const_iterator;
 
     Container(Container const&) = default;
-    virtual ~Container() { }
+    virtual ~Container() = default;
 
     iterator begin() noexcept { return m_container->begin(); }
     const_iterator begin() const noexcept { return m_container->begin(); }

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -44,6 +44,8 @@ private:
     void read() override;
 
 public:
+    ~MeshRecordComponent() override = default;
+
     template< typename T >
     std::vector< T > position() const;
     template< typename T >

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -37,9 +37,10 @@ class PatchRecord : public BaseRecord< PatchRecordComponent >
 
 public:
     PatchRecord& setUnitDimension(std::map< UnitDimension, double > const&);
+    ~PatchRecord() override = default;
 
 private:
-    PatchRecord();
+    PatchRecord() = default;
 
     void flush_impl(std::string const&) override;
     void read() override;

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -52,7 +52,7 @@ class AbstractIOHandlerImplCommon;
  *                      - whether the logical object has been modified compared
  *                        to last persistent state
  */
-class Writable
+class Writable final
 {
     friend class Attributable;
     template< typename T_elem >
@@ -81,7 +81,7 @@ class Writable
 
 public:
     Writable(Attributable* = nullptr);
-    virtual ~Writable();
+    ~Writable() = default;
 
 OPENPMD_private:
     std::shared_ptr< AbstractFilePosition > abstractFilePosition;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -76,11 +76,6 @@ ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl( AbstractIOHandler * handler )
 {
 }
 
-ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl( )
-{
-    this->flush( );
-}
-
 std::future< void > ADIOS2IOHandlerImpl::flush( )
 {
     auto res = AbstractIOHandlerImpl::flush( );
@@ -1331,12 +1326,6 @@ ADIOS2IOHandler::ADIOS2IOHandler( std::string path, openPMD::AccessType at,
 ADIOS2IOHandler::ADIOS2IOHandler( std::string path, AccessType at )
 : AbstractIOHandler( std::move( path ), at ), m_impl{this}
 {
-}
-
-
-ADIOS2IOHandler::~ADIOS2IOHandler( )
-{
-    this->flush( );
 }
 
 std::future< void > ADIOS2IOHandler::flush( )

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -18,11 +18,11 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#include <openPMD/IO/ADIOS/ADIOS2IOHandler.hpp>
 #include "openPMD/IO/AbstractIOHandlerHelper.hpp"
 #include "openPMD/IO/DummyIOHandler.hpp"
 #include "openPMD/IO/ADIOS/ADIOS1IOHandler.hpp"
 #include "openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
 #include "openPMD/IO/HDF5/HDF5IOHandler.hpp"
 #include "openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp"
 #include "openPMD/IO/JSON/JSONIOHandler.hpp"

--- a/src/IO/DummyIOHandler.cpp
+++ b/src/IO/DummyIOHandler.cpp
@@ -30,8 +30,6 @@ namespace openPMD
             : AbstractIOHandler(std::move(path), at)
     { }
 
-    DummyIOHandler::~DummyIOHandler() = default;
-
     void DummyIOHandler::enqueue(IOTask const&)
     { }
 

--- a/src/IO/JSON/JSONIOHandler.cpp
+++ b/src/IO/JSON/JSONIOHandler.cpp
@@ -24,9 +24,7 @@
 
 namespace openPMD
 {
-    JSONIOHandler::~JSONIOHandler( )
-    {}
-
+    JSONIOHandler::~JSONIOHandler( ) = default;
 
     JSONIOHandler::JSONIOHandler(
         std::string path,

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -23,7 +23,6 @@
 
 namespace openPMD
 {
-ParticlePatches::ParticlePatches() = default;
 
 size_t
 ParticlePatches::numPatches() const

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -25,7 +25,6 @@
 
 namespace openPMD
 {
-ParticleSpecies::ParticleSpecies() = default;
 
 void
 ParticleSpecies::read()

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -30,10 +30,6 @@ Record::Record()
     setTimeOffset(0.f);
 }
 
-Record::Record(Record const&) = default;
-Record& Record::operator=(Record const&) = default;
-Record::~Record() = default;
-
 Record&
 Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
 {

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -37,8 +37,6 @@ PatchRecord::setUnitDimension(std::map< UnitDimension, double > const& udim)
     return *this;
 }
 
-PatchRecord::PatchRecord() = default;
-
 void
 PatchRecord::flush_impl(std::string const& path)
 {

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -33,6 +33,4 @@ Writable::Writable(Attributable* a)
           written{false}
 { }
 
-Writable::~Writable() = default;
-
 } // openPMD


### PR DESCRIPTION
- [x] Activate further virtual override checks in clang tidy.
- [x] Add XCode 11.2.1 (11B500) to CI
- ~~destructors don't `override` https://github.com/isocpp/CppCoreGuidelines/issues/721 (all other virtual member functions do)~~ they do: https://github.com/isocpp/CppCoreGuidelines/commit/5fdfb20b760c5307bf86873798a146fcd7e912e6
- [x] `virtual` member function in a class triggers need for `virtual ~Type` destructor: https://www.geeksforgeeks.org/virtual-destructor/

Related to #631