### PR TITLE
[WIP] Series Input: Sanitize Prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Bug Fixes
 
 - Implement assignment operators for: ``IOTask``, ``Mesh``, ``Iteration``, ``BaseRecord``, ``Record`` #628
 - Missing ``virtual`` destructors added #632
+- Series: sanitize user paths to avoid parsing errors #633
 
 Other
 """""

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -991,24 +991,17 @@ matcher(std::string const& prefix, int padding, std::string const& postfix, Form
         nameReg.append("+");
     nameReg.append(")" + postfix);
 
+    // escape the dot before the file extension/suffix
+    nameReg.append( "\\" )
+           .append( suffix( f ) )
+           .append( "$" );
     switch( f )
     {
         case Format::HDF5:
-        {
-            nameReg.append("\\.h5$");
-            return buildMatcher(nameReg);
-        }
         case Format::ADIOS1:
         case Format::ADIOS2:
-        {
-            nameReg.append("\\.bp$");
-            return buildMatcher(nameReg);
-        }
         case Format::JSON:
-        {
-            nameReg.append("\\.json$");
             return buildMatcher(nameReg);
-        }
         default:
             return [](std::string const&) -> std::tuple< bool, int > { return std::tuple< bool, int >{false, 0}; };
     }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -32,7 +32,7 @@
 #include <string>
 #include <tuple>
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(_MSC_VER)
 #   if (__GNUC__ == 4 && __GNUC_MINOR__ < 9)
 #       define IS_GCC_48 1
 #   endif

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -697,3 +697,15 @@ TEST_CASE( "no_file_ending", "[core]" )
     REQUIRE_THROWS_WITH(Series("./new_openpmd_output_%05T", AccessType::CREATE),
                         Catch::Equals("Unknown file format! Did you specify a file ending?"));
 }
+
+TEST_CASE( "fancy_paths", "[core]" )
+{
+    auto a = Series("moreOutput/this/is-quite-sophisticated.N02.mine/output/json/data_%05T.json", AccessType::CREATE);
+    a.iterations[0].meshes["test"]["x"].resetDataset(Dataset(Datatype::DOUBLE, {4})).makeConstant<float>(42.);
+
+    auto b = Series("./moreOutput/even/more/con-fusing.N02.json/outputs/json/data_%05T.json", AccessType::CREATE);
+    b.iterations[0].meshes["test"]["x"].resetDataset(Dataset(Datatype::DOUBLE, {4})).makeConstant<float>(42.);
+
+    auto c = Series("moreOutput/my data can space/data_%05T.json", AccessType::CREATE);
+    c.iterations[0].meshes["test"]["x"].resetDataset(Dataset(Datatype::DOUBLE, {4})).makeConstant<float>(42.);
+}


### PR DESCRIPTION
The prefix matched still contains the whole path, including directories, etc.. User-input must be sanitized before passed into regex engines.

- [ ] add reproducer to CI

Fix #626 