### PR TITLE
Backends: Prefix Error Messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Bug Fixes
 Other
 """""
 
+- Backends: Prefix Error Messages #634
+
 
 0.10.1-alpha
 ------------

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -112,7 +112,7 @@ ADIOS1IOHandlerImpl::flush()
                     openFile(i.writable, *dynamic_cast< Parameter< O::OPEN_FILE >* >(i.parameter.get()));
                     break;
                 default:
-                    VERIFY(false, "Internal error: Wrong operation in ADIOS setup queue");
+                    VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS setup queue");
             }
         } catch (unsupported_data_error& e)
         {
@@ -171,7 +171,7 @@ ADIOS1IOHandlerImpl::flush()
                     listAttributes(i.writable, *dynamic_cast< Parameter< O::LIST_ATTS >* >(i.parameter.get()));
                     break;
                 default:
-                    VERIFY(false, "Internal error: Wrong operation in ADIOS work queue");
+                    VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS work queue");
             }
         } catch (unsupported_data_error& e)
         {
@@ -186,7 +186,7 @@ ADIOS1IOHandlerImpl::flush()
     {
         status = adios_perform_reads(file.first,
                                      1);
-        VERIFY(status == err_no_error, "Internal error: Failed to perform ADIOS reads during dataset reading");
+        VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to perform ADIOS reads during dataset reading");
 
         for( auto& sel : file.second )
             adios_selection_delete(sel);
@@ -201,11 +201,11 @@ ADIOS1IOHandlerImpl::init()
 {
     int status;
     status = adios_init_noxml(MPI_COMM_NULL);
-    VERIFY(status == err_no_error, "Internal error: Failed to initialize ADIOS");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to initialize ADIOS");
 
     m_readMethod = ADIOS_READ_METHOD_BP;
     status = adios_read_init_method(m_readMethod, MPI_COMM_NULL, "");
-    VERIFY(status == err_no_error, "Internal error: Failed to initialize ADIOS reading method");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to initialize ADIOS reading method");
 
 }
 #endif
@@ -275,7 +275,7 @@ ADIOS1IOHandlerImpl::open_write(Writable* writable)
                         res->second->c_str(),
                         mode.c_str(),
                         MPI_COMM_NULL);
-    VERIFY(status == err_no_error, "Internal error: Failed to open_write ADIOS file");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to open_write ADIOS file");
 
     return fd;
 }
@@ -287,8 +287,8 @@ ADIOS1IOHandlerImpl::open_read(std::string const & name)
     f = adios_read_open_file(name.c_str(),
                              m_readMethod,
                              MPI_COMM_NULL);
-    VERIFY(adios_errno != err_file_not_found, "Internal error: ADIOS file not found");
-    VERIFY(f != nullptr, "Internal error: Failed to open_read ADIOS file");
+    VERIFY(adios_errno != err_file_not_found, "[ADIOS1] Internal error: ADIOS file not found");
+    VERIFY(f != nullptr, "[ADIOS1] Internal error: Failed to open_read ADIOS file");
 
     return f;
 }
@@ -300,9 +300,9 @@ ADIOS1IOHandlerImpl::initialize_group(std::string const &name)
     int64_t group;
     ADIOS_STATISTICS_FLAG noStatistics = adios_stat_no;
     status = adios_declare_group(&group, name.c_str(), "", noStatistics);
-    VERIFY(status == err_no_error, "Internal error: Failed to declare ADIOS group");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to declare ADIOS group");
     status = adios_select_method(group, "POSIX", "", "");
-    VERIFY(status == err_no_error, "Internal error: Failed to select ADIOS method");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to select ADIOS method");
     return group;
 }
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -98,7 +98,7 @@ void ADIOS2IOHandlerImpl::createFile(
     Parameter< Operation::CREATE_FILE > const & parameters )
 {
     VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-                   "Creating a file in read-only mode is not possible." );
+                   "[ADIOS2] Creating a file in read-only mode is not possible." );
 
     if ( !writable->written )
     {
@@ -115,7 +115,7 @@ void ADIOS2IOHandlerImpl::createFile(
                ( !std::get< PE_NewlyCreated >( res_pair ) ||
                  auxiliary::file_exists( fullPath(
                      std::get< PE_InvalidatableFile >( res_pair ) ) ) ) ),
-            "Can only overwrite existing file in CREATE mode." );
+            "[ADIOS2] Can only overwrite existing file in CREATE mode." );
 
         if ( !std::get< PE_NewlyCreated >( res_pair ) )
         {
@@ -129,7 +129,7 @@ void ADIOS2IOHandlerImpl::createFile(
         if ( !auxiliary::directory_exists( dir ) )
         {
             auto success = auxiliary::create_directories( dir );
-            VERIFY( success, "Could not create directory." );
+            VERIFY( success, "[ADIOS2] Could not create directory." );
         }
 
         associateWithFile( writable, shared_name );
@@ -175,7 +175,7 @@ void ADIOS2IOHandlerImpl::createDataset(
 {
     if ( m_handler->accessTypeBackend == AccessType::READ_ONLY )
     {
-        throw std::runtime_error( "Creating a dataset in a file opened as read "
+        throw std::runtime_error( "[ADIOS2] Creating a dataset in a file opened as read "
                                   "only is not possible." );
     }
     if ( !writable->written )
@@ -213,7 +213,7 @@ void ADIOS2IOHandlerImpl::extendDataset(
     Writable *, const Parameter< Operation::EXTEND_DATASET > & )
 {
     throw std::runtime_error(
-        "Dataset extension not implemented in ADIOS backend" );
+        "[ADIOS2] Dataset extension not implemented in ADIOS backend" );
 }
 
 void ADIOS2IOHandlerImpl::openFile(
@@ -221,7 +221,7 @@ void ADIOS2IOHandlerImpl::openFile(
 {
     if ( !auxiliary::directory_exists( m_handler->directory ) )
     {
-        throw no_such_file_error( "Supplied directory is not valid: " +
+        throw no_such_file_error( "[ADIOS2] Supplied directory is not valid: " +
                                   m_handler->directory );
     }
 
@@ -276,13 +276,13 @@ void ADIOS2IOHandlerImpl::openDataset(
 void ADIOS2IOHandlerImpl::deleteFile(
     Writable *, const Parameter< Operation::DELETE_FILE > & )
 {
-    throw std::runtime_error( "ADIOS2 backend does not support deletion." );
+    throw std::runtime_error( "[ADIOS2] Backend does not support deletion." );
 }
 
 void ADIOS2IOHandlerImpl::deletePath(
     Writable *, const Parameter< Operation::DELETE_PATH > & )
 {
-    throw std::runtime_error( "ADIOS2 backend does not support deletion." );
+    throw std::runtime_error( "[ADIOS2] Backend does not support deletion." );
 }
 
 void
@@ -291,14 +291,14 @@ ADIOS2IOHandlerImpl::deleteDataset(
     const Parameter< Operation::DELETE_DATASET > & )
 {
     // call filedata.invalidateVariablesMap
-    throw std::runtime_error( "ADIOS2 backend does not support deletion." );
+    throw std::runtime_error( "[ADIOS2] Backend does not support deletion." );
 }
 
 void ADIOS2IOHandlerImpl::deleteAttribute(
     Writable *, const Parameter< Operation::DELETE_ATT > & )
 {
     // call filedata.invalidateAttributesMap
-    throw std::runtime_error( "ADIOS2 backend does not support deletion." );
+    throw std::runtime_error( "[ADIOS2] Backend does not support deletion." );
 }
 
 void ADIOS2IOHandlerImpl::writeDataset(
@@ -306,7 +306,7 @@ void ADIOS2IOHandlerImpl::writeDataset(
     const Parameter< Operation::WRITE_DATASET > & parameters )
 {
     VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-                   "Cannot write data in read-only mode." );
+                   "[ADIOS2] Cannot write data in read-only mode." );
     setAndGetFilePosition( writable );
     auto file = refreshFileFromParent( writable );
     detail::BufferedActions & ba = getFileData( file );
@@ -356,7 +356,7 @@ void ADIOS2IOHandlerImpl::listPaths(
 {
     VERIFY_ALWAYS(
         writable->written,
-        "Internal error: Writable not marked written during path listing" );
+        "[ADIOS2] Internal error: Writable not marked written during path listing" );
     auto file = refreshFileFromParent( writable );
     auto pos = setAndGetFilePosition( writable );
     std::string myName = filePositionToString( pos );
@@ -430,7 +430,7 @@ void ADIOS2IOHandlerImpl::listDatasets(
 {
     VERIFY_ALWAYS(
         writable->written,
-        "Internal error: Writable not marked written during path listing" );
+        "[ADIOS2] Internal error: Writable not marked written during path listing" );
     auto file = refreshFileFromParent( writable );
     auto pos = setAndGetFilePosition( writable );
     // adios2::Engine & engine = getEngine( file );
@@ -471,7 +471,7 @@ void ADIOS2IOHandlerImpl::listAttributes(
     Writable * writable, Parameter< Operation::LIST_ATTS > & parameters )
 {
     VERIFY_ALWAYS( writable->written,
-                   "Internal error: Writable not marked "
+                   "[ADIOS2] Internal error: Writable not marked "
                    "written during attribute writing" );
     auto file = refreshFileFromParent( writable );
     auto pos = setAndGetFilePosition( writable );
@@ -590,7 +590,7 @@ detail::BufferedActions &
 ADIOS2IOHandlerImpl::getFileData( InvalidatableFile file )
 {
     VERIFY_ALWAYS( file.valid( ),
-                   "Cannot retrieve file data for a file that has "
+                   "[ADIOS2] Cannot retrieve file data for a file that has "
                    "been overwritten or deleted." )
     auto it = m_fileData.find( file );
     if ( it == m_fileData.end( ) )
@@ -627,20 +627,20 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
         auto requiredType = adios2::GetType< T >( );
         auto actualType = IO.VariableType( varName );
         VERIFY_ALWAYS( requiredType == actualType,
-                       "Trying to access a dataset with wrong type (trying to "
+                       "[ADIOS2] Trying to access a dataset with wrong type (trying to "
                        "access dataset with type " +
                            requiredType + ", but has type " + actualType + ")" )
     }
     adios2::Variable< T > var = IO.InquireVariable< T >( varName );
     VERIFY_ALWAYS( var.operator bool( ),
-                   "Internal error: Failed opening ADIOS2 variable." )
+                   "[ADIOS2] Internal error: Failed opening ADIOS2 variable." )
     // TODO leave this check to ADIOS?
     adios2::Dims shape = var.Shape( );
     auto actualDim = shape.size( );
     {
         auto requiredDim = extent.size( );
         VERIFY_ALWAYS( requiredDim == actualDim,
-                       "Trying to access a dataset with wrong dimensionality "
+                       "[ADIOS2] Trying to access a dataset with wrong dimensionality "
                        "(trying to access dataset with dimensionality " +
                            std::to_string( requiredDim ) +
                            ", but has dimensionality " +
@@ -649,7 +649,7 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
     for ( unsigned int i = 0; i < actualDim; i++ )
     {
         VERIFY_ALWAYS( offset[i] + extent[i] <= shape[i],
-                       "Dataset access out of bounds." )
+                       "[ADIOS2] Dataset access out of bounds." )
     }
 
     var.SetSelection({
@@ -678,7 +678,7 @@ namespace detail
     void DatasetReader::operator( )( Params &&... )
     {
         throw std::runtime_error(
-            "Internal error: Unknown datatype trying to read a dataset." );
+            "[ADIOS2] Internal error: Unknown datatype trying to read a dataset." );
     }
 
     template < typename T >
@@ -717,7 +717,7 @@ namespace detail
     template < int n, typename... Params >
     Datatype AttributeReader::operator( )( Params &&... )
     {
-        throw std::runtime_error( "Internal error: Unknown datatype while "
+        throw std::runtime_error( "[ADIOS2] Internal error: Unknown datatype while "
                                   "trying to read an attribute." );
     }
 
@@ -729,7 +729,7 @@ namespace detail
 
         VERIFY_ALWAYS( impl->m_handler->accessTypeBackend !=
                            AccessType::READ_ONLY,
-                       "Cannot write attribute in read-only mode." );
+                       "[ADIOS2] Cannot write attribute in read-only mode." );
         auto pos = impl->setAndGetFilePosition( writable );
         auto file = impl->refreshFileFromParent( writable );
         auto fullName = impl->nameOfAttribute( writable, parameters.name );
@@ -748,13 +748,13 @@ namespace detail
         typename AttributeTypes< T >::Attr attr =
             AttributeTypes< T >::createAttribute(
                 IO, fullName, variantSrc::get< T >( parameters.resource ) );
-        VERIFY_ALWAYS( attr, "Failed creating attribute." )
+        VERIFY_ALWAYS( attr, "[ADIOS2] Failed creating attribute." )
     }
 
     template < int n, typename... Params >
     void AttributeWriter::operator( )( Params &&... )
     {
-        throw std::runtime_error( "Internal error: Unknown datatype while "
+        throw std::runtime_error( "[ADIOS2] Internal error: Unknown datatype while "
                                   "trying to write an attribute." );
     }
 
@@ -774,7 +774,7 @@ namespace detail
     void DatasetOpener::operator( )( Params &&... )
     {
         throw std::runtime_error(
-            "Unknown datatype while trying to open dataset." );
+            "[ADIOS2] Unknown datatype while trying to open dataset." );
     }
 
     WriteDataset::WriteDataset( ADIOS2IOHandlerImpl * handlerImpl )
@@ -793,7 +793,7 @@ namespace detail
     template < int n, typename... Params >
     void WriteDataset::operator( )( Params &&... )
     {
-        throw std::runtime_error( "WRITE_DATASET: Invalid datatype." );
+        throw std::runtime_error( "[ADIOS2] WRITE_DATASET: Invalid datatype." );
     }
 
     template < typename T >
@@ -810,7 +810,7 @@ namespace detail
     template < int n, typename... Params >
     void VariableDefiner::operator( )( adios2::IO &, Params &&... )
     {
-        throw std::runtime_error( "Defining a variable with undefined type." );
+        throw std::runtime_error( "[ADIOS2] Defining a variable with undefined type." );
     }
 
 
@@ -824,7 +824,7 @@ namespace detail
         if ( !attr )
         {
             throw std::runtime_error(
-                "Internal error: Failed defining attribute '" + name + "'." );
+                "[ADIOS2] Internal error: Failed defining attribute '" + name + "'." );
         }
         return attr;
     }
@@ -838,7 +838,7 @@ namespace detail
         if ( !attr )
         {
             throw std::runtime_error(
-                "Internal error: Failed reading attribute '" + name + "'." );
+                "[ADIOS2] Internal error: Failed reading attribute '" + name + "'." );
         }
         *resource = attr.Data( )[0];
     }
@@ -852,7 +852,7 @@ namespace detail
         if ( !attr )
         {
             throw std::runtime_error(
-                "Internal error: Failed defining attribute '" + name + "'." );
+                "[ADIOS2] Internal error: Failed defining attribute '" + name + "'." );
         }
         return attr;
     }
@@ -866,7 +866,7 @@ namespace detail
         if ( !attr )
         {
             throw std::runtime_error(
-                "Internal error: Failed reading attribute '" + name + "'." );
+                "[ADIOS2] Internal error: Failed reading attribute '" + name + "'." );
         }
         *resource = attr.Data( );
     }
@@ -880,7 +880,7 @@ namespace detail
         if ( !attr )
         {
             throw std::runtime_error(
-                "Internal error: Failed defining attribute '" + name + "'." );
+                "[ADIOS2] Internal error: Failed defining attribute '" + name + "'." );
         }
         return attr;
     }
@@ -894,7 +894,7 @@ namespace detail
         if ( !attr )
         {
             throw std::runtime_error(
-                "Internal error: Failed reading attribute '" + name + "'." );
+                "[ADIOS2] Internal error: Failed reading attribute '" + name + "'." );
         }
         auto data = attr.Data( );
         std::array< T, n > res;
@@ -922,7 +922,7 @@ namespace detail
         if ( !attr )
         {
             throw std::runtime_error(
-                "Internal error: Failed reading attribute '" + name + "'." );
+                "[ADIOS2] Internal error: Failed reading attribute '" + name + "'." );
         }
         *resource = fromRep( attr.Data( )[0] );
     }
@@ -946,7 +946,7 @@ namespace detail
         if ( !var )
         {
             throw std::runtime_error(
-                "Failed retrieving ADIOS2 Variable with name '" + varName +
+                "[ADIOS2] Failed retrieving ADIOS2 Variable with name '" + varName +
                 "' from file " + *file + "." );
         }
 
@@ -968,7 +968,7 @@ namespace detail
         if ( !var )
         {
             throw std::runtime_error(
-                "Failed retrieving ADIOS2 Variable with name '" + bp.name +
+                "[ADIOS2] Failed retrieving ADIOS2 Variable with name '" + bp.name +
                 "' from file " + fileName + "." );
         }
         auto ptr = std::static_pointer_cast< T >( bp.param.data ).get( );
@@ -988,7 +988,7 @@ namespace detail
         if ( !var )
         {
             throw std::runtime_error(
-                "Internal error: Could not create Variable '" + name + "'." );
+                "[ADIOS2] Internal error: Could not create Variable '" + name + "'." );
         }
         // check whether the unique_ptr has an element
         // and whether the held operator is valid
@@ -1006,7 +1006,7 @@ namespace detail
     {
         VERIFY_ALWAYS( m_impl->m_handler->accessTypeBackend !=
                            AccessType::READ_ONLY,
-                       "Cannot write data in read-only mode." );
+                       "[ADIOS2] Cannot write data in read-only mode." );
 
         auto ptr = std::static_pointer_cast< const T >( bp.param.data ).get( );
 
@@ -1029,7 +1029,7 @@ namespace detail
                             !DatasetTypes< T >::validType >::type >::throwErr( )
     {
         throw std::runtime_error(
-            "Trying to access dataset with unallowed datatype: " +
+            "[ADIOS2] Trying to access dataset with unallowed datatype: " +
             datatypeToString( determineDatatype< T >( ) ) );
     }
 
@@ -1087,7 +1087,7 @@ namespace detail
 
         if ( type == Datatype::UNDEFINED )
         {
-            throw std::runtime_error( "Requested attribute (" + name +
+            throw std::runtime_error( "[ADIOS2] Requested attribute (" + name +
                                       ") not found in backend." );
         }
 
@@ -1111,7 +1111,7 @@ namespace detail
         if ( !m_IO )
         {
             throw std::runtime_error(
-                "Internal error: Failed declaring ADIOS2 IO object for file " +
+                "[ADIOS2] Internal error: Failed declaring ADIOS2 IO object for file " +
                 m_file );
         }
         else
@@ -1171,7 +1171,7 @@ namespace detail
                 new adios2::Engine( m_IO.Open( m_file, m_mode ) ) );
             if ( !m_engine )
             {
-                throw std::runtime_error( "Failed opening ADIOS2 Engine." );
+                throw std::runtime_error( "[ADIOS2] Failed opening Engine." );
             }
         }
         return *m_engine;

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -28,7 +28,7 @@ CommonADIOS1IOHandlerImpl::close(int64_t fd)
 {
     int status;
     status = adios_close(fd);
-    VERIFY(status == err_no_error, "Internal error: Failed to close ADIOS file (open_write)");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to close ADIOS file (open_write)");
 }
 
 void
@@ -36,7 +36,7 @@ CommonADIOS1IOHandlerImpl::close(ADIOS_FILE* f)
 {
     int status;
     status = adios_read_close(f);
-    VERIFY(status == err_no_error, "Internal error: Failed to close ADIOS file (open_read)");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to close ADIOS file (open_read)");
 }
 
 void
@@ -98,7 +98,7 @@ CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& nam
             break;
         case DT::UNDEFINED:
         case DT::DATATYPE:
-            throw std::runtime_error("Unknown Attribute datatype (ADIOS1 Attribute flush)");
+            throw std::runtime_error("[ADIOS1] Unknown Attribute datatype (ADIOS1 Attribute flush)");
         default:
             nelems = 1;
     }
@@ -324,9 +324,9 @@ CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& nam
         }
         case DT::UNDEFINED:
         case DT::DATATYPE:
-            throw std::runtime_error("Unknown Attribute datatype (ADIOS1 Attribute flush)");
+            throw std::runtime_error("[ADIOS1] Unknown Attribute datatype (ADIOS1 Attribute flush)");
         default:
-            throw std::runtime_error("Datatype not implemented in ADIOS IO");
+            throw std::runtime_error("[ADIOS1] Datatype not implemented in ADIOS IO");
     }
 
     int status;
@@ -336,7 +336,7 @@ CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& nam
                                             getBP1DataType(att.dtype),
                                             nelems,
                                             values.get());
-    VERIFY(status == err_no_error, "Internal error: Failed to define ADIOS attribute by value");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to define ADIOS attribute by value");
 
     if( att.dtype == Datatype::VEC_STRING )
     {
@@ -351,14 +351,14 @@ CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
                                 Parameter< Operation::CREATE_FILE > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Creating a file in read-only mode is not possible.");
+        throw std::runtime_error("[ADIOS1] Creating a file in read-only mode is not possible.");
 
     if( !writable->written )
     {
         if( !auxiliary::directory_exists(m_handler->directory) )
         {
             bool success = auxiliary::create_directories(m_handler->directory);
-            VERIFY(success, "Internal error: Failed to create directories during ADIOS file creation");
+            VERIFY(success, "[ADIOS1] Internal error: Failed to create directories during ADIOS file creation");
         }
 
         std::string name = m_handler->directory + parameters.name;
@@ -383,7 +383,7 @@ CommonADIOS1IOHandlerImpl::createPath(Writable* writable,
                                 Parameter< Operation::CREATE_PATH > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Creating a path in a file opened as read only is not possible.");
+        throw std::runtime_error("[ADIOS1] Creating a path in a file opened as read only is not possible.");
 
     if( !writable->written )
     {
@@ -416,7 +416,7 @@ CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
                                    Parameter< Operation::CREATE_DATASET > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Creating a dataset in a file opened as read only is not possible.");
+        throw std::runtime_error("[ADIOS1] Creating a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
     {
@@ -450,10 +450,10 @@ CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
         {
             chunkSize[i] = "/tmp" + path + "_chunkSize" + std::to_string(i);
             id = adios_define_var(group, chunkSize[i].c_str(), "", adios_unsigned_long, "", "", "");
-            VERIFY(id != 0, "Internal error: Failed to define ADIOS variable during Dataset creation");
+            VERIFY(id != 0, "[ADIOS1] Internal error: Failed to define ADIOS variable during Dataset creation");
             chunkOffset[i] = "/tmp" + path + "_chunkOffset" + std::to_string(i);
             id = adios_define_var(group, chunkOffset[i].c_str(), "", adios_unsigned_long, "", "", "");
-            VERIFY(id != 0, "Internal error: Failed to define ADIOS variable during Dataset creation");
+            VERIFY(id != 0, "[ADIOS1] Internal error: Failed to define ADIOS variable during Dataset creation");
         }
 
         std::string chunkSizeParam = auxiliary::join(chunkSize, ",");
@@ -466,7 +466,7 @@ CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
                               chunkSizeParam.c_str(),
                               globalSize.c_str(),
                               chunkOffsetParam.c_str());
-        VERIFY(id != 0, "Internal error: Failed to define ADIOS variable during Dataset creation");
+        VERIFY(id != 0, "[ADIOS1] Internal error: Failed to define ADIOS variable during Dataset creation");
 
         if( !parameters.compression.empty() )
             std::cerr << "Custom compression not compatible with ADIOS1 backend. Use transform instead."
@@ -476,7 +476,7 @@ CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
         {
             int status;
             status = adios_set_transform(id, parameters.transform.c_str());
-            VERIFY(status == err_no_error, "Internal error: Failed to set ADIOS transform during Dataset cretaion");
+            VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to set ADIOS transform during Dataset cretaion");
         }
 
         writable->written = true;
@@ -490,7 +490,7 @@ void
 CommonADIOS1IOHandlerImpl::extendDataset(Writable*,
                                    Parameter< Operation::EXTEND_DATASET > const&)
 {
-    throw std::runtime_error("Dataset extension not implemented in ADIOS backend");
+    throw std::runtime_error("[ADIOS1] Dataset extension not implemented in ADIOS backend");
 }
 
 void
@@ -498,7 +498,7 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
                               Parameter< Operation::OPEN_FILE > const& parameters)
 {
     if( !auxiliary::directory_exists(m_handler->directory) )
-        throw no_such_file_error("Supplied directory is not valid: " + m_handler->directory);
+        throw no_such_file_error("[ADIOS1] Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.name;
     if( !auxiliary::ends_with(name, ".bp") )
@@ -571,8 +571,8 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
     ADIOS_VARINFO* vi;
     vi = adios_inq_var(f,
                        datasetname.c_str());
-    VERIFY(adios_errno == err_no_error, "Internal error: Failed to inquire about ADIOS variable during dataset opening");
-    VERIFY(vi != nullptr, "Internal error: Failed to inquire about ADIOS variable during dataset opening");
+    VERIFY(adios_errno == err_no_error, "[ADIOS1] Internal error: Failed to inquire about ADIOS variable during dataset opening");
+    VERIFY(vi != nullptr, "[ADIOS1] Internal error: Failed to inquire about ADIOS variable during dataset opening");
 
     Datatype dtype;
 
@@ -594,7 +594,7 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
             else if( sizeof(long long) == 2u )
                 dtype = DT::LONGLONG;
             else
-                throw unsupported_data_error("No native equivalent for Datatype adios_short found.");
+                throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_short found.");
             break;
         case adios_integer:
             if( sizeof(short) == 4u )
@@ -606,7 +606,7 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
             else if( sizeof(long long) == 4u )
                 dtype = DT::LONGLONG;                
             else
-                throw unsupported_data_error("No native equivalent for Datatype adios_integer found.");
+                throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_integer found.");
             break;
         case adios_long:
             if( sizeof(short) == 8u )
@@ -618,7 +618,7 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
             else if( sizeof(long long) == 8u )
                 dtype = DT::LONGLONG;
             else
-                throw unsupported_data_error("No native equivalent for Datatype adios_long found.");
+                throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_long found.");
             break;
         case adios_unsigned_byte:
             dtype = DT::UCHAR;
@@ -633,7 +633,7 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
             else if( sizeof(unsigned long long) == 2u )
                 dtype = DT::ULONGLONG;
             else
-                throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_short found.");
+                throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_short found.");
             break;
         case adios_unsigned_integer:
             if( sizeof(unsigned short) == 4u )
@@ -645,7 +645,7 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
             else if( sizeof(unsigned long long) == 4u )
                 dtype = DT::ULONGLONG;                
             else
-                throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_integer found.");
+                throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_integer found.");
             break;
         case adios_unsigned_long:
             if( sizeof(unsigned short) == 8u )
@@ -657,7 +657,7 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
             else if( sizeof(unsigned long long) == 8u )
                 dtype = DT::ULONGLONG;
             else
-                throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_long found.");
+                throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_long found.");
             break;
         case adios_real:
             dtype = DT::FLOAT;
@@ -674,7 +674,7 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
         case adios_complex:
         case adios_double_complex:
         default:
-            throw unsupported_data_error("Datatype not implemented for ADIOS dataset writing");
+            throw unsupported_data_error("[ADIOS1] Datatype not implemented for ADIOS dataset writing");
     }
     *parameters.dtype = dtype;
 
@@ -696,7 +696,7 @@ CommonADIOS1IOHandlerImpl::deleteFile(Writable* writable,
                                 Parameter< Operation::DELETE_FILE > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Deleting a file opened as read only is not possible.");
+        throw std::runtime_error("[ADIOS1] Deleting a file opened as read only is not possible.");
 
     if( writable->written )
     {
@@ -717,7 +717,7 @@ CommonADIOS1IOHandlerImpl::deleteFile(Writable* writable,
             name += ".bp";
 
         if( !auxiliary::file_exists(name) )
-            throw std::runtime_error("File does not exist: " + name);
+            throw std::runtime_error("[ADIOS1] File does not exist: " + name);
 
         auxiliary::remove_file(name);
 
@@ -732,21 +732,21 @@ void
 CommonADIOS1IOHandlerImpl::deletePath(Writable*,
                                 Parameter< Operation::DELETE_PATH > const&)
 {
-    throw std::runtime_error("Path deletion not implemented in ADIOS backend");
+    throw std::runtime_error("[ADIOS1] Path deletion not implemented in ADIOS backend");
 }
 
 void
 CommonADIOS1IOHandlerImpl::deleteDataset(Writable*,
                                    Parameter< Operation::DELETE_DATASET > const&)
 {
-    throw std::runtime_error("Dataset deletion not implemented in ADIOS backend");
+    throw std::runtime_error("[ADIOS1] Dataset deletion not implemented in ADIOS backend");
 }
 
 void
 CommonADIOS1IOHandlerImpl::deleteAttribute(Writable*,
                                      Parameter< Operation::DELETE_ATT > const&)
 {
-    throw std::runtime_error("Attribute deletion not implemented in ADIOS backend");
+    throw std::runtime_error("[ADIOS1] Attribute deletion not implemented in ADIOS backend");
 }
 
 void
@@ -754,7 +754,7 @@ CommonADIOS1IOHandlerImpl::writeDataset(Writable* writable,
                                   Parameter< Operation::WRITE_DATASET > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Writing into a dataset in a file opened as read only is not possible.");
+        throw std::runtime_error("[ADIOS1] Writing into a dataset in a file opened as read only is not possible.");
 
     /* file opening is deferred until the first dataset write to a file occurs */
     auto res = m_filePaths.find(writable);
@@ -779,16 +779,16 @@ CommonADIOS1IOHandlerImpl::writeDataset(Writable* writable,
     {
         chunkSize = "/tmp" + name + "_chunkSize" + std::to_string(i);
         status = adios_write(fd, chunkSize.c_str(), &parameters.extent[i]);
-        VERIFY(status == err_no_error, "Internal error: Failed to write ADIOS variable during Dataset writing");
+        VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to write ADIOS variable during Dataset writing");
         chunkOffset = "/tmp" + name + "_chunkOffset" + std::to_string(i);
         status = adios_write(fd, chunkOffset.c_str(), &parameters.offset[i]);
-        VERIFY(status == err_no_error, "Internal error: Failed to write ADIOS variable during Dataset writing");
+        VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to write ADIOS variable during Dataset writing");
     }
 
     status = adios_write(fd,
                          name.c_str(),
                          parameters.data.get());
-    VERIFY(status == err_no_error, "Internal error: Failed to write ADIOS variable during Dataset writing");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to write ADIOS variable during Dataset writing");
 }
 
 void
@@ -796,7 +796,7 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
                                     Parameter< Operation::WRITE_ATT > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Writing an attribute in a file opened as read only is not possible.");
+        throw std::runtime_error("[ADIOS1] Writing an attribute in a file opened as read only is not possible.");
 
     std::string name = concrete_bp1_file_position(writable);
     if( !auxiliary::ends_with(name, '/') )
@@ -835,23 +835,24 @@ CommonADIOS1IOHandlerImpl::readDataset(Writable* writable,
         case DT::BOOL:
             break;
         case DT::UNDEFINED:
-            throw std::runtime_error("Unknown Attribute datatype (ADIOS1 Dataset read)");
+            throw std::runtime_error("[ADIOS1] Unknown Attribute datatype (ADIOS1 Dataset read)");
         case DT::DATATYPE:
-            throw std::runtime_error("Meta-Datatype leaked into IO");
+            throw std::runtime_error("[ADIOS1] Meta-Datatype leaked into IO");
         default:
-            throw std::runtime_error("Datatype not implemented in ADIOS1 IO");
+            throw std::runtime_error("[ADIOS1] Datatype not implemented in ADIOS1 IO");
     }
 
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
-    VERIFY(std::strcmp(f->path, m_filePaths.at(writable)->c_str()) == 0, "Internal Error: Invalid ADIOS read file handle");
+    VERIFY(std::strcmp(f->path, m_filePaths.at(writable)->c_str()) == 0,
+           "[ADIOS1] Internal Error: Invalid ADIOS read file handle");
 
     ADIOS_SELECTION* sel;
     sel = adios_selection_boundingbox(parameters.extent.size(),
                                       parameters.offset.data(),
                                       parameters.extent.data());
-    VERIFY(sel != nullptr, "Internal error: Failed to select ADIOS bounding box during dataset reading");
-    VERIFY(adios_errno == err_no_error, "Internal error: Failed to select ADIOS bounding box during dataset reading");
+    VERIFY(sel != nullptr, "[ADIOS1] Internal error: Failed to select ADIOS bounding box during dataset reading");
+    VERIFY(adios_errno == err_no_error, "[ADIOS1] Internal error: Failed to select ADIOS bounding box during dataset reading");
 
     std::string varname = concrete_bp1_file_position(writable);
     void* data = parameters.data.get();
@@ -863,8 +864,8 @@ CommonADIOS1IOHandlerImpl::readDataset(Writable* writable,
                                  0,
                                  1,
                                  data);
-    VERIFY(status == err_no_error, "Internal error: Failed to schedule ADIOS read during dataset reading");
-    VERIFY(adios_errno == err_no_error, "Internal error: Failed to schedule ADIOS read during dataset reading");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to schedule ADIOS read during dataset reading");
+    VERIFY(adios_errno == err_no_error, "[ADIOS1] Internal error: Failed to schedule ADIOS read during dataset reading");
 
     m_scheduledReads[f].push_back(sel);
 }
@@ -874,7 +875,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                                    Parameter< Operation::READ_ATT >& parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during attribute reading");
+        throw std::runtime_error("[ADIOS1] Internal error: Writable not marked written during attribute reading");
 
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
@@ -894,9 +895,9 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                             &datatype,
                             &size,
                             &data);
-    VERIFY(status == 0, "Internal error: Failed to get ADIOS1 attribute during attribute read");
-    VERIFY(datatype != adios_unknown, "Internal error: Read unknown ADIOS1 datatype during attribute read");
-    VERIFY(size != 0, "Internal error: ADIOS1 read 0-size attribute");
+    VERIFY(status == 0, "[ADIOS1] Internal error: Failed to get ADIOS1 attribute during attribute read");
+    VERIFY(datatype != adios_unknown, "[ADIOS1] Internal error: Read unknown ADIOS1 datatype during attribute read");
+    VERIFY(size != 0, "[ADIOS1] Internal error: ADIOS1 read 0-size attribute");
 
     // size is returned in number of allocated bytes
     // note the ill-named fixed-byte adios_... types
@@ -944,7 +945,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
         case adios_double_complex:
         default:
             throw unsupported_data_error(
-                    "readAttribute: Unsupported ADIOS1 attribute datatype '" +
+                    "[ADIOS1] readAttribute: Unsupported ADIOS1 attribute datatype '" +
                     std::to_string(datatype) + "' in size check");
     }
 
@@ -981,7 +982,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                     a = Attribute(*reinterpret_cast< long long* >(data));
                 }
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_short found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_short found.");
                 break;
             case adios_integer:
                 if( sizeof(short) == 4u )
@@ -1005,7 +1006,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                     a = Attribute(*reinterpret_cast< long long* >(data));
                 }
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_integer found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_integer found.");
                 break;
             case adios_long:
                 if( sizeof(short) == 8u )
@@ -1029,7 +1030,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                     a = Attribute(*reinterpret_cast< long long* >(data));
                 }
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_long found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_long found.");
                 break;
             case adios_unsigned_byte:
                 dtype = DT::UCHAR;
@@ -1057,7 +1058,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                     a = Attribute(*reinterpret_cast< unsigned long long* >(data));
                 }
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_short found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_short found.");
                 break;
             case adios_unsigned_integer:
                 if( sizeof(unsigned short) == 4u )
@@ -1081,7 +1082,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                     a = Attribute(*reinterpret_cast< unsigned long long* >(data));
                 }
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_integer found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_integer found.");
                 break;
             case adios_unsigned_long:
                 if( sizeof(unsigned short) == 8u )
@@ -1105,7 +1106,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                     a = Attribute(*reinterpret_cast< unsigned long long* >(data));
                 }
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_long found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_long found.");
                 break;
             case adios_real:
                 dtype = DT::FLOAT;
@@ -1145,7 +1146,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
             case adios_double_complex:
             default:
                 throw unsupported_data_error(
-                    "readAttribute: Unsupported ADIOS1 attribute datatype '" +
+                    "[ADIOS1] readAttribute: Unsupported ADIOS1 attribute datatype '" +
                     std::to_string(datatype) + "' in scalar branch");
         }
     }
@@ -1176,7 +1177,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 else if( sizeof(long long) == 2u )
                     std::tie(a, dtype) = std::make_tuple(readVectorAttributeInternal< long long >(data, size), DT::VEC_LONGLONG);
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_short found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_short found.");
                 break;
             }
             case adios_integer:
@@ -1190,7 +1191,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 else if( sizeof(long long) == 4u )
                     std::tie(a, dtype) = std::make_tuple(readVectorAttributeInternal< long long >(data, size), DT::VEC_LONGLONG);
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_integer found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_integer found.");
                 break;
             }
             case adios_long:
@@ -1204,7 +1205,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 else if( sizeof(long long) == 8u )
                     std::tie(a, dtype) = std::make_tuple(readVectorAttributeInternal< long long >(data, size), DT::VEC_LONGLONG);
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_long found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_long found.");
                 break;
             }
             case adios_unsigned_byte:
@@ -1229,7 +1230,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 else if( sizeof(unsigned long long) == 2u )
                     std::tie(a, dtype) = std::make_tuple(readVectorAttributeInternal< unsigned long long >(data, size), DT::VEC_ULONGLONG);
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_short found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_short found.");
                 break;
             }
             case adios_unsigned_integer:
@@ -1243,7 +1244,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 else if( sizeof(unsigned long long) == 4u )
                     std::tie(a, dtype) = std::make_tuple(readVectorAttributeInternal< unsigned long long >(data, size), DT::VEC_ULONGLONG);
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_integer found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_integer found.");
                 break;
             }
             case adios_unsigned_long:
@@ -1257,7 +1258,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 else if( sizeof(unsigned long long) == 8u )
                     std::tie(a, dtype) = std::make_tuple(readVectorAttributeInternal< unsigned long long >(data, size), DT::VEC_ULONGLONG);
                 else
-                    throw unsupported_data_error("No native equivalent for Datatype adios_unsigned_long found.");
+                    throw unsupported_data_error("[ADIOS1] No native equivalent for Datatype adios_unsigned_long found.");
                 break;
             }
             case adios_real:
@@ -1319,7 +1320,7 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
             case adios_double_complex:
             default:
                 throw unsupported_data_error(
-                    "readAttribute: Unsupported ADIOS1 attribute datatype '" +
+                    "[ADIOS1] readAttribute: Unsupported ADIOS1 attribute datatype '" +
                     std::to_string(datatype) + "' in vector branch");
         }
     }
@@ -1335,7 +1336,7 @@ CommonADIOS1IOHandlerImpl::listPaths(Writable* writable,
                                Parameter< Operation::LIST_PATHS >& parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during path listing");
+        throw std::runtime_error("[ADIOS1] Internal error: Writable not marked written during path listing");
 
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
@@ -1393,7 +1394,7 @@ CommonADIOS1IOHandlerImpl::listDatasets(Writable* writable,
                                   Parameter< Operation::LIST_DATASETS >& parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during dataset listing");
+        throw std::runtime_error("[ADIOS1] Internal error: Writable not marked written during dataset listing");
 
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
@@ -1425,7 +1426,7 @@ CommonADIOS1IOHandlerImpl::listAttributes(Writable* writable,
                                     Parameter< Operation::LIST_ATTS >& parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during attribute listing");
+        throw std::runtime_error("[ADIOS1] Internal error: Writable not marked written during attribute listing");
 
     ADIOS_FILE* f;
     f = m_openReadFileHandles.at(m_filePaths.at(writable));
@@ -1438,8 +1439,8 @@ CommonADIOS1IOHandlerImpl::listAttributes(Writable* writable,
         ADIOS_VARINFO* info;
         info = adios_inq_var(f,
                              name.c_str());
-        VERIFY(adios_errno == err_no_error, "Internal error: Failed to inquire ADIOS variable during attribute listing");
-        VERIFY(info != nullptr, "Internal error: Failed to inquire ADIOS variable during attribute listing");
+        VERIFY(adios_errno == err_no_error, "[ADIOS1] Internal error: Failed to inquire ADIOS variable during attribute listing");
+        VERIFY(info != nullptr, "[ADIOS1] Internal error: Failed to inquire ADIOS variable during attribute listing");
 
         name += '/';
         parameters.attributes->reserve(info->nattrs);

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -47,7 +47,7 @@ ParallelADIOS1IOHandlerImpl::ParallelADIOS1IOHandlerImpl(AbstractIOHandler* hand
 {
     int status = MPI_SUCCESS;
     status = MPI_Comm_dup(comm, &m_mpiComm);
-    VERIFY(status == MPI_SUCCESS, "Internal error: Failed to duplicate MPI communicator");
+    VERIFY(status == MPI_SUCCESS, "[ADIOS1] Internal error: Failed to duplicate MPI communicator");
 }
 
 ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
@@ -118,7 +118,7 @@ ParallelADIOS1IOHandlerImpl::flush()
                     openFile(i.writable, *dynamic_cast< Parameter< O::OPEN_FILE >* >(i.parameter.get()));
                     break;
                 default:
-                    VERIFY(false, "Internal error: Wrong operation in ADIOS setup queue");
+                    VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS setup queue");
             }
         } catch (unsupported_data_error& e)
         {
@@ -177,7 +177,7 @@ ParallelADIOS1IOHandlerImpl::flush()
                     listAttributes(i.writable, *dynamic_cast< Parameter< O::LIST_ATTS >* >(i.parameter.get()));
                     break;
                 default:
-                    VERIFY(false, "Internal error: Wrong operation in ADIOS work queue");
+                    VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS work queue");
             }
         } catch (unsupported_data_error& e)
         {
@@ -192,7 +192,7 @@ ParallelADIOS1IOHandlerImpl::flush()
     {
         status = adios_perform_reads(file.first,
                                      1);
-        VERIFY(status == err_no_error, "Internal error: Failed to perform ADIOS reads during dataset reading");
+        VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to perform ADIOS reads during dataset reading");
 
         for( auto& sel : file.second )
             adios_selection_delete(sel);
@@ -207,12 +207,12 @@ ParallelADIOS1IOHandlerImpl::init()
 {
     int status;
     status = adios_init_noxml(m_mpiComm);
-    VERIFY(status == err_no_error, "Internal error: Failed to initialize ADIOS");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to initialize ADIOS");
 
     /** @todo ADIOS_READ_METHOD_BP_AGGREGATE */
     m_readMethod = ADIOS_READ_METHOD_BP;
     status = adios_read_init_method(m_readMethod, m_mpiComm, "");
-    VERIFY(status == err_no_error, "Internal error: Failed to initialize ADIOS reading method");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to initialize ADIOS reading method");
 }
 
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
@@ -281,7 +281,7 @@ ParallelADIOS1IOHandlerImpl::open_write(Writable* writable)
                         res->second->c_str(),
                         mode.c_str(),
                         m_mpiComm);
-    VERIFY(status == err_no_error, "Internal error: Failed to open_write ADIOS file");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to open_write ADIOS file");
 
     return fd;
 }
@@ -293,8 +293,8 @@ ParallelADIOS1IOHandlerImpl::open_read(std::string const & name)
     f = adios_read_open_file(name.c_str(),
                              m_readMethod,
                              m_mpiComm);
-    VERIFY(adios_errno != err_file_not_found, "Internal error: ADIOS file not found");
-    VERIFY(f != nullptr, "Internal error: Failed to open_read ADIOS file");
+    VERIFY(adios_errno != err_file_not_found, "[ADIOS1] Internal error: ADIOS file not found");
+    VERIFY(f != nullptr, "[ADIOS1] Internal error: Failed to open_read ADIOS file");
 
     return f;
 }
@@ -313,9 +313,9 @@ ParallelADIOS1IOHandlerImpl::initialize_group(std::string const &name)
     int64_t group;
     ADIOS_STATISTICS_FLAG noStatistics = adios_stat_no;
     status = adios_declare_group(&group, name.c_str(), "", noStatistics);
-    VERIFY(status == err_no_error, "Internal error: Failed to declare ADIOS group");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to declare ADIOS group");
     status = adios_select_method(group, "MPI_AGGREGATE", params_str.c_str(), "");
-    VERIFY(status == err_no_error, "Internal error: Failed to select ADIOS method");
+    VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to select ADIOS method");
     return group;
 }
 

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -51,16 +51,16 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(AbstractIOHandler* handler)
           m_fileAccessProperty{H5P_DEFAULT},
           m_H5T_BOOL_ENUM{H5Tenum_create(H5T_NATIVE_INT8)}
 {
-    VERIFY(m_H5T_BOOL_ENUM >= 0, "Internal error: Failed to create HDF5 enum");
+    VERIFY(m_H5T_BOOL_ENUM >= 0, "[HDF5] Internal error: Failed to create HDF5 enum");
     std::string t{"TRUE"};
     std::string f{"FALSE"};
     int64_t tVal = 1;
     int64_t fVal = 0;
     herr_t status;
     status = H5Tenum_insert(m_H5T_BOOL_ENUM, t.c_str(), &tVal);
-    VERIFY(status == 0, "Internal error: Failed to insert into HDF5 enum");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to insert into HDF5 enum");
     status = H5Tenum_insert(m_H5T_BOOL_ENUM, f.c_str(), &fVal);
-    VERIFY(status == 0, "Internal error: Failed to insert into HDF5 enum");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to insert into HDF5 enum");
 }
 
 HDF5IOHandlerImpl::~HDF5IOHandlerImpl()
@@ -96,14 +96,14 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
                               Parameter< Operation::CREATE_FILE > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Creating a file in read-only mode is not possible.");
+        throw std::runtime_error("[HDF5] Creating a file in read-only mode is not possible.");
 
     if( !writable->written )
     {
         if( !auxiliary::directory_exists(m_handler->directory) )
         {
             bool success = auxiliary::create_directories(m_handler->directory);
-            VERIFY(success, "Internal error: Failed to create directories during HDF5 file creation");
+            VERIFY(success, "[HDF5] Internal error: Failed to create directories during HDF5 file creation");
         }
 
         std::string name = m_handler->directory + parameters.name;
@@ -118,7 +118,7 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
                              flags,
                              H5P_DEFAULT,
                              m_fileAccessProperty);
-        VERIFY(id >= 0, "Internal error: Failed to create HDF5 file");
+        VERIFY(id >= 0, "[HDF5] Internal error: Failed to create HDF5 file");
 
         writable->written = true;
         writable->abstractFilePosition = std::make_shared< HDF5FilePosition >("/");
@@ -133,7 +133,7 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
                               Parameter< Operation::CREATE_PATH > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Creating a path in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Creating a path in a file opened as read only is not possible.");
 
     if( !writable->written )
     {
@@ -154,7 +154,7 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         hid_t node_id = H5Gopen(res->second,
                                 concrete_h5_file_position(position).c_str(),
                                 H5P_DEFAULT);
-        VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during path creation");
+        VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path creation");
 
         /* Create the path in the file */
         std::stack< hid_t > groups;
@@ -166,7 +166,7 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
                                        H5P_DEFAULT,
                                        H5P_DEFAULT,
                                        H5P_DEFAULT);
-            VERIFY(group_id >= 0, "Internal error: Failed to create HDF5 group during path creation");
+            VERIFY(group_id >= 0, "[HDF5] Internal error: Failed to create HDF5 group during path creation");
             groups.push(group_id);
         }
 
@@ -175,7 +175,7 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         while( !groups.empty() )
         {
             status = H5Gclose(groups.top());
-            VERIFY(status == 0, "Internal error: Failed to close HDF5 group during path creation");
+            VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during path creation");
             groups.pop();
         }
 
@@ -191,7 +191,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
                                  Parameter< Operation::CREATE_DATASET > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Creating a dataset in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Creating a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
     {
@@ -209,7 +209,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         hid_t node_id = H5Gopen(res->second,
                                 concrete_h5_file_position(writable).c_str(),
                                 H5P_DEFAULT);
-        VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during dataset creation");
+        VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset creation");
 
         Datatype d = parameters.dtype;
         if( d == Datatype::UNDEFINED )
@@ -225,7 +225,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
             dims.push_back(static_cast< hsize_t >(val));
 
         hid_t space = H5Screate_simple(static_cast< int >(dims.size()), dims.data(), dims.data());
-        VERIFY(space >= 0, "Internal error: Failed to create dataspace during dataset creation");
+        VERIFY(space >= 0, "[HDF5] Internal error: Failed to create dataspace during dataset creation");
 
         std::vector< hsize_t > chunkDims;
         for( auto const& val : parameters.chunkSize )
@@ -235,7 +235,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         hid_t datasetCreationProperty = H5Pcreate(H5P_DATASET_CREATE);
         herr_t status;
         //status = H5Pset_chunk(datasetCreationProperty, chunkDims.size(), chunkDims.data());
-        //VERIFY(status == 0, "Internal error: Failed to set chunk size during dataset creation");
+        //VERIFY(status == 0, "[HDF5] Internal error: Failed to set chunk size during dataset creation");
 
         std::string const& compression = parameters.compression;
         if( !compression.empty() )
@@ -249,7 +249,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
                 && args.size() == 2 )
             {
                 status = H5Pset_deflate(datasetCreationProperty, std::stoi(args[1]));
-                VERIFY(status == 0, "Internal error: Failed to set deflate compression during dataset creation");
+                VERIFY(status == 0, "[HDF5] Internal error: Failed to set deflate compression during dataset creation");
             } else if( format == "szip" || format == "nbit" || format == "scaleoffset" )
                 std::cerr << "Compression format " << format
                           << " not yet implemented. Data will not be compressed!"
@@ -267,7 +267,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
                       << std::endl;
 
         hid_t datatype = getH5DataType(a);
-        VERIFY(datatype >= 0, "Internal error: Failed to get HDF5 datatype during dataset creation");
+        VERIFY(datatype >= 0, "[HDF5] Internal error: Failed to get HDF5 datatype during dataset creation");
         hid_t group_id = H5Dcreate(node_id,
                                    name.c_str(),
                                    datatype,
@@ -275,18 +275,18 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
                                    H5P_DEFAULT,
                                    datasetCreationProperty,
                                    H5P_DEFAULT);
-        VERIFY(group_id >= 0, "Internal error: Failed to create HDF5 group during dataset creation");
+        VERIFY(group_id >= 0, "[HDF5] Internal error: Failed to create HDF5 group during dataset creation");
 
         status = H5Dclose(group_id);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 dataset during dataset creation");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataset during dataset creation");
         status = H5Tclose(datatype);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 datatype during dataset creation");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 datatype during dataset creation");
         status = H5Pclose(datasetCreationProperty);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 dataset creation property during dataset creation");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataset creation property during dataset creation");
         status = H5Sclose(space);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 dataset space during dataset creation");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataset space during dataset creation");
         status = H5Gclose(node_id);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 group during dataset creation");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during dataset creation");
 
         writable->written = true;
         writable->abstractFilePosition = std::make_shared< HDF5FilePosition >(name);
@@ -300,17 +300,17 @@ HDF5IOHandlerImpl::extendDataset(Writable* writable,
                                  Parameter< Operation::EXTEND_DATASET > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Extending a dataset in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Extending a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
-        throw std::runtime_error("Extending an unwritten Dataset is not possible.");
+        throw std::runtime_error("[HDF5] Extending an unwritten Dataset is not possible.");
 
     auto res = m_fileIDs.find(writable->parent);
     hid_t node_id, dataset_id;
     node_id = H5Gopen(res->second,
                       concrete_h5_file_position(writable->parent).c_str(),
                       H5P_DEFAULT);
-    VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during dataset extension");
+    VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset extension");
 
     /* Sanitize name */
     std::string name = parameters.name;
@@ -322,7 +322,7 @@ HDF5IOHandlerImpl::extendDataset(Writable* writable,
     dataset_id = H5Dopen(node_id,
                          name.c_str(),
                          H5P_DEFAULT);
-    VERIFY(dataset_id >= 0, "Internal error: Failed to open HDF5 dataset during dataset extension");
+    VERIFY(dataset_id >= 0, "[HDF5] Internal error: Failed to open HDF5 dataset during dataset extension");
 
     std::vector< hsize_t > size;
     for( auto const& val : parameters.extent )
@@ -330,12 +330,12 @@ HDF5IOHandlerImpl::extendDataset(Writable* writable,
 
     herr_t status;
     status = H5Dset_extent(dataset_id, size.data());
-    VERIFY(status == 0, "Internal error: Failed to extend HDF5 dataset during dataset extension");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to extend HDF5 dataset during dataset extension");
 
     status = H5Dclose(dataset_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 dataset during dataset extension");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataset during dataset extension");
     status = H5Gclose(node_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 group during dataset extension");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during dataset extension");
 }
 
 void
@@ -346,7 +346,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     //not possible with current implementation
     //quick idea - map with filenames as key
     if( !auxiliary::directory_exists(m_handler->directory) )
-        throw no_such_file_error("Supplied directory is not valid: " + m_handler->directory);
+        throw no_such_file_error("[HDF5] Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.name;
     if( !auxiliary::ends_with(name, ".h5") )
@@ -359,13 +359,13 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     else if( at == AccessType::READ_WRITE || at == AccessType::CREATE )
         flags = H5F_ACC_RDWR;
     else
-        throw std::runtime_error("Unknown file AccessType");
+        throw std::runtime_error("[HDF5] Unknown file AccessType");
     hid_t file_id;
     file_id = H5Fopen(name.c_str(),
                       flags,
                       m_fileAccessProperty);
     if( file_id < 0 )
-        throw no_such_file_error("Failed to open HDF5 file " + name);
+        throw no_such_file_error("[HDF5] Failed to open HDF5 file " + name);
 
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< HDF5FilePosition >("/");
@@ -384,7 +384,7 @@ HDF5IOHandlerImpl::openPath(Writable* writable,
     node_id = H5Gopen(res->second,
                       concrete_h5_file_position(writable->parent).c_str(),
                       H5P_DEFAULT);
-    VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during path opening");
+    VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path opening");
 
     /* Sanitize path */
     std::string path = parameters.path;
@@ -396,13 +396,13 @@ HDF5IOHandlerImpl::openPath(Writable* writable,
     path_id = H5Gopen(node_id,
                       path.c_str(),
                       H5P_DEFAULT);
-    VERIFY(path_id >= 0, "Internal error: Failed to open HDF5 group during path opening");
+    VERIFY(path_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path opening");
 
     herr_t status;
     status = H5Gclose(path_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 group during path opening");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during path opening");
     status = H5Gclose(node_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 group during path opening");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during path opening");
 
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< HDF5FilePosition >(path);
@@ -420,7 +420,7 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
     node_id = H5Gopen(res->second,
                       concrete_h5_file_position(writable->parent).c_str(),
                       H5P_DEFAULT);
-    VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during dataset opening");
+    VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset opening");
 
     /* Sanitize name */
     std::string name = parameters.name;
@@ -432,7 +432,7 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
     dataset_id = H5Dopen(node_id,
                          name.c_str(),
                          H5P_DEFAULT);
-    VERIFY(dataset_id >= 0, "Internal error: Failed to open HDF5 dataset during dataset opening");
+    VERIFY(dataset_id >= 0, "[HDF5] Internal error: Failed to open HDF5 dataset during dataset opening");
 
     hid_t dataset_type, dataset_space;
     dataset_type = H5Dget_type(dataset_id);
@@ -471,9 +471,9 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
         else if( H5Tget_class(dataset_type) == H5T_STRING )
             d = DT::STRING;
         else
-            throw std::runtime_error("Unknown dataset type");
+            throw std::runtime_error("[HDF5] Unknown dataset type");
     } else
-        throw std::runtime_error("Unsupported dataset class");
+        throw std::runtime_error("[HDF5] Unsupported dataset class");
 
     auto dtype = parameters.dtype;
     *dtype = d;
@@ -493,13 +493,13 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
 
     herr_t status;
     status = H5Sclose(dataset_space);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 dataset space during dataset opening");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataset space during dataset opening");
     status = H5Tclose(dataset_type);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 dataset type during dataset opening");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataset type during dataset opening");
     status = H5Dclose(dataset_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 dataset during dataset opening");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataset during dataset opening");
     status = H5Gclose(node_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 group during dataset opening");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during dataset opening");
 
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< HDF5FilePosition >(name);
@@ -512,20 +512,20 @@ HDF5IOHandlerImpl::deleteFile(Writable* writable,
                               Parameter< Operation::DELETE_FILE > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Deleting a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Deleting a file opened as read only is not possible.");
 
     if( writable->written )
     {
         hid_t file_id = m_fileIDs[writable];
         herr_t status = H5Fclose(file_id);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 file during file deletion");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 file during file deletion");
 
         std::string name = m_handler->directory + parameters.name;
         if( !auxiliary::ends_with(name, ".h5") )
             name += ".h5";
 
         if( !auxiliary::file_exists(name) )
-            throw std::runtime_error("File does not exist: " + name);
+            throw std::runtime_error("[HDF5] File does not exist: " + name);
 
         auxiliary::remove_file(name);
 
@@ -542,7 +542,7 @@ HDF5IOHandlerImpl::deletePath(Writable* writable,
                               Parameter< Operation::DELETE_PATH > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Deleting a path in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
     {
@@ -563,16 +563,16 @@ HDF5IOHandlerImpl::deletePath(Writable* writable,
         hid_t node_id = H5Gopen(res->second,
                                 concrete_h5_file_position(writable->parent).c_str(),
                                 H5P_DEFAULT);
-        VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during path deletion");
+        VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path deletion");
 
         path += static_cast< HDF5FilePosition* >(writable->abstractFilePosition.get())->location;
         herr_t status = H5Ldelete(node_id,
                                   path.c_str(),
                                   H5P_DEFAULT);
-        VERIFY(status == 0, "Internal error: Failed to delete HDF5 group");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to delete HDF5 group");
 
         status = H5Gclose(node_id);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 group during path deletion");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during path deletion");
 
         writable->written = false;
         writable->abstractFilePosition.reset();
@@ -586,7 +586,7 @@ HDF5IOHandlerImpl::deleteDataset(Writable* writable,
                                  Parameter< Operation::DELETE_DATASET > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Deleting a path in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
     {
@@ -607,16 +607,16 @@ HDF5IOHandlerImpl::deleteDataset(Writable* writable,
         hid_t node_id = H5Gopen(res->second,
                                 concrete_h5_file_position(writable->parent).c_str(),
                                 H5P_DEFAULT);
-        VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during dataset deletion");
+        VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset deletion");
 
         name += static_cast< HDF5FilePosition* >(writable->abstractFilePosition.get())->location;
         herr_t status = H5Ldelete(node_id,
                                   name.c_str(),
                                   H5P_DEFAULT);
-        VERIFY(status == 0, "Internal error: Failed to delete HDF5 group");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to delete HDF5 group");
 
         status = H5Gclose(node_id);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 group during dataset deletion");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during dataset deletion");
 
         writable->written = false;
         writable->abstractFilePosition.reset();
@@ -630,7 +630,7 @@ HDF5IOHandlerImpl::deleteAttribute(Writable* writable,
                                    Parameter< Operation::DELETE_ATT > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Deleting an attribute in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Deleting an attribute in a file opened as read only is not possible.");
 
     if( writable->written )
     {
@@ -643,14 +643,14 @@ HDF5IOHandlerImpl::deleteAttribute(Writable* writable,
         hid_t node_id = H5Oopen(res->second,
                                 concrete_h5_file_position(writable).c_str(),
                                 H5P_DEFAULT);
-        VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during attribute deletion");
+        VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during attribute deletion");
 
         herr_t status = H5Adelete(node_id,
                                   name.c_str());
-        VERIFY(status == 0, "Internal error: Failed to delete HDF5 attribute");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to delete HDF5 attribute");
 
         status = H5Oclose(node_id);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 group during attribute deletion");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during attribute deletion");
     }
 }
 
@@ -659,7 +659,7 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
                                 Parameter< Operation::WRITE_DATASET > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Writing into a dataset in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Writing into a dataset in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
@@ -670,7 +670,7 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
     dataset_id = H5Dopen(res->second,
                          concrete_h5_file_position(writable).c_str(),
                          H5P_DEFAULT);
-    VERIFY(dataset_id >= 0, "Internal error: Failed to open HDF5 dataset during dataset write");
+    VERIFY(dataset_id >= 0, "[HDF5] Internal error: Failed to open HDF5 dataset during dataset write");
 
     std::vector< hsize_t > start;
     for( auto const& val : parameters.offset )
@@ -688,7 +688,7 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
                                  stride.data(),
                                  count.data(),
                                  block.data());
-    VERIFY(status == 0, "Internal error: Failed to select hyperslab during dataset write");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to select hyperslab during dataset write");
 
     std::shared_ptr< void const > data = parameters.data;
 
@@ -696,7 +696,7 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
     Attribute a(0);
     a.dtype = parameters.dtype;
     hid_t dataType = getH5DataType(a);
-    VERIFY(dataType >= 0, "Internal error: Failed to get HDF5 datatype during dataset write");
+    VERIFY(dataType >= 0, "[HDF5] Internal error: Failed to get HDF5 datatype during dataset write");
     switch( a.dtype )
     {
         using DT = Datatype;
@@ -719,23 +719,23 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
                               filespace,
                               m_datasetTransferProperty,
                               data.get());
-            VERIFY(status == 0, "Internal error: Failed to write dataset " + concrete_h5_file_position(writable));
+            VERIFY(status == 0, "[HDF5] Internal error: Failed to write dataset " + concrete_h5_file_position(writable));
             break;
         case DT::UNDEFINED:
-            throw std::runtime_error("Undefined Attribute datatype");
+            throw std::runtime_error("[HDF5] Undefined Attribute datatype");
         case DT::DATATYPE:
-            throw std::runtime_error("Meta-Datatype leaked into IO");
+            throw std::runtime_error("[HDF5] Meta-Datatype leaked into IO");
         default:
-            throw std::runtime_error("Datatype not implemented in HDF5 IO");
+            throw std::runtime_error("[HDF5] Datatype not implemented in HDF5 IO");
     }
     status = H5Tclose(dataType);
-    VERIFY(status == 0, "Internal error: Failed to close dataset datatype during dataset write");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset datatype during dataset write");
     status = H5Sclose(filespace);
-    VERIFY(status == 0, "Internal error: Failed to close dataset file space during dataset write");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset file space during dataset write");
     status = H5Sclose(memspace);
-    VERIFY(status == 0, "Internal error: Failed to close dataset memory space during dataset write");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset memory space during dataset write");
     status = H5Dclose(dataset_id);
-    VERIFY(status == 0, "Internal error: Failed to close dataset " + concrete_h5_file_position(writable) + " during dataset write");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset " + concrete_h5_file_position(writable) + " during dataset write");
 
     m_fileIDs[writable] = res->second;
 }
@@ -745,7 +745,7 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
                                   Parameter< Operation::WRITE_ATT > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("Writing an attribute in a file opened as read only is not possible.");
+        throw std::runtime_error("[HDF5] Writing an attribute in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
@@ -754,7 +754,7 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
     node_id = H5Oopen(res->second,
                       concrete_h5_file_position(writable).c_str(),
                       H5P_DEFAULT);
-    VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 object during attribute write");
+    VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 object during attribute write");
     Attribute const att(parameters.resource);
     Datatype dtype = parameters.dtype;
     herr_t status;
@@ -763,27 +763,27 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
         dataType = m_H5T_BOOL_ENUM;
     else
         dataType = getH5DataType(att);
-    VERIFY(dataType >= 0, "Internal error: Failed to get HDF5 datatype during attribute write");
+    VERIFY(dataType >= 0, "[HDF5] Internal error: Failed to get HDF5 datatype during attribute write");
     std::string name = parameters.name;
     if( H5Aexists(node_id, name.c_str()) == 0 )
     {
         hid_t dataspace = getH5DataSpace(att);
-        VERIFY(dataspace >= 0, "Internal error: Failed to get HDF5 dataspace during attribute write");
+        VERIFY(dataspace >= 0, "[HDF5] Internal error: Failed to get HDF5 dataspace during attribute write");
         attribute_id = H5Acreate(node_id,
                                  name.c_str(),
                                  dataType,
                                  dataspace,
                                  H5P_DEFAULT,
                                  H5P_DEFAULT);
-        VERIFY(node_id >= 0, "Internal error: Failed to create HDF5 attribute during attribute write");
+        VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to create HDF5 attribute during attribute write");
         status = H5Sclose(dataspace);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 dataspace during attribute write");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 dataspace during attribute write");
     } else
     {
         attribute_id = H5Aopen(node_id,
                                name.c_str(),
                                H5P_DEFAULT);
-        VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 attribute during attribute write");
+        VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 attribute during attribute write");
     }
 
     using DT = Datatype;
@@ -962,22 +962,22 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
         }
         case DT::UNDEFINED:
         case DT::DATATYPE:
-            throw std::runtime_error("Unknown Attribute datatype (HDF5 Attribute write)");
+            throw std::runtime_error("[HDF5] Unknown Attribute datatype (HDF5 Attribute write)");
         default:
-            throw std::runtime_error("Datatype not implemented in HDF5 IO");
+            throw std::runtime_error("[HDF5] Datatype not implemented in HDF5 IO");
     }
-    VERIFY(status == 0, "Internal error: Failed to write attribute " + name + " at " + concrete_h5_file_position(writable));
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to write attribute " + name + " at " + concrete_h5_file_position(writable));
 
     if( dataType != m_H5T_BOOL_ENUM )
     {
         status = H5Tclose(dataType);
-        VERIFY(status == 0, "Internal error: Failed to close HDF5 datatype during Attribute write");
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 datatype during Attribute write");
     }
 
     status = H5Aclose(attribute_id);
-    VERIFY(status == 0, "Internal error: Failed to close attribute " + name + " at " + concrete_h5_file_position(writable) + " during attribute write");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close attribute " + name + " at " + concrete_h5_file_position(writable) + " during attribute write");
     status = H5Oclose(node_id);
-    VERIFY(status == 0, "Internal error: Failed to close " + concrete_h5_file_position(writable) + " during attribute write");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close " + concrete_h5_file_position(writable) + " during attribute write");
 
     m_fileIDs[writable] = res->second;
 }
@@ -994,7 +994,7 @@ HDF5IOHandlerImpl::readDataset(Writable* writable,
     dataset_id = H5Dopen(res->second,
                          concrete_h5_file_position(writable).c_str(),
                          H5P_DEFAULT);
-    VERIFY(dataset_id >= 0, "Internal error: Failed to open HDF5 dataset during dataset read");
+    VERIFY(dataset_id >= 0, "[HDF5] Internal error: Failed to open HDF5 dataset during dataset read");
 
     std::vector< hsize_t > start;
     for( auto const& val : parameters.offset )
@@ -1012,7 +1012,7 @@ HDF5IOHandlerImpl::readDataset(Writable* writable,
                                  stride.data(),
                                  count.data(),
                                  block.data());
-    VERIFY(status == 0, "Internal error: Failed to select hyperslab during dataset read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to select hyperslab during dataset read");
 
     void* data = parameters.data.get();
 
@@ -1036,30 +1036,30 @@ HDF5IOHandlerImpl::readDataset(Writable* writable,
         case DT::BOOL:
             break;
         case DT::UNDEFINED:
-            throw std::runtime_error("Unknown Attribute datatype (HDF5 Dataset read)");
+            throw std::runtime_error("[HDF5] Unknown Attribute datatype (HDF5 Dataset read)");
         case DT::DATATYPE:
-            throw std::runtime_error("Meta-Datatype leaked into IO");
+            throw std::runtime_error("[HDF5] Meta-Datatype leaked into IO");
         default:
-            throw std::runtime_error("Datatype not implemented in HDF5 IO");
+            throw std::runtime_error("[HDF5] Datatype not implemented in HDF5 IO");
     }
     hid_t dataType = getH5DataType(a);
-    VERIFY(dataType >= 0, "Internal error: Failed to get HDF5 datatype during dataset read");
+    VERIFY(dataType >= 0, "[HDF5] Internal error: Failed to get HDF5 datatype during dataset read");
     status = H5Dread(dataset_id,
                      dataType,
                      memspace,
                      filespace,
                      m_datasetTransferProperty,
                      data);
-    VERIFY(status == 0, "Internal error: Failed to read dataset");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to read dataset");
 
     status = H5Tclose(dataType);
-    VERIFY(status == 0, "Internal error: Failed to close dataset datatype during dataset read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset datatype during dataset read");
     status = H5Sclose(filespace);
-    VERIFY(status == 0, "Internal error: Failed to close dataset file space during dataset read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset file space during dataset read");
     status = H5Sclose(memspace);
-    VERIFY(status == 0, "Internal error: Failed to close dataset memory space during dataset read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset memory space during dataset read");
     status = H5Dclose(dataset_id);
-    VERIFY(status == 0, "Internal error: Failed to close dataset during dataset read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset during dataset read");
 }
 
 void
@@ -1067,7 +1067,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                                  Parameter< Operation::READ_ATT >& parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during attribute read");
+        throw std::runtime_error("[HDF5] Internal error: Writable not marked written during attribute read");
 
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
@@ -1078,12 +1078,12 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
     obj_id = H5Oopen(res->second,
                      concrete_h5_file_position(writable).c_str(),
                      H5P_DEFAULT);
-    VERIFY(obj_id >= 0, "Internal error: Failed to open HDF5 object during attribute read");
+    VERIFY(obj_id >= 0, "[HDF5] Internal error: Failed to open HDF5 object during attribute read");
     std::string const & attr_name = parameters.name;
     attr_id = H5Aopen(obj_id,
                       attr_name.c_str(),
                       H5P_DEFAULT);
-    VERIFY(attr_id >= 0, "Internal error: Failed to open HDF5 attribute during attribute read");
+    VERIFY(attr_id >= 0, "[HDF5] Internal error: Failed to open HDF5 attribute during attribute read");
 
     hid_t attr_type, attr_space;
     attr_type = H5Aget_type(attr_id);
@@ -1096,7 +1096,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
     status = H5Sget_simple_extent_dims(attr_space,
                                        dims.data(),
                                        maxdims.data());
-    VERIFY(status == ndims, "Internal error: Failed to get dimensions during attribute read");
+    VERIFY(status == ndims, "[HDF5] Internal error: Failed to get dimensions during attribute read");
 
     H5S_class_t attr_class = H5Sget_simple_extent_type(attr_space);
     Attribute a(0);
@@ -1236,15 +1236,15 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                                  &enumVal);
                 a = Attribute(static_cast< bool >(enumVal));
             } else
-                throw unsupported_data_error("Unsupported attribute enumeration");
+                throw unsupported_data_error("[HDF5] Unsupported attribute enumeration");
         } else if( H5Tget_class(attr_type) == H5T_COMPOUND )
-            throw unsupported_data_error("Compound attribute type not supported");
+            throw unsupported_data_error("[HDF5] Compound attribute type not supported");
         else
-            throw std::runtime_error("Unsupported scalar attribute type");
+            throw std::runtime_error("[HDF5] Unsupported scalar attribute type");
     } else if( attr_class == H5S_SIMPLE )
     {
         if( ndims != 1 )
-            throw std::runtime_error("Unsupported attribute (array with ndims != 1)");
+            throw std::runtime_error("[HDF5] Unsupported attribute (array with ndims != 1)");
 
         if( H5Tequal(attr_type, H5T_NATIVE_CHAR) )
         {
@@ -1374,15 +1374,15 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
             }
             a = Attribute(vs);
         } else
-            throw std::runtime_error("Unsupported simple attribute type");
+            throw std::runtime_error("[HDF5] Unsupported simple attribute type");
     } else
-        throw std::runtime_error("Unsupported attribute class");
-    VERIFY(status == 0, "Internal error: Failed to read attribute " + attr_name + " at " + concrete_h5_file_position(writable));
+        throw std::runtime_error("[HDF5] Unsupported attribute class");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to read attribute " + attr_name + " at " + concrete_h5_file_position(writable));
 
     status = H5Tclose(attr_type);
-    VERIFY(status == 0, "Internal error: Failed to close attribute datatype during attribute read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close attribute datatype during attribute read");
     status = H5Sclose(attr_space);
-    VERIFY(status == 0, "Internal error: Failed to close attribute file space during attribute read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close attribute file space during attribute read");
 
     auto dtype = parameters.dtype;
     *dtype = a.dtype;
@@ -1390,9 +1390,9 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
     *resource = a.getResource();
 
     status = H5Aclose(attr_id);
-    VERIFY(status == 0, "Internal error: Failed to close attribute " + attr_name + " at " + concrete_h5_file_position(writable) + " during attribute read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close attribute " + attr_name + " at " + concrete_h5_file_position(writable) + " during attribute read");
     status = H5Oclose(obj_id);
-    VERIFY(status == 0, "Internal error: Failed to close " + concrete_h5_file_position(writable) + " during attribute read");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close " + concrete_h5_file_position(writable) + " during attribute read");
 }
 
 void
@@ -1400,7 +1400,7 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
                              Parameter< Operation::LIST_PATHS > & parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during path listing");
+        throw std::runtime_error("[HDF5] Internal error: Writable not marked written during path listing");
 
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
@@ -1408,11 +1408,11 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
     hid_t node_id = H5Gopen(res->second,
                             concrete_h5_file_position(writable).c_str(),
                             H5P_DEFAULT);
-    VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during path listing");
+    VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path listing");
 
     H5G_info_t group_info;
     herr_t status = H5Gget_info(node_id, &group_info);
-    VERIFY(status == 0, "Internal error: Failed to get HDF5 group info for " + concrete_h5_file_position(writable) + " during path listing");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to get HDF5 group info for " + concrete_h5_file_position(writable) + " during path listing");
 
     auto paths = parameters.paths;
     for( hsize_t i = 0; i < group_info.nlinks; ++i )
@@ -1427,7 +1427,7 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
     }
 
     status = H5Gclose(node_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 group " + concrete_h5_file_position(writable) + " during path listing");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group " + concrete_h5_file_position(writable) + " during path listing");
 }
 
 void
@@ -1435,7 +1435,7 @@ HDF5IOHandlerImpl::listDatasets(Writable* writable,
                                 Parameter< Operation::LIST_DATASETS >& parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during dataset listing");
+        throw std::runtime_error("[HDF5] Internal error: Writable not marked written during dataset listing");
 
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
@@ -1443,11 +1443,11 @@ HDF5IOHandlerImpl::listDatasets(Writable* writable,
     hid_t node_id = H5Gopen(res->second,
                             concrete_h5_file_position(writable).c_str(),
                             H5P_DEFAULT);
-    VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during dataset listing");
+    VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset listing");
 
     H5G_info_t group_info;
     herr_t status = H5Gget_info(node_id, &group_info);
-    VERIFY(status == 0, "Internal error: Failed to get HDF5 group info for " + concrete_h5_file_position(writable) + " during dataset listing");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to get HDF5 group info for " + concrete_h5_file_position(writable) + " during dataset listing");
 
     auto datasets = parameters.datasets;
     for( hsize_t i = 0; i < group_info.nlinks; ++i )
@@ -1462,14 +1462,14 @@ HDF5IOHandlerImpl::listDatasets(Writable* writable,
     }
 
     status = H5Gclose(node_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 group " + concrete_h5_file_position(writable) + " during dataset listing");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group " + concrete_h5_file_position(writable) + " during dataset listing");
 }
 
 void HDF5IOHandlerImpl::listAttributes(Writable* writable,
                                        Parameter< Operation::LIST_ATTS >& parameters)
 {
     if( !writable->written )
-        throw std::runtime_error("Internal error: Writable not marked written during attribute listing");
+        throw std::runtime_error("[HDF5] Internal error: Writable not marked written during attribute listing");
 
     auto res = m_fileIDs.find(writable);
     if( res == m_fileIDs.end() )
@@ -1478,12 +1478,12 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
     node_id = H5Oopen(res->second,
                       concrete_h5_file_position(writable).c_str(),
                       H5P_DEFAULT);
-    VERIFY(node_id >= 0, "Internal error: Failed to open HDF5 group during attribute listing");
+    VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during attribute listing");
 
     H5O_info_t object_info;
     herr_t status;
     status = H5Oget_info(node_id, &object_info);
-    VERIFY(status == 0, "Internal error: Failed to get HDF5 object info for " + concrete_h5_file_position(writable) + " during attribute listing");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to get HDF5 object info for " + concrete_h5_file_position(writable) + " during attribute listing");
 
     auto attributes = parameters.attributes;
     for( hsize_t i = 0; i < object_info.num_attrs; ++i )
@@ -1509,7 +1509,7 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
     }
 
     status = H5Oclose(node_id);
-    VERIFY(status == 0, "Internal error: Failed to close HDF5 object during attribute listing");
+    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 object during attribute listing");
 }
 #endif
 

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -68,15 +68,15 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(AbstractIOHandler* handler,
         xfer_mode = H5FD_MPIO_INDEPENDENT;
     else
     {
-        VERIFY(hdf5_collective == "OFF", "Internal error: OPENPMD_HDF5_INDEPENDENT property must be either ON or OFF");
+        VERIFY(hdf5_collective == "OFF", "[HDF5] Internal error: OPENPMD_HDF5_INDEPENDENT property must be either ON or OFF");
     }
 
     herr_t status;
     status = H5Pset_dxpl_mpio(m_datasetTransferProperty, xfer_mode);
 
-    VERIFY(status >= 0, "Internal error: Failed to set HDF5 dataset transfer property");
+    VERIFY(status >= 0, "[HDF5] Internal error: Failed to set HDF5 dataset transfer property");
     status = H5Pset_fapl_mpio(m_fileAccessProperty, m_mpiComm, m_mpiInfo);
-    VERIFY(status >= 0, "Internal error: Failed to set HDF5 file access property");
+    VERIFY(status >= 0, "[HDF5] Internal error: Failed to set HDF5 file access property");
 }
 
 ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -70,7 +70,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-            "Creating a file in read-only mode is not possible." );
+            "[JSON] Creating a file in read-only mode is not possible." );
 
         if( !writable->written )
         {
@@ -88,7 +88,7 @@ namespace openPMD
             VERIFY_ALWAYS( !( m_handler->accessTypeBackend == AccessType::READ_WRITE &&
                               ( !std::get< 2 >( res_pair ) ||
                                 auxiliary::file_exists( fullPath( std::get< 0 >( res_pair ) ) ) ) ),
-                "Can only overwrite existing file in CREATE mode." );
+                "[JSON] Can only overwrite existing file in CREATE mode." );
 
             if( !std::get< 2 >( res_pair ) )
             {
@@ -103,7 +103,7 @@ namespace openPMD
             {
                 auto success = auxiliary::create_directories( dir );
                 VERIFY( success,
-                    "Could not create directory." );
+                    "[JSON] Could not create directory." );
             }
 
             associateWithFile(
@@ -190,7 +190,7 @@ namespace openPMD
     {
         if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         {
-            throw std::runtime_error( "Creating a dataset in a file opened as read only is not possible." );
+            throw std::runtime_error( "[JSON] Creating a dataset in a file opened as read only is not possible." );
         }
         if( !writable->written )
         {
@@ -224,7 +224,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-            "Cannot extend a dataset in read-only mode." )
+            "[JSON] Cannot extend a dataset in read-only mode." )
         refreshFileFromParent( writable );
         setAndGetFilePosition( writable );
         auto name = removeSlashes( parameters.name );
@@ -236,7 +236,7 @@ namespace openPMD
             VERIFY_ALWAYS( datasetExtent.size( ) ==
                            parameters.extent
                                .size( ),
-                "Cannot change dimensionality of a dataset" )
+                "[JSON] Cannot change dimensionality of a dataset" )
             for( size_t currentdim = 0;
                 currentdim <
                 parameters.extent
@@ -245,11 +245,11 @@ namespace openPMD
             {
                 VERIFY_ALWAYS( datasetExtent[currentdim] <=
                                parameters.extent[currentdim],
-                    "Cannot shrink the extent of a dataset" )
+                    "[JSON] Cannot shrink the extent of a dataset" )
             }
         } catch( json::basic_json::type_error & )
         {
-            throw std::runtime_error( "The specified location contains no valid dataset" );
+            throw std::runtime_error( "[JSON] The specified location contains no valid dataset" );
         }
         j["data"] = initializeNDArray( parameters.extent );
         writable->written = true;
@@ -265,7 +265,7 @@ namespace openPMD
         if( !auxiliary::directory_exists( m_handler->directory ) )
         {
             throw no_such_file_error(
-                "Supplied directory is not valid: " + m_handler->directory
+                "[JSON] Supplied directory is not valid: " + m_handler->directory
             );
         }
 
@@ -354,7 +354,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-            "Cannot delete files in read-only mode" )
+            "[JSON] Cannot delete files in read-only mode" )
 
         if( !writable->written )
         {
@@ -388,7 +388,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-            "Cannot delete paths in read-only mode" )
+            "[JSON] Cannot delete paths in read-only mode" )
 
         if( !writable->written )
         {
@@ -399,7 +399,7 @@ namespace openPMD
             parameters.path,
             '/'
         ),
-            "Paths passed for deletion should be relative, the given path is absolute (starts with '/')" )
+            "[JSON] Paths passed for deletion should be relative, the given path is absolute (starts with '/')" )
         auto file = refreshFileFromParent( writable );
         auto filepos = setAndGetFilePosition(
             writable,
@@ -407,7 +407,7 @@ namespace openPMD
         );
         auto path = removeSlashes( parameters.path );
         VERIFY( !path.empty( ),
-            "No path passed for deletion." )
+            "[JSON] No path passed for deletion." )
         nlohmann::json * j;
         if( path == "." )
         {
@@ -417,7 +417,7 @@ namespace openPMD
                     .to_string( );
             if( s == "/" )
             {
-                throw std::runtime_error( "Cannot delete the root group" );
+                throw std::runtime_error( "[JSON] Cannot delete the root group" );
             }
 
             auto i = s.rfind( '/' );
@@ -494,7 +494,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-            "Cannot delete datasets in read-only mode" )
+            "[JSON] Cannot delete datasets in read-only mode" )
 
         if( !writable->written )
         {
@@ -517,7 +517,7 @@ namespace openPMD
                     .to_string( );
             if( s.empty( ) )
             {
-                throw std::runtime_error( "Invalid position for a dataset in the JSON file." );
+                throw std::runtime_error( "[JSON] Invalid position for a dataset in the JSON file." );
             }
             dataset = s;
             auto i = dataset.rfind( '/' );
@@ -549,7 +549,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-            "Cannot delete attributes in read-only mode" )
+            "[JSON] Cannot delete attributes in read-only mode" )
         if( !writable->written )
         {
             return;
@@ -568,7 +568,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
-            "Cannot write data in read-only mode." );
+            "[JSON] Cannot write data in read-only mode." );
 
         auto pos = setAndGetFilePosition( writable );
         auto file = refreshFileFromParent( writable );
@@ -600,7 +600,7 @@ namespace openPMD
     {
         if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
         {
-            throw std::runtime_error( "Creating a dataset in a file opened as read only is not possible." );
+            throw std::runtime_error( "[JSON] Creating a dataset in a file opened as read only is not possible." );
         }
 
         /* Sanitize name */
@@ -661,7 +661,7 @@ namespace openPMD
             );
         } catch( json::basic_json::type_error & )
         {
-            throw std::runtime_error( "The given path does not contain a valid dataset." );
+            throw std::runtime_error( "[JSON] The given path does not contain a valid dataset." );
         }
     }
 
@@ -672,7 +672,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( writable->written,
-            "Attributes have to be written before reading." )
+            "[JSON] Attributes have to be written before reading." )
         refreshFileFromParent( writable );
         auto name = removeSlashes( parameters.name );
         auto & jsonLoc = obtainJsonContents( writable )["attributes"];
@@ -681,7 +681,7 @@ namespace openPMD
             jsonLoc,
             name
         ),
-            "No such attribute in the given location." )
+            "[JSON] No such attribute in the given location." )
         auto & j = jsonLoc[name];
         try
         {
@@ -696,7 +696,7 @@ namespace openPMD
             );
         } catch( json::type_error & )
         {
-            throw std::runtime_error( "The given location does not contain a properly formatted attribute" );
+            throw std::runtime_error( "[JSON] The given location does not contain a properly formatted attribute" );
         }
     }
 
@@ -707,7 +707,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( writable->written,
-            "Values have to be written before reading a directory" );
+            "[JSON] Values have to be written before reading a directory" );
         auto & j = obtainJsonContents( writable );
         setAndGetFilePosition( writable );
         refreshFileFromParent( writable );
@@ -730,7 +730,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( writable->written,
-            "Datasets have to be written before reading." )
+            "[JSON] Datasets have to be written before reading." )
         refreshFileFromParent( writable );
         auto filePosition = setAndGetFilePosition( writable );
         auto & j = obtainJsonContents( writable );
@@ -753,7 +753,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( writable->written,
-            "Attributes have to be written before reading." )
+            "[JSON] Attributes have to be written before reading." )
         refreshFileFromParent( writable );
         auto filePosition = setAndGetFilePosition( writable );
         auto & j = obtainJsonContents( writable )["attributes"];
@@ -772,7 +772,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( fileName.valid( ),
-            "Tried opening a file that has been overwritten or deleted." )
+            "[JSON] Tried opening a file that has been overwritten or deleted." )
         auto path = fullPath( std::move( fileName ) );
         auto fs = std::make_shared< std::fstream >( );
         switch( accessType )
@@ -792,7 +792,7 @@ namespace openPMD
                 break;
         }
         VERIFY( fs->good( ),
-            "Failed opening a file" );
+            "[JSON] Failed opening a file" );
         return fs;
     }
 
@@ -1062,7 +1062,7 @@ namespace openPMD
     JSONIOHandlerImpl::obtainJsonContents( File file )
     {
         VERIFY_ALWAYS( file.valid( ),
-            "File has been overwritten or deleted before reading" );
+            "[JSON] File has been overwritten or deleted before reading" );
         auto it = m_jsonVals.find( file );
         if( it != m_jsonVals.end( ) )
         {
@@ -1077,7 +1077,7 @@ namespace openPMD
             res = std::make_shared< nlohmann::json >( );
         *fh >> *res;
         VERIFY( fh->good( ),
-            "Failed reading from a file." );
+            "[JSON] Failed reading from a file." );
         m_jsonVals.emplace(
             file,
             res
@@ -1104,7 +1104,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( filename.valid( ),
-            "File has been overwritten/deleted before writing" );
+            "[JSON] File has been overwritten/deleted before writing" );
         auto it = m_jsonVals.find( filename );
         if( it != m_jsonVals.end( ) )
         {
@@ -1115,7 +1115,7 @@ namespace openPMD
             ( *it->second )["platform_byte_widths"] = platformSpecifics( );
             *fh << *it->second << std::endl;
             VERIFY( fh->good( ),
-                "Failed writing data to disk." )
+                "[JSON] Failed writing data to disk." )
             m_jsonVals.erase( it );
             if( unsetDirty )
             {
@@ -1257,7 +1257,7 @@ namespace openPMD
     )
     {
         VERIFY_ALWAYS( isDataset(j),
-            "Specified dataset does not exist or is not a dataset." );
+            "[JSON] Specified dataset does not exist or is not a dataset." );
 
         try
         {
@@ -1265,7 +1265,7 @@ namespace openPMD
             VERIFY_ALWAYS( datasetExtent.size( ) ==
                            parameters.extent
                                .size( ),
-                "Read/Write request does not fit the dataset's dimension" );
+                "[JSON] Read/Write request does not fit the dataset's dimension" );
             for( unsigned int dimension = 0;
                 dimension <
                 parameters.extent
@@ -1275,15 +1275,15 @@ namespace openPMD
                 VERIFY_ALWAYS( parameters.offset[dimension] +
                                parameters.extent[dimension] <=
                                datasetExtent[dimension],
-                    "Read/Write request exceeds the dataset's size" );
+                    "[JSON] Read/Write request exceeds the dataset's size" );
             }
             Datatype
                 dt = stringToDatatype( j["datatype"].get< std::string >( ) );
             VERIFY_ALWAYS( dt == parameters.dtype,
-                "Read/Write request does not fit the dataset's type" );
+                "[JSON] Read/Write request does not fit the dataset's type" );
         } catch( json::basic_json::type_error & )
         {
-            throw std::runtime_error( "The given path does not contain a valid dataset." );
+            throw std::runtime_error( "[JSON] The given path does not contain a valid dataset." );
         }
     }
 
@@ -1348,7 +1348,7 @@ namespace openPMD
         const Parameter< Operation::WRITE_DATASET > &
     )
     {
-        throw std::runtime_error( "Unknown datatype given for writing." );
+        throw std::runtime_error( "[JSON] Unknown datatype given for writing." );
     }
 
 
@@ -1385,7 +1385,7 @@ namespace openPMD
         Parameter< Operation::READ_DATASET > &
     )
     {
-        throw std::runtime_error( "Unknown datatype while reading a dataset." );
+        throw std::runtime_error( "[JSON] Unknown datatype while reading a dataset." );
     }
 
 
@@ -1406,7 +1406,7 @@ namespace openPMD
         Attribute::resource const &
     )
     {
-        throw std::runtime_error( "Unknown datatype in attribute writing." );
+        throw std::runtime_error( "[JSON] Unknown datatype in attribute writing." );
     }
 
 
@@ -1416,7 +1416,7 @@ namespace openPMD
         Parameter< Operation::READ_ATT > &
     )
     {
-        throw std::runtime_error( "Unknown datatype while reading attribute." );
+        throw std::runtime_error( "[JSON] Unknown datatype while reading attribute." );
     }
 
 


### PR DESCRIPTION
Prefix all thrown error messages in backends with the backend's name.

Since most exceptions are received by the frontend, this makes identifying the origin of an issue for users significantly easier.

Related to #626 