### PR TITLE
ADIOS1: Skip Invalid Scalar Particle Records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Other
 """""
 
 - Backends: Prefix Error Messages #634
+- ADIOS1: Skip Invalid Scalar Particle Records #635
 
 
 0.10.1-alpha


### PR DESCRIPTION
Spurious entries such as the legacy `particles_info` data set in PIConGPU will just be ignored (under verbose messages to stderr).

Related to #620

Work-around for https://github.com/ComputationalRadiationPhysics/picongpu/issues/3119