### PR TITLE
Support for Complex Types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Features
 
 - ``Record(Component)``: ``scalar()``, ``constant()``, ``empty()`` #711
 - Advanced backend configuration via JSON #569 #733
+- Support for complex floating point types #639
 - Functionality to close an iteration (and associated files) #746
 - Python:
 

--- a/docs/source/backends/adios1.rst
+++ b/docs/source/backends/adios1.rst
@@ -73,6 +73,10 @@ Limitations
    Mea culpa, we did better in the past (in PIConGPU).
    Please consider using our ADIOS2 backend instead, on which we focus our developments these days.
 
+.. note::
+
+   ADIOS1 does not support attributes that are `arrays of complex types <https://github.com/ornladios/ADIOS/issues/212>`_.
+
 
 Selected References
 -------------------

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2020 Fabian Koller, Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -31,6 +31,8 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <complex>
+
 
 
 namespace openPMD
@@ -43,6 +45,7 @@ enum class Datatype : int
     SHORT, INT, LONG, LONGLONG,
     USHORT, UINT, ULONG, ULONGLONG,
     FLOAT, DOUBLE, LONG_DOUBLE,
+    CFLOAT, CDOUBLE, CLONG_DOUBLE,
     STRING,
     VEC_CHAR,
     VEC_SHORT,
@@ -57,6 +60,9 @@ enum class Datatype : int
     VEC_FLOAT,
     VEC_DOUBLE,
     VEC_LONG_DOUBLE,
+    VEC_CFLOAT,
+    VEC_CDOUBLE,
+    VEC_CLONG_DOUBLE,
     VEC_STRING,
     ARR_DBL_7,
 
@@ -136,6 +142,9 @@ determineDatatype()
     else if( decay_equiv< T, float >::value ){ return DT::FLOAT; }
     else if( decay_equiv< T, double >::value ){ return DT::DOUBLE; }
     else if( decay_equiv< T, long double >::value ){ return DT::LONG_DOUBLE; }
+    else if( decay_equiv< T, std::complex< float > >::value ){ return DT::CFLOAT; }
+    else if( decay_equiv< T, std::complex< double > >::value ){ return DT::CDOUBLE; }
+    else if( decay_equiv< T, std::complex< long double > >::value ){ return DT::CLONG_DOUBLE; }
     else if( decay_equiv< T, std::string >::value ){ return DT::STRING; }
     else if( decay_equiv< T, std::vector< char > >::value ){ return DT::VEC_CHAR; }
     else if( decay_equiv< T, std::vector< short > >::value ){ return DT::VEC_SHORT; }
@@ -150,6 +159,9 @@ determineDatatype()
     else if( decay_equiv< T, std::vector< float > >::value ){ return DT::VEC_FLOAT; }
     else if( decay_equiv< T, std::vector< double > >::value ){ return DT::VEC_DOUBLE; }
     else if( decay_equiv< T, std::vector< long double > >::value ){ return DT::VEC_LONG_DOUBLE; }
+    else if( decay_equiv< T, std::vector< std::complex< float > > >::value ){ return DT::VEC_CFLOAT; }
+    else if( decay_equiv< T, std::vector< std::complex< double > > >::value ){ return DT::VEC_CDOUBLE; }
+    else if( decay_equiv< T, std::vector< std::complex< long double > > >::value ){ return DT::VEC_CLONG_DOUBLE; }
     else if( decay_equiv< T, std::vector< std::string > >::value ){ return DT::VEC_STRING; }
     else if( decay_equiv< T, std::array< double, 7 > >::value ){ return DT::ARR_DBL_7; }
     else if( decay_equiv< T, bool  >::value ){ return DT::BOOL; }
@@ -178,6 +190,9 @@ determineDatatype(std::shared_ptr< T >)
     else if( decay_equiv< T, float  >::value ){ return DT::FLOAT; }
     else if( decay_equiv< T, double  >::value ){ return DT::DOUBLE; }
     else if( decay_equiv< T, long double  >::value ){ return DT::LONG_DOUBLE; }
+    else if( decay_equiv< T, std::complex< float > >::value ){ return DT::CFLOAT; }
+    else if( decay_equiv< T, std::complex< double > >::value ){ return DT::CDOUBLE; }
+    else if( decay_equiv< T, std::complex< long double > >::value ){ return DT::CLONG_DOUBLE; }
     else if( decay_equiv< T, std::string >::value ){ return DT::STRING; }
     else if( decay_equiv< T, std::vector< char > >::value ){ return DT::VEC_CHAR; }
     else if( decay_equiv< T, std::vector< short > >::value ){ return DT::VEC_SHORT; }
@@ -192,6 +207,9 @@ determineDatatype(std::shared_ptr< T >)
     else if( decay_equiv< T, std::vector< float > >::value ){ return DT::VEC_FLOAT; }
     else if( decay_equiv< T, std::vector< double > >::value ){ return DT::VEC_DOUBLE; }
     else if( decay_equiv< T, std::vector< long double > >::value ){ return DT::VEC_LONG_DOUBLE; }
+    else if( decay_equiv< T, std::vector< std::complex< float > > >::value ){ return DT::VEC_CFLOAT; }
+    else if( decay_equiv< T, std::vector< std::complex< double > > >::value ){ return DT::VEC_CDOUBLE; }
+    else if( decay_equiv< T, std::vector< std::complex< long double > > >::value ){ return DT::VEC_CLONG_DOUBLE; }
     else if( decay_equiv< T, std::vector< std::string > >::value ){ return DT::VEC_STRING; }
     else if( decay_equiv< T, std::array< double, 7 > >::value ){ return DT::ARR_DBL_7; }
     else if( decay_equiv< T, bool  >::value ){ return DT::BOOL; }
@@ -255,6 +273,19 @@ toBytes( Datatype d )
         case DT::LONG_DOUBLE:
         case DT::VEC_LONG_DOUBLE:
             return sizeof(long double);
+            break;
+        case DT::CFLOAT:
+        case DT::VEC_CFLOAT:
+            return sizeof(float) * 2;
+            break;
+        case DT::CDOUBLE:
+        case DT::VEC_CDOUBLE:
+            return sizeof(double) * 2;
+            break;
+        case DT::CLONG_DOUBLE:
+        case DT::VEC_CLONG_DOUBLE:
+            return sizeof(long double) * 2;
+            break;
         case DT::BOOL:
             return sizeof(bool);
         case DT::DATATYPE:
@@ -300,6 +331,9 @@ isVector( Datatype d )
         case DT::VEC_FLOAT:
         case DT::VEC_DOUBLE:
         case DT::VEC_LONG_DOUBLE:
+        case DT::VEC_CFLOAT:
+        case DT::VEC_CDOUBLE:
+        case DT::VEC_CLONG_DOUBLE:
         case DT::VEC_STRING:
             return true;
         default:
@@ -327,6 +361,35 @@ isFloatingPoint( Datatype d )
         case DT::VEC_DOUBLE:
         case DT::LONG_DOUBLE:
         case DT::VEC_LONG_DOUBLE:
+        // note: complex floats are not std::is_floating_point
+            return true;
+            break;
+        default:
+            return false;
+            break;
+    }
+}
+
+/** Compare if a Datatype is a complex floating point type
+ *
+ * Includes our vector types
+ *
+ * @param d Datatype to test
+ * @return true if complex floating point, otherwise false
+ */
+inline bool
+isComplexFloatingPoint( Datatype d )
+{
+    using DT = Datatype;
+
+    switch( d )
+    {
+        case DT::CFLOAT:
+        case DT::VEC_CFLOAT:
+        case DT::CDOUBLE:
+        case DT::VEC_CDOUBLE:
+        case DT::CLONG_DOUBLE:
+        case DT::VEC_CLONG_DOUBLE:
             return true;
         default:
             return false;
@@ -347,6 +410,22 @@ isFloatingPoint()
     Datatype dtype = determineDatatype< T >();
 
     return isFloatingPoint( dtype );
+}
+
+/** Compare if a type is a complex floating point type
+ *
+ * Like isFloatingPoint but for complex floats
+ *
+ * @tparam T type to test
+ * @return true if complex floating point, otherwise false
+ */
+template< typename T >
+inline bool
+isComplexFloatingPoint()
+{
+    Datatype dtype = determineDatatype< T >();
+
+    return isComplexFloatingPoint(dtype);
 }
 
 /** Compare if a Datatype is an integer type
@@ -430,6 +509,32 @@ isSameFloatingPoint( Datatype d )
         return false;
 }
 
+/** Compare if a Datatype is equivalent to a complex floating point type
+ *
+ * @tparam T_CFP complex floating point type to compare
+ * @param d Datatype to compare
+ * @return true if both types are complex floating point and same bitness, else false
+ */
+template< typename T_CFP >
+inline bool
+isSameComplexFloatingPoint( Datatype d )
+{
+    // template
+    bool tt_is_cfp = isComplexFloatingPoint< T_CFP >();
+
+    // Datatype
+    bool dt_is_cfp = isComplexFloatingPoint( d );
+
+    if(
+        tt_is_cfp &&
+        dt_is_cfp &&
+        toBits( d ) == toBits( determineDatatype< T_CFP >() )
+    )
+        return true;
+    else
+        return false;
+}
+
 /** Compare if a Datatype is equivalent to an integer type
  *
  * @tparam T_Int signed or unsigned integer type to compare
@@ -496,6 +601,18 @@ isSame( openPMD::Datatype const d, openPMD::Datatype const e )
     if(
         d_is_fp &&
         e_is_fp &&
+        d_is_vec == e_is_vec &&
+        toBits( d ) == toBits( e )
+    )
+        return true;
+
+    // same complex floating point
+    bool d_is_cfp = isComplexFloatingPoint(d);
+    bool e_is_cfp = isComplexFloatingPoint(e);
+
+    if(
+        d_is_cfp &&
+        e_is_cfp &&
         d_is_vec == e_is_vec &&
         toBits( d ) == toBits( e )
     )
@@ -571,6 +688,15 @@ ReturnType switchType( Datatype dt, Action action, Args &&... args )
     case Datatype::LONG_DOUBLE:
         return action.OPENPMD_TEMPLATE_OPERATOR( )< long double >(
             std::forward< Args >( args )... );
+    case Datatype::CFLOAT:
+        return action.OPENPMD_TEMPLATE_OPERATOR( )< std::complex< float > >(
+                std::forward< Args >( args )... );
+    case Datatype::CDOUBLE:
+        return action.OPENPMD_TEMPLATE_OPERATOR( )< std::complex< double > >(
+                std::forward< Args >( args )... );
+    case Datatype::CLONG_DOUBLE:
+        return action.OPENPMD_TEMPLATE_OPERATOR( )< std::complex< long double > >(
+                std::forward< Args >( args )... );
     case Datatype::STRING:
         return action.OPENPMD_TEMPLATE_OPERATOR( )< std::string >(
             std::forward< Args >( args )... );
@@ -619,6 +745,16 @@ ReturnType switchType( Datatype dt, Action action, Args &&... args )
         return action
             .OPENPMD_TEMPLATE_OPERATOR( )< std::vector< long double > >(
                 std::forward< Args >( args )... );
+    case Datatype::VEC_CFLOAT:
+        return action.OPENPMD_TEMPLATE_OPERATOR( )< std::vector< std::complex< float > > >(
+                std::forward< Args >( args )... );
+    case Datatype::VEC_CDOUBLE:
+        return action.OPENPMD_TEMPLATE_OPERATOR( )< std::vector< std::complex< double > > >(
+                std::forward< Args >( args )... );
+    case Datatype::VEC_CLONG_DOUBLE:
+        return action
+                .OPENPMD_TEMPLATE_OPERATOR( )< std::vector< std::complex< long double > > >(
+                        std::forward< Args >( args )... );
     case Datatype::VEC_STRING:
         return action
             .OPENPMD_TEMPLATE_OPERATOR( )< std::vector< std::string > >(

--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -181,6 +181,15 @@ getBP1DataType(Datatype dtype)
         case DT::LONG_DOUBLE:
         case DT::VEC_LONG_DOUBLE:
             return adios_long_double;
+        case DT::CFLOAT:
+        case DT::VEC_CFLOAT:
+            return adios_complex;
+        case DT::CDOUBLE:
+        case DT::VEC_CDOUBLE:
+            return adios_double_complex;
+        case DT::CLONG_DOUBLE:
+        case DT::VEC_CLONG_DOUBLE:
+            throw unsupported_data_error("No native equivalent for Datatype::CLONG_DOUBLE found.");
         case DT::STRING:
             return adios_string;
         case DT::VEC_STRING:

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -25,6 +25,8 @@
 #if openPMD_HAVE_ADIOS2
 #include "openPMD/Datatype.hpp"
 #include <adios2.h>
+#include <complex>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -79,10 +81,30 @@ namespace detail
         getSize( adios2::IO &, std::string const & attributeName );
     };
 
+    template < > struct AttributeInfoHelper< std::complex< long double > >
+    {
+        static typename std::vector< long double >::size_type
+        getSize( adios2::IO &, std::string const & )
+        {
+            throw std::runtime_error(
+                "[ADIOS2] Internal error: no support for long double complex attribute types" );
+        }
+    };
+
     template < typename T > struct AttributeInfoHelper< std::vector< T > >
     {
         static typename std::vector< T >::size_type
         getSize( adios2::IO &, std::string const & attributeName );
+    };
+
+    template < > struct AttributeInfoHelper< std::vector< std::complex< long double > > >
+    {
+        static typename std::vector< std::complex< long double > >::size_type
+        getSize( adios2::IO &, std::string const & )
+        {
+            throw std::runtime_error(
+                "[ADIOS2] Internal error: no support for long double complex vector attribute types" );
+        }
     };
 
     template < typename T, std::size_t n >

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -335,7 +335,7 @@ namespace detail
         explicit DatasetReader( openPMD::ADIOS2IOHandlerImpl * impl );
 
 
-        template < typename T, typename = void >
+        template < typename T >
         void operator( )( BufferedGet & bp, adios2::IO & IO,
                           adios2::Engine & engine,
                           std::string const & fileName );
@@ -345,7 +345,7 @@ namespace detail
 
     struct AttributeReader
     {
-        template < typename T, typename = void >
+        template < typename T >
         Datatype operator( )( adios2::IO & IO, std::string name,
                           std::shared_ptr< Attribute::resource > resource );
 
@@ -355,7 +355,7 @@ namespace detail
 
     struct AttributeWriter
     {
-        template < typename T, typename = void >
+        template < typename T >
         void
         operator( )( ADIOS2IOHandlerImpl * impl, Writable * writable,
                      const Parameter< Operation::WRITE_ATT > & parameters );
@@ -372,7 +372,7 @@ namespace detail
         explicit DatasetOpener( ADIOS2IOHandlerImpl * impl );
 
 
-        template < typename T, typename = void >
+        template < typename T >
         void operator( )( InvalidatableFile, const std::string & varName,
                           Parameter< Operation::OPEN_DATASET > & parameters );
 
@@ -388,7 +388,7 @@ namespace detail
         WriteDataset( ADIOS2IOHandlerImpl * handlerImpl );
 
 
-        template < typename T, typename = void >
+        template < typename T >
         void operator( )( BufferedPut & bp, adios2::IO & IO,
                           adios2::Engine & engine );
 
@@ -398,7 +398,7 @@ namespace detail
     struct VariableDefiner
     {
         // Parameters such as DatasetHelper< T >::defineVariable
-        template < typename T, typename... Params, typename = void >
+        template < typename T, typename... Params >
         void operator( )( Params &&... params );
 
         template< int n, typename... Params >
@@ -546,6 +546,7 @@ namespace detail
         static constexpr bool validType = false;
     };
 
+    // missing std::complex< long double > type in ADIOS2 v2.6.0
     template <> struct DatasetTypes< std::complex< long double > >
     {
         static constexpr bool validType = false;
@@ -582,7 +583,7 @@ namespace detail
 
         /**
          * @brief Define a Variable of type T within the passed IO.
-         * 
+         *
          * @param IO The adios2::IO object within which to define the
          *           variable. The variable can later be retrieved from
          *           the IO using the passed name.
@@ -738,7 +739,7 @@ namespace detail
 
     private:
         /*
-         * ADIOS2 does not give direct access to its internal attribute and 
+         * ADIOS2 does not give direct access to its internal attribute and
          * variable maps, but will instead give access to copies of them.
          * In order to avoid unnecessary copies, we buffer the returned map.
          * The downside of this is that we need to pay attention to invalidate
@@ -748,7 +749,7 @@ namespace detail
          * been resolved
          * If false, the buffered map has been invalidated and needs to be
          * queried from ADIOS2 again. If true, the buffered map is equivalent to
-         * the map that would be returned by a call to 
+         * the map that would be returned by a call to
          * IO::Available(Attributes|Variables).
          */
         bool m_availableAttributesValid = false;

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -27,82 +27,103 @@
 
 #include <hdf5.h>
 
+#include <complex>
 #include <stack>
+#include <string>
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
 
 
 namespace openPMD
 {
-inline hid_t
-getH5DataType(Attribute const& att)
+struct GetH5DataType
 {
-    using DT = Datatype;
-    switch( att.dtype )
+    std::unordered_map< std::string, hid_t > m_userTypes;
+
+    GetH5DataType( std::unordered_map< std::string, hid_t > userTypes )
+    : m_userTypes{ std::move(userTypes) }
     {
-        case DT::CHAR:
-        case DT::VEC_CHAR:
-            return H5Tcopy(H5T_NATIVE_CHAR);
-        case DT::UCHAR:
-        case DT::VEC_UCHAR:
-            return H5Tcopy(H5T_NATIVE_UCHAR);
-        case DT::SHORT:
-        case DT::VEC_SHORT:
-            return H5Tcopy(H5T_NATIVE_SHORT);
-        case DT::INT:
-        case DT::VEC_INT:
-            return H5Tcopy(H5T_NATIVE_INT);
-        case DT::LONG:
-        case DT::VEC_LONG:
-            return H5Tcopy(H5T_NATIVE_LONG);
-        case DT::LONGLONG:
-        case DT::VEC_LONGLONG:
-            return H5Tcopy(H5T_NATIVE_LLONG);
-        case DT::USHORT:
-        case DT::VEC_USHORT:
-            return H5Tcopy(H5T_NATIVE_USHORT);
-        case DT::UINT:
-        case DT::VEC_UINT:
-            return H5Tcopy(H5T_NATIVE_UINT);
-        case DT::ULONG:
-        case DT::VEC_ULONG:
-            return H5Tcopy(H5T_NATIVE_ULONG);
-        case DT::ULONGLONG:
-        case DT::VEC_ULONGLONG:
-            return H5Tcopy(H5T_NATIVE_ULLONG);
-        case DT::FLOAT:
-        case DT::VEC_FLOAT:
-            return H5Tcopy(H5T_NATIVE_FLOAT);
-        case DT::DOUBLE:
-        case DT::ARR_DBL_7:
-        case DT::VEC_DOUBLE:
-            return H5Tcopy(H5T_NATIVE_DOUBLE);
-        case DT::LONG_DOUBLE:
-        case DT::VEC_LONG_DOUBLE:
-            return H5Tcopy(H5T_NATIVE_LDOUBLE);
-        case DT::STRING:
-        {
-            hid_t string_t_id = H5Tcopy(H5T_C_S1);
-            H5Tset_size(string_t_id, att.get< std::string >().size());
-            return string_t_id;
-        }
-        case DT::VEC_STRING:
-        {
-            hid_t string_t_id = H5Tcopy(H5T_C_S1);
-            size_t max_len = 0;
-            for( std::string const& s : att.get< std::vector< std::string > >() )
-                max_len = std::max(max_len, s.size());
-            H5Tset_size(string_t_id, max_len);
-            return string_t_id;
-        }
-        case DT::BOOL:
-            return H5Tcopy(H5T_NATIVE_HBOOL);
-        case DT::DATATYPE:
-            throw std::runtime_error("Meta-Datatype leaked into IO");
-        case DT::UNDEFINED:
-            throw std::runtime_error("Unknown Attribute datatype (HDF5 datatype)");
-        default:
-            throw std::runtime_error("Datatype not implemented in HDF5 IO");
     }
-}
+
+    hid_t
+    operator()(Attribute const &att)
+    {
+        using DT = Datatype;
+        switch (att.dtype) {
+            case DT::CHAR:
+            case DT::VEC_CHAR:
+                return H5Tcopy(H5T_NATIVE_CHAR);
+            case DT::UCHAR:
+            case DT::VEC_UCHAR:
+                return H5Tcopy(H5T_NATIVE_UCHAR);
+            case DT::SHORT:
+            case DT::VEC_SHORT:
+                return H5Tcopy(H5T_NATIVE_SHORT);
+            case DT::INT:
+            case DT::VEC_INT:
+                return H5Tcopy(H5T_NATIVE_INT);
+            case DT::LONG:
+            case DT::VEC_LONG:
+                return H5Tcopy(H5T_NATIVE_LONG);
+            case DT::LONGLONG:
+            case DT::VEC_LONGLONG:
+                return H5Tcopy(H5T_NATIVE_LLONG);
+            case DT::USHORT:
+            case DT::VEC_USHORT:
+                return H5Tcopy(H5T_NATIVE_USHORT);
+            case DT::UINT:
+            case DT::VEC_UINT:
+                return H5Tcopy(H5T_NATIVE_UINT);
+            case DT::ULONG:
+            case DT::VEC_ULONG:
+                return H5Tcopy(H5T_NATIVE_ULONG);
+            case DT::ULONGLONG:
+            case DT::VEC_ULONGLONG:
+                return H5Tcopy(H5T_NATIVE_ULLONG);
+            case DT::FLOAT:
+            case DT::VEC_FLOAT:
+                return H5Tcopy(H5T_NATIVE_FLOAT);
+            case DT::DOUBLE:
+            case DT::ARR_DBL_7:
+            case DT::VEC_DOUBLE:
+                return H5Tcopy(H5T_NATIVE_DOUBLE);
+            case DT::LONG_DOUBLE:
+            case DT::VEC_LONG_DOUBLE:
+                return H5Tcopy(H5T_NATIVE_LDOUBLE);
+            case DT::CFLOAT:
+            case DT::VEC_CFLOAT:
+                return H5Tcopy( m_userTypes.at( typeid(std::complex< float >).name() ) );
+            case DT::CDOUBLE:
+            case DT::VEC_CDOUBLE:
+                return H5Tcopy( m_userTypes.at( typeid(std::complex< double >).name() ) );
+            case DT::CLONG_DOUBLE:
+            case DT::VEC_CLONG_DOUBLE:
+                return H5Tcopy( m_userTypes.at( typeid(std::complex< long double >).name() ) );
+            case DT::STRING: {
+                hid_t string_t_id = H5Tcopy(H5T_C_S1);
+                H5Tset_size(string_t_id, att.get<std::string>().size());
+                return string_t_id;
+            }
+            case DT::VEC_STRING: {
+                hid_t string_t_id = H5Tcopy(H5T_C_S1);
+                size_t max_len = 0;
+                for (std::string const &s : att.get<std::vector<std::string> >())
+                    max_len = std::max(max_len, s.size());
+                H5Tset_size(string_t_id, max_len);
+                return string_t_id;
+            }
+            case DT::BOOL:
+                return H5Tcopy( m_userTypes.at( typeid(bool).name() ) );
+            case DT::DATATYPE:
+                throw std::runtime_error("[HDF5] Meta-Datatype leaked into IO");
+            case DT::UNDEFINED:
+                throw std::runtime_error("[HDF5] Unknown Attribute datatype (HDF5 datatype)");
+            default:
+                throw std::runtime_error("[HDF5] Datatype not implemented");
+        }
+    }
+};
 
 inline hid_t
 getH5DataSpace(Attribute const& att)
@@ -123,6 +144,9 @@ getH5DataSpace(Attribute const& att)
         case DT::FLOAT:
         case DT::DOUBLE:
         case DT::LONG_DOUBLE:
+        case DT::CFLOAT:
+        case DT::CDOUBLE:
+        case DT::CLONG_DOUBLE:
         case DT::STRING:
         case DT::BOOL:
             return H5Screate(H5S_SCALAR);
@@ -214,6 +238,27 @@ getH5DataSpace(Attribute const& att)
         {
             hid_t vec_t_id = H5Screate(H5S_SIMPLE);
             hsize_t dims[1] = {att.get< std::vector< long double > >().size()};
+            H5Sset_extent_simple(vec_t_id, 1, dims, nullptr);
+            return vec_t_id;
+        }
+        case DT::VEC_CFLOAT:
+        {
+            hid_t vec_t_id = H5Screate(H5S_SIMPLE);
+            hsize_t dims[1] = {att.get< std::vector< std::complex< float > > >().size()};
+            H5Sset_extent_simple(vec_t_id, 1, dims, nullptr);
+            return vec_t_id;
+        }
+        case DT::VEC_CDOUBLE:
+        {
+            hid_t vec_t_id = H5Screate(H5S_SIMPLE);
+            hsize_t dims[1] = {att.get< std::vector< std::complex< double > > >().size()};
+            H5Sset_extent_simple(vec_t_id, 1, dims, nullptr);
+            return vec_t_id;
+        }
+        case DT::VEC_CLONG_DOUBLE:
+        {
+            hid_t vec_t_id = H5Screate(H5S_SIMPLE);
+            hsize_t dims[1] = {att.get< std::vector< std::complex< long double > > >().size()};
             H5Sset_extent_simple(vec_t_id, 1, dims, nullptr);
             return vec_t_id;
         }

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -66,7 +66,11 @@ namespace openPMD
         hid_t m_datasetTransferProperty;
         hid_t m_fileAccessProperty;
 
+        // h5py compatible types for bool and complex
         hid_t m_H5T_BOOL_ENUM;
+        hid_t m_H5T_CFLOAT;
+        hid_t m_H5T_CDOUBLE;
+        hid_t m_H5T_CLONG_DOUBLE;
     }; // HDF5IOHandlerImpl
 #else
     class HDF5IOHandlerImpl

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -30,6 +30,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <complex>
 #include <fstream>
 #include <memory>
 #include <tuple>
@@ -145,6 +146,16 @@ namespace std
             return std::hash< shared_ptr< openPMD::File::FileState>> {}( s.fileState );
         }
     };
+
+    // std::complex handling
+    template< class T > void to_json(nlohmann::json &j, const std::complex< T > &p) {
+        j = nlohmann::json {p.real(), p.imag()};
+    }
+
+    template< class T > void from_json(const nlohmann::json &j, std::complex< T > &p) {
+        p.real(j.at(0));
+        p.imag(j.at(1));
+    }
 }
 
 namespace openPMD

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -273,7 +273,9 @@ RecordComponent::loadChunk(std::shared_ptr< T > data, Offset o, Extent e, double
         throw std::runtime_error("unitSI scaling during chunk loading not yet implemented");
     Datatype dtype = determineDatatype(data);
     if( dtype != getDatatype() )
-        if( !isSameInteger< T >( dtype ) && !isSameFloatingPoint< T >( dtype ) )
+        if( !isSameInteger< T >( dtype ) &&
+            !isSameFloatingPoint< T >( dtype ) &&
+            !isSameComplexFloatingPoint< T >( dtype ) )
             throw std::runtime_error("Type conversion during chunk loading not yet implemented");
 
     uint8_t dim = getDimensionality();

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -23,6 +23,7 @@
 #include "openPMD/Dataset.hpp"
 #include "openPMD/Datatype.hpp"
 
+#include <complex>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -59,6 +60,21 @@ allocatePtr(Datatype dtype, uint64_t numPoints)
         case DT::FLOAT:
             data = new float[numPoints];
             del = [](void* p){ delete[] static_cast< float* >(p); };
+            break;
+        case DT::VEC_CLONG_DOUBLE:
+        case DT::CLONG_DOUBLE:
+            data = new std::complex<long double>[numPoints];
+            del = [](void* p){ delete[] static_cast< std::complex<long double>* >(p); };
+            break;
+        case DT::VEC_CDOUBLE:
+        case DT::CDOUBLE:
+            data = new std::complex<double>[numPoints];
+            del = [](void* p){ delete[] static_cast< std::complex<double>* >(p); };
+            break;
+        case DT::VEC_CFLOAT:
+        case DT::CFLOAT:
+            data = new std::complex<float>[numPoints];
+            del = [](void* p){ delete[] static_cast< std::complex<float>* >(p); };
             break;
         case DT::VEC_SHORT:
         case DT::SHORT:

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <array>
+#include <complex>
 #include <cstdint>
 #include <iterator>
 #include <stdexcept>
@@ -52,6 +53,7 @@ class Attribute :
                             short, int, long, long long,
                             unsigned short, unsigned int, unsigned long, unsigned long long,
                             float, double, long double,
+                            std::complex< float >, std::complex< double >, std::complex< long double >,
                             std::string,
                             std::vector< char >,
                             std::vector< short >,
@@ -66,6 +68,9 @@ class Attribute :
                             std::vector< float >,
                             std::vector< double >,
                             std::vector< long double >,
+                            std::vector< std::complex< float > >,
+                            std::vector< std::complex< double > >,
+                            std::vector< std::complex< long double > >,
                             std::vector< std::string >,
                             std::array< double, 7 >,
                             bool >
@@ -171,6 +176,12 @@ getCast( Attribute const & a )
         return DoConvert<double, U>{}(pvalue_d);
     else if(auto pvalue_ld = variantSrc::get_if< long double >( &v ) )
         return DoConvert<long double, U>{}(pvalue_ld);
+    else if(auto pvalue_cf = variantSrc::get_if< std::complex< float > >( &v ) )
+        return DoConvert<std::complex< float >, U>{}(pvalue_cf);
+    else if(auto pvalue_cd = variantSrc::get_if< std::complex< double > >( &v ) )
+        return DoConvert<std::complex< double >, U>{}(pvalue_cd);
+    else if(auto pvalue_cld = variantSrc::get_if< std::complex< long double > >( &v ) )
+        return DoConvert<std::complex< long double >, U>{}(pvalue_cld);
     else if(auto pvalue_str = variantSrc::get_if< std::string >( &v ) )
         return DoConvert<std::string, U>{}(pvalue_str);
     // vector
@@ -200,6 +211,12 @@ getCast( Attribute const & a )
         return DoConvert<std::vector< double >, U>{}(pvalue_vd);
     else if(auto pvalue_vld = variantSrc::get_if< std::vector< long double > >( &v ) )
         return DoConvert<std::vector< long double >, U>{}(pvalue_vld);
+    else if(auto pvalue_vcf = variantSrc::get_if< std::vector< std::complex< float > > >( &v ) )
+        return DoConvert<std::vector< std::complex< float > >, U>{}(pvalue_vcf);
+    else if(auto pvalue_vcd = variantSrc::get_if< std::vector< std::complex< double > > >( &v ) )
+        return DoConvert<std::vector< std::complex< double > >, U>{}(pvalue_vcd);
+    else if(auto pvalue_vcld = variantSrc::get_if< std::vector< std::complex< long double > > >( &v ) )
+        return DoConvert<std::vector< std::complex< long double > >, U>{}(pvalue_vcld);
     else if(auto pvalue_vstr = variantSrc::get_if< std::vector< std::string > >( &v ) )
         return DoConvert<std::vector< std::string >, U>{}(pvalue_vstr);
     // extra

--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -57,6 +57,12 @@ namespace openPMD
             return Datatype::ULONG;
         else if( dt.is(pybind11::dtype("ulonglong")) )
             return Datatype::ULONGLONG;
+        else if( dt.is(pybind11::dtype("clongdouble")) )
+            return Datatype::CLONG_DOUBLE;
+        else if( dt.is(pybind11::dtype("cdouble")) )
+            return Datatype::CDOUBLE;
+        else if( dt.is(pybind11::dtype("csingle")) )
+            return Datatype::CFLOAT;
         else if( dt.is(pybind11::dtype("longdouble")) )
             return Datatype::LONG_DOUBLE;
         else if( dt.is(pybind11::dtype("double")) )
@@ -65,8 +71,10 @@ namespace openPMD
             return Datatype::FLOAT;
         else if( dt.is(pybind11::dtype("bool")) )
             return Datatype::BOOL;
-        else
+        else {
+            pybind11::print(dt);
             throw std::runtime_error("Datatype '...' not known in 'dtype_from_numpy'!"); // _s.format(dt)
+        }
     }
 
     /** Return openPMD::Datatype from py::buffer_info::format
@@ -79,7 +87,7 @@ namespace openPMD
         // refs:
         //   https://docs.scipy.org/doc/numpy-1.15.0/reference/arrays.interface.html
         //   https://docs.python.org/3/library/struct.html#format-characters
-        // std::cout << "  scalar type '" << buf.format << "'" << std::endl;
+        // std::cout << "  scalar type '" << fmt << "'" << std::endl;
         // typestring: encoding + type + number of bytes
         if( fmt.find("?") != std::string::npos )
             return DT::BOOL;
@@ -103,6 +111,12 @@ namespace openPMD
             return DT::ULONG;
         else if( fmt.find("Q") != std::string::npos )
             return DT::ULONGLONG;
+        else if( fmt.find("Zf") != std::string::npos )
+            return DT::CFLOAT;
+        else if( fmt.find("Zd") != std::string::npos )
+            return DT::CDOUBLE;
+        else if( fmt.find("Zg") != std::string::npos )
+            return DT::CLONG_DOUBLE;
         else if( fmt.find("f") != std::string::npos )
             return DT::FLOAT;
         else if( fmt.find("d") != std::string::npos )
@@ -178,6 +192,18 @@ namespace openPMD
             case DT::LONG_DOUBLE:
             case DT::VEC_LONG_DOUBLE:
                 return pybind11::dtype("longdouble");
+                break;
+            case DT::CFLOAT:
+            case DT::VEC_CFLOAT:
+                return pybind11::dtype("csingle");
+                break;
+            case DT::CDOUBLE:
+            case DT::VEC_CDOUBLE:
+                return pybind11::dtype("cdouble");
+                break;
+            case DT::CLONG_DOUBLE:
+            case DT::VEC_CLONG_DOUBLE:
+                return pybind11::dtype("clongdouble");
                 break;
             case DT::BOOL:
                 return pybind11::dtype("bool"); // also "?"

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -83,6 +83,15 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
         case DT::LONG_DOUBLE:
             os << "LONG_DOUBLE";
             break;
+        case DT::CFLOAT:
+            os << "CFLOAT";
+            break;
+        case DT::CDOUBLE:
+            os << "CDOUBLE";
+            break;
+        case DT::CLONG_DOUBLE:
+            os << "CLONG_DOUBLE";
+            break;
         case DT::STRING:
             os << "STRING";
             break;
@@ -124,6 +133,15 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
             break;
         case DT::VEC_LONG_DOUBLE:
             os << "VEC_LONG_DOUBLE";
+            break;
+        case DT::VEC_CFLOAT:
+            os << "VEC_CFLOAT";
+            break;
+        case DT::VEC_CDOUBLE:
+            os << "VEC_CDOUBLE";
+            break;
+        case DT::VEC_CLONG_DOUBLE:
+            os << "VEC_CLONG_DOUBLE";
             break;
         case DT::VEC_STRING:
             os << "VEC_STRING";
@@ -204,6 +222,18 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
                 Datatype::LONG_DOUBLE
             },
             {
+                "CFLOAT",
+                Datatype::CFLOAT
+            },
+            {
+                "CDOUBLE",
+                Datatype::CDOUBLE
+            },
+            {
+                "CLONG_DOUBLE",
+                Datatype::CLONG_DOUBLE
+            },
+            {
                 "STRING",
                 Datatype::STRING
             },
@@ -260,6 +290,18 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
                 Datatype::VEC_LONG_DOUBLE
             },
             {
+                "VEC_CFLOAT",
+                Datatype::VEC_CFLOAT
+            },
+            {
+                "VEC_CDOUBLE",
+                Datatype::VEC_CDOUBLE
+            },
+            {
+                "VEC_CLONG_DOUBLE",
+                Datatype::VEC_CLONG_DOUBLE
+            },
+            {
                 "VEC_STRING",
                 Datatype::VEC_STRING
             },
@@ -314,6 +356,9 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
            Datatype::FLOAT,
            Datatype::DOUBLE,
            Datatype::LONG_DOUBLE,
+           Datatype::CFLOAT,
+           Datatype::CDOUBLE,
+           Datatype::CLONG_DOUBLE,
            Datatype::STRING,
            Datatype::VEC_CHAR,
            Datatype::VEC_SHORT,
@@ -328,6 +373,9 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
            Datatype::VEC_FLOAT,
            Datatype::VEC_DOUBLE,
            Datatype::VEC_LONG_DOUBLE,
+           Datatype::VEC_CFLOAT,
+           Datatype::VEC_CDOUBLE,
+           Datatype::VEC_CLONG_DOUBLE,
            Datatype::VEC_STRING,
            Datatype::ARR_DBL_7,
            Datatype::BOOL,
@@ -363,7 +411,7 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
         if (it != map.end()) {
             return it->second;
         } else {
-            std::cerr << "Encountered non-basice type " << dt << ", aborting."
+            std::cerr << "Encountered non-basic type " << dt << ", aborting."
                     << std::endl;
             throw std::runtime_error("toVectorType: passed non-basic type.");
         }

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -93,6 +93,9 @@ namespace detail
             { "float", Datatype::FLOAT },
             { "double", Datatype::DOUBLE },
             { "long double", Datatype::LONG_DOUBLE },
+            { "float complex", Datatype::CFLOAT },
+            { "double complex", Datatype::CDOUBLE },
+            { "long double complex", Datatype::CLONG_DOUBLE }, // does not exist as of 2.6.0 but might come later
             { "uint8_t", Datatype::UCHAR },
             { "int8_t", Datatype::CHAR },
             { "uint16_t", determineDatatype< uint16_t >() },

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -766,13 +766,22 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
 
 namespace detail
 {
+    // missing std::complex< long double > type in ADIOS2 v2.6.0
+    template< typename T >
+    using disable_if_cld = typename std::enable_if<
+        ! std::is_same<
+            T, std::complex<long double>
+        >::value_type
+    >::type;
+
     DatasetReader::DatasetReader( openPMD::ADIOS2IOHandlerImpl * impl )
     : m_impl{impl}
     {
     }
 
-    template < typename T >
-    void DatasetReader::operator( )( detail::BufferedGet & bp, adios2::IO & IO,
+    template < typename T, typename = disable_if_cld<T> >
+    void
+    DatasetReader::operator( )( detail::BufferedGet & bp, adios2::IO & IO,
                                      adios2::Engine & engine,
                                      std::string const & fileName )
     {
@@ -786,7 +795,7 @@ namespace detail
             "[ADIOS2] Internal error: Unknown datatype trying to read a dataset." );
     }
 
-    template < typename T >
+    template < typename T, typename = disable_if_cld<T> >
     Datatype AttributeReader::
     operator( )( adios2::IO & IO, std::string name,
                  std::shared_ptr< Attribute::resource > resource )
@@ -826,7 +835,7 @@ namespace detail
                                   "trying to read an attribute." );
     }
 
-    template < typename T >
+    template < typename T, typename = disable_if_cld<T> >
     void AttributeWriter::
     operator( )( ADIOS2IOHandlerImpl * impl, Writable * writable,
                  const Parameter< Operation::WRITE_ATT > & parameters )
@@ -867,7 +876,7 @@ namespace detail
     {
     }
 
-    template < typename T >
+    template < typename T, typename = disable_if_cld<T> >
     void DatasetOpener::
     operator( )( InvalidatableFile file, const std::string & varName,
                  Parameter< Operation::OPEN_DATASET > & parameters )
@@ -887,7 +896,7 @@ namespace detail
     {
     }
 
-    template < typename T >
+    template < typename T, typename = disable_if_cld<T> >
     void WriteDataset::operator( )( detail::BufferedPut & bp, adios2::IO & IO,
                                     adios2::Engine & engine )
     {
@@ -901,7 +910,7 @@ namespace detail
         throw std::runtime_error( "[ADIOS2] WRITE_DATASET: Invalid datatype." );
     }
 
-    template < typename T, typename... Params >
+    template < typename T, typename... Params, typename = disable_if_cld<T> >
     void VariableDefiner::
     operator( )( Params &&... params )
     {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -766,20 +766,12 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
 
 namespace detail
 {
-    // missing std::complex< long double > type in ADIOS2 v2.6.0
-    template< typename T >
-    using disable_if_cld = typename std::enable_if<
-        ! std::is_same<
-            T, std::complex<long double>
-        >::value_type
-    >::type;
-
     DatasetReader::DatasetReader( openPMD::ADIOS2IOHandlerImpl * impl )
     : m_impl{impl}
     {
     }
 
-    template < typename T, typename = disable_if_cld<T> >
+    template < typename T>
     void
     DatasetReader::operator( )( detail::BufferedGet & bp, adios2::IO & IO,
                                      adios2::Engine & engine,
@@ -795,7 +787,7 @@ namespace detail
             "[ADIOS2] Internal error: Unknown datatype trying to read a dataset." );
     }
 
-    template < typename T, typename = disable_if_cld<T> >
+    template < typename T >
     Datatype AttributeReader::
     operator( )( adios2::IO & IO, std::string name,
                  std::shared_ptr< Attribute::resource > resource )
@@ -835,7 +827,7 @@ namespace detail
                                   "trying to read an attribute." );
     }
 
-    template < typename T, typename = disable_if_cld<T> >
+    template < typename T >
     void AttributeWriter::
     operator( )( ADIOS2IOHandlerImpl * impl, Writable * writable,
                  const Parameter< Operation::WRITE_ATT > & parameters )
@@ -876,7 +868,7 @@ namespace detail
     {
     }
 
-    template < typename T, typename = disable_if_cld<T> >
+    template < typename T >
     void DatasetOpener::
     operator( )( InvalidatableFile file, const std::string & varName,
                  Parameter< Operation::OPEN_DATASET > & parameters )
@@ -896,7 +888,7 @@ namespace detail
     {
     }
 
-    template < typename T, typename = disable_if_cld<T> >
+    template < typename T >
     void WriteDataset::operator( )( detail::BufferedPut & bp, adios2::IO & IO,
                                     adios2::Engine & engine )
     {
@@ -910,7 +902,7 @@ namespace detail
         throw std::runtime_error( "[ADIOS2] WRITE_DATASET: Invalid datatype." );
     }
 
-    template < typename T, typename... Params, typename = disable_if_cld<T> >
+    template < typename T, typename... Params >
     void VariableDefiner::
     operator( )( Params &&... params )
     {

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -314,25 +314,14 @@ CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& nam
                 ptr[i] = vec[i];
             break;
         }
+        /* not supported by ADIOS 1.13.1:
+         *   https://github.com/ornladios/ADIOS/issues/212
+         */
         case DT::VEC_CFLOAT:
-        {
-            auto ptr = reinterpret_cast< std::complex< float >* >(values.get());
-            auto const& vec = att.get< std::vector< std::complex< float > > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
         case DT::VEC_CDOUBLE:
-        {
-            auto ptr = reinterpret_cast< std::complex< double >* >(values.get());
-            auto const& vec = att.get< std::vector< std::complex< double > > >();
-            for( size_t i = 0; i < vec.size(); ++i )
-                ptr[i] = vec[i];
-            break;
-        }
         case DT::VEC_CLONG_DOUBLE:
         {
-            throw std::runtime_error("[ADIOS1] Unknown Attribute datatype (VEC_CLONG_DOUBLE)");
+            throw std::runtime_error("[ADIOS1] Arrays of complex attributes are not supported");
             break;
         }
         case DT::VEC_STRING:
@@ -1427,28 +1416,9 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
                 a = Attribute(vld);
                 break;
             }
-            case adios_complex:
-            {
-                dtype = DT::VEC_CFLOAT;
-                auto cf4 = reinterpret_cast< std::complex<float>* >(data);
-                std::vector< std::complex<float> > vcf;
-                vcf.resize(size);
-                for( int i = 0; i < size; ++i )
-                    vcf[i] = cf4[i];
-                a = Attribute(vcf);
-                break;
-            }
-            case adios_double_complex:
-            {
-                dtype = DT::VEC_CDOUBLE;
-                auto cd8 = reinterpret_cast< std::complex<double>* >(data);
-                std::vector< std::complex<double> > vcd;
-                vcd.resize(size);
-                for( int i = 0; i < size; ++i )
-                    vcd[i] = cd8[i];
-                a = Attribute(vcd);
-                break;
-            }
+            /* not supported by ADIOS 1.13.1: VEC_CFLOAT, VEC_CDOUBLE, VEC_CLONG_DOUBLE
+             *   https://github.com/ornladios/ADIOS/issues/212
+             */
             case adios_string:
             {
                 dtype = DT::STRING;

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1335,6 +1335,9 @@ namespace openPMD
             Datatype::FLOAT,
             Datatype::DOUBLE,
             Datatype::LONG_DOUBLE,
+            Datatype::CFLOAT,
+            Datatype::CDOUBLE,
+            Datatype::CLONG_DOUBLE,
             Datatype::BOOL
         };
         for( auto it = std::begin( datatypes );

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <climits>
+#include <complex>
 
 
 namespace openPMD
@@ -187,6 +188,15 @@ RecordComponent::readBase()
                 break;
             case DT::FLOAT:
                 makeConstant(a.get< float >());
+                break;
+            case DT::CLONG_DOUBLE:
+                makeConstant(a.get< std::complex< long double > >());
+                break;
+            case DT::CDOUBLE:
+                makeConstant(a.get< std::complex< double > >());
+                break;
+            case DT::CFLOAT:
+                makeConstant(a.get< std::complex< float > >());
                 break;
             case DT::SHORT:
                 makeConstant(a.get< short >());

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <set>
+#include <complex>
 
 
 namespace openPMD
@@ -219,6 +220,15 @@ Attributable::readAttributes()
             case DT::LONG_DOUBLE:
                 setAttribute(att, a.get< long double >());
                 break;
+            case DT::CFLOAT:
+                setAttribute(att, a.get< std::complex< float > >());
+                break;
+            case DT::CDOUBLE:
+                setAttribute(att, a.get< std::complex< double > >());
+                break;
+            case DT::CLONG_DOUBLE:
+                setAttribute(att, a.get< std::complex< long double > >());
+                break;
             case DT::STRING:
                 setAttribute(att, a.get< std::string >());
                 break;
@@ -260,6 +270,15 @@ Attributable::readAttributes()
                 break;
             case DT::VEC_LONG_DOUBLE:
                 setAttribute(att, a.get< std::vector< long double > >());
+                break;
+            case DT::VEC_CFLOAT:
+                setAttribute(att, a.get< std::vector< std::complex< float > > >());
+                break;
+            case DT::VEC_CDOUBLE:
+                setAttribute(att, a.get< std::vector< std::complex< double > > >());
+                break;
+            case DT::VEC_CLONG_DOUBLE:
+                setAttribute(att, a.get< std::vector< std::complex< long double > > >());
                 break;
             case DT::VEC_STRING:
                 setAttribute(att, a.get< std::vector< std::string > >());

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -27,9 +27,10 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/binding/python/Numpy.hpp"
 
+#include <array>
+#include <complex>
 #include <string>
 #include <vector>
-#include <array>
 
 
 // std::variant
@@ -113,6 +114,15 @@ bool setAttributeFromBufferInfo(
             case DT::LONG_DOUBLE:
                 return attr.setAttribute( key, *static_cast<long double*>(buf.ptr) );
                 break;
+            case DT::CFLOAT:
+                return attr.setAttribute( key, *static_cast<std::complex<float>*>(buf.ptr) );
+                break;
+            case DT::CDOUBLE:
+                return attr.setAttribute( key, *static_cast<std::complex<double>*>(buf.ptr) );
+                break;
+            case DT::CLONG_DOUBLE:
+                return attr.setAttribute( key, *static_cast<std::complex<long double>*>(buf.ptr) );
+                break;
             default:
                 throw std::runtime_error("set_attribute: Unknown "
                     "Python type '" + buf.format +
@@ -155,6 +165,7 @@ bool setAttributeFromBufferInfo(
                     static_cast<bool*>(buf.ptr) + buf.size
                 ) );
         else */
+        // std::cout << "+++++++++++ BUFFER: " << buf.format << std::endl;
         if( buf.format.find("b") != std::string::npos )
             return attr.setAttribute( key,
                 std::vector<char>(
@@ -215,6 +226,24 @@ bool setAttributeFromBufferInfo(
                     static_cast<unsigned long long*>(buf.ptr),
                     static_cast<unsigned long long*>(buf.ptr) + buf.size
                 ) );
+        else if( buf.format.find("Zf") != std::string::npos )
+            return attr.setAttribute( key,
+              std::vector<std::complex<float>>(
+                      static_cast<std::complex<float>*>(buf.ptr),
+                      static_cast<std::complex<float>*>(buf.ptr) + buf.size
+              ) );
+        else if( buf.format.find("Zd") != std::string::npos )
+            return attr.setAttribute( key,
+              std::vector<std::complex<double>>(
+                      static_cast<std::complex<double>*>(buf.ptr),
+                      static_cast<std::complex<double>*>(buf.ptr) + buf.size
+              ) );
+        else if( buf.format.find("Zg") != std::string::npos )
+            return attr.setAttribute( key,
+              std::vector<std::complex<long double>>(
+                      static_cast<std::complex<long double>*>(buf.ptr),
+                      static_cast<std::complex<long double>*>(buf.ptr) + buf.size
+              ) );
         else if( buf.format.find("f") != std::string::npos )
             return attr.setAttribute( key,
                 std::vector<float>(
@@ -307,7 +336,7 @@ void init_Attributable(py::module &m) {
         // .def("set_attribute", &Attributable::setAttribute< std::vector< char > >)
         .def("set_attribute", &Attributable::setAttribute< std::vector< unsigned char > >)
         .def("set_attribute", &Attributable::setAttribute< std::vector< long > >)
-        .def("set_attribute", &Attributable::setAttribute< std::vector< double > >)
+        .def("set_attribute", &Attributable::setAttribute< std::vector< double > >) // TODO: this implicitly casts list of complex
         // probably affected by bug https://github.com/pybind/pybind11/issues/1258
         .def("set_attribute", []( Attributable & attr, std::string const& key, std::vector< std::string > const& value ) {
             return attr.setAttribute( key, value );

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -27,6 +27,7 @@
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/binding/python/Numpy.hpp"
 
+#include <complex>
 #include <string>
 #include <algorithm>
 #include <tuple>
@@ -395,6 +396,12 @@ load_chunk(RecordComponent & r, Offset const & offset, Extent const & extent, st
         r.loadChunk<double>(shareRaw((double*) a.mutable_data()), offset, extent);
     else if( r.getDatatype() == Datatype::FLOAT )
         r.loadChunk<float>(shareRaw((float*) a.mutable_data()), offset, extent);
+    else if( r.getDatatype() == Datatype::CLONG_DOUBLE )
+        r.loadChunk<std::complex<long double>>(shareRaw((std::complex<long double>*) a.mutable_data()), offset, extent);
+    else if( r.getDatatype() == Datatype::CDOUBLE )
+        r.loadChunk<std::complex<double>>(shareRaw((std::complex<double>*) a.mutable_data()), offset, extent);
+    else if( r.getDatatype() == Datatype::CFLOAT )
+        r.loadChunk<std::complex<float>>(shareRaw((std::complex<float>*) a.mutable_data()), offset, extent);
     else if( r.getDatatype() == Datatype::BOOL )
         r.loadChunk<bool>(shareRaw((bool*) a.mutable_data()), offset, extent);
     else
@@ -507,6 +514,15 @@ void init_RecordComponent(py::module &m) {
                         break;
                     case DT::LONG_DOUBLE:
                         return rc.makeConstant( *static_cast<long double*>(buf.ptr) );
+                        break;
+                    case DT::CFLOAT:
+                        return rc.makeConstant( *static_cast<std::complex<float>*>(buf.ptr) );
+                        break;
+                    case DT::CDOUBLE:
+                        return rc.makeConstant( *static_cast<std::complex<double>*>(buf.ptr) );
+                        break;
+                    case DT::CLONG_DOUBLE:
+                        return rc.makeConstant( *static_cast<std::complex<long double>*>(buf.ptr) );
                         break;
                     default:
                         throw std::runtime_error("make_constant: "

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <sstream>
@@ -61,6 +62,12 @@ TEST_CASE( "attribute_dtype_test", "[core]" )
     REQUIRE(Datatype::DOUBLE == a.dtype);
     a = Attribute(static_cast< long double >(0.));
     REQUIRE(Datatype::LONG_DOUBLE == a.dtype);
+    a = Attribute(static_cast< std::complex< float > >(0.));
+    REQUIRE(Datatype::CFLOAT == a.dtype);
+    a = Attribute(static_cast< std::complex< double > >(0.));
+    REQUIRE(Datatype::CDOUBLE == a.dtype);
+    a = Attribute(static_cast< std::complex< long double > >(0.));
+    REQUIRE(Datatype::CLONG_DOUBLE == a.dtype);
     a = Attribute(std::string(""));
     REQUIRE(Datatype::STRING == a.dtype);
     a = Attribute(std::vector< char >());


### PR DESCRIPTION
Add support for complex numbers as fundamental data type.

Close #203 

- [x] Tests
- [x] internals: new types, comparisons, allowed casts, record components, patches and attributes, etc.
- [x] JSON (writes to pairs, read re-identification as complex is todo)
- [x] HDF5
- [x] ADIOS1 (no long double complex; no attributes of arrays of complex: https://github.com/ornladios/ADIOS/issues/212)
- [x] ADIOS2: (complex attributes: https://github.com/ornladios/ADIOS2/issues/1908);  (no long double complex https://github.com/ornladios/ADIOS2/pull/1907)
- [x] Python bindings
- [x] rebase after #768 is merged