### PR TITLE
Legacy HDF5 libSplash Handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Bug Fixes
 Other
 """""
 
+- Better handling of legacy libSplash HDF5 files #641
+
 
 0.10.2-alpha
 ------------

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -442,7 +442,7 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
 
     using DT = Datatype;
     Datatype d;
-    if( dataset_class == H5S_SIMPLE || dataset_class == H5S_SCALAR )
+    if( dataset_class == H5S_SIMPLE || dataset_class == H5S_SCALAR || dataset_class == H5S_NULL )
     {
         if( H5Tequal(dataset_type, H5T_NATIVE_CHAR) )
             d = DT::CHAR;

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -52,8 +52,8 @@ RecordComponent::resetDataset( Dataset d )
     if( written )
         throw std::runtime_error( "A record's Dataset cannot (yet) be changed "
                                   "after it has been written." );
-    if( d.extent.empty() )
-        throw std::runtime_error("Dataset extent must be at least 1D.");
+    //if( d.extent.empty() )
+    //    throw std::runtime_error("Dataset extent must be at least 1D.");
     if( std::any_of(
             d.extent.begin(),
             d.extent.end(),

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -681,8 +681,8 @@ TEST_CASE( "zero_extent_component", "[core]" )
 
     auto E_x = o.iterations[1].meshes["E"]["x"];
     E_x.setComment("Datasets must contain dimensions.");
-    REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {})),
-                        Catch::Equals("Dataset extent must be at least 1D."));
+    //REQUIRE_THROWS_WITH(E_x.resetDataset(Dataset(Datatype::LONG, {})),
+    //                    Catch::Equals("Dataset extent must be at least 1D."));
     REQUIRE_THROWS_WITH(E_x.makeEmpty<int>(0),
                         Catch::Equals("Dataset extent must be at least 1D."));
     E_x.resetDataset(Dataset(Datatype::DOUBLE, {1}));


### PR DESCRIPTION
##  HDF5: Gracefully handle Empty Datasets

Legacy implementations such as libSplash sometimes just plunge a NULL sized dataspace in HDF5 for fully filtered particles.

##  HDF5: Compound for Legacy Splash ColDim

Reimplement handling for the legacy CollectionDimensions type that was used for internal attributes in libSplash and map it to vector of three `unsigned long long`.
Avoids throwing a lot of warnings on reads of such files.

Close #626
