### PR TITLE
Allows multiple flush on the same file

### DIFF
--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -58,6 +58,8 @@ namespace openPMD
         void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
 
         std::unordered_map< Writable*, hid_t > m_fileIDs;
+        std::unordered_map< std::string,  hid_t > m_fileNamesWithID;
+
         std::unordered_set< hid_t > m_openFileIDs;
 
         hid_t m_datasetTransferProperty;

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -352,6 +352,11 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     if( !auxiliary::ends_with(name, ".h5") )
         name += ".h5";
 
+    auto search = m_fileIDs.find(writable);
+    if (search != m_fileIDs.end()) {
+      return;
+    }
+
     unsigned flags;
     AccessType at = m_handler->accessTypeBackend;
     if( at == AccessType::READ_ONLY )


### PR DESCRIPTION
This is to resolve [WarpX issue 561](https://github.com/ECP-WarpX/WarpX/issues/561), which flush is called more than once.  And the later times not all processes participated while H5Fopen is a collective call.