### PR TITLE
BaseRecord: Overwrite Erase with Iterator

### DIFF
--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -223,19 +223,30 @@ TEST_CASE( "container_access_test", "[auxiliary]" )
     c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
     c.IOHandler = c.m_writable->IOHandler.get();
 
-    c["firstWidget"] = Widget(0);
+    c["1firstWidget"] = Widget(0);
     REQUIRE(c.size() == 1);
 
-    c["firstWidget"] = Widget(1);
+    c["1firstWidget"] = Widget(1);
     REQUIRE(c.size() == 1);
 
-    c["secondWidget"] = Widget(2);
-    REQUIRE(c.size() == 2);
-    REQUIRE(c.erase("firstWidget") == true);
-    REQUIRE(c.size() == 1);
+    c["2secondWidget"] = Widget(2);
+    c["3thirdWidget"] = Widget(3);
+    c["4fourthWidget"] = Widget(4);
+    c["5fifthWidget"] = Widget(5);
+
+    REQUIRE(c.size() == 5);
+    REQUIRE(c.erase("1firstWidget") == true);
+    REQUIRE(c.size() == 4);
     REQUIRE(c.erase("nonExistentWidget") == false);
+    REQUIRE(c.size() == 4);
+    REQUIRE(c.erase("2secondWidget") == true);
+    REQUIRE(c.size() == 3);
+    REQUIRE(c.erase(c.find("5fifthWidget")) == c.end());
+    REQUIRE(c.size() == 2);
+    REQUIRE(c.erase(c.find("3thirdWidget")) == c.find("4fourthWidget"));
     REQUIRE(c.size() == 1);
-    REQUIRE(c.erase("secondWidget") == true);
+    REQUIRE(c.erase(c.find("4fourthWidget")) == c.end());
+    REQUIRE(c.size() == 0);
     REQUIRE(c.empty());
 #else
     std::cerr << "Invasive tests not enabled. Hierarchy is not visible.\n";

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -921,6 +921,13 @@ void deletion_test(const std::string & backend)
     e.erase("deletion_scalar");
     o.flush();
 
+    e["deletion_scalar_two"][RecordComponent::SCALAR].resetDataset(dset);
+    o.flush();
+
+    e["deletion_scalar_two"].erase(e["deletion_scalar_two"].find(RecordComponent::SCALAR));
+    e.erase(e.find("deletion_scalar_two"));
+    o.flush();
+
     double value = 0.;
     e["deletion_scalar_constant"][RecordComponent::SCALAR].resetDataset(dset);
     e["deletion_scalar_constant"][RecordComponent::SCALAR].makeConstant(value);


### PR DESCRIPTION
Fix warning of the form:
```
openPMD/backend/BaseRecord.hpp(39):
  warning: overloaded virtual function
  "openPMD::Container<T, T_key, T_container>::erase
    [with T=openPMD::MeshRecordComponent, T_key=std::__cxx11::string, T_container=std::map<std::__cxx11::string, openPMD::MeshRecordComponent, std::less<std::__cxx11::string>, std::allocator<std::pair<const std::__cxx11::string, openPMD::MeshRecordComponent>>>]"
    is only partially overridden in class
      "openPMD::BaseRecord<openPMD::MeshRecordComponent>"
  detected during instantiation of class
    "openPMD::BaseRecord<T_elem>
      [with T_elem=openPMD::MeshRecordComponent]"
    openPMD/Mesh.hpp(38): here
```

Introduced in #89

Seen on Summit (PPC64le) with WarpX (C++14) with NVCC 10.1.168, GCC 6.4.0.