### PR TITLE
Docs first read python typo

### DIFF
--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -145,7 +145,7 @@ Python
    print("openPMD version: ",
          series.openPMD)
 
-   if( series.contains_attribute("author") )
+   if( series.contains_attribute("author") ):
        print("Author: ",
              series.author)
 

--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -145,7 +145,7 @@ Python
    print("openPMD version: ",
          series.openPMD)
 
-   if( series.contains_attribute("author") ):
+   if series.contains_attribute("author"):
        print("Author: ",
              series.author)
 


### PR DESCRIPTION
Hi,
This PR addresses a really minor detail.
But, just in case anyone (who is not 100% familiar with python) tries to follow `docs/source/usage/firstread.rst` by copy pasting it's sections, I think there is an issue with the attributes part:
```
if( series.contains_attribute("author") )
    print("Author: ",
          series.author)
```
That I think is just a missing ":" at the end of the `if(...):` line.
This PR fixes that.
Cheers