### PR TITLE
MPark.Variant: Update NVCC Hotfix C++14

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Bug Fixes
 Other
 """""
 
+- nvcc: update NVCC C++14 hotfix #618 to upstream version #650
+
 
 0.10.3-alpha
 ------------

--- a/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
+++ b/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
@@ -2655,23 +2655,23 @@ namespace mpark {
     return false;
   }
 
-#if defined(MPARK_CPP14_CONSTEXPR) && !defined(__NVCC__)
+#if defined(MPARK_CPP14_CONSTEXPR)
   namespace detail {
 
-    inline constexpr bool all(std::initializer_list<bool> bs) {
+    inline constexpr bool any(std::initializer_list<bool> bs) {
       for (bool b : bs) {
-        if (!b) {
-          return false;
+        if (b) {
+          return true;
         }
       }
-      return true;
+      return false;
     }
 
   }  // namespace detail
 
   template <typename Visitor, typename... Vs>
   inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
-    return (detail::all({!vs.valueless_by_exception()...})
+    return (!detail::any({vs.valueless_by_exception()...})
                 ? (void)0
                 : throw_bad_variant_access()),
            detail::visitation::variant::visit_value(


### PR DESCRIPTION
Update the hotfix for C++14 builds with NVCC from the accepted PR in upstream.

Refs:
- #618
- https://github.com/mpark/variant/pull/73