### PR TITLE
Clang & GCC: Woverloaded-virtual, Wextra-semi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,7 +680,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # at runtime when used with symbol-hidden code (e.g. pybind11 module)
 
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wextra-semi")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,9 +680,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # at runtime when used with symbol-hidden code (e.g. pybind11 module)
 
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Warning C4503: "decorated name length exceeded, name was truncated"
     # Symbols longer than 4096 chars are truncated (and hashed instead)

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -78,8 +78,8 @@ extern std::vector< Datatype > openPMD_Datatypes;
  * indicated by a (multi-)pointer, a C-style array or a scalar) of one type
  * equals the fundamendtal datatype of another type.
  *
- * @tparam  T
- * @tparam  U
+ * @tparam  T first type
+ * @tparam  U second type
  */
 template<
         typename T,

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -111,7 +111,7 @@ template<>
 struct EXPORT Parameter< Operation::CREATE_FILE > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
+    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -127,7 +127,7 @@ template<>
 struct EXPORT Parameter< Operation::OPEN_FILE > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
+    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -143,7 +143,7 @@ template<>
 struct EXPORT Parameter< Operation::DELETE_FILE > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
+    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -159,7 +159,7 @@ template<>
 struct EXPORT Parameter< Operation::CREATE_PATH > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {};
+    Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -175,7 +175,7 @@ template<>
 struct EXPORT Parameter< Operation::OPEN_PATH > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {};
+    Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -191,7 +191,7 @@ template<>
 struct EXPORT Parameter< Operation::DELETE_PATH > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {};
+    Parameter(Parameter const & p) : AbstractParameter(), path(p.path) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -207,7 +207,7 @@ template<>
 struct EXPORT Parameter< Operation::LIST_PATHS > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), paths(p.paths) {};
+    Parameter(Parameter const & p) : AbstractParameter(), paths(p.paths) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -227,7 +227,7 @@ struct EXPORT Parameter< Operation::CREATE_DATASET > : public AbstractParameter
     Parameter(Parameter const & p) : AbstractParameter(),
         name(p.name), extent(p.extent), dtype(p.dtype),
         chunkSize(p.chunkSize), compression(p.compression),
-        transform(p.transform) {};
+        transform(p.transform) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -249,7 +249,7 @@ struct EXPORT Parameter< Operation::EXTEND_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
-        name(p.name), extent(p.extent) {};
+        name(p.name), extent(p.extent) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -267,7 +267,7 @@ struct EXPORT Parameter< Operation::OPEN_DATASET > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
-        name(p.name), dtype(p.dtype), extent(p.extent) {};
+        name(p.name), dtype(p.dtype), extent(p.extent) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -287,7 +287,7 @@ template<>
 struct EXPORT Parameter< Operation::DELETE_DATASET > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
+    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -305,7 +305,7 @@ struct EXPORT Parameter< Operation::WRITE_DATASET > : public AbstractParameter
     Parameter() = default;
     Parameter(Parameter<Operation::WRITE_DATASET> const & p) : AbstractParameter(),
         extent(p.extent), offset(p.offset), dtype(p.dtype),
-        data(p.data) {};
+        data(p.data) {}
 
     Parameter& operator=(const Parameter& p) {
         this->extent = p.extent;
@@ -334,7 +334,7 @@ struct EXPORT Parameter< Operation::READ_DATASET > : public AbstractParameter
     Parameter() = default;
     Parameter(Parameter<Operation::READ_DATASET> const & p) : AbstractParameter(),
         extent(p.extent), offset(p.offset), dtype(p.dtype),
-        data(p.data) {};
+        data(p.data) {}
 
     Parameter& operator=(const Parameter &p) {
         this->extent = p.extent;
@@ -362,7 +362,7 @@ struct EXPORT Parameter< Operation::LIST_DATASETS > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
-        datasets(p.datasets) {};
+        datasets(p.datasets) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -379,7 +379,7 @@ template<>
 struct EXPORT Parameter< Operation::DELETE_ATT > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {};
+    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -396,7 +396,7 @@ struct EXPORT Parameter< Operation::WRITE_ATT > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
-        name(p.name), dtype(p.dtype), resource(p.resource) {};
+        name(p.name), dtype(p.dtype), resource(p.resource) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -415,7 +415,7 @@ struct EXPORT Parameter< Operation::READ_ATT > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
-        name(p.name), dtype(p.dtype), resource(p.resource) {};
+        name(p.name), dtype(p.dtype), resource(p.resource) {}
 
     Parameter& operator=(const Parameter &p) {
         this->name = p.name;
@@ -443,7 +443,7 @@ struct EXPORT Parameter< Operation::LIST_ATTS > : public AbstractParameter
 {
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
-        attributes(p.attributes) {};
+        attributes(p.attributes) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -82,7 +82,7 @@ public:
     double timeUnitSI() const;
     /** Set the conversion factor to convert time and dt to seconds.
      *
-     * @param  newTimeUnitSI
+     * @param  newTimeUnitSI new value for timeUnitSI
      * @return Reference to modified iteration.
      */
     Iteration& setTimeUnitSI(double newTimeUnitSI);

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -73,10 +73,10 @@ public:
     Geometry geometry() const;
     /** Set the geometry of the mesh of the mesh record.
      *
-     * @param   geometry    geometry of the mesh of the mesh record.
+     * @param   g    geometry of the mesh of the mesh record.
      * @return  Reference to modified mesh.
      */
-    Mesh& setGeometry(Geometry geometry);
+    Mesh& setGeometry(Geometry g);
 
     /**
      * @throw   no_such_attribute_error If Mesh::geometry is not Mesh::Geometry::thetaMode.
@@ -97,10 +97,10 @@ public:
     DataOrder dataOrder() const;
     /** Set the memory layout of N-dimensional data.
      *
-     * @param   dataOrder   memory layout of N-dimensional data.
+     * @param   dor   memory layout of N-dimensional data.
      * @return  Reference to modified mesh.
      */
-    Mesh& setDataOrder(DataOrder dataOrder);
+    Mesh& setDataOrder(DataOrder dor);
 
     /**
      * @return  Ordering of the labels for the Mesh::geometry of the mesh.

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -177,10 +177,10 @@ private:
     /**
      * Internal method to be called by all methods that create an empty dataset.
      *
-     * @param The dataset description. Must have nonzero dimensions.
+     * @param d The dataset description. Must have nonzero dimensions.
      * @return Reference to this RecordComponent instance.
      */
-    RecordComponent& makeEmpty( Dataset );
+    RecordComponent& makeEmpty( Dataset d );
 }; // RecordComponent
 
 

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -69,14 +69,14 @@ namespace detail
  * respective type's default constructor.
  * Used to implement empty datasets in subclasses of BaseRecordComponent
  * (currently RecordComponent).
- * @param rc
+ * @param T_RecordComponent
  */
-template< typename RecordComponent_T >
+template< typename T_RecordComponent >
 struct DefaultValue
 {
     template< typename T >
     void
-    operator()( RecordComponent_T & rc )
+    operator()( T_RecordComponent & rc )
     {
         rc.makeConstant( T() );
     }


### PR DESCRIPTION
 GCC & Clang: `-Woverloaded-virtual`
Add warnings for partly overwritten virtual methods (GCC only).
Thrown anyway as a warning by nvcc (even without any flags): #648 

Clang: `-Wextra-semi`
Catch things like superfluous semicolons.

Fix some doxygen and clang `-Wdocumentation` warnings.

