### PR TITLE
Defaults for Date & Software Attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Features
 """"""""
 
 - ADIOS2: expose engine #656
+- defaults for ``date`` and software base attributes #657
+- ``Series::setSoftware()`` add second argument for version #658
 
 Bug Fixes
 """""""""
@@ -25,6 +27,7 @@ Bug Fixes
 Other
 """""
 
+- deprecated ``Series::setSoftwareVersion``: set the version with the second argument of ``setSoftware()`` #657
 - ADIOS2: require version 2.5.0+ #656
 - nvcc:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ set(CORE_SOURCE
         src/Record.cpp
         src/RecordComponent.cpp
         src/Series.cpp
+        src/auxiliary/Date.cpp
         src/auxiliary/Filesystem.cpp
         src/backend/Attributable.cpp
         src/backend/BaseRecordComponent.cpp

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,6 +3,14 @@
 Upgrade Guide
 =============
 
+0.11.0-alpha
+------------
+
+The ``Series::setSoftwareVersion`` method is now deprecated and will be removed in future versions of the library.
+Use ``Series::setSoftware(name, version)`` instead.
+Similarly for the Python API, use ``Series.set_software`` instead of ``Series.set_software_version``.
+
+
 0.10.0-alpha
 ------------
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/config.hpp"
+#include "openPMD/auxiliary/Deprecated.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
@@ -28,6 +29,7 @@
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/IterationEncoding.hpp"
+#include "openPMD/version.hpp"
 
 #if openPMD_HAVE_MPI
 #   include <mpi.h>
@@ -140,10 +142,11 @@ public:
     std::string software() const;
     /** Indicate the software/code/simulation that created the file.
      *
-     * @param   software    String indicating the software/code/simulation that created the file.
+     * @param   newName    String indicating the software/code/simulation that created the file.
+     * @param   newVersion String indicating the version of the software/code/simulation that created the file.
      * @return  Reference to modified series.
      */
-    Series& setSoftware(std::string const& software);
+    Series& setSoftware(std::string const& newName, std::string const& newVersion = std::string("unspecified"));
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -152,9 +155,12 @@ public:
     std::string softwareVersion() const;
     /** Indicate the version of the software/code/simulation that created the file.
      *
+     * @deprecated Set the version with the second argument of setSoftware()
+     *
      * @param   softwareVersion String indicating the version of the software/code/simulation that created the file.
      * @return  Reference to modified series.
      */
+    OPENPMDAPI_DEPRECATED("Set the version with the second argument of setSoftware()")
     Series& setSoftwareVersion(std::string const& softwareVersion);
 
     /**
@@ -251,7 +257,6 @@ OPENPMD_private:
     void readBase();
     void read();
 
-    static constexpr char const * const OPENPMD = "1.1.0";
     static constexpr char const * const BASEPATH = "/data/%T/";
 
     std::shared_ptr< IterationEncoding > m_iterationEncoding;

--- a/include/openPMD/auxiliary/Date.hpp
+++ b/include/openPMD/auxiliary/Date.hpp
@@ -1,0 +1,37 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+
+
+namespace openPMD
+{
+namespace auxiliary
+{
+    /** Return the current datetime as string
+     *
+     * @param format time format string, @see http://www.cplusplus.com/reference/ctime/strftime/
+     * @return std::string with formatted date
+     */
+    std::string getDateString( std::string const & format = std::string( "%F %T %z" ) );
+} // namespace auxiliary
+} // namespace openPMD

--- a/include/openPMD/auxiliary/Deprecated.hpp
+++ b/include/openPMD/auxiliary/Deprecated.hpp
@@ -1,0 +1,36 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+
+#if __cplusplus >= 201402L
+#   define OPENPMDAPI_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#   ifdef __clang__
+#       define OPENPMDAPI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#   elif defined(__GNUC__) && defined(__GNUC_PATCHLEVEL__)
+#       define OPENPMDAPI_DEPRECATED(msg) __attribute__((deprecated))
+#   elif defined(_MSC_VER)
+#       define OPENPMDAPI_DEPRECATED(msg) __declspec(deprecated)
+#   else
+#       define OPENPMDAPI_DEPRECATED(msg)
+#   endif
+#endif

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -49,6 +49,8 @@ namespace openPMD {}
 
 #include "openPMD/IO/AccessType.hpp"
 
+#include "openPMD/auxiliary/Date.hpp"
+#include "openPMD/auxiliary/Deprecated.hpp"
 #include "openPMD/auxiliary/OutOfRangeMsg.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/auxiliary/Variant.hpp"

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -18,6 +18,7 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+#include "openPMD/auxiliary/Date.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
@@ -226,9 +227,10 @@ Series::software() const
 }
 
 Series&
-Series::setSoftware(std::string const& s)
+Series::setSoftware( std::string const& newName, std::string const& newVersion )
 {
-    setAttribute("software", s);
+    setAttribute( "software", newName );
+    setAttribute( "softwareVersion", newVersion );
     return *this;
 }
 
@@ -519,9 +521,24 @@ Series::init(std::shared_ptr< AbstractIOHandler > ioHandler,
 void
 Series::initDefaults()
 {
-    setOpenPMD(OPENPMD);
+    std::stringstream openPMDstandard;
+    openPMDstandard << OPENPMD_STANDARD_MAJOR << "."
+                    << OPENPMD_STANDARD_MINOR << "."
+                    << OPENPMD_STANDARD_PATCH;
+    setOpenPMD( openPMDstandard.str() );
     setOpenPMDextension(0);
     setAttribute("basePath", std::string(BASEPATH));
+    setDate( auxiliary::getDateString() );
+
+    std::stringstream openPMDapi;
+    openPMDapi << OPENPMDAPI_VERSION_MAJOR << "."
+               << OPENPMDAPI_VERSION_MINOR << "."
+               << OPENPMDAPI_VERSION_PATCH;
+    if( std::string( OPENPMDAPI_VERSION_LABEL ).size() > 0 )
+        openPMDapi << "-" << OPENPMDAPI_VERSION_LABEL;
+    setSoftware( "openPMD-api", openPMDapi.str() );
+
+    //! @todo Potentially warn on flush if software and author are not user-provided (defaulted)
 }
 
 void

--- a/src/auxiliary/Date.cpp
+++ b/src/auxiliary/Date.cpp
@@ -1,0 +1,51 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "openPMD/auxiliary/Date.hpp"
+
+#include <ctime>
+#include <string>
+#include <sstream>
+
+
+namespace openPMD
+{
+namespace auxiliary
+{
+    std::string getDateString( std::string const & format )
+    {
+        constexpr size_t maxLen = 30u;
+        char buffer [maxLen];
+
+        time_t rawtime;
+        time( &rawtime );
+        struct tm* timeinfo;
+        // https://github.com/openPMD/openPMD-api/pull/657#issuecomment-574424885
+        timeinfo = localtime( &rawtime );  // lgtm[cpp/potentially-dangerous-function]
+
+        strftime( buffer, maxLen, format.c_str(), timeinfo );
+
+        std::stringstream dateString;
+        dateString << buffer;
+
+        return dateString.str();
+    }
+} // namespace auxiliary
+} // namespace openPMD

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -125,9 +125,13 @@ void init_Series(py::module &m) {
         .def_property_readonly("author", &Series::author)
         .def("set_author", &Series::setAuthor)
         .def_property_readonly("software", &Series::software)
-        .def("set_software", &Series::setSoftware)
+        .def("set_software", &Series::setSoftware,
+            py::arg("name"), py::arg("version") = std::string("unspecified"))
         .def_property_readonly("software_version", &Series::softwareVersion)
-        .def("set_software_version", &Series::setSoftwareVersion)
+        .def("set_software_version", [](Series & s, std::string const& softwareVersion) {
+            py::print("Series.set_software_version is deprecated. Set the version with the second argument of Series.set_software");
+            s.setSoftware(s.software(), softwareVersion);
+        })
         // softwareDependencies
         // machine
         .def_property_readonly("date", &Series::date)

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -136,7 +136,7 @@ TEST_CASE( "output_default_test", "[core]" )
     REQUIRE(o.iterationEncoding() == IE::fileBased);
     REQUIRE(o.iterationFormat() == "new_openpmd_output_%T");
     REQUIRE(o.iterations.empty());
-    REQUIRE(o.numAttributes() == 5); /* openPMD, openPMDextension, basePath, iterationEncoding, iterationFormat */
+    REQUIRE(o.numAttributes() == 8); /* openPMD, openPMDextension, basePath, software, softwareVersion, iterationEncoding, iterationFormat, date, software, softwareVersion */
     REQUIRE(o.name() == "new_openpmd_output_%T");
 
     o.iterations[0];
@@ -163,7 +163,7 @@ TEST_CASE( "output_constructor_test", "[core]" )
     REQUIRE(o.iterationEncoding() == IE::groupBased);
     REQUIRE(o.iterationFormat() == "/data/%T/");
     REQUIRE(o.iterations.size() == 1);
-    REQUIRE(o.numAttributes() == 7); /* openPMD, openPMDextension, basePath, meshesPath, particlesPath, iterationEncoding, iterationFormat */
+    REQUIRE(o.numAttributes() == 10); /* openPMD, openPMDextension, basePath, meshesPath, particlesPath, iterationEncoding, iterationFormat, date, software, softwareVersion */
     REQUIRE(o.name() == "MyCustomOutput");
 }
 

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -113,6 +113,11 @@ class APITest(unittest.TestCase):
             api.Access_Type.create
         )
 
+        # meta data
+        series.set_software("nonsense")  # with unspecified version
+        series.set_software_version("1.2.3")  # deprecated
+        series.set_software("openPMD-api-python-tests", "0.42.0")
+
         # write one of each supported types
         series.set_attribute("char", 'c')  # string
         series.set_attribute("pyint", 13)


### PR DESCRIPTION
Adds defaults for the date and software attributes, which are recommended openPMD attributes (missing is a warning in our validator).

Deprecate old API that allows to set the software version independent of the software name, which can lead to inconsistencies, e.g. if the default version is kept and only the software name is changed.