### PR TITLE
Overload ostream function operator<< not in std

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Features
 Bug Fixes
 """""""""
 
+- ``std::ostream& operator<<`` overloads are not declared in namespace ``std`` anymore #662
+
 Other
 """""
 

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -688,6 +688,10 @@ void
 warnWrongDtype(std::string const& key,
                Datatype store,
                Datatype request);
+
+std::ostream&
+operator<<(std::ostream&, openPMD::Datatype const&);
+
 } // namespace openPMD
 
 #if !defined(_MSC_VER)
@@ -717,9 +721,3 @@ operator!=( openPMD::Datatype d, openPMD::Datatype e )
 /** @}
  */
 #endif
-
-namespace std
-{
-    ostream&
-    operator<<(ostream&, openPMD::Datatype);
-} // namespace std

--- a/include/openPMD/IterationEncoding.hpp
+++ b/include/openPMD/IterationEncoding.hpp
@@ -20,7 +20,7 @@
  */
 #pragma once
 
-#include <iosfwd>
+#include <ostream>
 
 
 namespace openPMD
@@ -33,10 +33,8 @@ enum class IterationEncoding
 {
     fileBased, groupBased
 };
-} // openPMD
 
-namespace std
-{
-    ostream&
-    operator<<(ostream&, openPMD::IterationEncoding);
-} // std
+std::ostream&
+operator<<(std::ostream&, openPMD::IterationEncoding const&);
+
+} // openPMD

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -25,8 +25,9 @@
 #include "openPMD/backend/MeshRecordComponent.hpp"
 
 #include <array>
-#include <vector>
+#include <ostream>
 #include <string>
+#include <vector>
 
 
 namespace openPMD
@@ -192,13 +193,11 @@ template< typename T >
 inline T
 Mesh::timeOffset() const
 { return readFloatingpoint< T >("timeOffset"); }
+
+std::ostream&
+operator<<(std::ostream&, openPMD::Mesh::Geometry const&);
+
+std::ostream&
+operator<<(std::ostream&, openPMD::Mesh::DataOrder const&);
+
 } // openPMD
-
-namespace std
-{
-    ostream&
-    operator<<(ostream&, openPMD::Mesh::Geometry);
-
-    std::ostream&
-    operator<<(ostream&, openPMD::Mesh::DataOrder);
-} // std

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -37,11 +37,9 @@ void warnWrongDtype(std::string const& key,
               << ", requested as " << request
               << ". Casting unconditionally with possible loss of precision.\n";
 }
-} // openPMD
-
 
 std::ostream&
-std::operator<<(std::ostream& os, openPMD::Datatype d)
+operator<<(std::ostream& os, openPMD::Datatype const & d)
 {
     using DT = openPMD::Datatype;
     switch( d )
@@ -147,8 +145,6 @@ std::operator<<(std::ostream& os, openPMD::Datatype d)
     return os;
 }
 
-namespace openPMD
-{
     Datatype stringToDatatype( std::string s )
     {
         static std::unordered_map<

--- a/src/IterationEncoding.cpp
+++ b/src/IterationEncoding.cpp
@@ -24,7 +24,7 @@
 
 
 std::ostream&
-std::operator<<(std::ostream& os, openPMD::IterationEncoding ie)
+openPMD::operator<<(std::ostream& os, openPMD::IterationEncoding const& ie)
 {
     switch( ie )
     {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -365,7 +365,7 @@ Mesh::read()
 } // openPMD
 
 std::ostream&
-std::operator<<(std::ostream& os, openPMD::Mesh::Geometry go)
+openPMD::operator<<(std::ostream& os, openPMD::Mesh::Geometry const& go)
 {
     switch( go )
     {
@@ -386,7 +386,7 @@ std::operator<<(std::ostream& os, openPMD::Mesh::Geometry go)
 }
 
 std::ostream&
-std::operator<<(std::ostream& os, openPMD::Mesh::DataOrder dor)
+openPMD::operator<<(std::ostream& os, openPMD::Mesh::DataOrder const& dor)
 {
     switch( dor )
     {


### PR DESCRIPTION
Declaring a function overload in namespace `std` is undefined behaviour in C++.
Instead, just define the `std::ostream& operator<<` in `openPMD` namespace and ADL will catch it for `Datatype`, `IterationEncoding`, `openPMD::Mesh::Geometry` and `openPMD::Mesh::DataOrder`.

Refs.: https://en.cppreference.com/w/cpp/language/extending_std