### PR TITLE
Attribute Constructor: Move Argument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Other
   - remove all Doxygen warnings and add to CI #654
   - backend feature matrix #661
 - migrate static checks for python code to GitHub actions #660
+- ``Attribute`` constructor: move argument into place #663
 
 
 0.10.3-alpha

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -23,14 +23,15 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/Datatype.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
-#include <vector>
-#include <string>
 #include <iterator>
-#include <algorithm>
-#include <type_traits>
 #include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 
 namespace openPMD
@@ -70,7 +71,7 @@ class Attribute :
                             bool >
 {
 public:
-    Attribute(resource r) : Variant(r)
+    Attribute(resource r) : Variant(std::move(r))
     { }
 
     /** Retrieve a stored specific Attribute and cast if convertible.


### PR DESCRIPTION
The value-passed argument for the constructor of `Attribute` can be moved into place to avoid double copies.