### PR TITLE
Spack: ADIOS1 By Default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Other
   - backend feature matrix #661
 - migrate static checks for python code to GitHub actions #660
 - ``Attribute`` constructor: move argument into place #663
+- Spack: ADIOS1 backend now enabled by default #664
 
 
 0.10.3-alpha

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -10,6 +10,9 @@ The ``Series::setSoftwareVersion`` method is now deprecated and will be removed 
 Use ``Series::setSoftware(name, version)`` instead.
 Similarly for the Python API, use ``Series.set_software`` instead of ``Series.set_software_version``.
 
+Our `Spack <https://spack.io>`_ packages build the ADIOS1 backend now by default.
+Pass ``-adios1`` to the Spack spec to disable it: ``spack install openpmd-api -adios1`` (same for ``spack load``).
+
 
 0.10.0-alpha
 ------------

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Choose *one* of the install methods below to get started:
 [![Spack Status](https://img.shields.io/badge/method-recommended-brightgreen.svg)](https://spack.readthedocs.io/en/latest/package_list.html#openpmd-api)
 
 ```bash
-# optional:               +python +adios1 +adios2 -hdf5 -mpi
+# optional:               +python +adios2 -adios1 -hdf5 -mpi
 spack install openpmd-api
 spack load -r openpmd-api
 ```

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -31,7 +31,7 @@ A package for openPMD-api is available on the `Spack <https://spack.io>`_ packag
 
 .. code-block:: bash
 
-   # optional:               +python +adios1 +adios2 -hdf5 -mpi
+   # optional:               +python +adios2 -adios1 -hdf5 -mpi
    spack install openpmd-api
    spack load -r openpmd-api
 


### PR DESCRIPTION
The ADIOS1 variant in Spack is now enabled by default.

Ref.: https://github.com/spack/spack/pull/14599