### PR TITLE
Query API version & Variants at Runtime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Features
 - ADIOS2: expose engine #656
 - defaults for ``date`` and software base attributes #657
 - ``Series::setSoftware()`` add second argument for version #657
+- free standing functions to query the API version and feature variants at runtime #665
 
 Bug Fixes
 """""""""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ endif()
 # Targets #####################################################################
 #
 set(CORE_SOURCE
+        src/config.cpp
         src/Dataset.cpp
         src/Datatype.cpp
         src/Iteration.cpp
@@ -301,6 +302,7 @@ set(CORE_SOURCE
         src/Record.cpp
         src/RecordComponent.cpp
         src/Series.cpp
+        src/version.cpp
         src/auxiliary/Date.cpp
         src/auxiliary/Filesystem.cpp
         src/backend/Attributable.cpp

--- a/include/openPMD/version.hpp
+++ b/include/openPMD/version.hpp
@@ -20,18 +20,62 @@
  */
 #pragma once
 
-// version of the openPMD-api library
+#include <map>
+#include <string>
+
+/** version of the openPMD-api library (compile-time)
+ * @{
+ */
 #define OPENPMDAPI_VERSION_MAJOR 0
 #define OPENPMDAPI_VERSION_MINOR 11
 #define OPENPMDAPI_VERSION_PATCH 0
 #define OPENPMDAPI_VERSION_LABEL "dev"
+/** @} */
 
-// maximum supported version of the openPMD standard (read & write)
+/** maximum supported version of the openPMD standard (read & write, compile-time)
+ * @{
+ */
 #define OPENPMD_STANDARD_MAJOR 1
 #define OPENPMD_STANDARD_MINOR 1
 #define OPENPMD_STANDARD_PATCH 0
+/** @} */
 
-// minimum supported version of the openPMD standard (read)
+/** minimum supported version of the openPMD standard (read, compile-time)
+ * @{
+ */
 #define OPENPMD_STANDARD_MIN_MAJOR 1
 #define OPENPMD_STANDARD_MIN_MINOR 0
 #define OPENPMD_STANDARD_MIN_PATCH 0
+/** @} */
+
+// runtime functions (TODO: noinline qualifiers? what about LTO/IPO?)
+namespace openPMD
+{
+    /** Return the version of the openPMD-api library (run-time)
+     *
+     * @return std::string API version (dot separated)
+     */
+    std::string
+    getVersion( );
+
+    /** Return the maximum supported version of the openPMD standard (read & write, run-time)
+     *
+     * @return std::string openPMD standard version (dot separated)
+     */
+    std::string
+    getStandard( );
+
+    /** Return the minimum supported version of the openPMD standard (read, run-time)
+     *
+     * @return std::string minimum openPMD standard version (dot separated)
+     */
+    std::string
+    getStandardMinimum( );
+
+    /** Return the feature variants of the openPMD-api library (run-time)
+     *
+     * @return std::map< std::string, bool > with variants such as backends
+     */
+    std::map< std::string, bool >
+    getVariants( );
+} // namespace openPMD

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -77,23 +77,11 @@ PYBIND11_MODULE(openpmd_api, m) {
     init_Record(m);
     init_Series(m);
 
-    // build version
-    std::stringstream openPMDapi;
-    openPMDapi << OPENPMDAPI_VERSION_MAJOR << "."
-               << OPENPMDAPI_VERSION_MINOR << "."
-               << OPENPMDAPI_VERSION_PATCH;
-    if( std::string( OPENPMDAPI_VERSION_LABEL ).size() > 0 )
-        openPMDapi << "-" << OPENPMDAPI_VERSION_LABEL;
-    m.attr("__version__") = openPMDapi.str();
+    // API runtime version
+    m.attr("__version__") = openPMD::getVersion();
 
-    // feature variants
-    m.attr("variants") = std::map<std::string, bool>{
-        {"mpi", bool(openPMD_HAVE_MPI)},
-        {"json", true},
-        {"hdf5", bool(openPMD_HAVE_HDF5)},
-        {"adios1", bool(openPMD_HAVE_ADIOS1)},
-        {"adios2", bool(openPMD_HAVE_ADIOS2)}
-    };
+    // API runtime feature variants
+    m.attr("variants") = openPMD::getVariants();
 
     // TODO broken numpy if not at least v1.15.0: raise warning
     // auto numpy = py::module::import("numpy");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,38 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "openPMD/config.hpp"
+#include "openPMD/version.hpp"
+
+#include <map>
+#include <string>
+
+
+std::map< std::string, bool >
+openPMD::getVariants( )
+{
+    return std::map< std::string, bool >{
+            {"mpi", bool(openPMD_HAVE_MPI)},
+            {"json", true},
+            {"hdf5", bool(openPMD_HAVE_HDF5)},
+            {"adios1", bool(openPMD_HAVE_ADIOS1)},
+            {"adios2", bool(openPMD_HAVE_ADIOS2)}
+    };
+}

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,0 +1,60 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "openPMD/version.hpp"
+
+#include <sstream>
+#include <string>
+
+
+std::string
+openPMD::getVersion( )
+{
+    std::stringstream api;
+    api << OPENPMDAPI_VERSION_MAJOR << "."
+        << OPENPMDAPI_VERSION_MINOR << "."
+        << OPENPMDAPI_VERSION_PATCH;
+    if( std::string( OPENPMDAPI_VERSION_LABEL ).size() > 0 )
+        api << "-" << OPENPMDAPI_VERSION_LABEL;
+    std::string const apistr = api.str();
+    return apistr;
+}
+
+std::string
+openPMD::getStandard( )
+{
+    std::stringstream standard;
+    standard << OPENPMD_STANDARD_MAJOR << "."
+             << OPENPMD_STANDARD_MINOR << "."
+             << OPENPMD_STANDARD_PATCH;
+    std::string const standardstr = standard.str();
+    return standardstr;
+}
+
+std::string
+openPMD::getStandardMinimum( )
+{
+    std::stringstream standardMin;
+    standardMin << OPENPMD_STANDARD_MIN_MAJOR << "."
+                << OPENPMD_STANDARD_MIN_MINOR << "."
+                << OPENPMD_STANDARD_MIN_PATCH;
+    std::string const standardMinstr = standardMin.str();
+    return standardMinstr;
+}

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -7,6 +7,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <array>
@@ -17,6 +18,20 @@
 
 using namespace openPMD;
 
+TEST_CASE( "versions_test", "[core]" )
+{
+    auto const apiVersion = getVersion( );
+    REQUIRE(2u == std::count_if(apiVersion.begin(), apiVersion.end(), []( char const c ){ return c == '.';}));
+
+    auto const standard = getStandard( );
+    REQUIRE(standard == "1.1.0");
+
+    auto const standardMin = getStandardMinimum( );
+    REQUIRE(standardMin == "1.0.0");
+
+    auto const featureVariants = getVariants( );
+    REQUIRE(featureVariants.at("json") == true);
+}
 
 TEST_CASE( "attribute_dtype_test", "[core]" )
 {


### PR DESCRIPTION
Provides runtime APIs in form of free-standing functions to query the API version, supported openPMD standard and API feature variants at runtime.

Also implements a [xSDK mandatory policy](https://github.com/xsdk-project/xsdk-community-policies), see #575:
```
M8. Provide a runtime API to return the current version number of the software.
```

Open questions (see inline): should one add `noinline` attribute qualifiers to those functions and what happens at LTO/IPO (are those attributes ignored or honoured)?