### PR TITLE
CI: HDF5 Independent Stores Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -392,12 +392,12 @@ jobs:
         - CXX=g++-7 && CC=gcc-7
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 +MPI -PY +H5 +ADIOS1 -ADIOS2
+      name: gcc@7.4.0 +MPI -PY +H5 +H5_INDEP +ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON OPENPMD_HDF5_INDEPENDENT=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Other
 - migrate static checks for python code to GitHub actions #660
 - ``Attribute`` constructor: move argument into place #663
 - Spack: ADIOS1 backend now enabled by default #664
+- add independent HDF5 write test to CI #668
 
 
 0.10.3-alpha

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -2,6 +2,7 @@
  * To guarantee a correct call to Init, launch the tests manually.
  */
 #include "openPMD/openPMD.hpp"
+#include "openPMD/auxiliary/Environment.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -177,9 +178,12 @@ TEST_CASE( "hdf5_write_test_zero_extent", "[parallel][hdf5]" )
 
 TEST_CASE( "hdf5_write_test_skip_chunk", "[parallel][hdf5]" )
 {
-    //! @todo add with H5FD_MPIO_INDEPENDENT
-    // write_test_zero_extent( "h5", false );
-    REQUIRE(true);
+    //! @todo add via JSON option instead of environment read
+    auto const hdf5_collective = auxiliary::getEnvString( "OPENPMD_HDF5_INDEPENDENT", "OFF" );
+    if( hdf5_collective == "ON" )
+        write_test_zero_extent( "h5", false );
+    else
+        REQUIRE(true);
 }
 
 #else


### PR DESCRIPTION
Add a first independent storeChunk test for HDF5 to CI.

Follow-up to #446 

Should be replaced with a runtime API option as soon as #569 lands.