### PR TITLE
Parallel Test: Flush fileBased Some

### DIFF
--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -85,6 +85,7 @@ void write_test_zero_extent( bool fileBased, std::string file_ending, bool write
         e["position"]["x"].storeChunk(position_local, {offset}, {rank});
         e["positionOffset"]["x"].storeChunk(positionOffset_local, {offset}, {rank});
     }
+    o.flush();
 
     //TODO read back, verify
 }


### PR DESCRIPTION
Add an additional flush - which should be called implicitly anyway in the destructor - and which causes MPI issues.

Essentially what was added in #668

MPICH 3.3.2 error locally with ADIOS1 backend:
```
Fatal error in PMPI_Comm_dup: Other MPI error, error stack:
PMPI_Comm_dup(179)..................: MPI_Comm_dup(comm=0x84000002, new_comm=0x55c0ca44be1c) failed
PMPI_Comm_dup(164)..................: 
MPIR_Comm_dup_impl(57)..............: 
MPII_Comm_copy(571).................: 
MPIR_Get_contextid_sparse_group(495): 
MPIR_Allreduce_impl(293)............: 
MPIR_Allreduce_intra_auto(178)......: 
MPIR_Allreduce_intra_auto(84).......: 
MPIR_Bcast_impl(310)................: 
MPIR_Bcast_intra_auto(223)..........: 
MPIR_Bcast_intra_binomial(123)......: message sizes do not match across processes in the collective routine: Received 4 but expected 260
```

Weird: the MPI communicator is duplicated (and freed) in the ADIOS1 backend but not in the HDF5 and ADIOS2 backend.