### PR TITLE
CI: Prefer ADIOS2 in MPI-Parallel Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,11 +214,11 @@ jobs:
         # - dpkg -i openPMD*.deb
         - ls -R $HOME/openPMD-test-install | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//--/g' -e 's/^/   /' -e 's/-/|/'
     - <<: *test-cpp-unit
-      name: clang@5.0.0 +OMPI -PY +H5 +ADIOS1 +ADIOS2
+      name: clang@5.0.0 +OMPI -PY +H5 +ADIOS1 +ADIOS2 (BP4)
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
+        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON OPENPMD_BP_BACKEND=ADIOS2 USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -251,7 +251,7 @@ TEST_CASE( "adios_write_test_zero_extent", "[parallel][adios]" )
 TEST_CASE( "adios_write_test_skip_chunk", "[parallel][adios]" )
 {
     write_test_zero_extent( false, "bp", false );
-    write_test_zero_extent( true, "bp", false ); // FIXME fails!
+    write_test_zero_extent( true, "bp", false );
 }
 
 TEST_CASE( "hzdr_adios_sample_content_test", "[parallel][adios1]" )


### PR DESCRIPTION
Add an MPI-parallel test entry to Travis-CI in which ADIOS2 is actually the preferred BP backend.