### PR TITLE
ADIOS1: Create Attribute-Only Files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Bug Fixes
 """""""""
 
 - ``std::ostream& operator<<`` overloads are not declared in namespace ``std`` anymore #662
+- ADIOS1:
+
+  - ensure creation of files that only contain attributes #674
 
 Other
 """""

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -52,6 +52,8 @@ namespace openPMD
         ADIOS1IOHandler(std::string path, AccessType);
         ~ADIOS1IOHandler() override;
 
+        std::string backendName() const override { return "ADIOS1"; }
+
         std::future< void > flush() override;
 
         void enqueue(IOTask const&) override;
@@ -68,6 +70,8 @@ namespace openPMD
     public:
         ADIOS1IOHandler(std::string path, AccessType);
         ~ADIOS1IOHandler() override;
+
+        std::string backendName() const override { return "DUMMY_ADIOS1"; }
 
         std::future< void > flush() override;
 

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -658,6 +658,8 @@ public:
 
     ADIOS2IOHandler( std::string path, AccessType );
 
+    std::string backendName() const override { return "ADIOS2"; }
+
     std::future< void > flush( ) override;
 }; // ADIOS2IOHandler
 } // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -55,6 +55,8 @@ namespace openPMD
 #   endif
         ~ParallelADIOS1IOHandler() override;
 
+        std::string backendName() const override { return "MPI_ADIOS1"; }
+
         std::future< void > flush() override;
 #if openPMD_HAVE_ADIOS1
         void enqueue(IOTask const&) override;

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -97,6 +97,9 @@ public:
      */
     virtual std::future< void > flush() = 0;
 
+    /** The currently used backend */
+    virtual std::string backendName() const = 0;
+
     std::string const directory;
     AccessType const accessTypeBackend;
     AccessType const accessTypeFrontend;

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -37,6 +37,8 @@ public:
     HDF5IOHandler(std::string path, AccessType);
     ~HDF5IOHandler() override;
 
+    std::string backendName() const override { return "HDF5"; }
+
     std::future< void > flush() override;
 
 private:

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -42,6 +42,8 @@ namespace openPMD
     #endif
         ~ParallelHDF5IOHandler() override;
 
+        std::string backendName() const override { return "MPI_HDF5"; }
+
         std::future< void > flush() override;
 
     private:

--- a/include/openPMD/IO/JSON/JSONIOHandler.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandler.hpp
@@ -39,6 +39,8 @@ namespace openPMD
 
         ~JSONIOHandler( ) override;
 
+        std::string backendName() const override { return "JSON"; }
+
         std::future< void > flush( ) override;
 
     private:

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -237,6 +237,9 @@ public:
      */
     Series& setName(std::string const& name);
 
+    /** The currently used backend */
+    std::string backend() const;
+
     /** Execute all required remaining IO operations to write or read data.
      */
     void flush();

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -353,6 +353,12 @@ Series::setName(std::string const& n)
     return *this;
 }
 
+std::string
+Series::backend() const
+{
+    return IOHandler->backendName();
+}
+
 void
 Series::flush()
 {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -725,8 +725,7 @@ void fileBased_write_test(const std::string & backend)
         o.setOpenPMDextension(1);
         o.iterations[3].setTime(static_cast< double >(3));
         o.iterations[4].setTime(static_cast< double >(4));
-        if( o.backend() != "ADIOS1" )  // FIXME fails with ADIOS1
-            o.flush();
+        o.flush();
         o.iterations[5].setTime(static_cast< double >(5));
     }
     REQUIRE((auxiliary::file_exists("../samples/subdir/serial_fileBased_write00000001." + backend)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -724,9 +724,9 @@ void fileBased_write_test(const std::string & backend)
 
         o.setOpenPMDextension(1);
         o.iterations[3].setTime(static_cast< double >(3));
-
         o.iterations[4].setTime(static_cast< double >(4));
-        //o.flush(); // FIXME fails with ADIOS1
+        if( o.backend() != "ADIOS1" )  // FIXME fails with ADIOS1
+            o.flush();
         o.iterations[5].setTime(static_cast< double >(5));
     }
     REQUIRE((auxiliary::file_exists("../samples/subdir/serial_fileBased_write00000001." + backend)


### PR DESCRIPTION
Extend Test: Flush more exotic write patterns in serial write, such as attribute-only series.

Demonstrates and fixes another ADIOS1 backend bug (open files either if attributes or dataset are going to be created).

Implement a `backendName()` property in `IOHandler`s for development/debugging purposes.