### PR TITLE
ADIOS2: New Default for BP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,11 +214,11 @@ jobs:
         # - dpkg -i openPMD*.deb
         - ls -R $HOME/openPMD-test-install | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//--/g' -e 's/^/   /' -e 's/-/|/'
     - <<: *test-cpp-unit
-      name: clang@5.0.0 +OMPI -PY +H5 +ADIOS1 +ADIOS2 (BP4)
+      name: clang@5.0.0 +OMPI -PY +H5 +ADIOS1 (BP3) +ADIOS2
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON OPENPMD_BP_BACKEND=ADIOS2 USE_SAMPLES=ON
+        - CXXSPEC="%clang@5.0.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON OPENPMD_BP_BACKEND=ADIOS1 USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,10 @@ Changes to "0.10.3-alpha"
 Features
 """"""""
 
-- ADIOS2: expose engine #656
+- ADIOS2:
+
+  - new default for ``.bp`` files (over ADIOS1) #676
+  - expose engine #656
 - defaults for ``date`` and software base attributes #657
 - ``Series::setSoftware()`` add second argument for version #657
 - free standing functions to query the API version and feature variants at runtime #665
@@ -29,6 +32,7 @@ Bug Fixes
 - ADIOS1:
 
   - ensure creation of files that only contain attributes #674
+  - deprecated in favor of ADIOS2 backend #676
 
 Other
 """""

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,12 +6,17 @@ Upgrade Guide
 0.11.0-alpha
 ------------
 
+ADIOS2 is now the default backend for ``.bp`` files.
+As soon as the ADIOS2 backend is enabled it will take precedence over a potentially also enabled ADIOS1 backend.
+In order to prefer the legacy ADIOS1 backend in such a situation, set an environment variable: ``export OPENPMD_BP_BACKEND="ADIOS1"``.
+Support for ADIOS1 is now deprecated.
+
+Our `Spack <https://spack.io>`_ packages build the ADIOS2 backend now by default.
+Pass ``-adios2`` to the Spack spec to disable it: ``spack install openpmd-api -adios2`` (same for ``spack load``).
+
 The ``Series::setSoftwareVersion`` method is now deprecated and will be removed in future versions of the library.
 Use ``Series::setSoftware(name, version)`` instead.
 Similarly for the Python API, use ``Series.set_software`` instead of ``Series.set_software_version``.
-
-Our `Spack <https://spack.io>`_ packages build the ADIOS1 backend now by default.
-Pass ``-adios1`` to the Spack spec to disable it: ``spack install openpmd-api -adios1`` (same for ``spack load``).
 
 
 0.10.0-alpha

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Choose *one* of the install methods below to get started:
 [![Spack Status](https://img.shields.io/badge/method-recommended-brightgreen.svg)](https://spack.readthedocs.io/en/latest/package_list.html#openpmd-api)
 
 ```bash
-# optional:               +python +adios2 -adios1 -hdf5 -mpi
+# optional:               +python +adios1 -adios2 -hdf5 -mpi
 spack install openpmd-api
 spack load -r openpmd-api
 ```

--- a/docs/source/backends/adios1.rst
+++ b/docs/source/backends/adios1.rst
@@ -9,6 +9,10 @@ To build openPMD with support for ADIOS, use the CMake option ``-DopenPMD_USE_AD
 For further information, check out the :ref:`installation guide <install>`,
 :ref:`build dependencies <development-dependencies>` and the :ref:`build options <development-buildoptions>`.
 
+.. note::
+
+   This backend is deprecated, please use ADIOS2 instead.
+
 
 I/O Method
 ----------
@@ -29,12 +33,13 @@ environment variable                 default    description
 ``OPENPMD_ADIOS_NUM_AGGREGATORS``    ``1``      Number of I/O aggregator nodes for ADIOS1 ``MPI_AGGREGATE`` transport method.
 ``OPENPMD_ADIOS_NUM_OST``            ``0``      Number of I/O OSTs for ADIOS1 ``MPI_AGGREGATE`` transport method.
 ``OPENPMD_ADIOS_HAVE_METADATA_FILE`` ``1``      Online creation of the adios journal file (``1``: yes, ``0``: no).
-``OPENPMD_BP_BACKEND``               ``ADIOS1`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
+``OPENPMD_BP_BACKEND``               ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ==================================== ========== ================================================================================
 
 Please refer to the `ADIOS1 manual, section 6.1.5 <https://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.13.1.pdf>`_ for details on I/O tuning.
 
-In case both the ADIOS1 backend and the :ref:`ADIOS2 backend <backends-adios2>` are enabled, set ``OPENPMD_BP_BACKEND`` to ``ADIOS2`` to enforce using ADIOS2.
+In case both the ADIOS1 backend and the :ref:`ADIOS2 backend <backends-adios2>` are enabled, set ``OPENPMD_BP_BACKEND`` to ``ADIOS1`` to enforce using ADIOS1.
+If only the ADIOS1 backend was compiled but not the :ref:`ADIOS2 backend <backends-adios2>`, the default of ``OPENPMD_BP_BACKEND`` is automatically switched to ``ADIOS1``.
 Be advised that ADIOS1 only supports ``.bp`` files up to the internal version BP3, while ADIOS2 supports BP3, BP4 and later formats.
 
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -9,11 +9,6 @@ To build openPMD with support for ADIOS2, use the CMake option ``-DopenPMD_USE_A
 For further information, check out the :ref:`installation guide <install>`,
 :ref:`build dependencies <development-dependencies>` and the :ref:`build options <development-buildoptions>`.
 
-.. note::
-
-   The ADIOS2 backend in a preview in this release!
-   Its data representation, such as choice of attributes and variables in ``.bp`` files, might change without further notice in the upcoming releases.
-
 
 I/O Method
 ----------
@@ -35,12 +30,12 @@ environment variable                  default    description
 ``OPENPMD_ADIOS2_HAVE_METADATA_FILE`` ``1``      Online creation of the adios journal file (``1``: yes, ``0``: no).
 ``OPENPMD_ADIOS2_NUM_SUBSTREAMS``     ``0``      Number of files to be created, 0 indicates maximum number possible.
 ``OPENPMD_ADIOS2_ENGINE``             ``File``   `ADIOS2 engine <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_
-``OPENPMD_BP_BACKEND``                ``ADIOS1`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
+``OPENPMD_BP_BACKEND``                ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ===================================== ========== ================================================================================
 
 Please refer to the `ADIOS2 manual, section 5.1 <https://media.readthedocs.org/pdf/adios2/latest/adios2.pdf>`_ for details on I/O tuning.
 
-In case only the ADIOS2 backend is enabled but not the :ref:`ADIOS1 backend <backends-adios1>`, the default of ``OPENPMD_BP_BACKEND`` is automatically switched to ``ADIOS2``.
+In case the ADIOS2 backend was not compiled but only the deprecated :ref:`ADIOS1 backend <backends-adios1>`, the default of ``OPENPMD_BP_BACKEND`` will fall back to ``ADIOS1``.
 Be advised that ADIOS1 only supports ``.bp`` files up to the internal version BP3, while ADIOS2 supports BP3, BP4 and later formats.
 
 

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -31,7 +31,7 @@ A package for openPMD-api is available on the `Spack <https://spack.io>`_ packag
 
 .. code-block:: bash
 
-   # optional:               +python +adios2 -adios1 -hdf5 -mpi
+   # optional:               +python +adios1 -adios2 -hdf5 -mpi
    spack install openpmd-api
    spack load -r openpmd-api
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -892,12 +892,12 @@ determineFormat(std::string const& filename)
     {
         auto const bp_backend = auxiliary::getEnvString(
             "OPENPMD_BP_BACKEND",
-#if openPMD_HAVE_ADIOS1
-            "ADIOS1"
-#elif openPMD_HAVE_ADIOS2
+#if openPMD_HAVE_ADIOS2
             "ADIOS2"
-#else
+#elif openPMD_HAVE_ADIOS1
             "ADIOS1"
+#else
+            "ADIOS2"
 #endif
         );
 


### PR DESCRIPTION
Use the ADIOS2 backend by default for `.bp` files.
Deprecate ADIOS1 due to:

- upstream support focuses on ADIOS2
- lack of quality in our ADIOS1 backend implementation