### PR TITLE
Parallel HDF5: Independent I/O By Default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -294,12 +294,12 @@ jobs:
         # - find / -name libclang_rt*
     # Clang 8.0.0 + Python 3.8.0 @ Bionic
     - <<: *test-cpp-unit
-      name: clang@8.0.0 +MPICH +PY@3.8 +H5 +H5_INDEP +ADIOS1 +ADIOS2
+      name: clang@8.0.0 +MPICH +PY@3.8 +H5 (collective) +ADIOS1 +ADIOS2
       dist: bionic
       language: python
       python: "3.8"
       env:
-        - CXXSPEC="%clang@8.0.0" USE_MPI=ON MPI_FLAVOR="^mpich" USE_PYTHON=ON USE_HDF5=ON OPENPMD_HDF5_INDEPENDENT=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
+        - CXXSPEC="%clang@8.0.0" USE_MPI=ON MPI_FLAVOR="^mpich" USE_PYTHON=ON USE_HDF5=ON OPENPMD_HDF5_INDEPENDENT=OFF USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       addons:
         apt:
@@ -412,12 +412,12 @@ jobs:
         - CXX=g++-7 && CC=gcc-7
       script: *script-cpp-unit
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 +OMPI -PY +H5 +H5_INDEP +ADIOS1 -ADIOS2
+      name: gcc@7.4.0 +OMPI -PY +H5 (collective) +ADIOS1 -ADIOS2
       dist: trusty
       language: python
       python: "3.6"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON OPENPMD_HDF5_INDEPENDENT=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%gcc@7.4.0" USE_MPI=ON USE_PYTHON=OFF USE_HDF5=ON OPENPMD_HDF5_INDEPENDENT=OFF USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Features
 
   - new default for ``.bp`` files (over ADIOS1) #676
   - expose engine #656
+- HDF5: ``OPENPMD_HDF5_INDEPENDENT=ON`` is now default in parallel I/O #677
 - defaults for ``date`` and software base attributes #657
 - ``Series::setSoftware()`` add second argument for version #657
 - free standing functions to query the API version and feature variants at runtime #665

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,6 +11,11 @@ As soon as the ADIOS2 backend is enabled it will take precedence over a potentia
 In order to prefer the legacy ADIOS1 backend in such a situation, set an environment variable: ``export OPENPMD_BP_BACKEND="ADIOS1"``.
 Support for ADIOS1 is now deprecated.
 
+Independent MPI-I/O is now the default in parallel HDF5.
+For the old default, collective parallel I/O, set the environment variable ``export OPENPMD_HDF5_INDEPENDENT="OFF"``.
+Collective parallel I/O makes more functionality, such as ``storeChunk`` and ``loadChunk``, MPI-collective.
+HDF5 attribute writes are MPI-collective in either case, due to HDF5 restrictions.
+
 Our `Spack <https://spack.io>`_ packages build the ADIOS2 backend now by default.
 Pass ``-adios2`` to the Spack spec to disable it: ``spack install openpmd-api -adios2`` (same for ``spack load``).
 

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -21,17 +21,17 @@ Backend-Specific Controls
 
 The following environment variables control HDF5 I/O behavior at runtime.
 
-===================================== ========= ================================================================================
+===================================== ========= ====================================================================================
 environment variable                  default   description
-===================================== ========= ================================================================================
-``OPENPMD_HDF5_INDEPENDENT``          ``OFF``   Sets the MPI-parallel transfer mode to collective or independent.
-===================================== ========= ================================================================================
+===================================== ========= ====================================================================================
+``OPENPMD_HDF5_INDEPENDENT``          ``ON``    Sets the MPI-parallel transfer mode to collective (``OFF``) or independent (``ON``).
+===================================== ========= ====================================================================================
 
-``OPENPMD_HDF5_INDEPENDENT``: by default, the HDF5's MPI-parallel write/read operations are `MPI-collective <https://www.mpi-forum.org/docs/mpi-2.2/mpi22-report/node87.htm#Node87>`_.
-Since we call those underneath each ``storeChunk`` and ``loadChunk`` call, these methods become MPI-collective as well.
-Please refer to the `HDF5 manual, function H5Pset_dxpl_mpio <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_dxpl_mpio.htm>`_ for more details.
-In case you decide to use independent I/O with parallel HDF5, be advised that we did see performance penalties as well problems with some MPI-I/O implementations in the past.
+``OPENPMD_HDF5_INDEPENDENT``: by default, we implement MPI-parallel data ``storeChunk`` (write) and ``loadChunk`` (read) calls as `none-collective MPI operations <https://www.mpi-forum.org/docs/mpi-2.2/mpi22-report/node87.htm#Node87>`_.
+Attribute writes are always collective in parallel HDF5.
+Although we choose the default to be non-collective (independent) for ease of use, be advised that performance penalties may occur, although this depends heavily on the use-case.
 For independent parallel I/O, potentially prefer using a modern version of the MPICH implementation (especially, use ROMIO instead of OpenMPI's ompio implementation).
+Please refer to the `HDF5 manual, function H5Pset_dxpl_mpio <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_dxpl_mpio.htm>`_ for more details.
 
 
 Selected References

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -63,7 +63,7 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(AbstractIOHandler* handler,
     m_fileAccessProperty = H5Pcreate(H5P_FILE_ACCESS);
 
     H5FD_mpio_xfer_t xfer_mode = H5FD_MPIO_COLLECTIVE;
-    auto const hdf5_collective = auxiliary::getEnvString( "OPENPMD_HDF5_INDEPENDENT", "OFF" );
+    auto const hdf5_collective = auxiliary::getEnvString( "OPENPMD_HDF5_INDEPENDENT", "ON" );
     if( hdf5_collective == "ON" )
         xfer_mode = H5FD_MPIO_INDEPENDENT;
     else

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -188,7 +188,7 @@ TEST_CASE( "hdf5_write_test_zero_extent", "[parallel][hdf5]" )
 TEST_CASE( "hdf5_write_test_skip_chunk", "[parallel][hdf5]" )
 {
     //! @todo add via JSON option instead of environment read
-    auto const hdf5_collective = auxiliary::getEnvString( "OPENPMD_HDF5_INDEPENDENT", "OFF" );
+    auto const hdf5_collective = auxiliary::getEnvString( "OPENPMD_HDF5_INDEPENDENT", "ON" );
     if( hdf5_collective == "ON" )
     {
         write_test_zero_extent( false, "h5", false );


### PR DESCRIPTION
Set independent I/O to be the default option for ease-of-use.