### PR TITLE
added accesstype check before adding read operations

### DIFF
--- a/.rodare.json
+++ b/.rodare.json
@@ -14,6 +14,12 @@
             "name": "Huebl, Axel",
             "affiliation": "Lawrence Berkeley National Laboratory",
             "orcid": "0000-0003-1943-7141"
+        },
+        {
+            "affiliation": "Lawrence Berkeley National Laboratory",
+            "name": "Gu, Junmin",
+            "orcid": "0000-0002-1521-8534",
+            "type": "Other"
         }
     ],
     "contributors": [
@@ -79,12 +85,6 @@
             "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",
             "name": "Pausch, Richard",
             "orcid": "0000-0001-7990-9564",
-            "type": "Other"
-        },
-        {
-            "affiliation": "Lawrence Berkeley National Laboratory",
-            "name": "Gu, Junmin",
-            "orcid": "0000-0002-1521-8534",
             "type": "Other"
         },
         {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Bug Fixes
 
   - ensure creation of files that only contain attributes #674
   - deprecated in favor of ADIOS2 backend #676
+  - allow non-collective ``storeChunk()`` calls with multiple iterations #679
 
 Other
 """""

--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ The following people and institutions [contributed](https://github.com/openPMD/o
   initial library design and implementation with HDF5 & ADIOS1 backend
 * [Franz Poeschel (HZDR)](https://github.com/franzpoeschel):
   added JSON & ADIOS2 backend, data staging/streaming
+* [Junmin Gu (LBNL)](https://github.com/guj):
+  non-collective parallel I/O fixes, ADIOS improvements
 
 Further thanks go to improvements and contributions from:
 
@@ -361,8 +363,6 @@ Further thanks go to improvements and contributions from:
   compatibility testing
 * [Richard Pausch (HZDR)](https://github.com/PrometheusPi):
   compatibility testing
-* [Junmin Gu (LBNL)](https://github.com/guj):
-  non-collective parallel I/O testing
 * [Paweł Ordyna (HZDR)](https://github.com/pordyna):
   report on NVCC warnings
 

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -93,6 +93,10 @@ namespace openPMD
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
         std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
         std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
+        /**
+         * Call this function to get adios file id for a Writable. Will create one if does not exist
+         * @return  returns an adios file id. 
+         */	  
         int64_t GetFileHandle(Writable*);
     }; // ADIOS1IOHandlerImpl
 #else

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -93,6 +93,7 @@ namespace openPMD
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
         std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
         std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
+        int64_t GetFileHandle(Writable*);
     }; // ADIOS1IOHandlerImpl
 #else
     class EXPORT ADIOS1IOHandlerImpl

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -94,6 +94,7 @@ namespace openPMD
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
         std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
         std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
+        int64_t GetFileHandle(Writable*);
         MPI_Comm m_mpiComm;
         MPI_Info m_mpiInfo;
     }; // ParallelADIOS1IOHandlerImpl

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -94,6 +94,10 @@ namespace openPMD
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
         std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
         std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
+        /**
+         * Call this function to get adios file id for a Writable. Will create one if does not exist
+         * @return  returns an adios file id. 
+         */	  
         int64_t GetFileHandle(Writable*);
         MPI_Comm m_mpiComm;
         MPI_Info m_mpiInfo;

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -55,23 +55,13 @@ ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
 
     if( this->m_handler->accessTypeBackend != AccessType::READ_ONLY )
     {
-        for( auto& f : m_openWriteFileHandles )
-            close(f.second);
-        m_openWriteFileHandles.clear();
-
         for( auto& group : m_attributeWrites )
             for( auto& att : group.second )
                 flush_attribute(group.first, att.first, att.second);
 
-        /* create all files, even if ADIOS file creation has been deferred,
-         * but execution of the deferred operation has never been triggered
-         * (happens when no Operation::WRITE_DATASET is performed) */
-        for( auto& f : m_filePaths )
-            if( m_openWriteFileHandles.find(f.second) == m_openWriteFileHandles.end() )
-                m_openWriteFileHandles[f.second] = open_write(f.first);
-
         for( auto& f : m_openWriteFileHandles )
             close(f.second);
+        m_openWriteFileHandles.clear();
     }
 
     int status;

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -376,7 +376,7 @@ CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
         /* defer actually opening the file handle until the first Operation::WRITE_DATASET occurs */
         m_existsOnDisk[m_filePaths[writable]] = false;
 
-	int64_t fd = GetFileHandle(writable);
+    int64_t fd = GetFileHandle(writable);
     }
 }
 
@@ -757,12 +757,12 @@ int64_t CommonADIOS1IOHandlerImpl::GetFileHandle(Writable* writable)
       // write all opening handles and close them
       {
         for( auto& group : m_attributeWrites )
-	  for( auto& att : group.second )
-	    flush_attribute(group.first, att.first, att.second);
-	
-	for( auto& f : m_openWriteFileHandles )
-	  close(f.second);
-	m_openWriteFileHandles.clear();
+      for( auto& att : group.second )
+        flush_attribute(group.first, att.first, att.second);
+    
+    for( auto& f : m_openWriteFileHandles )
+      close(f.second);
+    m_openWriteFileHandles.clear();
       }
 
       fd = open_write(writable);

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -759,7 +759,7 @@ int64_t CommonADIOS1IOHandlerImpl::GetFileHandle(Writable* writable)
         for( auto& group : m_attributeWrites )
       for( auto& att : group.second )
         flush_attribute(group.first, att.first, att.second);
-    
+
     for( auto& f : m_openWriteFileHandles )
       close(f.second);
     m_openWriteFileHandles.clear();
@@ -823,12 +823,12 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
     int64_t fd = -1;
 
     if( m_openWriteFileHandles.find(res->second) == m_openWriteFileHandles.end()) {
-      // 
-      // not a perfect splot: 
-      // past iterators still tend to write attributes. 
-      // if file is not there anymore, return. 
+      //
+      // not a perfect splot:
+      // past iterators still tend to write attributes.
+      // if file is not there anymore, return.
       // should not be here in the first place if dirty flag is set properly (for storeChunk & setAttribute)
-      // 
+      //
       return;
       //fd = open_write(writable);
       //m_openWriteFileHandles[res->second] = fd;

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -770,7 +770,7 @@ CommonADIOS1IOHandlerImpl::writeDataset(Writable* writable,
                                   Parameter< Operation::WRITE_DATASET > const& parameters)
 {
     if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
-        throw std::runtime_error("[ADIOS1] Writing into a dataset in a file opened as read only is not possible.");
+        throw std::runtime_error("[ADIOS1] Writing into a dataset in a file opened as read-only is not possible.");
 
     int64_t fd = GetFileHandle(writable);
 

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -812,7 +812,6 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
     auto res = m_filePaths.find(writable);
     if( res == m_filePaths.end() )
         res = m_filePaths.find(writable->parent);
-    //int64_t fd = GetFileHandle(writable);
     GetFileHandle(writable);
 
     int64_t group = m_groups[res->second];

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -511,10 +511,10 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
 
     if( m_handler->accessTypeBackend == AccessType::CREATE )
     {
-        // called at Series.flush for iterations that has been flushed before
-    // this is to make sure to point the Series.m_writer points to this iteration
-    // so when call Series.flushAttribute(), the atributes can be flushed to the iteration level file.
-    m_filePaths[writable] = filePath;
+        // called at Series::flush for iterations that has been flushed before
+        // this is to make sure to point the Series.m_writer points to this iteration
+        // so when call Series.flushAttribute(), the attributes can be flushed to the iteration level file.
+        m_filePaths[writable] = filePath;
         writable->written = true;
         writable->abstractFilePosition = std::make_shared< ADIOS1FilePosition >("/");
         return;
@@ -765,13 +765,13 @@ int64_t CommonADIOS1IOHandlerImpl::GetFileHandle(Writable* writable)
 
     if( m_openWriteFileHandles.find(res->second) == m_openWriteFileHandles.end() )
     {
-      std::string  name  = *(res->second);
-      m_groups[m_filePaths[writable]] = initialize_group(name);
+        std::string  name  = *(res->second);
+        m_groups[m_filePaths[writable]] = initialize_group(name);
 
-      fd = open_write(writable);
-      m_openWriteFileHandles[res->second] = fd;
+        fd = open_write(writable);
+        m_openWriteFileHandles[res->second] = fd;
     } else
-      fd = m_openWriteFileHandles.at(res->second);
+        fd = m_openWriteFileHandles.at(res->second);
 
     return fd;
 }

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -376,7 +376,7 @@ CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
         /* defer actually opening the file handle until the first Operation::WRITE_DATASET occurs */
         m_existsOnDisk[m_filePaths[writable]] = false;
 
-    int64_t fd = GetFileHandle(writable);
+        /*int64_t fd = */GetFileHandle(writable);
     }
 }
 
@@ -833,9 +833,8 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
       //fd = open_write(writable);
       //m_openWriteFileHandles[res->second] = fd;
     } else {
-      fd = m_openWriteFileHandles.at(res->second);
+      //fd = m_openWriteFileHandles.at(res->second);
     }
-
 
     int64_t group = m_groups[res->second];
 

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -509,6 +509,16 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
     else
         filePath = it->second;
 
+    if( m_handler->accessTypeBackend == AccessType::CREATE )
+    {
+        // called at Series.flush for iterations that has been flushed before
+	// this is to make sure to point the Series.m_writer points to this iteration
+	// so when call Series.flushAttribute(), the atributes can be flushed to the iteration level file.
+	m_filePaths[writable] = filePath;
+        writable->written = true;
+        writable->abstractFilePosition = std::make_shared< ADIOS1FilePosition >("/");
+        return;
+     }
     /* close the handle that corresponds to the file we want to open */
     if( m_openWriteFileHandles.find(filePath) != m_openWriteFileHandles.end() )
     {

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -376,7 +376,7 @@ CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
         /* defer actually opening the file handle until the first Operation::WRITE_DATASET occurs */
         m_existsOnDisk[m_filePaths[writable]] = false;
 
-        /*int64_t fd = */GetFileHandle(writable);
+        GetFileHandle(writable);
     }
 }
 

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -512,9 +512,9 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
     if( m_handler->accessTypeBackend == AccessType::CREATE )
     {
         // called at Series.flush for iterations that has been flushed before
-	// this is to make sure to point the Series.m_writer points to this iteration
-	// so when call Series.flushAttribute(), the atributes can be flushed to the iteration level file.
-	m_filePaths[writable] = filePath;
+    // this is to make sure to point the Series.m_writer points to this iteration
+    // so when call Series.flushAttribute(), the atributes can be flushed to the iteration level file.
+    m_filePaths[writable] = filePath;
         writable->written = true;
         writable->abstractFilePosition = std::make_shared< ADIOS1FilePosition >("/");
         return;

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -812,7 +812,8 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
     auto res = m_filePaths.find(writable);
     if( res == m_filePaths.end() )
         res = m_filePaths.find(writable->parent);
-    int64_t fd = GetFileHandle(writable);
+    //int64_t fd = GetFileHandle(writable);
+    GetFileHandle(writable);
 
     int64_t group = m_groups[res->second];
 

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -820,7 +820,7 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
     if( res == m_filePaths.end() )
         res = m_filePaths.find(writable->parent);
 
-    int64_t fd = -1;
+    //int64_t fd = -1;
 
     if( m_openWriteFileHandles.find(res->second) == m_openWriteFileHandles.end()) {
       //

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -63,21 +63,21 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
             for( auto& att : group.second )
                 flush_attribute(group.first, att.first, att.second);
 
-	// unordered map caused the value of the same container
-	// stored with different orders in different processors. 
-	// which  caused trouble with  close(), which is collective
-	// so I just sort by file name to force  all processors  close
-	// all the fids in the same order
-	std::map< std::string, int64_t> allFiles;
+    // unordered map caused the value of the same container
+    // stored with different orders in different processors. 
+    // which  caused trouble with  close(), which is collective
+    // so I just sort by file name to force  all processors  close
+    // all the fids in the same order
+    std::map< std::string, int64_t> allFiles;
         for( auto& f : m_openWriteFileHandles )
             allFiles[*(f.first)] = f.second;
-	
-	for (auto p :  allFiles)
-	  {
-	    auto fid =  p.second;
-	    close(fid);
-	  }
-	
+    
+    for (auto p :  allFiles)
+      {
+        auto fid =  p.second;
+        close(fid);
+      }
+    
         m_openWriteFileHandles.clear();
     }
 

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -58,25 +58,24 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
 
     if( this->m_handler->accessTypeBackend != AccessType::READ_ONLY )
     {
-
         for( auto& group : m_attributeWrites )
             for( auto& att : group.second )
                 flush_attribute(group.first, att.first, att.second);
 
-    // unordered map caused the value of the same container
-    // stored with different orders in different processors.
-    // which  caused trouble with  close(), which is collective
-    // so I just sort by file name to force  all processors  close
-    // all the fids in the same order
-    std::map< std::string, int64_t> allFiles;
+        // unordered map caused the value of the same container
+        // stored with different orders in different processors.
+        // which  caused trouble with  close(), which is collective
+        // so I just sort by file name to force  all processors  close
+        // all the fids in the same order
+        std::map< std::string, int64_t > allFiles;
         for( auto& f : m_openWriteFileHandles )
             allFiles[*(f.first)] = f.second;
 
-    for (auto const& p :  allFiles)
-      {
-        auto const fid = p.second;
-        close(fid);
-      }
+        for( auto const& p : allFiles )
+        {
+            auto const fid = p.second;
+            close(fid);
+        }
 
         m_openWriteFileHandles.clear();
     }

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -61,14 +61,18 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
         for( auto& group : m_attributeWrites )
             for( auto& att : group.second )
                 flush_attribute(group.first, att.first, att.second);
-
+#ifdef NEVER
+	//
+	// not needed anymore b/c file is created at create_file
+	//
         /* create all files, even if ADIOS file creation has been deferred,
          * but execution of the deferred operation has never been triggered
          * (happens when no Operation::WRITE_DATASET is performed) */
+  
         for( auto& f : m_filePaths )
             if( m_openWriteFileHandles.find(f.second) == m_openWriteFileHandles.end() )
                 m_openWriteFileHandles[f.second] = open_write(f.first);
-
+#endif  
         for( auto& f : m_openWriteFileHandles )
             close(f.second);
         m_openWriteFileHandles.clear();

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -72,7 +72,7 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
         for( auto& f : m_openWriteFileHandles )
             allFiles[*(f.first)] = f.second;
 
-    for (auto& p :  allFiles)
+    for (auto const& p :  allFiles)
       {
         auto const fid = p.second;
         close(fid);

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -74,7 +74,7 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
 
     for (auto p :  allFiles)
       {
-        auto fid =  p.second;
+        auto const fid = p.second;
         close(fid);
       }
 

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -64,20 +64,20 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
                 flush_attribute(group.first, att.first, att.second);
 
     // unordered map caused the value of the same container
-    // stored with different orders in different processors. 
+    // stored with different orders in different processors.
     // which  caused trouble with  close(), which is collective
     // so I just sort by file name to force  all processors  close
     // all the fids in the same order
     std::map< std::string, int64_t> allFiles;
         for( auto& f : m_openWriteFileHandles )
             allFiles[*(f.first)] = f.second;
-    
+
     for (auto p :  allFiles)
       {
         auto fid =  p.second;
         close(fid);
       }
-    
+
         m_openWriteFileHandles.clear();
     }
 

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -62,9 +62,9 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
             for( auto& att : group.second )
                 flush_attribute(group.first, att.first, att.second);
 #ifdef NEVER
-	//
-	// not needed anymore b/c file is created at create_file
-	//
+    //
+    // not needed anymore b/c file is created at create_file
+    //
         /* create all files, even if ADIOS file creation has been deferred,
          * but execution of the deferred operation has never been triggered
          * (happens when no Operation::WRITE_DATASET is performed) */

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -68,11 +68,11 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
         /* create all files, even if ADIOS file creation has been deferred,
          * but execution of the deferred operation has never been triggered
          * (happens when no Operation::WRITE_DATASET is performed) */
-  
+
         for( auto& f : m_filePaths )
             if( m_openWriteFileHandles.find(f.second) == m_openWriteFileHandles.end() )
                 m_openWriteFileHandles[f.second] = open_write(f.first);
-#endif  
+#endif
         for( auto& f : m_openWriteFileHandles )
             close(f.second);
         m_openWriteFileHandles.clear();

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -72,7 +72,7 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
         for( auto& f : m_openWriteFileHandles )
             allFiles[*(f.first)] = f.second;
 
-    for (auto p :  allFiles)
+    for (auto& p :  allFiles)
       {
         auto const fid = p.second;
         close(fid);

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -162,6 +162,10 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         groups.push(node_id);
         for( std::string const& folder : auxiliary::split(path, "/", false) )
         {
+            htri_t found = H5Lexists(groups.top(), folder.c_str(), H5P_DEFAULT);
+            if (found > 0)
+              continue;
+
             hid_t group_id = H5Gcreate(groups.top(),
                                        folder.c_str(),
                                        H5P_DEFAULT,

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -162,7 +162,8 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         groups.push(node_id);
         for( std::string const& folder : auxiliary::split(path, "/", false) )
         {
-            htri_t found = H5Lexists(groups.top(), folder.c_str(), H5P_DEFAULT);
+            // avoid creation of paths that already exist
+            htri_t const found = H5Lexists(groups.top(), folder.c_str(), H5P_DEFAULT);
             if (found > 0)
               continue;
 

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -119,12 +119,12 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     } else
     {
       if (IOHandler->accessTypeFrontend == AccessType::CREATE)
-    { 
+    {
       flush();
       return;
     }
 
-        // operations for read mode 
+        // operations for read mode
         /* open file */
         auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
         Parameter< Operation::OPEN_FILE > fOpen;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -121,7 +121,12 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
       if ((IOHandler->accessTypeFrontend == AccessType::CREATE)
           && ( (IOHandler->backendName() == "MPI_ADIOS1") || (IOHandler->backendName() == "ADIOS1")))
     {
+      auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
+      Parameter< Operation::OPEN_FILE > fOpen;
+      fOpen.name = filename;
+      IOHandler->enqueue(IOTask(s, fOpen));
       flush();
+
       return;
     }
 

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -119,7 +119,7 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     } else
     {
       if ((IOHandler->accessTypeFrontend == AccessType::CREATE)
-      && (IOHandler->backendName() == "MPI_ADIOS1"))
+          && ( (IOHandler->backendName() == "MPI_ADIOS1") || (IOHandler->backendName() == "ADIOS1")))
     {
       flush();
       return;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -118,7 +118,8 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
         IOHandler->enqueue(IOTask(this, pCreate));
     } else
     {
-      if (IOHandler->accessTypeFrontend == AccessType::CREATE)
+      if ((IOHandler->accessTypeFrontend == AccessType::CREATE)
+	  && (IOHandler->backendName() == "MPI_ADIOS1"))
     {
       flush();
       return;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -119,10 +119,10 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     } else
     {
       if (IOHandler->accessTypeFrontend == AccessType::CREATE)
-	{ 
-	  flush();
-	  return;
-	}
+    { 
+      flush();
+      return;
+    }
 
         // operations for read mode 
         /* open file */

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -118,19 +118,20 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
         IOHandler->enqueue(IOTask(this, pCreate));
     } else
     {
-      if ((IOHandler->accessTypeFrontend == AccessType::CREATE)
-          && ( (IOHandler->backendName() == "MPI_ADIOS1") || (IOHandler->backendName() == "ADIOS1")))
-    {
-      auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
-      Parameter< Operation::OPEN_FILE > fOpen;
-      fOpen.name = filename;
-      IOHandler->enqueue(IOTask(s, fOpen));
-      flush();
+        // operations for create mode
+        if( ( IOHandler->accessTypeFrontend == AccessType::CREATE ) &&
+            ( (IOHandler->backendName() == "MPI_ADIOS1") || (IOHandler->backendName() == "ADIOS1") ) )
+        {
+            auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
+            Parameter< Operation::OPEN_FILE > fOpen;
+            fOpen.name = filename;
+            IOHandler->enqueue(IOTask(s, fOpen));
+            flush();
 
-      return;
-    }
+            return;
+        }
 
-        // operations for read mode
+        // operations for read/read-write mode
         /* open file */
         auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
         Parameter< Operation::OPEN_FILE > fOpen;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -119,7 +119,7 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     } else
     {
       if ((IOHandler->accessTypeFrontend == AccessType::CREATE)
-	  && (IOHandler->backendName() == "MPI_ADIOS1"))
+      && (IOHandler->backendName() == "MPI_ADIOS1"))
     {
       flush();
       return;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -118,6 +118,13 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
         IOHandler->enqueue(IOTask(this, pCreate));
     } else
     {
+      if (IOHandler->accessTypeFrontend == AccessType::CREATE)
+	{ 
+	  flush();
+	  return;
+	}
+
+        // operations for read mode 
         /* open file */
         auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
         Parameter< Operation::OPEN_FILE > fOpen;

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -39,9 +39,7 @@ void write_test_zero_extent( bool fileBased, std::string file_ending, bool write
         filePath += "_%07T";
     Series o = Series( filePath.append(".").append(file_ending), AccessType::CREATE, MPI_COMM_WORLD);
 
-    int max_step = 100;
-    // this is an ADIOS1 bug, comment the following line to see it
-    if( o.backend() == "MPI_ADIOS1" ) max_step = 1;
+    int const max_step = 100;
 
     for( int step=0; step<=max_step; step+=20 ) {
         Iteration it = o.iterations[step];

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -721,7 +721,7 @@ void fileBased_write_test(const std::string & backend)
             o.flush();
         }
 
-        o.setOpenPMDextension(1); 
+        o.setOpenPMDextension(1);
         o.iterations[3].setTime(static_cast< double >(3));
         o.iterations[4].setTime(static_cast< double >(4));
         //o.flush();

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -673,7 +673,6 @@ void fileBased_write_test(const std::string & backend)
         std::shared_ptr< uint64_t > positionOffset_local_1(new uint64_t);
         e_1["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_1), {4}));
 
-        o.setOpenPMDextension(1); // this would be before the first flush
         for( uint64_t i = 0; i < 4; ++i )
         {
             *position_local_1 = position_global[i];
@@ -722,10 +721,10 @@ void fileBased_write_test(const std::string & backend)
             o.flush();
         }
 
-        //o.setOpenPMDextension(1); // this will make iteration 1&2 have extension 0.
+        o.setOpenPMDextension(1); 
         o.iterations[3].setTime(static_cast< double >(3));
         o.iterations[4].setTime(static_cast< double >(4));
-        o.flush();
+        //o.flush();
         o.iterations[5].setTime(static_cast< double >(5));
     }
     REQUIRE((auxiliary::file_exists("../samples/subdir/serial_fileBased_write00000001." + backend)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -722,7 +722,7 @@ void fileBased_write_test(const std::string & backend)
             o.flush();
         }
 
-        //o.setOpenPMDextension(1); // this will make iteration 1&2 have extension 0. 
+        //o.setOpenPMDextension(1); // this will make iteration 1&2 have extension 0.
         o.iterations[3].setTime(static_cast< double >(3));
         o.iterations[4].setTime(static_cast< double >(4));
         o.flush();

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -673,7 +673,7 @@ void fileBased_write_test(const std::string & backend)
         std::shared_ptr< uint64_t > positionOffset_local_1(new uint64_t);
         e_1["positionOffset"]["x"].resetDataset(Dataset(determineDatatype(positionOffset_local_1), {4}));
 
-        //o.setOpenPMDextension(1); // this would be before the first flush
+        o.setOpenPMDextension(1); // this would be before the first flush
         for( uint64_t i = 0; i < 4; ++i )
         {
             *position_local_1 = position_global[i];
@@ -722,7 +722,7 @@ void fileBased_write_test(const std::string & backend)
             o.flush();
         }
 
-        o.setOpenPMDextension(1);
+        //o.setOpenPMDextension(1); // this will make iteration 1&2 have extension 0. 
         o.iterations[3].setTime(static_cast< double >(3));
         o.iterations[4].setTime(static_cast< double >(4));
         o.flush();

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -724,7 +724,7 @@ void fileBased_write_test(const std::string & backend)
         o.setOpenPMDextension(1);
         o.iterations[3].setTime(static_cast< double >(3));
         o.iterations[4].setTime(static_cast< double >(4));
-        //o.flush();
+        o.flush();
         o.iterations[5].setTime(static_cast< double >(5));
     }
     REQUIRE((auxiliary::file_exists("../samples/subdir/serial_fileBased_write00000001." + backend)


### PR DESCRIPTION
this is to avoid have read operations showing up in (multiple) write flushes
for the same iteration