### PR TITLE
LGTM: OpenMPI-Enabled

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,10 +2,7 @@ extraction:
   cpp:
     prepare:
       packages:
-        # MPI-enabled ADIOS missing on cosmic (but is available on disco+)
-        #- libhdf5-mpich-dev
-        #- libadios-mpich-dev
-        #- mpich
-        #- libmpich-dev
-        - libhdf5-dev
-        - libadios-dev
+        - openmpi-bin
+        - libopenmpi-dev
+        - libhdf5-openmpi-dev
+        - libadios-dev  # this is OpenMPI-enabled, explicit name on disco+


### PR DESCRIPTION
Enable ancient OpenMPI builds on LGTM for HDF5 & ADIOS1.