### PR TITLE
Tests: Multiple Series Active

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,7 @@ Other
 - ``Attribute`` constructor: move argument into place #663
 - Spack: ADIOS1 backend now enabled by default #664
 - add independent HDF5 write test to CI #669
+- add test of multiple active ``Series`` #686
 
 
 0.10.3-alpha


### PR DESCRIPTION
Test if multiple Series objects can be active at the same time.
This currently only fails for ADIOS1, likely due to an upstream bug.

## To Do

- [x] document limitation #685
- [x] rebase after #684