### PR TITLE
Pip: Bootstrap of Setuptools/CMake

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Bug Fixes
   - ensure creation of files that only contain attributes #674
   - deprecated in favor of ADIOS2 backend #676
   - allow non-collective ``storeChunk()`` calls with multiple iterations #679
+- Pip: work-around setuptools/CMake bootstrap issues on some systems #689
 
 Other
 """""

--- a/README.md
+++ b/README.md
@@ -174,8 +174,9 @@ python3 -m pip install openpmd-api
 
 or with MPI support:
 ```bash
-# optional:                                          --user
-python3 -m pip install -U pip setuptools wheel cmake
+# optional:                                    --user
+python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U cmake
 
 # optional:                                                                   --user
 openPMD_USE_MPI=ON python3 -m pip install openpmd-api --no-binary openpmd-api

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -80,8 +80,9 @@ or with MPI support:
 
 .. code-block:: bash
 
-   # optional:                                          --user
-   python3 -m pip install -U pip setuptools wheel cmake
+   # optional:                                    --user
+   python3 -m pip install -U pip setuptools wheel
+   python3 -m pip install -U cmake
 
    # optional:                                                                   --user
    openPMD_USE_MPI=ON python3 -m pip install openpmd-api --no-binary openpmd-api


### PR DESCRIPTION
Wow pip, thank you:
```
$ python3 -m pip install -U pip setuptools wheel cmake --user
> Collecting pip ...
Collecting setuptools ...
Collecting wheel ...
Collecting cmake ...
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'
```

Seen on Ubuntu 18.04 in Azure nightly testing.
https://dev.azure.com/axelhuebl/openPMD-api/_build/results?buildId=201

Ref.: https://github.com/openPMD/openPMD-api/commit/edf904b22133b9c845278b83c9465882f0a70b07