### PR TITLE
HDF5: Support 1.12 Release Series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -252,12 +252,12 @@ jobs:
         - CXX=clang++-6.0 && CC=clang-6.0 && CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -I/usr/include/libcxxabi/"
     # Clang 7.0.0 + Python 3.8.0 @ Xenial
     - <<: *test-cpp-unit
-      name: clang@7.0.0 +OMPI +PY@3.8 +H5 +ADIOS1 +ADIOS2 +Release
+      name: clang@7.0.0 +OMPI +PY@3.8 +H5@1.10.6 +ADIOS1 +ADIOS2 +Release
       dist: xenial
       language: python
       python: "3.8"
       env:
-        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON BUILD_TYPE="Release"
+        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON HDF5_VERSION=@1.10.6 USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON BUILD_TYPE="Release"
       compiler: clang
       addons:
         apt:

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1534,7 +1534,11 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
 
     H5O_info_t object_info;
     herr_t status;
+#if H5_VERSION_GE(1,12,0)
+    status = H5Oget_info(node_id, &object_info, H5O_INFO_NUM_ATTRS);
+#else
     status = H5Oget_info(node_id, &object_info);
+#endif
     VERIFY(status == 0, "[HDF5] Internal error: Failed to get HDF5 object info for " + concrete_h5_file_position(writable) + " during attribute listing");
 
     auto attributes = parameters.attributes;


### PR DESCRIPTION
Cover major releases: 1.8, 1.10. 1.12 (latest)

Refs.:
- https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO
- fix #695