### PR TITLE
Examples: Namespace Alias io

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Features
 
 - HDF5: Support 1.12 release #696
 - Doxygen: per-version index in Sphinx pages #697
+- Examples:
+
+  - document theta mode read/write #678
+  - better example namespace alias (io) #698
 
 Bug Fixes
 """""""""

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,10 +138,10 @@ RUN        ls -hal /usr/local/lib/python3.7/dist-packages/
 # RUN        ls -hal /usr/local/lib/python3.7/dist-packages/.libsopenpmd_api
 # RUN        objdump -x /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so | grep RPATH
 RUN        ldd /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so
-RUN        python3 -c "import openpmd_api as api; print(api.__version__); print(api.variants)"
+RUN        python3 -c "import openpmd_api as io; print(api.__version__); print(api.variants)"
 #RUN        openpmd-ls --help
 #RUN        echo "* soft core 100000" >> /etc/security/limits.conf && \
-#           python3 -c "import openpmd_api as api;"; \
+#           python3 -c "import openpmd_api as io;"; \
 #           gdb -ex bt -c core
 
 # test in fresh env: Debian:Sid + Python 3.8
@@ -155,7 +155,7 @@ RUN        python3.8 --version \
            && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
            && python3.8 get-pip.py \
            && python3.8 -m pip install openPMD_api-*-cp38-cp38-manylinux2010_x86_64.whl
-RUN        python3.8 -c "import openpmd_api as api; print(api.__version__); print(api.variants)"
+RUN        python3.8 -c "import openpmd_api as io; print(api.__version__); print(api.variants)"
 
 # test in fresh env: Ubuntu:18.04 + Python 3.6
 FROM       ubuntu:18.04
@@ -167,7 +167,7 @@ RUN        apt-get update \
 RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp36-cp36m-manylinux2010_x86_64.whl
-RUN        python3 -c "import openpmd_api as api; print(api.__version__); print(api.variants)"
+RUN        python3 -c "import openpmd_api as io; print(api.__version__); print(api.variants)"
 #RUN        openpmd-ls --help
 
 # test in fresh env: Debian:Stretch + Python 3.5
@@ -180,7 +180,7 @@ RUN        apt-get update \
 RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp35-cp35m-manylinux2010_x86_64.whl
-RUN        python3 -c "import openpmd_api as api; print(api.__version__); print(api.variants)"
+RUN        python3 -c "import openpmd_api as io; print(api.__version__); print(api.variants)"
 #RUN        openpmd-ls --help
 
 

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -66,16 +66,16 @@ C++11
    #include <openPMD/openPMD.hpp>
    #include <iostream>
 
-   namespace api = openPMD;
+   namespace io = openPMD;
 
    // ...
    std::cout << "openPMD-api: "
-             << api::getVersion() << std::endl;
+             << io::getVersion() << std::endl;
    std::cout << "openPMD-standard: "
-             << api::getStandard() << std::endl;
+             << io::getStandard() << std::endl;
 
    std::cout << "openPMD-api backend variants: " << std::endl;
-   for( auto const & v : api::getVariants() )
+   for( auto const & v : io::getVariants() )
        std::cout << "  " << v.first << ": "
                  << v.second << std::endl;
 
@@ -84,10 +84,10 @@ Python
 
 .. code-block:: python3
 
-   import openpmd_api as api
+   import openpmd_api as io
 
    print("openPMD-api: {}"
-         .format(api.__version__))
+         .format(io.__version__))
    print("openPMD-api backend variants: {}"
-         .format(api.variants))
+         .format(io.variants))
 

--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -60,14 +60,14 @@ C++11
    #include <iostream> // std::cout
    #include <memory>   // std::shared_ptr
 
-   namespace api = openPMD;
+   namespace io = openPMD;
 
 Python
 ^^^^^^
 
 .. code-block:: python3
 
-   import openpmd_api as api
+   import openpmd_api as io
 
    # example: data handling
    import numpy as np
@@ -85,9 +85,9 @@ C++11
 
 .. code-block:: cpp
 
-   auto series = api::Series(
+   auto series = io::Series(
        "data%T.h5",
-       api::AccessType::READ_ONLY);
+       io::AccessType::READ_ONLY);
 
 
 Python
@@ -95,9 +95,9 @@ Python
 
 .. code-block:: python3
 
-   series = api.Series(
+   series = io.Series(
        "data%T.h5",
-       api.Access_Type.read_only)
+       io.Access_Type.read_only)
 
 Iteration
 ---------
@@ -195,7 +195,7 @@ C++11
    auto E_unitDim = E.unitDimension();
 
    // ...
-   // api::UnitDimension::M
+   // io::UnitDimension::M
 
    // conversion to SI
    double x_unit = E_x.unitSI();
@@ -209,7 +209,7 @@ Python
    E_unitDim = E.unit_dimension
 
    # ...
-   # api.Unit_Dimension.M
+   # io.Unit_Dimension.M
 
    # conversion to SI
    x_unit = E_x.unit_SI

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -58,14 +58,14 @@ C++11
    #include <numeric>  // std::iota
    #include <vector>   // std::vector
 
-   namespace api = openPMD;
+   namespace io = openPMD;
 
 Python
 ^^^^^^
 
 .. code-block:: python3
 
-   import openpmd_api as api
+   import openpmd_api as io
 
    # example: data handling
    import numpy as np
@@ -83,9 +83,9 @@ C++11
 
 .. code-block:: cpp
 
-   auto series = api::Series(
+   auto series = io::Series(
        "myOutput/data_%05T.h5",
-       api::AccessType::CREATE);
+       io::AccessType::CREATE);
 
 
 Python
@@ -93,9 +93,9 @@ Python
 
 .. code-block:: python3
 
-   series = api.Series(
+   series = io.Series(
        "myOutput/data_%05T.h5",
-       api.Access_Type.create)
+       io.Access_Type.create)
 
 Iteration
 ---------
@@ -209,8 +209,8 @@ C++11
    auto B_y = B["y"];
    auto B_z = B["z"];
 
-   auto dataset = api::Dataset(
-       api::determineDatatype<float>(),
+   auto dataset = io::Dataset(
+       io::determineDatatype<float>(),
        {150, 300});
    B_x.resetDataset(dataset);
    B_y.resetDataset(dataset);
@@ -229,7 +229,7 @@ Python
    B_y = B["y"]
    B_z = B["z"]
 
-   dataset = api.Dataset(
+   dataset = io.Dataset(
        x_data.dtype,
        x_data.shape)
    B_x.reset_dataset(dataset)
@@ -252,9 +252,9 @@ C++11
 
    // unit system agnostic dimension
    B.setUnitDimension({
-       {api::UnitDimension::M,  1},
-       {api::UnitDimension::I, -1},
-       {api::UnitDimension::T, -2}
+       {io::UnitDimension::M,  1},
+       {io::UnitDimension::I, -1},
+       {io::UnitDimension::T, -2}
    });
 
    // conversion to SI
@@ -269,9 +269,9 @@ Python
 
    # unit system agnostic dimension
    B.set_unit_dimension({
-       api.Unit_Dimension.M:  1,
-       api.Unit_Dimension.I: -1,
-       api.Unit_Dimension.T: -2
+       io.Unit_Dimension.M:  1,
+       io.Unit_Dimension.I: -1,
+       io.Unit_Dimension.T: -2
    })
 
    # conversion to SI
@@ -298,10 +298,10 @@ C++11
 .. code-block:: cpp
 
    B_x.storeChunk(
-       api::shareRaw(x_data),
+       io::shareRaw(x_data),
        {0, 0}, {150, 300});
    B_z.storeChunk(
-       api::shareRaw(z_data),
+       io::shareRaw(z_data),
        {0, 0}, {150, 300});
 
    B_y.makeConstant(y_data);

--- a/examples/3a_write_thetaMode_serial.py
+++ b/examples/3a_write_thetaMode_serial.py
@@ -6,15 +6,15 @@ Copyright 2020 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-import openpmd_api as api
+import openpmd_api as io
 import numpy as np
 
 
 if __name__ == "__main__":
     # open file for writing
-    series = api.Series(
+    series = io.Series(
         "../samples/3_write_thetaMode_serial_py.h5",
-        api.Access_Type.create
+        io.Access_Type.create
     )
 
     # configure and setup geometry
@@ -32,35 +32,35 @@ if __name__ == "__main__":
     geometry_parameters = "m={0};imag=+".format(num_modes)
 
     E = series.iterations[0].meshes["E"]
-    E.set_geometry(api.Geometry.thetaMode)
+    E.set_geometry(io.Geometry.thetaMode)
     E.set_geometry_parameters(geometry_parameters)
-    E.set_data_order(api.Data_Order.C)
+    E.set_data_order(io.Data_Order.C)
     E.set_grid_spacing([1.0, 1.0])
     E.set_grid_global_offset([0.0, 0.0])
     E.set_grid_unit_SI(1.0)
     E.set_axis_labels(["r", "z"])
-    E.set_unit_dimension({api.Unit_Dimension.I: 1.0,
-                          api.Unit_Dimension.J: 2.0})
+    E.set_unit_dimension({io.Unit_Dimension.I: 1.0,
+                          io.Unit_Dimension.J: 2.0})
 
     # write components: E_z, E_r, E_t
     E_z = E["z"]
     E_z.set_unit_SI(10.)
     # E_z.set_position([0.0, 0.5])  # TODO add me
     #   (modes, r, z) see set_geometry_parameters
-    E_z.reset_dataset(api.Dataset(api.Datatype.FLOAT, [num_fields, N_r, N_z]))
+    E_z.reset_dataset(io.Dataset(io.Datatype.FLOAT, [num_fields, N_r, N_z]))
     E_z.make_constant(42.54)
 
     # write all modes at once (otherwise iterate over modes and first index
     E_r = E["r"]
     E_r.set_unit_SI(10.)
     # E_r.set_position([0.5, 0.0])  # TOOD add me
-    E_r.reset_dataset(api.Dataset(E_r_data.dtype, E_r_data.shape))
+    E_r.reset_dataset(io.Dataset(E_r_data.dtype, E_r_data.shape))
     E_r.store_chunk(E_r_data)
 
     E_t = E["t"]
     E_t.set_unit_SI(10.)
     # E_t.set_position([0.0, 0.0])  # TODO add me
-    E_t.reset_dataset(api.Dataset(E_t_data.dtype, E_t_data.shape))
+    E_t.reset_dataset(io.Dataset(E_t_data.dtype, E_t_data.shape))
     E_t.store_chunk(E_t_data)
 
     series.flush()

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -6,7 +6,7 @@ Authors: Axel Huebl, Carsten Fortmann-Grote
 License: LGPLv3+
 """
 
-import openpmd_api as api
+import openpmd_api as io
 
 import os
 import shutil
@@ -46,10 +46,10 @@ class APITest(unittest.TestCase):
                 os.path.join("issue-sample", "no_fields", "data%T.h5"))
         path_to_data = generateTestFilePath(
                 os.path.join("git-sample", "data%T.h5"))
-        mode = api.Access_Type.read_only
-        self.__field_series = api.Series(path_to_field_data, mode)
-        self.__particle_series = api.Series(path_to_particle_data, mode)
-        self.__series = api.Series(path_to_data, mode)
+        mode = io.Access_Type.read_only
+        self.__field_series = io.Series(path_to_field_data, mode)
+        self.__particle_series = io.Series(path_to_particle_data, mode)
+        self.__series = io.Series(path_to_data, mode)
 
     def tearDown(self):
         """ Tearing down a test. """
@@ -108,9 +108,9 @@ class APITest(unittest.TestCase):
 
     def attributeRoundTrip(self, file_ending):
         # write
-        series = api.Series(
+        series = io.Series(
             "unittest_py_API." + file_ending,
-            api.Access_Type.create
+            io.Access_Type.create
         )
 
         # meta data
@@ -206,9 +206,9 @@ class APITest(unittest.TestCase):
         del series
 
         # read back
-        series = api.Series(
+        series = io.Series(
             "unittest_py_API." + file_ending,
-            api.Access_Type.read_only
+            io.Access_Type.read_only
         )
 
         self.assertEqual(series.get_attribute("char"), "c")
@@ -300,21 +300,21 @@ class APITest(unittest.TestCase):
             'hdf5': 'h5',
             'adios1': 'bp'
         }
-        for b in api.variants:
-            if api.variants[b] is True and b in backend_filesupport:
+        for b in io.variants:
+            if io.variants[b] is True and b in backend_filesupport:
                 self.attributeRoundTrip(backend_filesupport[b])
 
     def makeConstantRoundTrip(self, file_ending):
         # write
-        series = api.Series(
+        series = io.Series(
             "unittest_py_constant_API." + file_ending,
-            api.Access_Type.create
+            io.Access_Type.create
         )
 
         ms = series.iterations[0].meshes
-        SCALAR = api.Mesh_Record_Component.SCALAR
-        DS = api.Dataset
-        DT = api.Datatype
+        SCALAR = io.Mesh_Record_Component.SCALAR
+        DS = io.Dataset
+        DT = io.Datatype
 
         extent = [42, 24, 11]
 
@@ -355,9 +355,9 @@ class APITest(unittest.TestCase):
         del series
 
         # read back
-        series = api.Series(
+        series = io.Series(
             "unittest_py_constant_API." + file_ending,
-            api.Access_Type.read_only
+            io.Access_Type.read_only
         )
 
         ms = series.iterations[0].meshes
@@ -414,8 +414,8 @@ class APITest(unittest.TestCase):
             'hdf5': 'h5',
             'adios1': 'bp'
         }
-        for b in api.variants:
-            if api.variants[b] is True and b in backend_filesupport:
+        for b in io.variants:
+            if io.variants[b] is True and b in backend_filesupport:
                 self.makeConstantRoundTrip(backend_filesupport[b])
 
     def testData(self):
@@ -423,7 +423,7 @@ class APITest(unittest.TestCase):
 
         # Get series.
         series = self.__series
-        self.assertIsInstance(series, api.Series)
+        self.assertIsInstance(series, io.Series)
 
         self.assertEqual(series.openPMD, "1.1.0")
 
@@ -435,7 +435,7 @@ class APITest(unittest.TestCase):
         # Check type.
         self.assertTrue(400 in series.iterations)
         i = series.iterations[400]
-        self.assertIsInstance(i, api.Iteration)
+        self.assertIsInstance(i, io.Iteration)
         with self.assertRaises(TypeError):
             series.iterations[-1]
         with self.assertRaises(IndexError):
@@ -451,7 +451,7 @@ class APITest(unittest.TestCase):
 
         # Get a mesh.
         E = i.meshes["E"]
-        self.assertIsInstance(E, api.Mesh)
+        self.assertIsInstance(E, io.Mesh)
 
         self.assertEqual(len(i.particles), 1)
         for ps in i.particles:
@@ -459,9 +459,9 @@ class APITest(unittest.TestCase):
 
         # Get a particle species.
         electrons = i.particles["electrons"]
-        self.assertIsInstance(electrons, api.ParticleSpecies)
+        self.assertIsInstance(electrons, io.ParticleSpecies)
         pos_y = electrons["position"]["y"]
-        w = electrons["weighting"][api.Record_Component.SCALAR]
+        w = electrons["weighting"][io.Record_Component.SCALAR]
         assert pos_y.dtype == np.double
         assert w.dtype == np.double
 
@@ -530,7 +530,7 @@ class APITest(unittest.TestCase):
 
         # Get series.
         series = self.__series
-        self.assertIsInstance(series, api.Series)
+        self.assertIsInstance(series, io.Series)
 
         self.assertEqual(series.openPMD, "1.1.0")
 
@@ -539,12 +539,12 @@ class APITest(unittest.TestCase):
 
         # Get series.
         series = self.__series
-        self.assertRaises(TypeError, api.list_series)
-        api.list_series(series)
-        api.list_series(series, False)
-        api.list_series(series, True)
+        self.assertRaises(TypeError, io.list_series)
+        io.list_series(series)
+        io.list_series(series, False)
+        io.list_series(series, True)
 
-        print(api.list_series.__doc__)
+        print(io.list_series.__doc__)
 
     def testSliceRead(self):
         """ Testing sliced read on record components. """
@@ -566,7 +566,7 @@ class APITest(unittest.TestCase):
         # Get some record components
         E_x = E["x"]
         pos_y = electrons["position"]["y"]
-        w = electrons["weighting"][api.Record_Component.SCALAR]
+        w = electrons["weighting"][io.Record_Component.SCALAR]
 
         if found_numpy:
             np.testing.assert_allclose(electrons["position"].unit_dimension,
@@ -849,8 +849,8 @@ class APITest(unittest.TestCase):
             'hdf5': 'h5',
             'adios1': 'bp'
         }
-        for b in api.variants:
-            if api.variants[b] is True and b in backend_filesupport:
+        for b in io.variants:
+            if io.variants[b] is True and b in backend_filesupport:
                 self.backend_write_slices(backend_filesupport[b])
 
     def backend_write_slices(self, file_ending):
@@ -860,9 +860,9 @@ class APITest(unittest.TestCase):
             return
 
         # get series
-        series = api.Series(
+        series = io.Series(
             "unittest_py_slice_API." + file_ending,
-            api.Access_Type.create
+            io.Access_Type.create
         )
         i = series.iterations[0]
 
@@ -884,9 +884,9 @@ class APITest(unittest.TestCase):
         more_axes = np.ascontiguousarray(more_axes)
 
         # get a mesh record component
-        rho = i.meshes["rho"][api.Record_Component.SCALAR]
+        rho = i.meshes["rho"][io.Record_Component.SCALAR]
 
-        rho.reset_dataset(api.Dataset(data.dtype, data.shape))
+        rho.reset_dataset(io.Dataset(data.dtype, data.shape))
 
         # normal write
         rho[()] = data
@@ -930,16 +930,16 @@ class APITest(unittest.TestCase):
         series = self.__series
 
         # Loop over iterations.
-        self.assertIsInstance(series.iterations, api.Iteration_Container)
+        self.assertIsInstance(series.iterations, io.Iteration_Container)
         self.assertTrue(hasattr(series.iterations, "__getitem__"))
         for i in series.iterations:
             # self.assertIsInstance(i, int)
-            self.assertIsInstance(series.iterations[i], api.Iteration)
+            self.assertIsInstance(series.iterations[i], io.Iteration)
 
         # Check type.
         self.assertTrue(100 in series.iterations)
         i = series.iterations[100]
-        self.assertIsInstance(i, api.Iteration)
+        self.assertIsInstance(i, io.Iteration)
 
     def testMeshes(self):
         """ Test querying a mesh. """
@@ -954,7 +954,7 @@ class APITest(unittest.TestCase):
         self.assertTrue(hasattr(i.meshes, "__getitem__"))
         for m in i.meshes:
             # self.assertIsInstance(m, str)
-            self.assertIsInstance(i.meshes[m], api.Mesh)
+            self.assertIsInstance(i.meshes[m], io.Mesh)
 
     def testParticles(self):
         """ Test querying a particle species. """
@@ -968,45 +968,45 @@ class APITest(unittest.TestCase):
         self.assertTrue(hasattr(i.particles, "__getitem__"))
         for ps in i.particles:
             # self.assertIsInstance(ps, str)
-            self.assertIsInstance(i.particles[ps], api.ParticleSpecies)
+            self.assertIsInstance(i.particles[ps], io.ParticleSpecies)
 
     def testData_Order(self):
         """ Test Data_Order. """
-        obj = api.Data_Order('C')
+        obj = io.Data_Order('C')
         del obj
 
     def testDatatype(self):
         """ Test Datatype. """
-        data_type = api.Datatype(1)
+        data_type = io.Datatype(1)
         del data_type
 
     def testDataset(self):
         """ Test Dataset. """
-        data_type = api.Datatype.LONG
+        data_type = io.Datatype.LONG
         extent = [1, 1, 1]
-        obj = api.Dataset(data_type, extent)
+        obj = io.Dataset(data_type, extent)
         if found_numpy:
             d = np.array((1, 1, 1, ), dtype=np.int_)
-            obj2 = api.Dataset(d.dtype, d.shape)
-            assert data_type == api.determine_datatype(d.dtype)
+            obj2 = io.Dataset(d.dtype, d.shape)
+            assert data_type == io.determine_datatype(d.dtype)
             assert obj2.dtype == obj.dtype
             assert obj2.dtype == obj.dtype
         del obj
 
     def testGeometry(self):
         """ Test Geometry. """
-        obj = api.Geometry(0)
+        obj = io.Geometry(0)
         del obj
 
     def testIteration(self):
         """ Test Iteration. """
-        self.assertRaises(TypeError, api.Iteration)
+        self.assertRaises(TypeError, io.Iteration)
 
         iteration = self.__particle_series.iterations[400]
 
         # just a shallow copy "alias"
-        copy_iteration = api.Iteration(iteration)
-        self.assertIsInstance(copy_iteration, api.Iteration)
+        copy_iteration = io.Iteration(iteration)
+        self.assertIsInstance(copy_iteration, io.Iteration)
 
         # TODO open as readwrite
         # TODO verify copy and source are identical
@@ -1015,30 +1015,30 @@ class APITest(unittest.TestCase):
 
     def testIteration_Encoding(self):
         """ Test Iteration_Encoding. """
-        obj = api.Iteration_Encoding(1)
+        obj = io.Iteration_Encoding(1)
         del obj
 
     def testMesh(self):
         """ Test Mesh. """
-        self.assertRaises(TypeError, api.Mesh)
+        self.assertRaises(TypeError, io.Mesh)
         mesh = self.__series.iterations[100].meshes['E']
-        copy_mesh = api.Mesh(mesh)
+        copy_mesh = io.Mesh(mesh)
 
-        self.assertIsInstance(copy_mesh, api.Mesh)
+        self.assertIsInstance(copy_mesh, io.Mesh)
 
     def testMesh_Container(self):
         """ Test Mesh_Container. """
-        self.assertRaises(TypeError, api.Mesh_Container)
+        self.assertRaises(TypeError, io.Mesh_Container)
 
     def backend_particle_patches(self, file_ending):
-        DS = api.Dataset
-        SCALAR = api.Record_Component.SCALAR
+        DS = io.Dataset
+        SCALAR = io.Record_Component.SCALAR
         extent = [123, ]
         num_patches = 2
 
-        series = api.Series(
+        series = io.Series(
             "unittest_py_particle_patches." + file_ending,
-            api.Access_Type.create
+            io.Access_Type.create
         )
         e = series.iterations[42].particles["electrons"]
 
@@ -1081,9 +1081,9 @@ class APITest(unittest.TestCase):
         # read back
         del series
 
-        series = api.Series(
+        series = io.Series(
             "unittest_py_particle_patches." + file_ending,
-            api.Access_Type.read_only
+            io.Access_Type.read_only
         )
         e = series.iterations[42].particles["electrons"]
 
@@ -1111,49 +1111,49 @@ class APITest(unittest.TestCase):
             offset_y, [0., 0.])
 
     def testParticlePatches(self):
-        self.assertRaises(TypeError, api.Particle_Patches)
+        self.assertRaises(TypeError, io.Particle_Patches)
 
         backend_filesupport = {
             'json': 'json',
             'hdf5': 'h5',
             'adios1': 'bp'
         }
-        for b in api.variants:
-            if api.variants[b] is True and b in backend_filesupport:
+        for b in io.variants:
+            if io.variants[b] is True and b in backend_filesupport:
                 self.backend_particle_patches(backend_filesupport[b])
 
     def testParticleSpecies(self):
         """ Test ParticleSpecies. """
-        self.assertRaises(TypeError, api.ParticleSpecies)
+        self.assertRaises(TypeError, io.ParticleSpecies)
 
     def testParticle_Container(self):
         """ Test Particle_Container. """
-        self.assertRaises(TypeError, api.Particle_Container)
+        self.assertRaises(TypeError, io.Particle_Container)
 
     def testRecord(self):
         """ Test Record. """
         # Has only copy constructor.
-        self.assertRaises(TypeError, api.Record)
+        self.assertRaises(TypeError, io.Record)
 
         # Get a record.
         electrons = self.__series.iterations[400].particles['electrons']
         position = electrons['position']
-        self.assertIsInstance(position, api.Record)
+        self.assertIsInstance(position, io.Record)
         x = position['x']
-        self.assertIsInstance(x, api.Record_Component)
+        self.assertIsInstance(x, io.Record_Component)
 
         # Copy.
-        # copy_record = api.Record(position)
-        # copy_record_component = api.Record(x)
+        # copy_record = io.Record(position)
+        # copy_record_component = io.Record(x)
 
         # Check.
-        # self.assertIsInstance(copy_record, api.Record)
+        # self.assertIsInstance(copy_record, io.Record)
         # self.assertIsInstance(copy_record_component,
-        #                       api.Record_Component)
+        #                       io.Record_Component)
 
     def testRecord_Component(self):
         """ Test Record_Component. """
-        self.assertRaises(TypeError, api.Record_Component)
+        self.assertRaises(TypeError, io.Record_Component)
 
     def testFieldRecord(self):
         """ Test querying for a non-scalar field record. """
@@ -1161,7 +1161,7 @@ class APITest(unittest.TestCase):
         E = self.__series.iterations[100].meshes["E"]
         Ex = E["x"]
 
-        self.assertIsInstance(Ex, api.Mesh_Record_Component)
+        self.assertIsInstance(Ex, io.Mesh_Record_Component)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Use "io" instead of "api" as namespace alias in Python and C++.