### PR TITLE
Add particle info in serial example read

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,7 @@ Other
 - safer internal ``*dynamic_cast``s of pointers #745
 - CMake: subproject inclusion cleanup #751
 - Python: remove redundant move in container #753
+- read example: show particle load #706
 
 
 0.11.1-alpha

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -56,8 +56,8 @@ int main()
         }
     }
 
-    std::pair<std::string,openPMD::ParticleSpecies> s_e = *i.particles.begin();
-    std::pair<std::string,openPMD::Record> s_c = *s_e.second.begin();
+    std::pair<std::string, openPMD::ParticleSpecies> s_e = *i.particles.begin();
+    std::pair<std::string, openPMD::Record> s_c = *s_e.second.begin();
     auto charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<double>().get()[0];
     cout << "And first particle in particle species " << s_e.first
          << " has " << s_c.first << " = " << charge.get()[0];

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -59,7 +59,8 @@ int main()
     std::pair<std::string,openPMD::ParticleSpecies> s_e = *i.particles.begin();
     std::pair<std::string,openPMD::Record> s_c = *s_e.second.begin();
     auto charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<double>().get()[0];
-    cout << "And " << s_c.first << " = " << charge;
+    cout << "And first particle in particle species " << s_e.first
+         << " has " << s_c.first << " = " << charge.get()[0];
     cout << '\n';
 
     MeshRecordComponent E_x = i.meshes["E"]["x"];

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -58,6 +58,7 @@ int main()
 
     openPMD::ParticleSpecies electrons = i.particles["electrons"];
     std::shared_ptr<double> charge = electrons["charge"][openPMD::RecordComponent::SCALAR].loadChunk<double>();
+    series.flush();
     cout << "And the first electron particle has a charge = " << charge.get()[0];
     cout << '\n';
 

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -55,7 +55,7 @@ int main()
             cout << '\n';
         }
     }
-    
+
     std::pair<std::string,openPMD::ParticleSpecies> s_e = *i.particles.begin();
     std::pair<std::string,openPMD::Record> s_c = *s_e.second.begin();
     auto charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<double>().get()[0];

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -58,7 +58,7 @@ int main()
     
     std::pair<std::string,openPMD::ParticleSpecies> s_e = *i.particles.begin();
     std::pair<std::string,openPMD::Record> s_c = *s_e.second.begin();
-    auto charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<amrex::Real>().get()[0];
+    auto charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<double>().get()[0];
     cout << "And " << s_c.first << " = " << charge;
     cout << '\n';
 

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -58,7 +58,7 @@ int main()
 
     std::pair<std::string, openPMD::ParticleSpecies> s_e = *i.particles.begin();
     std::pair<std::string, openPMD::Record> s_c = *s_e.second.begin();
-    auto charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<double>().get()[0];
+    std::shared_ptr< double > charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<double>();
     cout << "And first particle in particle species " << s_e.first
          << " has " << s_c.first << " = " << charge.get()[0];
     cout << '\n';

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -50,7 +50,7 @@ int main()
     cout << "Iteration 100 contains " << i.particles.size() << " particle species:";
     for( auto const& ps : i.particles ) {
         cout << "\n\t" << ps.first;
-        for( auto const& r : ps.second ){
+        for( auto const& r : ps.second ) {
             cout << "\n\t" << r.first;
             cout << '\n';
         }

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -48,7 +48,7 @@ int main()
         cout << "\n\t" << m.first;
     cout << '\n';
     cout << "Iteration 100 contains " << i.particles.size() << " particle species:";
-    for( auto const& ps : i.particles ){
+    for( auto const& ps : i.particles ) {
         cout << "\n\t" << ps.first;
         for( auto const& r : ps.second ){
             cout << "\n\t" << r.first;

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -56,11 +56,9 @@ int main()
         }
     }
 
-    std::pair<std::string, openPMD::ParticleSpecies> s_e = *i.particles.begin();
-    std::pair<std::string, openPMD::Record> s_c = *s_e.second.begin();
-    std::shared_ptr< double > charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<double>();
-    cout << "And first particle in particle species " << s_e.first
-         << " has " << s_c.first << " = " << charge.get()[0];
+    openPMD::ParticleSpecies electrons = i.particles["electrons"];
+    std::shared_ptr<double> charge = electrons["charge"][openPMD::RecordComponent::SCALAR].loadChunk<double>();
+    cout << "And the first electron particle has a charge = " << charge.get()[0];
     cout << '\n';
 
     MeshRecordComponent E_x = i.meshes["E"]["x"];

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -48,8 +48,18 @@ int main()
         cout << "\n\t" << m.first;
     cout << '\n';
     cout << "Iteration 100 contains " << i.particles.size() << " particle species:";
-    for( auto const& ps : i.particles )
+    for( auto const& ps : i.particles ){
         cout << "\n\t" << ps.first;
+        for( auto const& r : ps.second ){
+            cout << "\n\t" << r.first;
+            cout << '\n';
+        }
+    }
+    
+    std::pair<std::string,openPMD::ParticleSpecies> s_e = *i.particles.begin();
+    std::pair<std::string,openPMD::Record> s_c = *s_e.second.begin();
+    auto charge = s_c.second[openPMD::RecordComponent::SCALAR].loadChunk<amrex::Real>().get()[0];
+    cout << "And " << s_c.first << " = " << charge;
     cout << '\n';
 
     MeshRecordComponent E_x = i.meshes["E"]["x"];

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     # printing a scalar value
     electrons = i.particles["electrons"]
-    charge = electrons["charge][openpmd_api.Mesh_Record_Component.SCALAR]
+    charge = electrons["charge"][openpmd_api.Mesh_Record_Component.SCALAR]
     print("And the first electron particle has a charge {}"
           .format(charge[0]))
     print("")

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -34,8 +34,8 @@ if __name__ == "__main__":
             print("\t {0}".format(r))
 
     # printing a scalar value
-    s_e=[ps for ps in i.particles][0]
-    s_c=[r for r in i.particles[s_e]][0]
+    s_e = [ps for ps in i.particles][0]
+    s_c = [r for r in i.particles[s_e]][0]
     charge=i.particles[s_e][s_c][openpmd_api.Mesh_Record_Component.SCALAR][0]
     print("And ", s_c, " = ", charge)
     print("")

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -34,11 +34,10 @@ if __name__ == "__main__":
             print("\t {0}".format(r))
 
     # printing a scalar value
-    s_e = [ps for ps in i.particles][0]
-    s_c = [r for r in i.particles[s_e]][0]
-    charge=i.particles[s_e][s_c][openpmd_api.Mesh_Record_Component.SCALAR][0]
-    print("And first particle in particle species {0} has {1} = {2}"
-          .format(s_e, s_c, charge))
+    electrons = i.particles["electrons"]
+    charge = electrons["charge][openpmd_api.Mesh_Record_Component.SCALAR]
+    print("And the first electron particle has a charge {}"
+          .format(charge[0]))
     print("")
 
     E_x = i.meshes["E"]["x"]

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     # printing a scalar value
     s_e=[ps for ps in i.particles][0]
-    s_c=[r for r in i.particles[s_electrons]][0]
+    s_c=[r for r in i.particles[s_e]][0]
     charge=i.particles[s_e][s_c][openpmd_api.Mesh_Record_Component.SCALAR][0]
     print("And ", s_c, " = ",charge)
     print("")

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     s_e=[ps for ps in i.particles][0]
     s_c=[r for r in i.particles[s_e]][0]
     charge=i.particles[s_e][s_c][openpmd_api.Mesh_Record_Component.SCALAR][0]
-    print("And ", s_c, " = ",charge)
+    print("And ", s_c, " = ", charge)
     print("")
 
     E_x = i.meshes["E"]["x"]

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -37,7 +37,8 @@ if __name__ == "__main__":
     s_e = [ps for ps in i.particles][0]
     s_c = [r for r in i.particles[s_e]][0]
     charge=i.particles[s_e][s_c][openpmd_api.Mesh_Record_Component.SCALAR][0]
-    print("And ", s_c, " = ", charge)
+    print("And first particle in particle species {0} has {1} = {2}"
+          .format(s_e, s_c, charge))
     print("")
 
     E_x = i.meshes["E"]["x"]

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         print("With records:")
         for r in i.particles[ps]:
             print("\t {0}".format(r))
-    
+
     # printing a scalar value
     s_e=[ps for ps in i.particles][0]
     s_c=[r for r in i.particles[s_electrons]][0]

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     # printing a scalar value
     electrons = i.particles["electrons"]
-    charge = electrons["charge"][openpmd_api.Mesh_Record_Component.SCALAR]
+    charge = electrons["charge"][io.Mesh_Record_Component.SCALAR]
     series.flush()
     print("And the first electron particle has a charge {}"
           .format(charge[0]))

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
     # printing a scalar value
     electrons = i.particles["electrons"]
     charge = electrons["charge"][openpmd_api.Mesh_Record_Component.SCALAR]
+    series.flush()
     print("And the first electron particle has a charge {}"
           .format(charge[0]))
     print("")

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -29,6 +29,15 @@ if __name__ == "__main__":
         len(i.particles)))
     for ps in i.particles:
         print("\t {0}".format(ps))
+        print("With records:")
+        for r in i.particles[ps]:
+            print("\t {0}".format(r))
+    
+    # printing a scalar value
+    s_e=[ps for ps in i.particles][0]
+    s_c=[r for r in i.particles[s_electrons]][0]
+    charge=i.particles[s_e][s_c][openpmd_api.Mesh_Record_Component.SCALAR][0]
+    print("And ", s_c, " = ",charge)
     print("")
 
     E_x = i.meshes["E"]["x"]


### PR DESCRIPTION
Hi all,
This mini PR is just to add the option of reading a scalar from a `ParticleSpecies Record` (as an example) in the files:

- **examples/2_read_serial.cpp**
- **examples/2_read_serial.py**

I think it is very useful to add it because it can really help the new users (such as myself) understand it better.

I am not sure if this is the more clean/elegant way to show how to do that to new users.
Or even if these changes should be added instead to the Docs first read entry. 
What do you think?

ps: I am having a minor issue testing the cpp file (hence the WIP).

Thanks again for openPMD!
Diana