### PR TITLE
Catch Throw in Series Ctor/Dtor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Features
 Bug Fixes
 """""""""
 
+- ``flush()`` exceptions in ``~Series``/``~..IOHandler`` do not abort anymore #709
+
 Other
 """""
 

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -31,7 +31,9 @@
 #include "openPMD/backend/Writable.hpp"
 
 #include <array>
+#include <exception>
 #include <future>
+#include <iostream>
 #include <memory> // shared_ptr
 #include <string>
 #include <unordered_map>
@@ -643,7 +645,19 @@ private:
 public:
     ~ADIOS2IOHandler( ) override
     {
-        this->flush( );
+        // we must not throw in a destructor
+        try
+        {
+            this->flush( );
+        }
+        catch( std::exception const & ex )
+        {
+            std::cerr << "[~ADIOS2IOHandler] An error occurred: " << ex.what() << std::endl;
+        }
+        catch( ... )
+        {
+            std::cerr << "[~ADIOS2IOHandler] An error occurred." << std::endl;
+        }
     }
 
 #else

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -26,6 +26,9 @@
 #include "openPMD/Datatype.hpp"
 #include "openPMD/IO/JSON/JSONIOHandlerImpl.hpp"
 
+#include <exception>
+#include <iostream>
+
 
 namespace openPMD
 {
@@ -45,7 +48,19 @@ namespace openPMD
 
     JSONIOHandlerImpl::~JSONIOHandlerImpl( )
     {
-        flush( );
+        // we must not throw in a destructor
+        try
+        {
+            flush( );
+        }
+        catch( std::exception const & ex )
+        {
+            std::cerr << "[~JSONIOHandlerImpl] An error occurred: " << ex.what() << std::endl;
+        }
+        catch( ... )
+        {
+            std::cerr << "[~JSONIOHandlerImpl] An error occurred." << std::endl;
+        }
     }
 
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -26,6 +26,7 @@
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/Series.hpp"
 
+#include <exception>
 #include <iomanip>
 #include <iostream>
 #include <set>
@@ -104,7 +105,19 @@ Series::Series(std::string const& filepath,
 
 Series::~Series()
 {
-    flush();
+    // we must not throw in a destructor
+    try
+    {
+        flush();
+    }
+    catch( std::exception const & ex )
+    {
+        std::cerr << "[~Series] An error occurred: " << ex.what() << std::endl;
+    }
+    catch( ... )
+    {
+        std::cerr << "[~Series] An error occurred." << std::endl;
+    }
 }
 
 std::string

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1092,6 +1092,25 @@ TEST_CASE( "deletion_test", "[serial]" )
 }
 
 inline
+void read_missing_throw_test(const std::string & backend)
+{
+    try
+    {
+        auto s = Series("this/does/definitely/not/exist." + backend, AccessType::READ_ONLY);
+    }
+    catch( ... )
+    {
+        std::cout << "read missing: successfully caught! " << backend << std::endl;
+    }
+}
+
+TEST_CASE( "read_missing_throw_test", "[serial]" )
+{
+    for (auto const & t: backends)
+        read_missing_throw_test(std::get<0>(t));
+}
+
+inline
 void optional_paths_110_test(const std::string & backend)
 {
     try


### PR DESCRIPTION
Destructors must not throw, which would abort e.g. if `flush()` reports a late problem in `~Series` or a backend's `~...IOHandler`.
Constructors can throw, but we must be able to catch this.

Typical problem: read-only opening of non-existent files throws in Ctor as it flushes all reads.