### PR TITLE
MeshRecordComponent: Python position

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Features
 """"""""
 
 - ``Record(Component)``: ``scalar()``, ``constant()``, ``empty()`` #711
+- ``MeshRecordComponent``: add ``position`` read-write property #713
 
 Bug Fixes
 """""""""

--- a/examples/3a_write_thetaMode_serial.py
+++ b/examples/3a_write_thetaMode_serial.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     # write components: E_z, E_r, E_t
     E_z = E["z"]
     E_z.set_unit_SI(10.)
-    # E_z.set_position([0.0, 0.5])  # TODO add me
+    E_z.position = [0.0, 0.5]
     #   (modes, r, z) see set_geometry_parameters
     E_z.reset_dataset(io.Dataset(io.Datatype.FLOAT, [num_fields, N_r, N_z]))
     E_z.make_constant(42.54)
@@ -53,13 +53,13 @@ if __name__ == "__main__":
     # write all modes at once (otherwise iterate over modes and first index
     E_r = E["r"]
     E_r.set_unit_SI(10.)
-    # E_r.set_position([0.5, 0.0])  # TOOD add me
+    E_r.position = [0.5, 0.0]
     E_r.reset_dataset(io.Dataset(E_r_data.dtype, E_r_data.shape))
     E_r.store_chunk(E_r_data)
 
     E_t = E["t"]
     E_t.set_unit_SI(10.)
-    # E_t.set_position([0.0, 0.0])  # TODO add me
+    E_t.position = [0.0, 0.0]
     E_t.reset_dataset(io.Dataset(E_t_data.dtype, E_t_data.shape))
     E_t.store_chunk(E_t_data)
 

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -46,11 +46,34 @@ private:
 public:
     ~MeshRecordComponent() override = default;
 
+    /** Position on an element
+     *
+     * Relative on an element (node/cell/voxel) of the mesh
+     *
+     * @return relative position within range of [0.0:1.0)
+     */
     template< typename T >
     std::vector< T > position() const;
-    template< typename T >
-    MeshRecordComponent& setPosition(std::vector< T >);
 
+    /** Position on an element
+     *
+     * Relative on an element (node/cell/voxel) of the mesh
+     *
+     * @param[in] pos relative position in range [0.0:1.0)
+     */
+    template< typename T >
+    MeshRecordComponent& setPosition(std::vector< T > pos);
+
+    /** Create a dataset with regular extent and constant value
+     *
+     * In a constant record component, the value for each date in its extent is
+     * the same. Implemented by storing only a constant value as meta-data.
+     *
+     * @see RecordComponent::makeConstant
+     *
+     * @tparam T type of the stored value
+     * @return A reference to this RecordComponent.
+     */
     template< typename T >
     MeshRecordComponent& makeConstant(T);
 };
@@ -68,4 +91,4 @@ MeshRecordComponent::makeConstant(T value)
     RecordComponent::makeConstant(value);
     return *this;
 }
-} // openPMD
+} // namespace openPMD

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -39,6 +39,18 @@ void init_MeshRecordComponent(py::module &m) {
             }
         )
 
-        // @todo add position
+        .def_property("position",
+            &MeshRecordComponent::position<float>,
+            &MeshRecordComponent::setPosition<float>,
+            "Relative position of the component on an element (node/cell/voxel) of the mesh")
+        .def_property("position",
+            &MeshRecordComponent::position<double>,
+            &MeshRecordComponent::setPosition<double>,
+            "Relative position of the component on an element (node/cell/voxel) of the mesh")
+        .def_property("position",
+            &MeshRecordComponent::position<long double>,
+            &MeshRecordComponent::setPosition<long double>,
+            "Relative position of the component on an element (node/cell/voxel) of the mesh")
+
     ;
 }

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -329,6 +329,10 @@ class APITest(unittest.TestCase):
         ms["pybool"][SCALAR].reset_dataset(DS(DT.BOOL, extent))
         ms["pybool"][SCALAR].make_constant(False)
 
+        # staggering meta data
+        ms["pyint"][SCALAR].position = [0.25, 0.5]
+        ms["pyfloat"][SCALAR].position = [0.5, 0.75]
+
         self.assertTrue(ms["char"][SCALAR].constant)
         self.assertTrue(ms["pyint"][SCALAR].constant)
         self.assertTrue(ms["pyfloat"][SCALAR].constant)
@@ -387,6 +391,12 @@ class APITest(unittest.TestCase):
             self.assertEqual(ms["pybool"][SCALAR].load_chunk(o, e), False)
 
         if found_numpy:
+            # staggering meta data
+            np.testing.assert_allclose(ms["pyint"][SCALAR].position,
+                                       [0.25, 0.5])
+            np.testing.assert_allclose(ms["pyfloat"][SCALAR].position,
+                                       [0.5, 0.75])
+
             self.assertTrue(ms["int16"].scalar)
             self.assertTrue(ms["int32"].scalar)
             self.assertTrue(ms["int64"].scalar)
@@ -530,6 +540,8 @@ class APITest(unittest.TestCase):
         if found_numpy:
             np.testing.assert_allclose(E.unit_dimension,
                                        [1., 1., -3., -1., 0., 0., 0.])
+            np.testing.assert_allclose(E_x.position,
+                                       [0.5, 0., 0.])
         self.assertAlmostEqual(E_x.unit_SI, 1.0)
 
         self.assertSequenceEqual(shape, [26, 26, 201])
@@ -926,6 +938,7 @@ class APITest(unittest.TestCase):
 
         # get a mesh record component
         rho = i.meshes["rho"][io.Record_Component.SCALAR]
+        rho.position = [0., 0.]  # Yee staggered
 
         rho.reset_dataset(io.Dataset(data.dtype, data.shape))
 


### PR DESCRIPTION
Add the position property to the python bindings of `MeshRecordComponent`.