### PR TITLE
Wheels: Cleanup, Prep. i686 and aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,9 @@ jobs:
         CIBW_SKIP: cp27-* pp27-* *-win32 *-manylinux_i686 *win*
         # Install dependencies on Linux and OSX
         CIBW_BEFORE_BUILD: bash -x .github/library_builders.sh
-        # CMake shall search for static dependencies of HDF5 and ADIOS1
-        HDF5_USE_STATIC_LIBRARIES: ON
-        ADIOS_USE_STATIC_LIBS: ON
+        # for the openPMD-api build, CMake shall search for
+        # static dependencies of HDF5 and ADIOS1 (see setup.py)
+        CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' ADIOS_USE_STATIC_LIBS='ON'
       run: |
         cd src
         python setup.py sdist --dist-dir ../wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ env:
 jobs:
   include:
     # perform a linux ARMv8 build
-    # blocked by https://github.com/ornladios/ADIOS2/issues/2137
-    # - services: docker
-    #   arch: aarch64
+    - services: docker
+      arch: aarch64
 
     # perform a linux PPC64LE build
     # blocked by https://github.com/pypa/auditwheel/issues/36

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,45 @@ branches:
 
 env:
   global:
+    - OPENPMD_GIT_REF="0.11.1-alpha"
+
     # (1,2) Skip building for Python 2.7 on all platforms
-    - CIBW_SKIP="cp27-* pp27-*"
+    # (3) GNU 7.3.1 & MPark.Variant 1.4.0 on i686:
+    #     https://github.com/pypa/manylinux/issues/543
+    #       variant.hpp:2241:9: internal compiler error:
+    #       unexpected expression ‘I’ of kind template_parm_index
+    #       typename T = lib::type_pack_element_t<I, Ts...>,
+    - CIBW_SKIP="cp27-* pp27-* *-manylinux_i686"
     # Install dependencies on Linux and OSX
     - CIBW_BEFORE_BUILD="bash -x .github/library_builders.sh"
+    # for the openPMD-api build, CMake shall search for
+    # static dependencies of HDF5 and ADIOS1 (see setup.py)
+    - CIBW_ENVIRONMENT="HDF5_USE_STATIC_LIBRARIES='ON' ADIOS_USE_STATIC_LIBS='ON'"
 
 jobs:
   include:
     # perform a linux ARMv8 build
-    - services: docker
-      arch: aarch64
+    # blocked by https://github.com/scikit-build/cmake-python-distributions/issues/96
+    #            https://github.com/pypa/manylinux/issues/544
+    # - services: docker
+    #   arch: arm64
+    #   env:
+    #     - CIBW_BUILD="*_aarch64"
 
     # perform a linux PPC64LE build
     # blocked by https://github.com/pypa/auditwheel/issues/36
     #            https://github.com/pypa/auditwheel/pull/213
     # - services: docker
     #   arch: ppc64le
+    #  env:
+    #    - CIBW_BUILD="*_ppc64le"
 
     # perform a linux S390X build
     # blocked by https://github.com/GTkorvo/dill/issues/15
     # - services: docker
     #   arch: s390x
+    #  env:
+    #    - CIBW_BUILD="*_s390x"
 
     # and a build for old macOS versions (10.13 with xcode9.4.1 ~2017)
     - os: osx
@@ -35,7 +53,7 @@ jobs:
       python: 3.6
 
 install:
-  - git clone --branch 0.11.1-alpha --depth 1 https://github.com/openPMD/openPMD-api.git src
+  - git clone --branch ${OPENPMD_GIT_REF} --depth 1 https://github.com/openPMD/openPMD-api.git src
   - cp library_builders.sh src/.github/
   - python3 -m pip install cibuildwheel==1.3.0
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -83,6 +83,8 @@ function build_adios2 {
     cd ADIOS2-*
     curl -sLo adios2-static.patch https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/1828.patch
     patch -p1 < adios2-static.patch
+    curl -sLo adios2-i686.patch   https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/2138.patch
+    patch -p1 < adios2-i686.patch
     cd ..
     mkdir build-ADIOS2
     cd build-ADIOS2

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -56,7 +56,10 @@ function build_adios1 {
     if [ -e adios1-stamp ]; then return; fi
     
     # avoid picking up a static libpthread in adios (also: those libs lack -fPIC)
-    # rm /usr/lib64/libpthread.a /usr/lib64/libm.a /usr/lib64/librt.a
+    if [ "$(uname -s)" = "Linux" ]
+    then
+        rm -f /usr/lib64/libpthread.a /usr/lib64/libm.a /usr/lib64/librt.a
+    fi
 
     curl -sLo adios-1.13.1.tar.gz \
         http://users.nccs.gov/~pnorbert/adios-1.13.1.tar.gz
@@ -151,10 +154,6 @@ function build_hdf5 {
 # static libs need relocatable symbols for linking to shared python lib
 export CFLAGS+=" -fPIC"
 export CXXFLAGS+=" -fPIC"
-
-# CMake shall search for static dependencies of HDF5 and ADIOS1
-export HDF5_USE_STATIC_LIBRARIES="ON"
-export ADIOS_USE_STATIC_LIBS="ON"
 
 install_buildessentials
 build_blosc


### PR DESCRIPTION
Fix compilation issue on 32bit Linux with ADIOS 2.5.0. (Verification for https://github.com/ornladios/ADIOS2/pull/2138 .) Since https://github.com/pypa/manylinux/issues/543 is still blocking this, we still have to skip this architecture.

Prepare also aarch64 builds.