### PR TITLE
Python: Add __init__.py Facade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,10 @@ Features
 """"""""
 
 - ``Record(Component)``: ``scalar()``, ``constant()``, ``empty()`` #711
-- ``MeshRecordComponent``: add ``position`` read-write property #713
+- Python:
+
+  - ``__init__.py`` facade #720
+  - add ``Mesh_Record_Component.position`` read-write property #713
 
 Bug Fixes
 """""""""
@@ -35,6 +38,7 @@ Other
   - migrate to GitHub checkout action v2 #712
   - move ``.travis/`` to ``.github/ci/`` #715
   - move example file download scripts to ``share/openPMD/`` #715
+- CD: autodeploy wheels #716 #719
 - ``listSeries``: remove unused parameters in try-catch #706
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,7 +560,7 @@ if(openPMD_HAVE_PYTHON)
 
     if(WIN32)
         set(CMAKE_INSTALL_PYTHONDIR_DEFAULT
-            "${CMAKE_INSTALL_LIBDIR}\\site-packages"
+            "${CMAKE_INSTALL_LIBDIR}/site-packages"
         )
     else()
         set(CMAKE_INSTALL_PYTHONDIR_DEFAULT
@@ -575,13 +575,13 @@ if(openPMD_HAVE_PYTHON)
         CACHE PATH "Build directory for python modules"
     )
     set_target_properties(openPMD.py PROPERTIES
-        ARCHIVE_OUTPUT_NAME openpmd_api
-        LIBRARY_OUTPUT_NAME openpmd_api
-        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
-        PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
-        COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
+        ARCHIVE_OUTPUT_NAME openpmd_api_cxx
+        LIBRARY_OUTPUT_NAME openpmd_api_cxx
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
+        PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
+        COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
     )
 endif()
 
@@ -794,8 +794,14 @@ install(TARGETS ${openPMD_INSTALL_TARGET_NAMES}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 if(openPMD_HAVE_PYTHON)
-    install(TARGETS openPMD.py
+    install(
+        DIRECTORY   ${openPMD_SOURCE_DIR}/src/binding/python/openpmd_api
         DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
+        PATTERN "*pyc" EXCLUDE
+        PATTERN "__pycache__" EXCLUDE
+    )
+    install(TARGETS openPMD.py
+        DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/openpmd_api
     )
 endif()
 install(DIRECTORY "${openPMD_SOURCE_DIR}/include/openPMD"
@@ -963,6 +969,14 @@ if(BUILD_CLI_TOOLS)
     endif()
 endif()
 
+if(openPMD_HAVE_PYTHON)
+    add_custom_command(TARGET openPMD.py POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${openPMD_SOURCE_DIR}/src/binding/python/openpmd_api
+                ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
+    )
+endif()
+
 # Python Examples
 # Current examples all use HDF5, elaborate if other backends are used
 if(openPMD_HAVE_PYTHON AND openPMD_HAVE_HDF5)
@@ -976,6 +990,23 @@ if(openPMD_HAVE_PYTHON AND openPMD_HAVE_HDF5)
             message(STATUS "Note: mpi4py not found. "
                            "Skipping MPI-parallel Python examples.")
         endif()
+
+        #add_test(NAME Module.py.Help
+        #    COMMAND ${PYTHON_EXECUTABLE} -m openpmd-ls --help
+        #    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        #)
+        #if(WIN32)
+        #    set_tests_properties(Module.py.Help
+        #        PROPERTY ENVIRONMENT
+        #            "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
+        #            "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+        #    )
+        #else()
+        #    set_tests_properties(Module.py.Help
+        #        PROPERTIES ENVIRONMENT
+        #            "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+        #    )
+        #endif()
 
         foreach(examplename ${openPMD_PYTHON_EXAMPLE_NAMES})
             add_custom_command(TARGET openPMD.py POST_BUILD

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV        CXXFLAGS="-fPIC ${CXXFLAGS}"
 # install dependencies
 #   CMake, zlib?, HDF5, c-blosc, ADIOS1, ADIOS2
 RUN        yum check-update -y \
-           && yum -y install \
+           ; yum -y install \
                glibc-static \
                tar
 #RUN        curl -sOL https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.tar.gz \
@@ -26,7 +26,8 @@ RUN        yum check-update -y \
 #ENV        PATH=/opt/cmake/bin:${PATH}
 RUN        for PY_TARGET in ${PY_VERSIONS}; do \
                PY_BIN=/opt/python/cp${PY_TARGET:0:2}-cp${PY_TARGET}/bin/python \
-               && ${PY_BIN} -m pip install setuptools cmake; \
+               && ${PY_BIN} -m pip install -U pip               \
+               && ${PY_BIN} -m pip install -U setuptools cmake; \
            done;
 
 RUN        curl -sLo hdf5-1.10.5.tar.gz https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/hdf5-1.10.5.tar.gz \

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ class CMakeBuild(build_ext):
             extdir += os.path.sep
 
         cmake_args = [
-            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' +
+            os.path.join(extdir, "openpmd_api"),
             # '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=' + extdir,
             '-DBUILD_CLI_TOOLS:BOOL=OFF',  # TODO: how to install properly?
             '-DCMAKE_PYTHON_OUTPUT_DIRECTORY=' + extdir,
@@ -161,7 +162,7 @@ setup(
         'Source': 'https://github.com/openPMD/openPMD-api',
         'Tracker': 'https://github.com/openPMD/openPMD-api/issues',
     },
-    ext_modules=[CMakeExtension('openpmd_api')],
+    ext_modules=[CMakeExtension('openpmd_api_cxx')],
     cmdclass=dict(build_ext=CMakeBuild),
     # scripts=['openpmd-ls'],
     zip_safe=False,

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -54,11 +54,11 @@ void init_Series(py::module &);
 void init_UnitDimension(py::module &);
 
 
-PYBIND11_MODULE(openpmd_api, m) {
+PYBIND11_MODULE(openpmd_api_cxx, m) {
     m.doc() = R"pbdoc(
             openPMD-api
             -----------
-            .. currentmodule:: openpmd_api
+            .. currentmodule:: openpmd_api_cxx
 
             .. autosummary::
                :toctree: _generate
@@ -110,6 +110,9 @@ PYBIND11_MODULE(openpmd_api, m) {
 
     // API runtime feature variants
     m.attr("variants") = openPMD::getVariants();
+
+    // license SPDX identifier
+    m.attr("__license__") = "LGPL-3.0-or-later";
 
     // TODO broken numpy if not at least v1.15.0: raise warning
     // auto numpy = py::module::import("numpy");

--- a/src/binding/python/openpmd_api/__init__.py
+++ b/src/binding/python/openpmd_api/__init__.py
@@ -1,0 +1,7 @@
+from . import openpmd_api_cxx as cxx
+from .openpmd_api_cxx import *  # noqa
+
+__version__ = cxx.__version__
+__doc__ = cxx.__doc__
+__license__ = cxx.__license__
+# __author__ = cxx.__author__

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -52,6 +52,15 @@ class APITest(unittest.TestCase):
         self.__particle_series = io.Series(path_to_particle_data, mode)
         self.__series = io.Series(path_to_data, mode)
 
+        assert io.__version__ is not None
+        assert io.__version__ != ""
+        assert io.__doc__ is not None
+        assert io.__doc__ != ""
+        assert io.__license__ is not None
+        assert io.__license__ != ""
+        # assert io.__author__ is not None
+        # assert io.__author__ != ""
+
     def tearDown(self):
         """ Tearing down a test. """
         for f in self.__files_to_remove:


### PR DESCRIPTION
Adding an extra directory and importing the C++ module internally.

This will help us to:
- extend the python bindings with Python scripts
- add the C++ CLI tools to wheel installs (as script or entrypoint)
- clean up libs in python install prefix a bit more