### PR TITLE
openpmd-ls: install in setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -213,6 +213,7 @@ jobs:
         # - make package
         # - dpkg -i openPMD*.deb
         - ls -R $HOME/openPMD-test-install | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//--/g' -e 's/^/   /' -e 's/-/|/'
+        # run CLI tools such as openpmd-ls
     - <<: *test-cpp-unit
       name: clang@5.0.0 +OMPI -PY +H5 +ADIOS1 (BP3) +ADIOS2
       language: python

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Features
 
   - ``__init__.py`` facade #720
   - add ``Mesh_Record_Component.position`` read-write property #713
+  - add ``openpmd-ls`` tool in ``pip`` installs #721
 
 Bug Fixes
 """""""""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,7 @@ set(openPMD_TEST_NAMES
 set(openPMD_CLI_TOOL_NAMES
     ls
 )
+set(openPMD_PYTHON_CLI_MODULE_NAMES ${openPMD_CLI_TOOL_NAMES})
 # examples
 set(openPMD_EXAMPLE_NAMES
     1_structure
@@ -975,6 +976,30 @@ if(openPMD_HAVE_PYTHON)
                 ${openPMD_SOURCE_DIR}/src/binding/python/openpmd_api
                 ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
     )
+
+    # Python CLI Modules
+    # (Note that during setuptools install, these are furthermore installed as
+    #  console scripts and replace the all-binary CLI tools.)
+    # TODO not sure how to expose the CLI scripts also as python module without
+    #      also defining an imported function in the main module
+    #foreach(pymodulename ${openPMD_PYTHON_CLI_MODULE_NAMES})
+    #     add_test(NAME CLI.py.help.${pymodulename}
+    #         COMMAND ${PYTHON_EXECUTABLE} -m openpmd_api.cli:${pymodulename} --help
+    #         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    #    )
+    #    if(WIN32)
+    #        set_tests_properties(CLI.py.help.${pymodulename}
+    #            PROPERTY ENVIRONMENT
+    #                "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
+    #                "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+    #        )
+    #    else()
+    #        set_tests_properties(CLI.py.help.${pymodulename}
+    #            PROPERTIES ENVIRONMENT
+    #                "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+    #        )
+    #    endif()
+    #endforeach()
 endif()
 
 # Python Examples
@@ -990,23 +1015,6 @@ if(openPMD_HAVE_PYTHON AND openPMD_HAVE_HDF5)
             message(STATUS "Note: mpi4py not found. "
                            "Skipping MPI-parallel Python examples.")
         endif()
-
-        #add_test(NAME Module.py.Help
-        #    COMMAND ${PYTHON_EXECUTABLE} -m openpmd-ls --help
-        #    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        #)
-        #if(WIN32)
-        #    set_tests_properties(Module.py.Help
-        #        PROPERTY ENVIRONMENT
-        #            "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
-        #            "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
-        #    )
-        #else()
-        #    set_tests_properties(Module.py.Help
-        #        PROPERTIES ENVIRONMENT
-        #            "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
-        #    )
-        #endif()
 
         foreach(examplename ${openPMD_PYTHON_EXAMPLE_NAMES})
             add_custom_command(TARGET openPMD.py POST_BUILD

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,8 @@ RUN        ls -hal /usr/local/lib/python3.7/dist-packages/
 # RUN        objdump -x /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so | grep RPATH
 RUN        ldd /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so
 RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-#RUN        openpmd-ls --help
+#RUN        python3 -m openpmd_api.cli:ls --help
+RUN        openpmd-ls --help
 #RUN        echo "* soft core 100000" >> /etc/security/limits.conf && \
 #           python3 -c "import openpmd_api as io"; \
 #           gdb -ex bt -c core
@@ -157,6 +158,8 @@ RUN        python3.8 --version \
            && python3.8 get-pip.py \
            && python3.8 -m pip install openPMD_api-*-cp38-cp38-manylinux2010_x86_64.whl
 RUN        python3.8 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
+#RUN        python3.8 -m openpmd_api.cli:ls --help
+RUN        openpmd-ls --help
 
 # test in fresh env: Ubuntu:18.04 + Python 3.6
 FROM       ubuntu:18.04
@@ -169,7 +172,8 @@ RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp36-cp36m-manylinux2010_x86_64.whl
 RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-#RUN        openpmd-ls --help
+#RUN        python3 -m openpmd_api.cli:ls --help
+RUN        openpmd-ls --help
 
 # test in fresh env: Debian:Stretch + Python 3.5
 FROM       debian:stretch
@@ -182,7 +186,8 @@ RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp35-cp35m-manylinux2010_x86_64.whl
 RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-#RUN        openpmd-ls --help
+#RUN        python3 -m openpmd_api.cli:ls --help
+RUN        openpmd-ls --help
 
 
 # copy binary artifacts (wheels)

--- a/include/openPMD/cli/ls.hpp
+++ b/include/openPMD/cli/ls.hpp
@@ -48,6 +48,11 @@ namespace ls
         std::cout << "    " << program_name << " ./samples/serial_patch.bp\n";
     }
 
+    /** Run the openpmd-ls command line tool
+     *
+     * @param argv command line arguments 1-N
+     * @return exit code (zero for success)
+     */
     inline int
     run( std::vector< std::string > const & argv )
     {

--- a/include/openPMD/cli/ls.hpp
+++ b/include/openPMD/cli/ls.hpp
@@ -1,0 +1,88 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "openPMD/Series.hpp"
+#include "openPMD/helper/list_series.hpp"
+
+#include <exception>
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+namespace openPMD
+{
+namespace cli
+{
+namespace ls
+{
+    inline void
+    print_help( std::string const program_name )
+    {
+        std::cout << "Usage: " << program_name << " openPMD-series\n";
+        std::cout << "List information about an openPMD data series.\n\n";
+        std::cout << "Options:\n    -h, --help    display this help and exit\n\n";
+        std::cout << "Examples:\n";
+        std::cout << "    " << program_name << " ./samples/git-sample/data%T.h5\n";
+        std::cout << "    " << program_name << " ./samples/git-sample/data%08T.h5\n";
+        std::cout << "    " << program_name << " ./samples/serial_write.json\n";
+        std::cout << "    " << program_name << " ./samples/serial_patch.bp\n";
+    }
+
+    inline int
+    run( std::vector< std::string > const & argv )
+    {
+        using namespace openPMD;
+        auto const argc = argv.size();
+
+        if (argc < 2) {
+            print_help(argv[0]);
+            return 0;
+        }
+        if (std::string("--help") == argv[1] || std::string("-h") == argv[1]) {
+            print_help(argv[0]);
+            return 0;
+        }
+        if (argc > 2) {
+            std::cerr << "Too many arguments! See: " << argv[0] << " --help\n";
+            return 1;
+        }
+
+        try {
+            auto s = Series(
+                argv[1],
+                AccessType::READ_ONLY
+            );
+
+            helper::listSeries(s, true, std::cout);
+        }
+        catch (std::exception const &e) {
+            std::cerr << "An error occurred while opening the specified openPMD series!\n";
+            std::cerr << e.what() << std::endl;
+            return 2;
+        }
+
+        return 0;
+    }
+} // namespace ls
+} // namespace cli
+} // namespace openPMD

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class CMakeBuild(build_ext):
             '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' +
             os.path.join(extdir, "openpmd_api"),
             # '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=' + extdir,
-            '-DBUILD_CLI_TOOLS:BOOL=OFF',  # TODO: how to install properly?
+            '-DBUILD_CLI_TOOLS:BOOL=OFF',  # note: provided as console scripts
             '-DCMAKE_PYTHON_OUTPUT_DIRECTORY=' + extdir,
             '-DPYTHON_EXECUTABLE=' + sys.executable,
             # variants
@@ -83,11 +83,6 @@ class CMakeBuild(build_ext):
                     cfg.upper(),
                     extdir
                 )
-                # TODO: how to install properly?
-                # '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{}={}'.format(
-                #     cfg.upper(),
-                #     extdir
-                # )
             ]
             if sys.maxsize > 2**32:
                 cmake_args += ['-A', 'x64']
@@ -169,12 +164,12 @@ setup(
     python_requires='>=3.5, <3.9',
     # tests_require=['pytest'],
     install_requires=install_requires,
-#   see: https://github.com/scikit-build/cmake-python-distributions/blob/master/cmake/__init__.py
-#    entry_points={
-#        'console_scripts': [
-#            'openpmd-ls = openpmd_api:ls'
-#        ]
-#    },
+    # see: src/bindings/python/cli
+    entry_points={
+        'console_scripts': [
+            'openpmd-ls = openpmd_api.cli:ls'
+        ]
+    },
     # we would like to use this mechanism, but pip / setuptools do not
     # influence the build and build_ext with it.
     # therefore, we use environment vars to control.

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,12 @@ setup(
     python_requires='>=3.5, <3.9',
     # tests_require=['pytest'],
     install_requires=install_requires,
+#   see: https://github.com/scikit-build/cmake-python-distributions/blob/master/cmake/__init__.py
+#    entry_points={
+#        'console_scripts': [
+#            'openpmd-ls = openpmd_api:ls'
+#        ]
+#    },
     # we would like to use this mechanism, but pip / setuptools do not
     # influence the build and build_ext with it.
     # therefore, we use environment vars to control.

--- a/src/binding/python/Helper.cpp
+++ b/src/binding/python/Helper.cpp
@@ -21,10 +21,13 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "openPMD/cli/ls.hpp"
 #include "openPMD/helper/list_series.hpp"
 #include "openPMD/Series.hpp"
 
+#include <string>
 #include <sstream>
+#include <vector>
 
 
 namespace py = pybind11;
@@ -40,5 +43,11 @@ void init_Helper(py::module &m) {
         py::arg("series"),
         py::arg_v("longer", false, "Print more verbose output."),
         "List information about an openPMD data series"
+    )
+    // CLI entry point
+    .def("ls", // &cli::ls::run
+        [](std::vector< std::string > & argv) {
+            return cli::ls::run( argv );
+        }
     );
 }

--- a/src/binding/python/Helper.cpp
+++ b/src/binding/python/Helper.cpp
@@ -45,7 +45,7 @@ void init_Helper(py::module &m) {
         "List information about an openPMD data series"
     )
     // CLI entry point
-    .def("ls", // &cli::ls::run
+    .def("_ls_run", // &cli::ls::run
         [](std::vector< std::string > & argv) {
             return cli::ls::run( argv );
         }

--- a/src/binding/python/openpmd_api/__init__.py
+++ b/src/binding/python/openpmd_api/__init__.py
@@ -1,6 +1,7 @@
 from . import openpmd_api_cxx as cxx
 from .openpmd_api_cxx import *  # noqa
 
+
 __version__ = cxx.__version__
 __doc__ = cxx.__doc__
 __license__ = cxx.__license__

--- a/src/binding/python/openpmd_api/cli.py
+++ b/src/binding/python/openpmd_api/cli.py
@@ -1,0 +1,22 @@
+"""
+This file is part of the openPMD-api.
+
+This module provides functions that are wrapped into sys.exit(...()) calls by
+the setuptools (setup.py) "entry_points" -> "console_scripts" generator.
+
+Copyright 2020 openPMD contributors
+Authors: Axel Huebl
+License: LGPLv3+
+"""
+import sys
+from .openpmd_api_cxx import _ls_run
+
+
+def ls():
+    """ see command line interface (CLI): openpmd-ls --help """
+    return _ls_run(sys.argv)
+
+
+__all__ = [
+    'ls'
+]

--- a/src/cli/ls.cpp
+++ b/src/cli/ls.cpp
@@ -19,64 +19,19 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "openPMD/openPMD.hpp"
+#include "openPMD/cli/ls.hpp"
 
-#include <iostream>
 #include <string>
-#include <exception>
+#include <vector>
 
-
-inline void
-print_help( std::string const program_name )
-{
-    std::cout << "Usage: " << program_name << " openPMD-series\n";
-    std::cout << "List information about an openPMD data series.\n\n";
-    std::cout << "Options:\n    -h, --help    display this help and exit\n\n";
-    std::cout << "Examples:\n";
-    std::cout << "    " << program_name << " ./samples/git-sample/data%T.h5\n";
-    std::cout << "    " << program_name << " ./samples/git-sample/data%08T.h5\n";
-    std::cout << "    " << program_name << " ./samples/serial_write.json\n";
-    std::cout << "    " << program_name << " ./samples/serial_patch.bp\n";
-}
 
 int main(
     int argc,
     char * argv[]
 )
 {
-    using namespace openPMD;
+    std::vector< std::string > str_argv;
+    for( int i = 0; i < argc; ++i ) str_argv.push_back(argv[i]);
 
-    if( argc < 2 )
-    {
-        print_help( argv[0] );
-        return 0;
-    }
-    if( std::string("--help") == argv[1] || std::string("-h") == argv[1] )
-    {
-        print_help( argv[0] );
-        return 0;
-    }
-    if( argc > 2 )
-    {
-        std::cerr << "Too many arguments! See: " << argv[0] << " --help\n";
-        return 1;
-    }
-
-    try
-    {
-        auto s = Series(
-                argv[1],
-                AccessType::READ_ONLY
-        );
-
-        helper::listSeries(s, true, std::cout);
-    }
-    catch( std::exception const  & e )
-    {
-        std::cerr << "An error occurred while opening the specified openPMD series!\n";
-        std::cerr << e.what() << std::endl;
-        return 2;
-    }
-
-    return 0;
+    return openPMD::cli::ls::run( str_argv );
 }


### PR DESCRIPTION
Adds the `openpmd-ls` CLI tool in setuptools (sdist/wheel) installs for our `pip` install method.

Since we cannot expose binaries as console scripts (grr...), we have to design entry hooks that can add command line arguments before calling our C++ logic.