### PR TITLE
Travis CI: Add GCC 9.3.0 on Bionic

### DIFF
--- a/.github/ci/spack/compilers.yaml
+++ b/.github/ci/spack/compilers.yaml
@@ -159,3 +159,16 @@ compilers:
       fc: /usr/bin/gfortran-8
     spec: gcc@8.1.0
     target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu18.04
+    paths:
+      cc: /usr/bin/gcc-9
+      cxx: /usr/bin/g++-9
+      f77: /usr/bin/gfortran-9
+      fc: /usr/bin/gfortran-9
+    spec: gcc@9.3.0
+    target: x86_64

--- a/.github/ci/spack/compilers.yaml
+++ b/.github/ci/spack/compilers.yaml
@@ -86,19 +86,6 @@ compilers:
     extra_rpaths: []
     flags: {}
     modules: []
-    operating_system: ubuntu18.04
-    paths:
-      cc: /usr/bin/clang-8
-      cxx: /usr/bin/clang++-8
-      f77: /usr/bin/gfortran-7.4
-      fc: /usr/bin/gfortran-7.4
-    spec: clang@8.0.0
-    target: x86_64
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules: []
     operating_system: ubuntu14.04
     paths:
       cc: /usr/bin/gcc-4.8
@@ -158,6 +145,32 @@ compilers:
       f77: /usr/bin/gfortran-8
       fc: /usr/bin/gfortran-8
     spec: gcc@8.1.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu18.04
+    paths:
+      cc: /usr/bin/gcc-7
+      cxx: /usr/bin/g++-7
+      f77: /usr/bin/gfortran-7
+      fc: /usr/bin/gfortran-7
+    spec: gcc@7.4.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu18.04
+    paths:
+      cc: /usr/bin/clang-8
+      cxx: /usr/bin/clang++-8
+      f77: /usr/bin/gfortran-7.4
+      fc: /usr/bin/gfortran-7.4
+    spec: clang@8.0.0
     target: x86_64
 - compiler:
     environment: {}

--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -1,13 +1,13 @@
 packages:
   perl:
-    version: [5.14.0, 5.18.2, 5.22.4, 5.26.1]
+    version: [5.14.0, 5.18.2, 5.22.4, 5.26.2]
     paths:
       perl@5.14.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /usr
       perl@5.14.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
       perl@5.14.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /usr
       perl@5.14.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /usr
       perl@5.22.4%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
-      perl@5.26.1%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
+      perl@5.26.2%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
       perl@5.22.4%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.22.4%clang@6.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr

--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -7,6 +7,7 @@ packages:
       perl@5.14.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /usr
       perl@5.14.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /usr
       perl@5.22.4%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
+      perl@5.26.1%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
       perl@5.22.4%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.22.4%clang@6.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
@@ -23,6 +24,7 @@ packages:
       cmake@3.11.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
+      cmake@3.11.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%clang@5.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
       cmake@3.11.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
@@ -32,13 +34,14 @@ packages:
       cmake@3.11.0%clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
-    version: [1.6.5, 1.10.2]
+    version: [1.6.5, 1.10.2, 2.1.1]
     paths:
       openmpi@1.6.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.6.5%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.10.2%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
+      openmpi@2.1.1%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
       openmpi@1.10.2%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr
       openmpi@1.10.2%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
     buildable: False
@@ -61,6 +64,7 @@ packages:
       python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
       python@3.6.3%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6
       python@3.6.3%clang@5.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6
+      python@3.8.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /home/travis/virtualenv/python3.8
       python@3.6.3%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
       python@3.5.5%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
@@ -85,4 +89,4 @@ packages:
     target: ['x86_64']
     providers:
       mpi: [openmpi, mpich]
-    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@8.0.0, clang@9.1.0, clang@10.0.0, clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0]
+    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@8.0.0, clang@9.1.0, clang@10.0.0, clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0, gcc@8.1.0, gcc@9.3.0]

--- a/.travis.yml
+++ b/.travis.yml
@@ -396,25 +396,25 @@ jobs:
             - openmpi-bin
       before_install: *gcc49_init
       script: *script-cpp-unit
-    # GCC 7.4.0
+    # GCC 9.3.0
     - <<: *test-cpp-unit
-      name: gcc@7.4.0 -MPI -PY +H5 +ADIOS1 +ADIOS2@2.5.0
-      dist: trusty
+      name: gcc@9.3.0 -MPI -PY +H5 +ADIOS1 +ADIOS2@2.5.0
+      dist: bionic
       language: python
-      python: "3.6"
+      python: "3.8"
       env:
-        - CXXSPEC="%gcc@7.4.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON ADIOS2_VERSION=@2.5.0 USE_SAMPLES=ON
+        - CXXSPEC="%gcc@9.3.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=ON ADIOS2_VERSION=@2.5.0 USE_SAMPLES=ON
       compiler: gcc
       addons:
         apt:
           <<: *apt_common_sources
-          packages: &gcc73_deps
+          packages: &gcc93_deps
             - environment-modules
-            - gfortran-7
-            - gcc-7
-            - g++-7
-      before_install: &gcc73_init
-        - CXX=g++-7 && CC=gcc-7
+            - gfortran-9
+            - gcc-9
+            - g++-9
+      before_install: &gcc93_init
+        - CXX=g++-9 && CC=gcc-9
       script: *script-cpp-unit
     - <<: *test-cpp-unit
       name: gcc@7.4.0 +OMPI -PY +H5 (collective) +ADIOS1 -ADIOS2
@@ -427,11 +427,15 @@ jobs:
       addons:
         apt:
           <<: *apt_common_sources
-          packages:
-            - *gcc73_deps
+          packages: &gcc74_deps
+            - environment-modules
+            - gfortran-7
+            - gcc-7
+            - g++-7
             - libopenmpi-dev
             - openmpi-bin
-      before_install: *gcc73_init
+      before_install: &gcc74_init
+        - CXX=g++-7 && CC=gcc-7
       script: *script-cpp-unit
     # GCC 6.5.0 + Python 3.5
     - <<: *test-cpp-unit

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Other
   - migrate to GitHub checkout action v2 #712
   - move ``.travis/`` to ``.github/ci/`` #715
   - move example file download scripts to ``share/openPMD/`` #715
+  - add GCC 9.3 builds #723
 - extended write example: remove MSVC warning #752
 - ``listSeries``: remove unused parameters in try-catch #706
 - safer internal ``*dynamic_cast``s of pointers #745


### PR DESCRIPTION
Transform a GCC 7.4.0 build into a modern Ubuntu Bionic (18.04) GCC 9.3.0 build.