### PR TITLE
Python CLI: Module Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Features
 
   - ``__init__.py`` facade #720
   - add ``Mesh_Record_Component.position`` read-write property #713
-  - add ``openpmd-ls`` tool in ``pip`` installs #721
+  - add ``openpmd-ls`` tool in ``pip`` installs and as module #721 #724
 
 Bug Fixes
 """""""""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,26 +980,24 @@ if(openPMD_HAVE_PYTHON)
     # Python CLI Modules
     # (Note that during setuptools install, these are furthermore installed as
     #  console scripts and replace the all-binary CLI tools.)
-    # TODO not sure how to expose the CLI scripts also as python module without
-    #      also defining an imported function in the main module
-    #foreach(pymodulename ${openPMD_PYTHON_CLI_MODULE_NAMES})
-    #     add_test(NAME CLI.py.help.${pymodulename}
-    #         COMMAND ${PYTHON_EXECUTABLE} -m openpmd_api.cli:${pymodulename} --help
-    #         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-    #    )
-    #    if(WIN32)
-    #        set_tests_properties(CLI.py.help.${pymodulename}
-    #            PROPERTY ENVIRONMENT
-    #                "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
-    #                "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
-    #        )
-    #    else()
-    #        set_tests_properties(CLI.py.help.${pymodulename}
-    #            PROPERTIES ENVIRONMENT
-    #                "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
-    #        )
-    #    endif()
-    #endforeach()
+    foreach(pymodulename ${openPMD_PYTHON_CLI_MODULE_NAMES})
+         add_test(NAME CLI.py.help.${pymodulename}
+             COMMAND ${PYTHON_EXECUTABLE} -m openpmd_api.${pymodulename} --help
+             WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
+        if(WIN32)
+            set_property(TEST CLI.py.help.${pymodulename}
+                PROPERTY ENVIRONMENT
+                    "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
+                    "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+            )
+        else()
+            set_tests_properties(CLI.py.help.${pymodulename}
+                PROPERTIES ENVIRONMENT
+                    "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+            )
+        endif()
+    endforeach()
 endif()
 
 # Python Examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,7 @@ RUN        ls -hal /usr/local/lib/python3.7/dist-packages/
 # RUN        objdump -x /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so | grep RPATH
 RUN        ldd /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so
 RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-#RUN        python3 -m openpmd_api.cli:ls --help
+RUN        python3 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 #RUN        echo "* soft core 100000" >> /etc/security/limits.conf && \
 #           python3 -c "import openpmd_api as io"; \
@@ -158,7 +158,7 @@ RUN        python3.8 --version \
            && python3.8 get-pip.py \
            && python3.8 -m pip install openPMD_api-*-cp38-cp38-manylinux2010_x86_64.whl
 RUN        python3.8 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-#RUN        python3.8 -m openpmd_api.cli:ls --help
+RUN        python3.8 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
 # test in fresh env: Ubuntu:18.04 + Python 3.6
@@ -172,7 +172,7 @@ RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp36-cp36m-manylinux2010_x86_64.whl
 RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-#RUN        python3 -m openpmd_api.cli:ls --help
+RUN        python3 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
 # test in fresh env: Debian:Stretch + Python 3.5
@@ -186,7 +186,7 @@ RUN        python3 --version \
            && python3 -m pip install -U pip \
            && python3 -m pip install openPMD_api-*-cp35-cp35m-manylinux2010_x86_64.whl
 RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-#RUN        python3 -m openpmd_api.cli:ls --help
+RUN        python3 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
 

--- a/docs/source/utilities/cli.rst
+++ b/docs/source/utilities/cli.rst
@@ -10,5 +10,15 @@ These terminal-focused tools help to quickly explore, manage or manipulate openP
 --------------
 
 List information about an openPMD data series.
-See ``openpmd-ls --help`` for help.
 
+The syntax of the command line tool is printed via:
+
+.. code-block:: bash
+
+   openpmd-ls --help
+
+With some ``pip``-based python installations, you might have to run this as a module:
+
+.. code-block:: python3
+
+   python -m openpmd_api.ls --help

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ setup(
     # see: src/bindings/python/cli
     entry_points={
         'console_scripts': [
-            'openpmd-ls = openpmd_api.cli:ls'
+            'openpmd-ls = openpmd_api.ls.__main__:main'
         ]
     },
     # we would like to use this mechanism, but pip / setuptools do not

--- a/share/openPMD/download_samples.ps1
+++ b/share/openPMD/download_samples.ps1
@@ -7,7 +7,8 @@ Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/draft/
 7z.exe x -r example-thetaMode.tar
 Move-Item -Path example-3d\hdf5\* samples\git-sample\
 Move-Item -Path example-thetaMode\hdf5\* samples\git-sample\thetaMode/
-Remove-Item -Recurse -Force example-3d* example-thetaMode*
+Remove-Item -Recurse -Force example-3d*
+Remove-Item -Recurse -Force example-thetaMode*
 
 # Ref.: https://github.com/yt-project/yt/pull/1645
 New-item -ItemType directory -Name samples\issue-sample\

--- a/src/binding/python/openpmd_api/ls/__init__.py
+++ b/src/binding/python/openpmd_api/ls/__init__.py
@@ -1,0 +1,1 @@
+__doc__ = "for usage documentation, call this module's main with --help"

--- a/src/binding/python/openpmd_api/ls/__main__.py
+++ b/src/binding/python/openpmd_api/ls/__main__.py
@@ -9,14 +9,13 @@ Authors: Axel Huebl
 License: LGPLv3+
 """
 import sys
-from .openpmd_api_cxx import _ls_run
+from ..openpmd_api_cxx import _ls_run
 
 
-def ls():
-    """ see command line interface (CLI): openpmd-ls --help """
+def main():
+    """ for usage documentation, call this with a --help argument """
     return _ls_run(sys.argv)
 
 
-__all__ = [
-    'ls'
-]
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Also add module support for `openpmd-ls` via:

    python -m openpmd_api.ls <arguments>

Very helpful: numpy's `f2py` docs and implementation:
- https://numpy.org/devdocs/f2py/usage.html
- https://github.com/numpy/numpy/tree/master/numpy/f2py