### PR TITLE
Examples: Fix ED-PIC "weighting"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Bug Fixes
 
 - ``flush()`` exceptions in ``~Series``/``~..IOHandler`` do not abort anymore #709
 - readme: python example syntax was broken and outdated #722
+- examples: fix ``"weighting"`` record attribute (ED-PIC) #728
 
 Other
 """""

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -117,7 +117,7 @@ write2()
         electrons["displacement"].setUnitDimension({{UnitDimension::M, 1}});
         electrons["displacement"]["x"].setUnitSI(1e-6);
         electrons.erase("displacement");
-        electrons["weighting"][RecordComponent::SCALAR].setUnitSI(1e-5);
+        electrons["weighting"][RecordComponent::SCALAR].makeConstant(1.e-5);
     }
 
     Mesh& mesh = cur_it.meshes["lowRez_2D_field"];

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     electrons["displacement"].set_unit_dimension({Unit_Dimension.M: 1})
     electrons["displacement"]["x"].set_unit_SI(1.e-6)
     del electrons["displacement"]
-    electrons["weighting"][SCALAR].set_unit_SI(1.e-5)
+    electrons["weighting"][SCALAR].make_constant(1.e-5)
 
     mesh = cur_it.meshes["lowRez_2D_field"]
     mesh.set_axis_labels(["x", "y"])

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     # don't like it anymore? remove it with:
     # del electrons["displacement"]
 
-    electrons["weighting"][SCALAR].set_unit_SI(1.e-5)
+    electrons["weighting"][SCALAR].make_constant(1.e-5)
 
     particlePos_x = np.random.rand(234).astype(np.float32)
     particlePos_y = np.random.rand(234).astype(np.float32)


### PR DESCRIPTION
The ED-PIC extension defines a "weighting". Its attributes are fixed
and the current example is confusing (thx to @LDAmorim for the hint) and actually also ED-PIC extension-violating.