### PR TITLE
Linux: i686 Wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,8 @@ jobs:
       env:
         # (1,2) Skip building for Python 2.7 on all platforms
         # (3) CMake/Pybind11 scripts not clever enough to build 32bit Windows with 64bit compiler
-        # (4) GNU 7.3.1 & MPark.Variant 1.4.0 on i686:
-        #     https://github.com/pypa/manylinux/issues/543
-        #       variant.hpp:2241:9: internal compiler error:
-        #       unexpected expression ‘I’ of kind template_parm_index
-        #       typename T = lib::type_pack_element_t<I, Ts...>,
-        # (5) skip Windows until we add HDF5 and ADIOS2 build scripts
-        CIBW_SKIP: cp27-* pp27-* *-win32 *-manylinux_i686 *win*
+        # (4) skip Windows until we add HDF5 and ADIOS2 build scripts
+        CIBW_SKIP: cp27-* pp27-* *-win32 *win*
         # Install dependencies on Linux and OSX
         CIBW_BEFORE_BUILD: bash -x .github/library_builders.sh
         # for the openPMD-api build, CMake shall search for

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,7 @@ env:
     - OPENPMD_GIT_REF="0.11.1-alpha1"
 
     # (1,2) Skip building for Python 2.7 on all platforms
-    # (3) GNU 7.3.1 & MPark.Variant 1.4.0 on i686:
-    #     https://github.com/pypa/manylinux/issues/543
-    #       variant.hpp:2241:9: internal compiler error:
-    #       unexpected expression ‘I’ of kind template_parm_index
-    #       typename T = lib::type_pack_element_t<I, Ts...>,
-    - CIBW_SKIP="cp27-* pp27-* *-manylinux_i686"
+    - CIBW_SKIP="cp27-* pp27-*"
     # Install dependencies on Linux and OSX
     - CIBW_BEFORE_BUILD="bash -x .github/library_builders.sh"
     # for the openPMD-api build, CMake shall search for


### PR DESCRIPTION
Add i686 builds for Linux.
manylinux2014 was recently updated to a newer GCC toolchain.

Refs.:
- https://github.com/pypa/manylinux/pull/564
- https://github.com/pypa/manylinux/pull/565
- https://github.com/openPMD/openPMD-api/pull/718