### PR TITLE
Linux: More Wheel Archs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,33 +24,32 @@ env:
 jobs:
   include:
     # perform a linux ARMv8 build
-    # blocked by https://github.com/scikit-build/cmake-python-distributions/issues/96
-    #            https://github.com/pypa/manylinux/issues/544
-    # - services: docker
-    #   arch: arm64
-    #   env:
-    #     - CIBW_BUILD="*_aarch64"
+    - services: docker
+      arch: arm64
+      env:
+        - CIBW_BUILD="*_aarch64"
 
     # perform a linux PPC64LE build
     # blocked by https://github.com/pypa/auditwheel/issues/36
     #            https://github.com/pypa/auditwheel/pull/213
-    # - services: docker
-    #   arch: ppc64le
-    #  env:
-    #    - CIBW_BUILD="*_ppc64le"
+    - services: docker
+      arch: ppc64le
+      env:
+        - CIBW_BUILD="*_ppc64le"
 
     # perform a linux S390X build
     # blocked by https://github.com/GTkorvo/dill/issues/15
-    # - services: docker
-    #   arch: s390x
-    #  env:
-    #    - CIBW_BUILD="*_s390x"
+    - services: docker
+      arch: s390x
+      env:
+        - CIBW_BUILD="*_s390x"
 
     # and a build for old macOS versions (10.13 with xcode9.4.1 ~2017)
-    - os: osx
-      osx_image: xcode9.4
-      language: shell
-      python: 3.6
+    # already covered with a 10.9+ build by GH Action
+    #- os: osx
+    #  osx_image: xcode9.4
+    #  language: shell
+    #  python: 3.6
 
 install:
   - git clone --branch ${OPENPMD_GIT_REF} --depth 1 https://github.com/openPMD/openPMD-api.git src


### PR DESCRIPTION
Try to enable more wheel architectures on Linux with recently updated `manylinux2014` toolchains.

Disable macOS travis builds (covered well by GH Action build).

Refs.:
- https://github.com/pypa/manylinux/pull/564