### PR TITLE
Remove noisy ADIOS2 JSON warning

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -88,9 +88,6 @@ ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
 {
     if( !cfg.contains( "adios2" ) )
     {
-        std::cerr << "Warning: ADIOS2 is not configured in the JSON "
-                     "configuration. Running with default settings."
-                  << std::endl;
         return;
     }
     m_config = std::move( cfg[ "adios2" ] );


### PR DESCRIPTION
ADIOS2 backend currently always issues a warning when not configured
explicitly (which is the default). Remove that.