### PR TITLE
[Draft] MeshRecordComponent: Properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Bug Fixes
 - ``flush()`` exceptions in ``~Series``/``~..IOHandler`` do not abort anymore #709
 - readme: python example syntax was broken and outdated #722
 - examples: fix ``"weighting"`` record attribute (ED-PIC) #728
+- ADIOS2: remove noisy warning for default options #733
 
 Other
 """""

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -22,6 +22,8 @@
 
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/backend/MeshGeometry.hpp"
+#include "openPMD/backend/MeshDataOrder.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
 
 #include <array>
@@ -49,24 +51,14 @@ public:
     /** @brief Enumerated datatype for the geometry of the mesh.
      *
      * @note If the default values do not suit your application, you can set arbitrary
-     *       Geometry with MeshRecordComponent::setAttribute("geometry", VALUE).
+     *       Geometry with Mesh::setAttribute("geometry", VALUE).
      *       Note that this might break openPMD compliance and tool support.
      */
-    enum class Geometry
-    {
-        cartesian,
-        thetaMode,
-        cylindrical,
-        spherical
-    };  //Geometry
+    using Geometry = MeshGeometry;
 
     /** @brief Enumerated datatype for the memory layout of N-dimensional data.
      */
-    enum class DataOrder : char
-    {
-        C = 'C',
-        F = 'F'
-    };  //DataOrder
+    using DataOrder = MeshDataOrder;
 
     /**
      * @return String representing the geometry of the mesh of the mesh record.

--- a/include/openPMD/backend/MeshDataOrder.hpp
+++ b/include/openPMD/backend/MeshDataOrder.hpp
@@ -1,0 +1,33 @@
+/* Copyright 2017-2020 Axel Huebl, Fabian Koller
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+
+namespace openPMD
+{
+    /** @brief Enumerated datatype for the memory layout of N-dimensional data.
+     */
+    enum class MeshDataOrder : char
+    {
+        C = 'C',
+        F = 'F'
+    };
+} // namespace openPMD

--- a/include/openPMD/backend/MeshGeometry.hpp
+++ b/include/openPMD/backend/MeshGeometry.hpp
@@ -1,0 +1,37 @@
+/* Copyright 2017-2020 Axel Huebl, Fabian Koller
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+
+namespace openPMD
+{
+    /** Enumerated datatype for the geometry of a mesh.
+     *
+     * Mesh geometries as defined in the openPMD base standard.
+     */
+    enum class MeshGeometry
+    {
+        cartesian,
+        thetaMode,
+        cylindrical, // reserved
+        spherical    // reserved
+    };
+} // namespace openPMD

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -21,6 +21,8 @@
 #pragma once
 
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/backend/MeshGeometry.hpp"
+#include "openPMD/backend/MeshDataOrder.hpp"
 
 #include <vector>
 
@@ -76,6 +78,65 @@ public:
      */
     template< typename T >
     MeshRecordComponent& makeConstant(T);
+
+    // below are read-only attributes from Mesh, duplicated for user read-convenience
+
+    /** @brief Enumerated datatype for the geometry of the mesh.
+     *
+     * @note If the default values do not suit your application, you can set arbitrary
+     *       Geometry with Mesh::setAttribute("geometry", VALUE).
+     *       Note that this might break openPMD compliance and tool support.
+     */
+    using Geometry = MeshGeometry;
+
+    /** @brief Enumerated datatype for the memory layout of N-dimensional data.
+     */
+    using DataOrder = MeshDataOrder;
+
+    /**
+     * @return String representing the geometry of the mesh of the mesh record.
+     */
+    Geometry geometry() const;
+
+    /**
+     * @throw   no_such_attribute_error If Mesh::geometry is not Mesh::Geometry::thetaMode.
+     * @return  String representing additional parameters for the geometry, separated by a @code ; @endcode.
+     */
+    std::string geometryParameters() const;
+
+    /**
+     * @return  Memory layout of N-dimensional data.
+     */
+    DataOrder dataOrder() const;
+
+    /**
+     * @return  Ordering of the labels for the Mesh::geometry of the mesh.
+     */
+    std::vector< std::string > axisLabels() const;
+
+    /**
+     * @tparam  T   Floating point type of user-selected precision (e.g. float, double).
+     * @return  vector of T representing the spacing of the grid points along each dimension (in the units of the simulation).
+     */
+    template< typename T >
+    std::vector< T > gridSpacing() const;
+
+    /**
+     * @return  Vector of (double) representing the start of the current domain of the simulation (position of the beginning of the first cell) in simulation units.
+     */
+    std::vector< double > gridGlobalOffset() const;
+
+    /**
+     * @return  Unit-conversion factor to multiply each value in Mesh::gridSpacing and Mesh::gridGlobalOffset, in order to convert from simulation units to SI units.
+     */
+    double gridUnitSI() const;
+
+    /**
+     * @tparam  T   Floating point type of user-selected precision (e.g. float, double).
+     * @return  Offset between the time at which this record is defined and the Iteration::time attribute of the Series::basePath level.
+     */
+    template< typename T >
+    T timeOffset() const;
 };
 
 
@@ -91,4 +152,15 @@ MeshRecordComponent::makeConstant(T value)
     RecordComponent::makeConstant(value);
     return *this;
 }
+
+template< typename T >
+inline std::vector< T >
+MeshRecordComponent::gridSpacing() const
+{ return m_writable->parent->attributable->readVectorFloatingpoint< T >("gridSpacing"); }
+
+template< typename T >
+inline T
+MeshRecordComponent::timeOffset() const
+{ return m_writable->parent->attributable->readFloatingpoint< T >("timeOffset"); }
+
 } // namespace openPMD

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -65,6 +65,7 @@ class Writable final
     friend class Container;
     friend class Iteration;
     friend class Mesh;
+    friend class MeshRecordComponent;
     friend class ParticleSpecies;
     friend class Series;
     friend class Record;

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -18,6 +18,7 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+#include "openPMD/backend/MeshDataOrder.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
 
 
@@ -54,6 +55,8 @@ MeshRecordComponent::read()
     else
         throw std::runtime_error( "Unexpected Attribute datatype for 'position'");
 
+    // auto xx = m_writable->parent->attributable->getAttribute("gridUnitSI").get< double >();
+
     readBase();
 }
 
@@ -77,4 +80,53 @@ MeshRecordComponent::setPosition(std::vector< double > pos);
 template
 MeshRecordComponent&
 MeshRecordComponent::setPosition(std::vector< long double > pos);
-} // openPMD
+
+MeshGeometry
+MeshRecordComponent::geometry() const
+{
+    auto const attributable = m_writable->parent->attributable;
+    std::string ret = attributable->getAttribute("geometry").get< std::string >();
+    if( "cartesian" == ret ) { return Geometry::cartesian; }
+    else if( "thetaMode" == ret ) { return Geometry::thetaMode; }
+    else if( "cylindrical" == ret ) { return Geometry::cylindrical; }
+    else if( "spherical" == ret ) { return Geometry::spherical; }
+    else { throw std::runtime_error("Unknown geometry " + ret); }
+}
+
+std::string
+MeshRecordComponent::geometryParameters() const
+{
+    auto const attributable = m_writable->parent->attributable;
+    return attributable->getAttribute("geometryParameters").get< std::string >();
+}
+
+MeshDataOrder
+MeshRecordComponent::dataOrder() const
+{
+    auto const attributable = m_writable->parent->attributable;
+    return MeshDataOrder(attributable->getAttribute("dataOrder").get< std::string >().c_str()[0]);
+}
+
+std::vector< std::string >
+MeshRecordComponent::axisLabels() const
+{
+    auto const attributable = m_writable->parent->attributable;
+    return attributable->getAttribute("axisLabels").get< std::vector< std::string > >();
+}
+
+
+std::vector< double >
+MeshRecordComponent::gridGlobalOffset() const
+{
+    auto const attributable = m_writable->parent->attributable;
+    return attributable->getAttribute("gridGlobalOffset").get< std::vector< double> >();
+}
+
+double
+MeshRecordComponent::gridUnitSI() const
+{
+    auto const attributable = m_writable->parent->attributable;
+    return attributable->getAttribute("gridUnitSI").get< double >();
+}
+
+} // namespace openPMD


### PR DESCRIPTION
Add `Mesh` properties as read-only properties to `MeshRecordComponent` as well. This simplifies read logic.

### To Do

- [ ] update testing coverage
- [ ] add python bindings
- [ ] check if general (particle) `RecordComponent` has similar properties that can be forwarded