### PR TITLE
Python: More Idiomatic Unit Properties

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,6 +3,16 @@
 Upgrade Guide
 =============
 
+0.12.0-alpha
+------------
+
+Python
+^^^^^^
+
+The already existing read-only properties ``unit_dimension``, ``unit_SI``, and ``time_offset`` are now declared as read-write properties.
+``set_unit_dimension``, ``set_unit_SI``, and ``set_time_offset`` are now deprecated and will be removed in future versions of the library.
+
+
 0.11.0-alpha
 ------------
 

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -239,7 +239,7 @@ Python
 Units
 -----
 
-Let's decribe this magnetic field :math:`\vec B` in more detail.
+Let's describe this magnetic field :math:`\vec B` in more detail.
 Independent of the absolute unit system, a magnetic field has the `physical dimension <https://en.wikipedia.org/wiki/Dimensional_analysis>`_ of [mass (M)\ :sup:`1` :math:`\cdot` electric current (I)\ :sup:`-1` :math:`\cdot` time (T)\ :sup:`-2`].
 
 Ouch, our magnetic field was measured in `cgs units <https://en.wikipedia.org/wiki/Gaussian_units>`_!
@@ -268,21 +268,21 @@ Python
 .. code-block:: python3
 
    # unit system agnostic dimension
-   B.set_unit_dimension({
+   B.unit_dimension = {
        io.Unit_Dimension.M:  1,
        io.Unit_Dimension.I: -1,
        io.Unit_Dimension.T: -2
-   })
+   }
 
    # conversion to SI
-   B_x.set_unit_SI(1.e-4)
-   B_y.set_unit_SI(1.e-4)
-   B_z.set_unit_SI(1.e-4)
+   B_x.unit_SI = 1.e-4
+   B_y.unit_SI = 1.e-4
+   B_z.unit_SI = 1.e-4
 
 .. tip::
 
    Annotating the *physical dimension* (``unitDimension``) of a record allows us to read data sets with *arbitrary names* and understand their purpose simply by `dimensional analysis <https://en.wikipedia.org/wiki/Dimensional_analysis>`_.
-   The dimensional `base quantities <https://en.wikipedia.org/wiki/International_System_of_Quantities#Base_quantities>`_ in openPMD are lenght (``L``), mass (``M``), time (``T``), electric current (``I``), thermodynamic temperature (``theta``), amount of substance (``N``), luminous intensity (``J``) after the international system of quantities (ISQ).
+   The dimensional `base quantities <https://en.wikipedia.org/wiki/International_System_of_Quantities#Base_quantities>`_ in openPMD are length (``L``), mass (``M``), time (``T``), electric current (``I``), thermodynamic temperature (``theta``), amount of substance (``N``), luminous intensity (``J``) after the international system of quantities (ISQ).
    The *factor to SI* (``unitSI``) on the other hand allows us to convert values between absolute unit systems.
 
 Register Chunk

--- a/examples/3a_write_thetaMode_serial.py
+++ b/examples/3a_write_thetaMode_serial.py
@@ -39,12 +39,12 @@ if __name__ == "__main__":
     E.set_grid_global_offset([0.0, 0.0])
     E.set_grid_unit_SI(1.0)
     E.set_axis_labels(["r", "z"])
-    E.set_unit_dimension({io.Unit_Dimension.I: 1.0,
-                          io.Unit_Dimension.J: 2.0})
+    E.unit_dimension = {io.Unit_Dimension.I: 1.0,
+                        io.Unit_Dimension.J: 2.0}
 
     # write components: E_z, E_r, E_t
     E_z = E["z"]
-    E_z.set_unit_SI(10.)
+    E_z.unit_SI = 10.
     E_z.position = [0.0, 0.5]
     #   (modes, r, z) see set_geometry_parameters
     E_z.reset_dataset(io.Dataset(io.Datatype.FLOAT, [num_fields, N_r, N_z]))
@@ -52,13 +52,13 @@ if __name__ == "__main__":
 
     # write all modes at once (otherwise iterate over modes and first index
     E_r = E["r"]
-    E_r.set_unit_SI(10.)
+    E_r.unit_SI = 10.
     E_r.position = [0.5, 0.0]
     E_r.reset_dataset(io.Dataset(E_r_data.dtype, E_r_data.shape))
     E_r.store_chunk(E_r_data)
 
     E_t = E["t"]
-    E_t.set_unit_SI(10.)
+    E_t.unit_SI = 10.
     E_t.position = [0.0, 0.0]
     E_t.reset_dataset(io.Dataset(E_t_data.dtype, E_t_data.shape))
     E_t.store_chunk(E_t_data)

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -69,8 +69,8 @@ if __name__ == "__main__":
     # the underlying concept for numeric data is the openPMD Record
     # https://github.com/openPMD/openPMD-standard/blob/upcoming-1.0.1/STANDARD.md#scalar-vector-and-tensor-records
     # Meshes are specialized records
-    cur_it.meshes["generic_2D_field"].set_unit_dimension(
-        {Unit_Dimension.L: -3, Unit_Dimension.M: 1})
+    cur_it.meshes["generic_2D_field"].unit_dimension = {
+        Unit_Dimension.L: -3, Unit_Dimension.M: 1}
 
     # as this is a reference, it modifies the original resource
     lowRez = cur_it.meshes["generic_2D_field"]
@@ -86,8 +86,8 @@ if __name__ == "__main__":
     electrons.set_attribute(
         "NoteWorthyParticleSpeciesProperty",
         "Observing this species was a blast.")
-    electrons["displacement"].set_unit_dimension({Unit_Dimension.M: 1})
-    electrons["displacement"]["x"].set_unit_SI(1.e-6)
+    electrons["displacement"].unit_dimension = {Unit_Dimension.M: 1}
+    electrons["displacement"]["x"].unit_SI = 1.e-6
     del electrons["displacement"]
     electrons["weighting"][SCALAR].make_constant(1.e-5)
 
@@ -183,7 +183,7 @@ if __name__ == "__main__":
             ], dtype=np.float32))
 
     mesh["y"].reset_dataset(d)
-    mesh["y"].set_unit_SI(4)
+    mesh["y"].unit_SI = 4
     constant_value = 0.3183098861837907
     # for datasets that contain a single unique value, openPMD offers
     # constant records

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
         "Just kidding.")
 
     # let's set a weird user-defined record this time
-    electrons["displacement"].set_unit_dimension({Unit_Dimension.M: 1})
-    electrons["displacement"][SCALAR].set_unit_SI(1.e-6)
+    electrons["displacement"].unit_dimension = {Unit_Dimension.M: 1}
+    electrons["displacement"][SCALAR].unit_SI = 1.e-6
     dset = Dataset(np.dtype("float64"), extent=[2])
     electrons["displacement"][SCALAR].reset_dataset(dset)
     electrons["displacement"][SCALAR].make_constant(42.43)

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -63,7 +63,23 @@ public:
     //! @todo add also, as soon as added in Container:
     // iterator erase(const_iterator first, const_iterator last) override;
 
-    virtual std::array< double, 7 > unitDimension() const;
+    /** Return the physical dimension (quantity) of a record
+     *
+     * Annotating the physical dimension of a record allows us to read data
+     * sets with arbitrary names and understand their purpose simply by
+     * dimensional analysis. The dimensional base quantities in openPMD are
+     * in order: length (L), mass (M), time (T), electric current (I),
+     * thermodynamic temperature (theta), amount of substance (N),
+     * luminous intensity (J) after the international system of quantities
+     * (ISQ).
+     *
+     * @see https://en.wikipedia.org/wiki/Dimensional_analysis
+     * @see https://en.wikipedia.org/wiki/International_System_of_Quantities#Base_quantities
+     * @see https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#required-for-each-record
+     *
+     * @return powers of the 7 base measures in the order specified above
+     */
+    std::array< double, 7 > unitDimension() const;
 
     /** Returns true if this record only contains a single component
      *

--- a/include/openPMD/binding/python/UnitDimension.hpp
+++ b/include/openPMD/binding/python/UnitDimension.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+namespace openPMD
+{
+namespace python
+{
+    constexpr auto doc_unit_dimension = R"docstr(
+Return the physical dimension (quantity) of a record
+
+Annotating the physical dimension of a record allows us to read data
+sets with arbitrary names and understand their purpose simply by
+dimensional analysis. The dimensional base quantities in openPMD are
+in order: length (L), mass (M), time (T), electric current (I),
+thermodynamic temperature (theta), amount of substance (N),
+luminous intensity (J) after the international system of quantities
+(ISQ).
+
+See https://en.wikipedia.org/wiki/Dimensional_analysis
+See https://en.wikipedia.org/wiki/International_System_of_Quantities#Base_quantities
+See https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#required-for-each-record
+
+Returns the powers of the 7 base measures in the order specified above.
+)docstr";
+
+} // namespace python
+} // namespace openPMD

--- a/src/binding/python/BaseRecord.cpp
+++ b/src/binding/python/BaseRecord.cpp
@@ -26,24 +26,25 @@
 #include "openPMD/backend/MeshRecordComponent.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"
-
-#include <string>
+#include "openPMD/binding/python/UnitDimension.hpp"
 
 namespace py = pybind11;
 using namespace openPMD;
 
 
 void init_BaseRecord(py::module &m) {
-    py::class_<BaseRecord< RecordComponent >, Container< RecordComponent > >(m, "Base_Record_Record_Component")
-        .def_property_readonly("unit_dimension", &BaseRecord< RecordComponent >::unitDimension)
-        .def_property_readonly("scalar", &BaseRecord< RecordComponent >::scalar);
-    py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Base_Record_Mesh_Record_Component")
-        .def_property_readonly("unit_dimension", &BaseRecord< MeshRecordComponent >::unitDimension)
-        .def_property_readonly("scalar", &BaseRecord< MeshRecordComponent >::scalar);
+    constexpr auto doc_scalar = R"docstr(
+Returns true if this record only contains a single component.
+)docstr";
+
     py::class_<BaseRecord< BaseRecordComponent >, Container< BaseRecordComponent > >(m, "Base_Record_Base_Record_Component")
-        .def_property_readonly("unit_dimension", &BaseRecord< BaseRecordComponent >::unitDimension)
-        .def_property_readonly("scalar", &BaseRecord< BaseRecordComponent >::scalar);
+        .def_property_readonly("unit_dimension", &BaseRecord< BaseRecordComponent >::unitDimension, python::doc_unit_dimension)
+        .def_property_readonly("scalar", &BaseRecord< BaseRecordComponent >::scalar, doc_scalar);
+
+    py::class_<BaseRecord< RecordComponent >, Container< RecordComponent > >(m, "Base_Record_Record_Component")
+        .def_property_readonly("scalar", &BaseRecord< RecordComponent >::scalar, doc_scalar);
+    py::class_<BaseRecord< MeshRecordComponent >, Container< MeshRecordComponent > >(m, "Base_Record_Mesh_Record_Component")
+        .def_property_readonly("scalar", &BaseRecord< MeshRecordComponent >::scalar, doc_scalar);
     py::class_<BaseRecord< PatchRecordComponent >, Container< PatchRecordComponent > >(m, "Base_Record_Patch_Record_Component")
-        .def_property_readonly("unit_dimension", &BaseRecord< PatchRecordComponent >::unitDimension)
-        .def_property_readonly("scalar", &BaseRecord< PatchRecordComponent >::scalar);
+        .def_property_readonly("scalar", &BaseRecord< PatchRecordComponent >::scalar, doc_scalar);
 }

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -24,6 +24,7 @@
 #include "openPMD/Mesh.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
+#include "openPMD/binding/python/UnitDimension.hpp"
 
 #include <string>
 
@@ -40,6 +41,11 @@ void init_Mesh(py::module &m) {
                 return "<openPMD.Mesh record with '" + std::to_string(mesh.size()) + "' record components>";
             }
         )
+
+        .def_property("unit_dimension",
+            &Mesh::unitDimension,
+            &Mesh::setUnitDimension,
+            python::doc_unit_dimension)
 
         .def_property_readonly("geometry", &Mesh::geometry)
         .def("set_geometry", &Mesh::setGeometry)
@@ -59,15 +65,13 @@ void init_Mesh(py::module &m) {
         .def("set_grid_global_offset", &Mesh::setGridGlobalOffset)
         .def_property_readonly("grid_unit_SI", &Mesh::gridUnitSI)
         .def("set_grid_unit_SI", &Mesh::setGridUnitSI)
-        .def("set_unit_dimension", &Mesh::setUnitDimension)
-        .def_property_readonly("time_offset", &Mesh::timeOffset<float>)
-        .def_property_readonly("time_offset", &Mesh::timeOffset<double>)
-        .def_property_readonly("time_offset", &Mesh::timeOffset<long double>)
+        .def_property("time_offset", &Mesh::timeOffset<float>, &Mesh::setTimeOffset<float>)
+        .def_property("time_offset", &Mesh::timeOffset<double>, &Mesh::setTimeOffset<double>)
+        .def_property("time_offset", &Mesh::timeOffset<long double>, &Mesh::setTimeOffset<long double>)
 
-        // TODO missing specializations
-        // .def("set_time_offset", &Mesh::setTimeOffset<float>)
-        // .def("set_time_offset", &Mesh::setTimeOffset<double>)
-        // .def("set_time_offset", &Mesh::setTimeOffset<long double>)
+        // TODO remove in future versions (deprecated)
+        .def("set_unit_dimension", &Mesh::setUnitDimension)
+
     ;
 
     py::enum_<Mesh::Geometry>(m, "Geometry")

--- a/src/binding/python/PatchRecord.cpp
+++ b/src/binding/python/PatchRecord.cpp
@@ -24,6 +24,7 @@
 #include "openPMD/backend/PatchRecord.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
+#include "openPMD/binding/python/UnitDimension.hpp"
 
 namespace py = pybind11;
 using namespace openPMD;
@@ -31,6 +32,12 @@ using namespace openPMD;
 
 void init_PatchRecord(py::module &m) {
     py::class_<PatchRecord, BaseRecord< PatchRecordComponent > >(m, "Patch_Record")
+        .def_property("unit_dimension",
+                      &PatchRecord::unitDimension,
+                      &PatchRecord::setUnitDimension,
+                      python::doc_unit_dimension)
+
+        // TODO remove in future versions (deprecated)
         .def("set_unit_dimension", &PatchRecord::setUnitDimension)
     ;
 }

--- a/src/binding/python/PatchRecordComponent.cpp
+++ b/src/binding/python/PatchRecordComponent.cpp
@@ -32,7 +32,8 @@ using namespace openPMD;
 
 void init_PatchRecordComponent(py::module &m) {
     py::class_<PatchRecordComponent, BaseRecordComponent >(m, "Patch_Record_Component")
-        .def("set_unit_SI", &PatchRecordComponent::setUnitSI)
+        .def_property("unit_SI", &BaseRecordComponent::unitSI, &PatchRecordComponent::setUnitSI)
+
         .def("reset_dataset", &PatchRecordComponent::resetDataset)
         .def_property_readonly("ndims", &PatchRecordComponent::getDimensionality)
         .def_property_readonly("shape", &PatchRecordComponent::getExtent)
@@ -160,5 +161,8 @@ void init_PatchRecordComponent(py::module &m) {
             py::arg("idx"), py::arg("data"))
 
         // TODO implement convenient, patch-object level store/load
+
+        // TODO remove in future versions (deprecated)
+        .def("set_unit_SI", &PatchRecordComponent::setUnitSI)
     ;
 }

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -24,6 +24,7 @@
 #include "openPMD/Record.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/binding/python/UnitDimension.hpp"
 
 namespace py = pybind11;
 using namespace openPMD;
@@ -39,10 +40,17 @@ void init_Record(py::module &m) {
             }
         )
 
+        .def_property("unit_dimension",
+                      &Record::unitDimension,
+                      &Record::setUnitDimension,
+                      python::doc_unit_dimension)
+
+        .def_property("time_offset", &Record::timeOffset<float>, &Record::setTimeOffset<float>)
+        .def_property("time_offset", &Record::timeOffset<double>, &Record::setTimeOffset<double>)
+        .def_property("time_offset", &Record::timeOffset<long double>, &Record::setTimeOffset<long double>)
+
+        // TODO remove in future versions (deprecated)
         .def("set_unit_dimension", &Record::setUnitDimension)
-        .def_property_readonly("time_offset", &Record::timeOffset<float>)
-        .def_property_readonly("time_offset", &Record::timeOffset<double>)
-        .def_property_readonly("time_offset", &Record::timeOffset<long double>)
         .def("set_time_offset", &Record::setTimeOffset<float>)
         .def("set_time_offset", &Record::setTimeOffset<double>)
         .def("set_time_offset", &Record::setTimeOffset<long double>)

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -429,7 +429,8 @@ void init_RecordComponent(py::module &m) {
             }
         )
 
-        .def("set_unit_SI", &RecordComponent::setUnitSI)
+        .def_property("unit_SI", &BaseRecordComponent::unitSI, &RecordComponent::setUnitSI)
+
         .def("reset_dataset", &RecordComponent::resetDataset)
 
         .def_property_readonly("ndim", &RecordComponent::getDimensionality)
@@ -627,6 +628,9 @@ void init_RecordComponent(py::module &m) {
         )
 
         .def_property_readonly_static("SCALAR", [](py::object){ return RecordComponent::SCALAR; })
+
+        // TODO remove in future versions (deprecated)
+        .def("set_unit_SI", &RecordComponent::setUnitSI) // deprecated
     ;
 
     py::enum_<RecordComponent::Allocation>(m, "Allocation")


### PR DESCRIPTION
Expose `unit_dimension`, `unit_SI` and `time_offset` as python idiomatic read/write properties instead of read-only properties and write-setters.

The old "setters" are now deprecated and will be removed in a future version of the library.