### PR TITLE
[WIP] C++ Attributes More Idiomatic

### DIFF
--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -251,7 +251,7 @@ C++11
 .. code-block:: cpp
 
    // unit system agnostic dimension
-   B.setUnitDimension({
+   B.unitDimension({
        {io::UnitDimension::M,  1},
        {io::UnitDimension::I, -1},
        {io::UnitDimension::T, -2}

--- a/examples/3a_write_thetaMode_serial.cpp
+++ b/examples/3a_write_thetaMode_serial.cpp
@@ -65,7 +65,7 @@ int main()
         {UnitDimension::I, 1.0},
         {UnitDimension::J, 2.0}
     };
-    E.setUnitDimension( unitDimensions );
+    E.unitDimension( unitDimensions );
 
     // write components: E_z, E_r, E_t
     auto E_z = E["z"];

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -92,7 +92,7 @@ write2()
     // the underlying concept for numeric data is the openPMD Record
     // https://github.com/openPMD/openPMD-standard/blob/upcoming-1.0.1/STANDARD.md#scalar-vector-and-tensor-records
     // Meshes are specialized records
-    cur_it.meshes["generic_2D_field"].setUnitDimension({{UnitDimension::L, -3}, {UnitDimension::M, 1}});
+    cur_it.meshes["generic_2D_field"].unitDimension({{UnitDimension::L, -3}, {UnitDimension::M, 1}});
 
     {
         // TODO outdated!
@@ -114,7 +114,7 @@ write2()
         ParticleSpecies& electrons = cur_it.particles["electrons"];
         electrons.setAttribute("NoteWorthyParticleSpeciesProperty",
                                std::string("Observing this species was a blast."));
-        electrons["displacement"].setUnitDimension({{UnitDimension::M, 1}});
+        electrons["displacement"].unitDimension({{UnitDimension::M, 1}});
         electrons["displacement"]["x"].setUnitSI(1e-6);
         electrons.erase("displacement");
         electrons["weighting"][RecordComponent::SCALAR].makeConstant(1.e-5);
@@ -153,9 +153,9 @@ write2()
     electrons.particlePatches["numParticlesOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
     dset = Dataset(Datatype::FLOAT, {2});
-    electrons.particlePatches["offset"].setUnitDimension({{UnitDimension::L, 1}});
+    electrons.particlePatches["offset"].unitDimension({{UnitDimension::L, 1}});
     electrons.particlePatches["offset"]["x"].resetDataset(dset);
-    electrons.particlePatches["extent"].setUnitDimension({{UnitDimension::L, 1}});
+    electrons.particlePatches["extent"].unitDimension({{UnitDimension::L, 1}});
     electrons.particlePatches["extent"]["x"].resetDataset(dset);
 
     // at any point in time you may decide to dump already created output to disk

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/Deprecated.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
@@ -159,6 +160,10 @@ public:
      * @param   unitDimension   map containing pairs of (UnitDimension, double) that represent the power of the particular base.
      * @return  Reference to modified mesh.
      */
+    Mesh& unitDimension(std::map< UnitDimension, double > const& unitDimension);
+    using BaseRecord< MeshRecordComponent >::unitDimension;
+
+    OPENPMDAPI_DEPRECATED("Set unitDimension with unitDimension(std::map)")
     Mesh& setUnitDimension(std::map< UnitDimension, double > const& unitDimension);
 
     /**

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -20,8 +20,9 @@
  */
 #pragma once
 
-#include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/auxiliary/Deprecated.hpp"
+#include "openPMD/backend/BaseRecord.hpp"
 
 #include <map>
 #include <type_traits>
@@ -41,6 +42,10 @@ public:
     Record& operator=(Record const&) = default;
     ~Record() override = default;
 
+    Record& unitDimension(std::map< UnitDimension, double > const&);
+    using BaseRecord< RecordComponent >::unitDimension;
+
+    OPENPMDAPI_DEPRECATED("Set unitDimension with unitDimension(std::map)")
     Record& setUnitDimension(std::map< UnitDimension, double > const&);
 
     template< typename T >

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/Deprecated.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
 
@@ -36,6 +37,10 @@ class PatchRecord : public BaseRecord< PatchRecordComponent >
     friend class ParticlePatches;
 
 public:
+    PatchRecord& unitDimension(std::map< UnitDimension, double > const&);
+    using BaseRecord< PatchRecordComponent >::unitDimension;
+
+    OPENPMDAPI_DEPRECATED("Set unitDimension with unitDimension(std::map)")
     PatchRecord& setUnitDimension(std::map< UnitDimension, double > const&);
     ~PatchRecord() override = default;
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -159,16 +159,22 @@ Mesh::setGridUnitSI(double gusi)
 }
 
 Mesh&
-Mesh::setUnitDimension(std::map< UnitDimension, double > const& udim)
+Mesh::unitDimension(std::map< UnitDimension, double > const& udim)
 {
     if( !udim.empty() )
     {
-        std::array< double, 7 > tmpUnitDimension = this->unitDimension();
+        std::array< double, 7 > tmpUnitDimension = unitDimension();
         for( auto const& entry : udim )
             tmpUnitDimension[static_cast<uint8_t>(entry.first)] = entry.second;
         setAttribute("unitDimension", tmpUnitDimension);
     }
     return *this;
+}
+
+Mesh&
+Mesh::setUnitDimension(std::map< UnitDimension, double > const& udim)
+{
+    return unitDimension(udim);
 }
 
 template< typename T >

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -123,10 +123,10 @@ ParticleSpecies::flush(std::string const& path)
     {
         iterator it = find("position");
         if ( it != end() )
-            it->second.setUnitDimension({{UnitDimension::L, 1}});
+            it->second.unitDimension({{UnitDimension::L, 1}});
         it = find("positionOffset");
         if ( it != end() )
-            it->second.setUnitDimension({{UnitDimension::L, 1}});
+            it->second.unitDimension({{UnitDimension::L, 1}});
 
         Container< Record >::flush(path);
 

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -33,16 +33,22 @@ Record::Record()
 }
 
 Record&
-Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
+Record::unitDimension(std::map< UnitDimension, double > const& udim)
 {
     if( !udim.empty() )
     {
-        std::array< double, 7 > tmpUnitDimension = this->unitDimension();
+        std::array< double, 7 > tmpUnitDimension = unitDimension();
         for( auto const& entry : udim )
             tmpUnitDimension[static_cast<uint8_t>(entry.first)] = entry.second;
         setAttribute("unitDimension", tmpUnitDimension);
     }
     return *this;
+}
+
+Record&
+Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
+{
+    return unitDimension(udim);
 }
 
 void

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -25,7 +25,7 @@
 namespace openPMD
 {
 PatchRecord&
-PatchRecord::setUnitDimension(std::map< UnitDimension, double > const& udim)
+PatchRecord::unitDimension(std::map< UnitDimension, double > const& udim)
 {
     if( !udim.empty() )
     {
@@ -35,6 +35,12 @@ PatchRecord::setUnitDimension(std::map< UnitDimension, double > const& udim)
         setAttribute("unitDimension", tmpUnitDimension);
     }
     return *this;
+}
+
+PatchRecord&
+PatchRecord::setUnitDimension(std::map< UnitDimension, double > const& udim)
+{
+    return unitDimension(udim);
 }
 
 void

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -31,6 +31,11 @@
 namespace py = pybind11;
 using namespace openPMD;
 
+// C++11 work-around for C++14 py::overload_cast
+//   https://pybind11.readthedocs.io/en/stable/classes.html
+template <typename... Args>
+using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
+
 
 void init_Mesh(py::module &m) {
     py::class_<Mesh, BaseRecord<MeshRecordComponent> >(m, "Mesh")
@@ -43,8 +48,8 @@ void init_Mesh(py::module &m) {
         )
 
         .def_property("unit_dimension",
-            &Mesh::unitDimension,
-            &Mesh::setUnitDimension,
+            overload_cast_<>()(&Mesh::unitDimension, py::const_),
+            overload_cast_< std::map< UnitDimension, double > const& >()(&Mesh::unitDimension),
             python::doc_unit_dimension)
 
         .def_property_readonly("geometry", &Mesh::geometry)
@@ -70,7 +75,8 @@ void init_Mesh(py::module &m) {
         .def_property("time_offset", &Mesh::timeOffset<long double>, &Mesh::setTimeOffset<long double>)
 
         // TODO remove in future versions (deprecated)
-        .def("set_unit_dimension", &Mesh::setUnitDimension)
+        .def("set_unit_dimension",
+            overload_cast_< std::map< UnitDimension, double > const& >()(&Mesh::unitDimension))
 
     ;
 

--- a/src/binding/python/PatchRecord.cpp
+++ b/src/binding/python/PatchRecord.cpp
@@ -29,15 +29,21 @@
 namespace py = pybind11;
 using namespace openPMD;
 
+// C++11 work-around for C++14 py::overload_cast
+//   https://pybind11.readthedocs.io/en/stable/classes.html
+template <typename... Args>
+using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
+
 
 void init_PatchRecord(py::module &m) {
     py::class_<PatchRecord, BaseRecord< PatchRecordComponent > >(m, "Patch_Record")
         .def_property("unit_dimension",
-                      &PatchRecord::unitDimension,
-                      &PatchRecord::setUnitDimension,
-                      python::doc_unit_dimension)
+                      overload_cast_<>()(&PatchRecord::unitDimension, py::const_),
+                      overload_cast_< std::map< UnitDimension, double > const& >()(&PatchRecord::unitDimension),
+        python::doc_unit_dimension)
 
         // TODO remove in future versions (deprecated)
-        .def("set_unit_dimension", &PatchRecord::setUnitDimension)
+        .def("set_unit_dimension",
+             overload_cast_< std::map< UnitDimension, double > const& >()(&PatchRecord::unitDimension))
     ;
 }

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -29,6 +29,11 @@
 namespace py = pybind11;
 using namespace openPMD;
 
+// C++11 work-around for C++14 py::overload_cast
+//   https://pybind11.readthedocs.io/en/stable/classes.html
+template <typename... Args>
+using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
+
 
 void init_Record(py::module &m) {
     py::class_<Record, BaseRecord< RecordComponent > >(m, "Record")
@@ -41,8 +46,8 @@ void init_Record(py::module &m) {
         )
 
         .def_property("unit_dimension",
-                      &Record::unitDimension,
-                      &Record::setUnitDimension,
+                      overload_cast_<>()(&Record::unitDimension, py::const_),
+                      overload_cast_< std::map< UnitDimension, double > const& >()(&Record::unitDimension),
                       python::doc_unit_dimension)
 
         .def_property("time_offset", &Record::timeOffset<float>, &Record::setTimeOffset<float>)
@@ -50,7 +55,8 @@ void init_Record(py::module &m) {
         .def_property("time_offset", &Record::timeOffset<long double>, &Record::setTimeOffset<long double>)
 
         // TODO remove in future versions (deprecated)
-        .def("set_unit_dimension", &Record::setUnitDimension)
+        .def("set_unit_dimension",
+             overload_cast_< std::map< UnitDimension, double > const& >()(&Record::unitDimension))
         .def("set_time_offset", &Record::setTimeOffset<float>)
         .def("set_time_offset", &Record::setTimeOffset<double>)
         .def("set_time_offset", &Record::setTimeOffset<long double>)

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -301,15 +301,14 @@ TEST_CASE( "record_modification_test", "[core]" )
     species["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
     using RUD = UnitDimension;
-    r.setUnitDimension({{RUD::L, 1.},
-                        {RUD::M, 1.},
-                        {RUD::T, -3.},
-                        {RUD::I, -1.}});
+    r.unitDimension({{RUD::L, 1.},
+                    {RUD::M, 1.},
+                    {RUD::T, -3.},
+                    {RUD::I, -1.}});
     std::array< double, 7 > e_field_unitDimension{{1., 1., -3., -1., 0., 0., 0.}};
     REQUIRE(r.unitDimension() == e_field_unitDimension);
 
-    r.setUnitDimension({{RUD::L, 0.},
-                        {RUD::T, -2.}});
+    r.unitDimension({{RUD::L, 0.}, {RUD::T, -2.}});
     std::array< double, 7 > b_field_unitDimension{{0., 1., -2., -1., 0., 0., 0.}};
     REQUIRE(r.unitDimension() == b_field_unitDimension);
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -208,7 +208,7 @@ void constant_scalar(std::string file_ending)
         E_mesh.setGridGlobalOffset( gridGlobalOffset );
         E_mesh.setGridUnitSI( gridUnitSI );
         E_mesh.setAxisLabels( axisLabels );
-        E_mesh.setUnitDimension(unitDimensions);
+        E_mesh.unitDimension( unitDimensions );
         E_mesh.setTimeOffset( timeOffset );
 
         // constant scalar
@@ -1011,7 +1011,7 @@ void sample_write_thetaMode(std::string file_ending)
             {UnitDimension::I, 1.0},
             {UnitDimension::J, 2.0}
         };
-        E.setUnitDimension( unitDimensions );
+        E.unitDimension( unitDimensions );
         E.setTimeOffset( 1.e-12 * double(i) );
 
         auto E_z = E["z"];


### PR DESCRIPTION
Similar to #735 but for C++: Attempt to be a bit more idiomatic for unit properties (`Attributables`) in the C++ API.

In the long term, we should:
- get rid of all setters/getters accessors
- move attributes out of methods and use them as encapsulated member variables instead
- use `snake_case` everywhere, just as the STL

Refs.:
- https://kirit.com/C%2B%2B%20killed%20the%20get%20%26%20set%20accessors

