### PR TITLE
Rename AccessType -> Access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Other
 """""
 
 - separate header for export macros #704
+- rename ``AccessType``/``Access_Type`` to ``Access`` #740
 - CI:
 
   - migration to travis-ci.com / GitHub app #703
@@ -411,7 +412,7 @@ Other
   - more info on MPI #449
   - new "first steps" section #473 #478
   - update invasive test info #474
-  - more info on ``AccessType`` #483
+  - more info on ``Access`` #483
   - improved MPI-parallel write example #496
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,7 +521,7 @@ endif()
 if(openPMD_HAVE_PYTHON)
     pybind11_add_module(openPMD.py MODULE SYSTEM
         src/binding/python/openPMD.cpp
-        src/binding/python/AccessType.cpp
+        src/binding/python/Access.cpp
         src/binding/python/Attributable.cpp
         src/binding/python/BaseRecord.cpp
         src/binding/python/BaseRecordComponent.cpp

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,6 +12,15 @@ Python
 The already existing read-only properties ``unit_dimension``, ``unit_SI``, and ``time_offset`` are now declared as read-write properties.
 ``set_unit_dimension``, ``set_unit_SI``, and ``set_time_offset`` are now deprecated and will be removed in future versions of the library.
 
+``Access_Type`` is now called ``Access``.
+Using it by the old name is deprecated and will be removed in future versions of the library.
+
+C++
+^^^
+
+``AccessType`` is now called ``Access``.
+Using it by the old name is deprecated and will be removed in future versions of the library.
+
 
 0.11.0-alpha
 ------------

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Writing & reading through those backends and their associated files is supported
 
 // ...
 
-auto s = openPMD::Series("samples/git-sample/data%T.h5", openPMD::AccessType::READ_ONLY);
+auto s = openPMD::Series("samples/git-sample/data%T.h5", openPMD::Access::READ_ONLY);
 
 for( auto const& i : s.iterations ) {
     std::cout << "Iteration: " << i.first << "\n";
@@ -75,7 +75,7 @@ import openpmd_api as io
 
 # ...
 
-series = io.Series("samples/git-sample/data%T.h5", io.Access_Type.read_only)
+series = io.Series("samples/git-sample/data%T.h5", io.Access.read_only)
 
 for k_i, i in series.iterations.items():
     print("Iteration: {0}".format(k_i))

--- a/docs/source/dev/backend.rst
+++ b/docs/source/dev/backend.rst
@@ -81,7 +81,7 @@ On the very basic level, you will need to derive a class from ``AbstractIOHandle
     class JSONIOHandler : public AbstractIOHandler
     {
     public:
-        JSONIOHandler(std::string const& path, AccessType);
+        JSONIOHandler(std::string const& path, Access);
         virtual ~JSONIOHandler();
 
         std::future< void > flush() override;
@@ -95,7 +95,7 @@ On the very basic level, you will need to derive a class from ``AbstractIOHandle
 
     namespace openPMD
     {
-    JSONIOHandler::JSONIOHandler(std::string const& path, AccessType at)
+    JSONIOHandler::JSONIOHandler(std::string const& path, Access at)
             : AbstractIOHandler(path, at)
     { }
 
@@ -115,7 +115,7 @@ Familiarizing your backend with the rest of the API happens in just one place in
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
         std::string const& path,
-        AccessType at,
+        Access at,
         Format f,
         MPI_Comm comm
     )
@@ -134,7 +134,7 @@ Familiarizing your backend with the rest of the API happens in just one place in
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
         std::string const& path,
-        AccessType at,
+        Access at,
         Format f
     )
     {

--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -87,7 +87,7 @@ C++11
 
    auto series = io::Series(
        "data%T.h5",
-       io::AccessType::READ_ONLY);
+       io::Access::READ_ONLY);
 
 
 Python
@@ -97,7 +97,7 @@ Python
 
    series = io.Series(
        "data%T.h5",
-       io.Access_Type.read_only)
+       io.Access.read_only)
 
 Iteration
 ---------

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -85,7 +85,7 @@ C++11
 
    auto series = io::Series(
        "myOutput/data_%05T.h5",
-       io::AccessType::CREATE);
+       io::Access::CREATE);
 
 
 Python
@@ -95,7 +95,7 @@ Python
 
    series = io.Series(
        "myOutput/data_%05T.h5",
-       io.Access_Type.create)
+       io.Access.create)
 
 Iteration
 ---------

--- a/examples/1_structure.cpp
+++ b/examples/1_structure.cpp
@@ -27,7 +27,7 @@ int main()
 {
     /* The root of any openPMD output spans across all data for all iterations is a 'Series'.
      * Data is either in a single file or spread across multiple files. */
-    Series series = Series("../samples/1_structure.h5", AccessType::CREATE);
+    Series series = Series("../samples/1_structure.h5", Access::CREATE);
 
     /* Every element that structures your file (groups and datasets for example) can be annotated with attributes. */
     series.setComment("This string will show up at the root ('/') of the output with key 'comment'.");

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -32,7 +32,7 @@ int main()
 {
     Series series = Series(
         "../samples/git-sample/data%T.h5",
-        AccessType::READ_ONLY
+        Access::READ_ONLY
     );
     cout << "Read a Series with openPMD standard version "
          << series.openPMD() << '\n';

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -6,12 +6,12 @@ Copyright 2018-2020 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-import openpmd_api
+import openpmd_api as io
 
 
 if __name__ == "__main__":
-    series = openpmd_api.Series("../samples/git-sample/data%T.h5",
-                                openpmd_api.Access_Type.read_only)
+    series = io.Series("../samples/git-sample/data%T.h5",
+                       io.Access.read_only)
     print("Read a Series with openPMD standard version %s" %
           series.openPMD)
 

--- a/examples/2a_read_thetaMode_serial.cpp
+++ b/examples/2a_read_thetaMode_serial.cpp
@@ -32,7 +32,7 @@ int main()
 {
     Series series = Series(
         "../samples/git-sample/thetaMode/data%T.h5",
-        AccessType::READ_ONLY
+        Access::READ_ONLY
     );
 
     Iteration i = series.iterations[500];

--- a/examples/2a_read_thetaMode_serial.py
+++ b/examples/2a_read_thetaMode_serial.py
@@ -6,12 +6,12 @@ Copyright 2020 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-import openpmd_api
+import openpmd_api as io
 
 
 if __name__ == "__main__":
-    series = openpmd_api.Series("../samples/git-sample/thetaMode/data%T.h5",
-                                openpmd_api.Access_Type.read_only)
+    series = io.Series("../samples/git-sample/thetaMode/data%T.h5",
+                       io.Access.read_only)
 
     i = series.iterations[500]
     E_z_modes = i.meshes["E"]["z"]
@@ -30,8 +30,8 @@ if __name__ == "__main__":
     # reconstruct E_z, E_t, and E_r
     # TODO add helper functions
     #   user change frequency: time ~= component >> theta >> selected modes
-    # toCylindrical      = openpmd_api.thetaMode.toCylindrical(modes="all")
-    # toCylindricalSlice = openpmd_api.thetaMode.toCylindricalSlice(
+    # toCylindrical      = io.thetaMode.toCylindrical(modes="all")
+    # toCylindricalSlice = io.thetaMode.toCylindricalSlice(
     #     theta_radian=1.5708, modes="all")  # and theta_degree
     # reconstruction to 2D slice in cylindrical coordinates (r, z)
     #   for a fixed theta
@@ -43,9 +43,9 @@ if __name__ == "__main__":
     # series.flush()
 
     # reconstruction to 3D and 2D cartesian: E_x, E_y, E_z
-    # toCartesian        = openpmd_api.thetaMode.toCartesian(
+    # toCartesian        = io.thetaMode.toCartesian(
     #     discretize={'x': 1.e-6, 'y': 1.e-6}, modes="all")
-    # toCartesianSliceYZ = openpmd_api.thetaMode.toCartesianSlice(
+    # toCartesianSliceYZ = io.thetaMode.toCartesianSlice(
     #     discretize={'x': 1.e-6, 'y': 1.e-6}, slice_dir='x',
     #     slice_rel=0., modes="all")  # and absolute slice position
     # E_z_xyz = toCartesian(E_z_modes)[:, :, :]      # (x, y, z)

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
     // open file for writing
     Series series = Series(
         "../samples/3_write_serial.h5",
-        AccessType::CREATE
+        Access::CREATE
     );
     cout << "Created an empty " << series.iterationEncoding() << " Series\n";
 

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -6,7 +6,7 @@ Copyright 2018-2020 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-import openpmd_api
+import openpmd_api as io
 import numpy as np
 
 
@@ -21,18 +21,18 @@ if __name__ == "__main__":
         size, size))
 
     # open file for writing
-    series = openpmd_api.Series(
+    series = io.Series(
         "../samples/3_write_serial_py.h5",
-        openpmd_api.Access_Type.create
+        io.Access.create
     )
 
     print("Created an empty {0} Series".format(series.iteration_encoding))
 
     print(len(series.iterations))
     rho = series.iterations[1]. \
-        meshes["rho"][openpmd_api.Mesh_Record_Component.SCALAR]
+        meshes["rho"][io.Mesh_Record_Component.SCALAR]
 
-    dataset = openpmd_api.Dataset(data.dtype, data.shape)
+    dataset = io.Dataset(data.dtype, data.shape)
 
     print("Created a Dataset of size {0}x{1} and Datatype {2}".format(
         dataset.extent[0], dataset.extent[1], dataset.dtype))

--- a/examples/3a_write_thetaMode_serial.cpp
+++ b/examples/3a_write_thetaMode_serial.cpp
@@ -34,7 +34,7 @@ int main()
     // open file for writing
     Series series = Series(
         "../samples/3_write_thetaMode_serial.h5",
-        AccessType::CREATE
+        Access::CREATE
     );
 
     // configure and setup geometry

--- a/examples/3a_write_thetaMode_serial.py
+++ b/examples/3a_write_thetaMode_serial.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     # open file for writing
     series = io.Series(
         "../samples/3_write_thetaMode_serial_py.h5",
-        io.Access_Type.create
+        io.Access.create
     )
 
     # configure and setup geometry

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     {
         Series series = Series(
             "../samples/git-sample/data%T.h5",
-            AccessType::READ_ONLY,
+            Access::READ_ONLY,
             MPI_COMM_WORLD
         );
         if( 0 == mpi_rank )

--- a/examples/4_read_parallel.py
+++ b/examples/4_read_parallel.py
@@ -12,16 +12,16 @@ License: LGPLv3+
 # exit hook: calls MPI_Finalize()
 from mpi4py import MPI
 
-import openpmd_api
+import openpmd_api as io
 
 
 if __name__ == "__main__":
     # also works with any other MPI communicator
     comm = MPI.COMM_WORLD
 
-    series = openpmd_api.Series(
+    series = io.Series(
         "../samples/git-sample/data%T.h5",
-        openpmd_api.Access_Type.read_only,
+        io.Access.read_only,
         comm
     )
     if 0 == comm.rank:

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
         // open file for writing
         Series series = Series(
             "../samples/5_parallel_write.h5",
-            AccessType::CREATE,
+            Access::CREATE,
             MPI_COMM_WORLD
         );
         if( 0 == mpi_rank )

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -12,7 +12,7 @@ License: LGPLv3+
 # exit hook: calls MPI_Finalize()
 from mpi4py import MPI
 
-import openpmd_api
+import openpmd_api as io
 import numpy as np
 
 
@@ -30,9 +30,9 @@ if __name__ == "__main__":
               "that will be written to disk".format(comm.size))
 
     # open file for writing
-    series = openpmd_api.Series(
+    series = io.Series(
         "../samples/5_parallel_write_py.h5",
-        openpmd_api.Access_Type.create,
+        io.Access.create,
         comm
     )
     if 0 == comm.rank:
@@ -40,11 +40,11 @@ if __name__ == "__main__":
               comm.size))
 
     mymesh = series.iterations[1]. \
-        meshes["mymesh"][openpmd_api.Mesh_Record_Component.SCALAR]
+        meshes["mymesh"][io.Mesh_Record_Component.SCALAR]
 
     # example 1D domain decomposition in first index
     global_extent = [comm.size * 10, 300]
-    dataset = openpmd_api.Dataset(local_data.dtype, global_extent)
+    dataset = io.Dataset(local_data.dtype, global_extent)
 
     if 0 == comm.rank:
         print("Prepared a Dataset of size {} and Datatype {}".format(

--- a/examples/6_dump_filebased_series.cpp
+++ b/examples/6_dump_filebased_series.cpp
@@ -8,7 +8,7 @@ using namespace openPMD;
 
 int main()
 {
-    Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_ONLY);
+    Series o = Series("../samples/git-sample/data%T.h5", Access::READ_ONLY);
 
     std::cout << "Read iterations ";
     for( auto const& val : o.iterations )

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -9,7 +9,7 @@ using namespace openPMD;
 void
 write()
 {
-    Series o = Series("../samples/serial_write.h5", AccessType::CREATE);
+    Series o = Series("../samples/serial_write.h5", Access::CREATE);
     ParticleSpecies& e = o.iterations[1].particles["e"];
 
     std::vector< double > position_global(4);
@@ -47,7 +47,7 @@ write()
 void
 write2()
 {
-    Series f = Series("working/directory/2D_simData.h5", AccessType::CREATE);
+    Series f = Series("working/directory/2D_simData.h5", Access::CREATE);
 
     // all required openPMD attributes will be set to reasonable default values (all ones, all zeros, empty strings,...)
     // manually setting them enforces the openPMD standard
@@ -218,7 +218,7 @@ write2()
 void
 w()
 {
-    Series o = Series("../samples/serial_write_%T.h5", AccessType::CREATE);
+    Series o = Series("../samples/serial_write_%T.h5", Access::CREATE);
 
     /* The files in 'o' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -6,7 +6,7 @@ Copyright 2018-2020 openPMD contributors
 Authors: Axel Huebl, Fabian Koller
 License: LGPLv3+
 """
-from openpmd_api import Series, Access_Type, Dataset, Mesh_Record_Component, \
+from openpmd_api import Series, Access, Dataset, Mesh_Record_Component, \
     Unit_Dimension
 import numpy as np
 
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     # open file for writing
     f = Series(
         "working/directory/2D_simData_py.h5",
-        Access_Type.create
+        Access.create
     )
 
     # all required openPMD attributes will be set to reasonable default values

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -6,7 +6,7 @@ Copyright 2019-2020 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """
-from openpmd_api import Series, Access_Type, Dataset, Mesh_Record_Component, \
+from openpmd_api import Series, Access, Dataset, Mesh_Record_Component, \
     Unit_Dimension
 import numpy as np
 
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     # open file for writing
     f = Series(
         "../samples/7_particle_write_serial_py.h5",
-        Access_Type.create
+        Access.create
     )
 
     # all required openPMD attributes will be set to reasonable default values

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -42,7 +42,7 @@ namespace openPMD
         friend class ADIOS1IOHandlerImpl;
 
     public:
-        ADIOS1IOHandler(std::string path, AccessType);
+        ADIOS1IOHandler(std::string path, Access);
         ~ADIOS1IOHandler() override;
 
         std::string backendName() const override { return "ADIOS1"; }
@@ -61,7 +61,7 @@ namespace openPMD
         friend class ADIOS1IOHandlerImpl;
 
     public:
-        ADIOS1IOHandler(std::string path, AccessType);
+        ADIOS1IOHandler(std::string path, Access);
         ~ADIOS1IOHandler() override;
 
         std::string backendName() const override { return "DUMMY_ADIOS1"; }

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -172,7 +172,7 @@ public:
      * @brief The ADIOS2 access type to chose for Engines opened
      * within this instance.
      */
-    adios2::Mode adios2Accesstype( );
+    adios2::Mode adios2AccessMode( );
 
 
 private:
@@ -748,10 +748,10 @@ public:
 #if openPMD_HAVE_MPI
 
     ADIOS2IOHandler(
-            std::string path,
-            Access,
-            MPI_Comm,
-            nlohmann::json options
+        std::string path,
+        Access,
+        MPI_Comm,
+        nlohmann::json options
     );
 
 #endif

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -748,15 +748,15 @@ public:
 #if openPMD_HAVE_MPI
 
     ADIOS2IOHandler(
-        std::string path,
-        AccessType,
-        MPI_Comm,
-        nlohmann::json options
+            std::string path,
+            Access,
+            MPI_Comm,
+            nlohmann::json options
     );
 
 #endif
 
-    ADIOS2IOHandler( std::string path, AccessType, nlohmann::json options );
+    ADIOS2IOHandler(std::string path, Access, nlohmann::json options );
 
     std::string backendName() const override { return "ADIOS2"; }
 

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -42,9 +42,9 @@ namespace openPMD
 
     public:
 #   if openPMD_HAVE_MPI
-        ParallelADIOS1IOHandler(std::string path, AccessType, MPI_Comm);
+        ParallelADIOS1IOHandler(std::string path, Access, MPI_Comm);
 #   else
-        ParallelADIOS1IOHandler(std::string path, AccessType);
+        ParallelADIOS1IOHandler(std::string path, Access);
 #   endif
         ~ParallelADIOS1IOHandler() override;
 

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -71,14 +71,14 @@ public:
 #if openPMD_HAVE_MPI
     AbstractIOHandler(std::string path, Access at, MPI_Comm)
         : directory{std::move(path)},
-          accessTypeBackend{at},
-          accessTypeFrontend{at}
+          m_backendAccess{at},
+          m_frontendAccess{at}
     { }
 #endif
     AbstractIOHandler(std::string path, Access at)
         : directory{std::move(path)},
-          accessTypeBackend{at},
-          accessTypeFrontend{at}
+          m_backendAccess{at},
+          m_frontendAccess{at}
     { }
     virtual ~AbstractIOHandler() = default;
 
@@ -101,8 +101,8 @@ public:
     virtual std::string backendName() const = 0;
 
     std::string const directory;
-    Access const accessTypeBackend;
-    Access const accessTypeFrontend;
+    Access const m_backendAccess;
+    Access const m_frontendAccess;
     std::queue< IOTask > m_work;
 }; // AbstractIOHandler
 

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -21,7 +21,7 @@
 #pragma once
 
 #include "openPMD/config.hpp"
-#include "openPMD/IO/AccessType.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/IO/IOTask.hpp"
 
@@ -69,13 +69,13 @@ class AbstractIOHandler
 {
 public:
 #if openPMD_HAVE_MPI
-    AbstractIOHandler(std::string path, AccessType at, MPI_Comm)
+    AbstractIOHandler(std::string path, Access at, MPI_Comm)
         : directory{std::move(path)},
           accessTypeBackend{at},
           accessTypeFrontend{at}
     { }
 #endif
-    AbstractIOHandler(std::string path, AccessType at)
+    AbstractIOHandler(std::string path, Access at)
         : directory{std::move(path)},
           accessTypeBackend{at},
           accessTypeFrontend{at}
@@ -101,8 +101,8 @@ public:
     virtual std::string backendName() const = 0;
 
     std::string const directory;
-    AccessType const accessTypeBackend;
-    AccessType const accessTypeFrontend;
+    Access const accessTypeBackend;
+    Access const accessTypeFrontend;
     std::queue< IOTask > m_work;
 }; // AbstractIOHandler
 

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -31,7 +31,7 @@ namespace openPMD
     /** Construct an appropriate specific IOHandler for the desired IO mode that may be MPI-aware.
      *
      * @param   path        Path to root folder for all operations associated with the desired handler.
-     * @param   accessType  AccessType describing desired operations and permissions of the desired handler.
+     * @param   access      Access mode describing desired operations and permissions of the desired handler.
      * @param   format      Format describing the IO backend of the desired handler.
      * @param   comm        MPI communicator used for IO.
      * @param   options     JSON-formatted option string, to be interpreted by
@@ -40,18 +40,18 @@ namespace openPMD
      */
 std::shared_ptr< AbstractIOHandler >
 createIOHandler(
-    std::string path,
-    AccessType accessType,
-    Format format,
-    MPI_Comm comm,
-    std::string const & options = "{}" );
+        std::string path,
+        Access access,
+        Format format,
+        MPI_Comm comm,
+        std::string const & options = "{}" );
 #endif
 
 /** Construct an appropriate specific IOHandler for the desired IO mode.
  *
  * @param   path        Path to root folder for all operations associated with
  * the desired handler.
- * @param   accessType  AccessType describing desired operations and permissions
+ * @param   accessType  Access describing desired operations and permissions
  * of the desired handler.
  * @param   format      Format describing the IO backend of the desired handler.
  * @param   options     JSON-formatted option string, to be interpreted by
@@ -60,8 +60,8 @@ createIOHandler(
  */
 std::shared_ptr< AbstractIOHandler >
 createIOHandler(
-    std::string path,
-    AccessType accessType,
-    Format format,
-    std::string const & options = "{}" );
+        std::string path,
+        Access accessType,
+        Format format,
+        std::string const & options = "{}" );
 } // namespace openPMD

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -40,18 +40,18 @@ namespace openPMD
      */
 std::shared_ptr< AbstractIOHandler >
 createIOHandler(
-        std::string path,
-        Access access,
-        Format format,
-        MPI_Comm comm,
-        std::string const & options = "{}" );
+    std::string path,
+    Access access,
+    Format format,
+    MPI_Comm comm,
+    std::string const & options = "{}" );
 #endif
 
 /** Construct an appropriate specific IOHandler for the desired IO mode.
  *
  * @param   path        Path to root folder for all operations associated with
  * the desired handler.
- * @param   accessType  Access describing desired operations and permissions
+ * @param   access      Access describing desired operations and permissions
  * of the desired handler.
  * @param   format      Format describing the IO backend of the desired handler.
  * @param   options     JSON-formatted option string, to be interpreted by
@@ -60,8 +60,8 @@ createIOHandler(
  */
 std::shared_ptr< AbstractIOHandler >
 createIOHandler(
-        std::string path,
-        Access accessType,
-        Format format,
-        std::string const & options = "{}" );
+    std::string path,
+    Access access,
+    Format format,
+    std::string const & options = "{}" );
 } // namespace openPMD

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -117,18 +117,18 @@ public:
 
   /** Create a new file in physical storage, possibly overriding an existing file.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The new file should be located in m_handler->directory.
    * The new file should have the filename parameters.name.
    * The filename should include the correct corresponding filename extension.
-   * Any existing file should be overwritten if m_handler->accessType is AccessType::CREATE.
+   * Any existing file should be overwritten if m_handler->accessType is Access::CREATE.
    * The Writables file position should correspond to the root group "/" of the hierarchy.
    * The Writable should be marked written when the operation completes successfully.
    */
   virtual void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) = 0;
   /** Create all necessary groups for a path, possibly recursively.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The path parameters.path may contain multiple levels (e.g. first/second/third/).
    * The Writables file position should correspond to the complete newly created path (i.e. first/second/third/ should be assigned to the Writables file position).
    * The Writable should be marked written when the operation completes successfully.
@@ -136,7 +136,7 @@ public:
   virtual void createPath(Writable*, Parameter< Operation::CREATE_PATH > const&) = 0;
   /** Create a new dataset of given type, extent and storage properties.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The path may contain multiple levels (e.g. group/dataset).
    * The new dataset should have the name parameters.name. This name should not start or end with a slash ("/").
    * The new dataset should be of datatype parameters.dtype.
@@ -151,7 +151,7 @@ public:
   virtual void createDataset(Writable*, Parameter< Operation::CREATE_DATASET > const&) = 0;
   /** Increase the extent of an existing dataset.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The operation should fail if the dataset does not yet exist.
    * The dataset should have the name parameters.name. This name should not start or end with a slash ("/").
    * The operation should fail if the new extent is not strictly large in every dimension.
@@ -163,7 +163,7 @@ public:
    * The operation should fail if m_handler->directory is not accessible.
    * The opened file should have filename parameters.name and include the correct corresponding filename extension.
    * The operation should not open files more than once.
-   * If possible, the file should be opened with read-only permissions if m_handler->accessType is AccessType::READ_ONLY.
+   * If possible, the file should be opened with read-only permissions if m_handler->accessType is Access::READ_ONLY.
    * The Writables file position should correspond to the root group "/" of the hierarchy in the opened file.
    * The Writable should be marked written when the operation completes successfully.
    */
@@ -188,7 +188,7 @@ public:
   virtual void openDataset(Writable*, Parameter< Operation::OPEN_DATASET > &) = 0;
   /** Delete an existing file from physical storage.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * All handles that correspond to the file should be closed before deletion.
    * The file to delete should have the filename parameters.name.
@@ -199,7 +199,7 @@ public:
   virtual void deleteFile(Writable*, Parameter< Operation::DELETE_FILE > const&) = 0;
   /** Delete all objects within an existing path.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * The path parameters.path may contain multiple levels (e.g. first/second/third/). This path should be relative (i.e. it should not start with a slash "/"). It may also contain the current group ".".
    * All groups and datasets starting from the path should not be accessible in physical storage after the operation completes successfully.
@@ -209,7 +209,7 @@ public:
   virtual void deletePath(Writable*, Parameter< Operation::DELETE_PATH > const&) = 0;
   /** Delete an existing dataset.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * The dataset should have the name parameters.name. This name should not start or end with a slash ("/"). It may also contain the current dataset ".".
    * The dataset should not be accessible in physical storage after the operation completes successfully.
@@ -219,7 +219,7 @@ public:
   virtual void deleteDataset(Writable*, Parameter< Operation::DELETE_DATASET > const&) = 0;
   /** Delete an existing attribute.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * The attribute should be associated with the Writable and have the name parameters.name before deletion.
    * The attribute should not be accessible in physical storage after the operation completes successfully.
@@ -227,7 +227,7 @@ public:
   virtual void deleteAttribute(Writable*, Parameter< Operation::DELETE_ATT > const&) = 0;
   /** Write a chunk of data into an existing dataset.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The dataset should be associated with the Writable.
    * The operation should fail if the dataset does not exist.
    * The operation should fail if the chunk extent parameters.extent is not smaller or equals in every dimension.
@@ -239,7 +239,7 @@ public:
   virtual void writeDataset(Writable*, Parameter< Operation::WRITE_DATASET > const&) = 0;
   /** Create a single attribute and fill the value, possibly overwriting an existing attribute.
    *
-   * The operation should fail if m_handler->accessType is AccessType::READ_ONLY.
+   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
    * The attribute should have the name parameters.name. This name should not contain a slash ("/").
    * The attribute should be of datatype parameters.dtype.
    * Any existing attribute with the same name should be overwritten. If possible, only the value should be changed if the datatype stays the same.

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -117,18 +117,18 @@ public:
 
   /** Create a new file in physical storage, possibly overriding an existing file.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The new file should be located in m_handler->directory.
    * The new file should have the filename parameters.name.
    * The filename should include the correct corresponding filename extension.
-   * Any existing file should be overwritten if m_handler->accessType is Access::CREATE.
+   * Any existing file should be overwritten if m_handler->m_frontendAccess is Access::CREATE.
    * The Writables file position should correspond to the root group "/" of the hierarchy.
    * The Writable should be marked written when the operation completes successfully.
    */
   virtual void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) = 0;
   /** Create all necessary groups for a path, possibly recursively.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The path parameters.path may contain multiple levels (e.g. first/second/third/).
    * The Writables file position should correspond to the complete newly created path (i.e. first/second/third/ should be assigned to the Writables file position).
    * The Writable should be marked written when the operation completes successfully.
@@ -136,7 +136,7 @@ public:
   virtual void createPath(Writable*, Parameter< Operation::CREATE_PATH > const&) = 0;
   /** Create a new dataset of given type, extent and storage properties.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The path may contain multiple levels (e.g. group/dataset).
    * The new dataset should have the name parameters.name. This name should not start or end with a slash ("/").
    * The new dataset should be of datatype parameters.dtype.
@@ -151,7 +151,7 @@ public:
   virtual void createDataset(Writable*, Parameter< Operation::CREATE_DATASET > const&) = 0;
   /** Increase the extent of an existing dataset.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The operation should fail if the dataset does not yet exist.
    * The dataset should have the name parameters.name. This name should not start or end with a slash ("/").
    * The operation should fail if the new extent is not strictly large in every dimension.
@@ -163,7 +163,7 @@ public:
    * The operation should fail if m_handler->directory is not accessible.
    * The opened file should have filename parameters.name and include the correct corresponding filename extension.
    * The operation should not open files more than once.
-   * If possible, the file should be opened with read-only permissions if m_handler->accessType is Access::READ_ONLY.
+   * If possible, the file should be opened with read-only permissions if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The Writables file position should correspond to the root group "/" of the hierarchy in the opened file.
    * The Writable should be marked written when the operation completes successfully.
    */
@@ -188,7 +188,7 @@ public:
   virtual void openDataset(Writable*, Parameter< Operation::OPEN_DATASET > &) = 0;
   /** Delete an existing file from physical storage.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * All handles that correspond to the file should be closed before deletion.
    * The file to delete should have the filename parameters.name.
@@ -199,7 +199,7 @@ public:
   virtual void deleteFile(Writable*, Parameter< Operation::DELETE_FILE > const&) = 0;
   /** Delete all objects within an existing path.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * The path parameters.path may contain multiple levels (e.g. first/second/third/). This path should be relative (i.e. it should not start with a slash "/"). It may also contain the current group ".".
    * All groups and datasets starting from the path should not be accessible in physical storage after the operation completes successfully.
@@ -209,7 +209,7 @@ public:
   virtual void deletePath(Writable*, Parameter< Operation::DELETE_PATH > const&) = 0;
   /** Delete an existing dataset.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * The dataset should have the name parameters.name. This name should not start or end with a slash ("/"). It may also contain the current dataset ".".
    * The dataset should not be accessible in physical storage after the operation completes successfully.
@@ -219,7 +219,7 @@ public:
   virtual void deleteDataset(Writable*, Parameter< Operation::DELETE_DATASET > const&) = 0;
   /** Delete an existing attribute.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The operation should pass if the Writable was not marked written.
    * The attribute should be associated with the Writable and have the name parameters.name before deletion.
    * The attribute should not be accessible in physical storage after the operation completes successfully.
@@ -227,7 +227,7 @@ public:
   virtual void deleteAttribute(Writable*, Parameter< Operation::DELETE_ATT > const&) = 0;
   /** Write a chunk of data into an existing dataset.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The dataset should be associated with the Writable.
    * The operation should fail if the dataset does not exist.
    * The operation should fail if the chunk extent parameters.extent is not smaller or equals in every dimension.
@@ -239,7 +239,7 @@ public:
   virtual void writeDataset(Writable*, Parameter< Operation::WRITE_DATASET > const&) = 0;
   /** Create a single attribute and fill the value, possibly overwriting an existing attribute.
    *
-   * The operation should fail if m_handler->accessType is Access::READ_ONLY.
+   * The operation should fail if m_handler->m_frontendAccess is Access::READ_ONLY.
    * The attribute should have the name parameters.name. This name should not contain a slash ("/").
    * The attribute should be of datatype parameters.dtype.
    * Any existing attribute with the same name should be overwritten. If possible, only the value should be changed if the datatype stays the same.

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2017-2020 Fabian Koller and Franz Poeschel
  *
  * This file is part of openPMD-api.
  *
@@ -18,19 +18,22 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#pragma once
 
-#include "openPMD/IO/AccessType.hpp"
-
-namespace py = pybind11;
-using namespace openPMD;
+#include "openPMD/auxiliary/Deprecated.hpp"
 
 
-void init_AccessType(py::module &m) {
-    py::enum_<AccessType>(m, "Access_Type")
-        .value("read_only", AccessType::READ_ONLY)
-        .value("read_write", AccessType::READ_WRITE)
-        .value("create", AccessType::CREATE)
-    ;
-}
+namespace openPMD
+{
+    /** File access mode to use during IO.
+     */
+    enum class Access
+    {
+        READ_ONLY,  //!< open series as read-only, fails if series is not found
+        READ_WRITE, //!< open existing series as writable
+        CREATE      //!< create new series and truncate existing (files)
+    }; // Access
+
+
+    using Access_Type OPENPMDAPI_DEPRECATED("Access_Type is deprecated, use Access instead.") = Access;
+} // namespace openPMD

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -35,5 +35,11 @@ namespace openPMD
     }; // Access
 
 
+#if (__cplusplus < 201402L) && defined(_MSC_VER)
+    // this is a non-standard order
+    //   https://en.cppreference.com/w/cpp/language/attributes/deprecated
+    typedef OPENPMDAPI_DEPRECATED("Access_Type is deprecated, use Access instead.") Access Access_Type;
+#else
     using Access_Type OPENPMDAPI_DEPRECATED("Access_Type is deprecated, use Access instead.") = Access;
+#endif
 } // namespace openPMD

--- a/include/openPMD/IO/DummyIOHandler.hpp
+++ b/include/openPMD/IO/DummyIOHandler.hpp
@@ -21,7 +21,7 @@
 #pragma once
 
 #include "openPMD/IO/AbstractIOHandler.hpp"
-#include "openPMD/IO/AccessType.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/IO/IOTask.hpp"
 
 #include <string>
@@ -35,7 +35,7 @@ namespace openPMD
     class DummyIOHandler : public AbstractIOHandler
     {
     public:
-        DummyIOHandler(std::string, AccessType);
+        DummyIOHandler(std::string, Access);
         ~DummyIOHandler() override = default;
 
         /** No-op consistent with the IOHandler interface to enable library use without IO.

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -34,7 +34,7 @@ class HDF5IOHandlerImpl;
 class HDF5IOHandler : public AbstractIOHandler
 {
 public:
-    HDF5IOHandler(std::string path, AccessType);
+    HDF5IOHandler(std::string path, Access);
     ~HDF5IOHandler() override;
 
     std::string backendName() const override { return "HDF5"; }

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -36,9 +36,9 @@ namespace openPMD
     {
     public:
     #if openPMD_HAVE_MPI
-        ParallelHDF5IOHandler(std::string path, AccessType, MPI_Comm);
+        ParallelHDF5IOHandler(std::string path, Access, MPI_Comm);
     #else
-        ParallelHDF5IOHandler(std::string path, AccessType);
+        ParallelHDF5IOHandler(std::string path, Access);
     #endif
         ~ParallelHDF5IOHandler() override;
 

--- a/include/openPMD/IO/JSON/JSONIOHandler.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandler.hpp
@@ -33,8 +33,8 @@ namespace openPMD
     {
     public:
         JSONIOHandler(
-            std::string path,
-            AccessType at
+                std::string path,
+                Access at
         );
 
         ~JSONIOHandler( ) override;

--- a/include/openPMD/IO/JSON/JSONIOHandler.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandler.hpp
@@ -33,8 +33,8 @@ namespace openPMD
     {
     public:
         JSONIOHandler(
-                std::string path,
-                Access at
+            std::string path,
+            Access at
         );
 
         ~JSONIOHandler( ) override;

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -25,7 +25,7 @@
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
-#include "openPMD/IO/AccessType.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/IO/JSON/JSONFilePosition.hpp"
 
 #include <nlohmann/json.hpp>
@@ -278,9 +278,9 @@ namespace openPMD
         // shared pointer to circumvent the fact that c++ pre 17 does
         // not enforce (only allow) copy elision in return statements
         std::shared_ptr< FILEHANDLE > getFilehandle(
-            File,
-            AccessType accessType
-        ); //, AccessType accessTypeFrontend=this->m_handler->accessTypeFrontend);
+                File,
+                Access accessType
+        ); //, Access accessTypeFrontend=this->m_handler->accessTypeFrontend);
 
         // full operating system path of the given file
         std::string fullPath( File );

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -278,9 +278,9 @@ namespace openPMD
         // shared pointer to circumvent the fact that c++ pre 17 does
         // not enforce (only allow) copy elision in return statements
         std::shared_ptr< FILEHANDLE > getFilehandle(
-                File,
-                Access accessType
-        ); //, Access accessTypeFrontend=this->m_handler->accessTypeFrontend);
+            File,
+            Access access
+        ); //, Access m_frontendAccess=this->m_handler->m_frontendAccess);
 
         // full operating system path of the given file
         std::string fullPath( File );

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -25,7 +25,7 @@
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
-#include "openPMD/IO/AccessType.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/IterationEncoding.hpp"
@@ -60,14 +60,14 @@ public:
 #if openPMD_HAVE_MPI
     Series(
         std::string const & filepath,
-        AccessType at,
+        Access at,
         MPI_Comm comm,
         std::string const & options = "{}" );
 #endif
 
     Series(
         std::string const & filepath,
-        AccessType at,
+        Access at,
         std::string const & options = "{}" );
     ~Series();
 

--- a/include/openPMD/auxiliary/Deprecated.hpp
+++ b/include/openPMD/auxiliary/Deprecated.hpp
@@ -29,7 +29,7 @@
 #   elif defined(__GNUC__) && defined(__GNUC_PATCHLEVEL__)
 #       define OPENPMDAPI_DEPRECATED(msg) __attribute__((deprecated))
 #   elif defined(_MSC_VER)
-#       define OPENPMDAPI_DEPRECATED(msg) __declspec(deprecated)
+#       define OPENPMDAPI_DEPRECATED(msg) __declspec(deprecated(msg))
 #   else
 #       define OPENPMDAPI_DEPRECATED(msg)
 #   endif

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -208,7 +208,7 @@ template< typename T >
 inline bool
 Attributable::setAttribute(std::string const& key, T const& value)
 {
-    if( IOHandler && AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
+    if(IOHandler && Access::READ_ONLY == IOHandler->accessTypeFrontend )
     {
         auxiliary::OutOfRangeMsg const out_of_range_msg(
             "Attribute",

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -208,7 +208,7 @@ template< typename T >
 inline bool
 Attributable::setAttribute(std::string const& key, T const& value)
 {
-    if(IOHandler && Access::READ_ONLY == IOHandler->accessTypeFrontend )
+    if(IOHandler && Access::READ_ONLY == IOHandler->m_frontendAccess )
     {
         auxiliary::OutOfRangeMsg const out_of_range_msg(
             "Attribute",

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -107,12 +107,12 @@ public:
 
     /** Remove all objects from the container and (if written) from disk.
      *
-     * @note    Calling this operation on any container in a Series with <code>AccessType::READ_ONLY</code> will throw an exception.
+     * @note    Calling this operation on any container in a Series with <code>Access::READ_ONLY</code> will throw an exception.
      * @throws  std::runtime_error
      */
     void clear()
     {
-        if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
+        if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
             throw std::runtime_error("Can not clear a container in a read-only Series.");
 
         clear_unchecked();
@@ -146,7 +146,7 @@ public:
             return it->second;
         else
         {
-            if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
+            if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
             {
                 auxiliary::OutOfRangeMsg const out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
@@ -173,7 +173,7 @@ public:
             return it->second;
         else
         {
-            if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
+            if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
             {
                 auxiliary::OutOfRangeMsg out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
@@ -207,14 +207,14 @@ public:
 
     /** Remove a single element from the container and (if written) from disk.
      *
-     * @note    Calling this operation on any container in a Series with <code>AccessType::READ_ONLY</code> will throw an exception.
+     * @note    Calling this operation on any container in a Series with <code>Access::READ_ONLY</code> will throw an exception.
      * @throws  std::runtime_error
      * @param   key Key of the element to remove.
      * @return  Number of elements removed (either 0 or 1).
      */
     virtual size_type erase(key_type const& key)
     {
-        if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
+        if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
         auto res = m_container->find(key);
@@ -231,7 +231,7 @@ public:
     //! @todo why does const_iterator not work compile with pybind11?
     virtual iterator erase(iterator res)
     {
-        if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
+        if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
         if( res != m_container->end() && res->second.written )

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -112,7 +112,7 @@ public:
      */
     void clear()
     {
-        if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
+        if(Access::READ_ONLY == IOHandler->m_frontendAccess )
             throw std::runtime_error("Can not clear a container in a read-only Series.");
 
         clear_unchecked();
@@ -146,7 +146,7 @@ public:
             return it->second;
         else
         {
-            if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
+            if(Access::READ_ONLY == IOHandler->m_frontendAccess )
             {
                 auxiliary::OutOfRangeMsg const out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
@@ -173,7 +173,7 @@ public:
             return it->second;
         else
         {
-            if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
+            if(Access::READ_ONLY == IOHandler->m_frontendAccess )
             {
                 auxiliary::OutOfRangeMsg out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
@@ -214,7 +214,7 @@ public:
      */
     virtual size_type erase(key_type const& key)
     {
-        if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
+        if(Access::READ_ONLY == IOHandler->m_frontendAccess )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
         auto res = m_container->find(key);
@@ -231,7 +231,7 @@ public:
     //! @todo why does const_iterator not work compile with pybind11?
     virtual iterator erase(iterator res)
     {
-        if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
+        if(Access::READ_ONLY == IOHandler->m_frontendAccess )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
         if( res != m_container->end() && res->second.written )

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -402,7 +402,7 @@ namespace openPMD
         // open file for writing
         Series series = Series(
             m_benchmark->m_basePath + "." + extension,
-            AccessType::CREATE,
+            Access::CREATE,
             m_benchmark->communicator
         );
 
@@ -475,7 +475,7 @@ namespace openPMD
 
         Series series = Series(
             m_benchmark->m_basePath + "." + extension,
-            AccessType::READ_ONLY,
+            Access::READ_ONLY,
             m_benchmark->communicator
         );
 

--- a/include/openPMD/cli/ls.hpp
+++ b/include/openPMD/cli/ls.hpp
@@ -75,7 +75,7 @@ namespace ls
         try {
             auto s = Series(
                 argv[1],
-                AccessType::READ_ONLY
+                Access::READ_ONLY
             );
 
             helper::listSeries(s, true, std::cout);

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -47,7 +47,7 @@ namespace openPMD {}
 #include "openPMD/backend/PatchRecordComponent.hpp"
 #include "openPMD/backend/Writable.hpp"
 
-#include "openPMD/IO/AccessType.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/IO/Format.hpp"
 
 #include "openPMD/auxiliary/Date.hpp"

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -53,7 +53,7 @@ ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
         close(f.second);
     m_openReadFileHandles.clear();
 
-    if( this->m_handler->accessTypeBackend != AccessType::READ_ONLY )
+    if( this->m_handler->m_backendAccess != Access::READ_ONLY )
     {
         for( auto& group : m_attributeWrites )
             for( auto& att : group.second )
@@ -201,7 +201,7 @@ ADIOS1IOHandlerImpl::init()
 #endif
 
 #if openPMD_HAVE_ADIOS1
-ADIOS1IOHandler::ADIOS1IOHandler(std::string path, AccessType at)
+ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at)
         : AbstractIOHandler(std::move(path), at),
           m_impl{new ADIOS1IOHandlerImpl(this)}
 {
@@ -303,7 +303,7 @@ ADIOS1IOHandlerImpl::initialize_group(std::string const &name)
 #endif
 
 #else
-ADIOS1IOHandler::ADIOS1IOHandler(std::string path, AccessType at)
+ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without ADIOS1 support");

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -167,7 +167,7 @@ void ADIOS2IOHandlerImpl::createFile(
     Writable * writable,
     Parameter< Operation::CREATE_FILE > const & parameters )
 {
-    VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+    VERIFY_ALWAYS( m_handler->accessTypeBackend != Access::READ_ONLY,
                    "[ADIOS2] Creating a file in read-only mode is not possible." );
 
     if ( !writable->written )
@@ -181,7 +181,7 @@ void ADIOS2IOHandlerImpl::createFile(
         auto res_pair = getPossiblyExisting( name );
         InvalidatableFile shared_name = InvalidatableFile( name );
         VERIFY_ALWAYS(
-            !( m_handler->accessTypeBackend == AccessType::READ_WRITE &&
+            !( m_handler->accessTypeBackend == Access::READ_WRITE &&
                ( !std::get< PE_NewlyCreated >( res_pair ) ||
                  auxiliary::file_exists( fullPath(
                      std::get< PE_InvalidatableFile >( res_pair ) ) ) ) ),
@@ -243,7 +243,7 @@ void ADIOS2IOHandlerImpl::createDataset(
     Writable * writable,
     const Parameter< Operation::CREATE_DATASET > & parameters )
 {
-    if ( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if ( m_handler->accessTypeBackend == Access::READ_ONLY )
     {
         throw std::runtime_error( "[ADIOS2] Creating a dataset in a file opened as read "
                                   "only is not possible." );
@@ -390,7 +390,7 @@ void ADIOS2IOHandlerImpl::writeDataset(
     Writable * writable,
     const Parameter< Operation::WRITE_DATASET > & parameters )
 {
-    VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+    VERIFY_ALWAYS( m_handler->accessTypeBackend != Access::READ_ONLY,
                    "[ADIOS2] Cannot write data in read-only mode." );
     setAndGetFilePosition( writable );
     auto file = refreshFileFromParent( writable );
@@ -585,11 +585,11 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2Accesstype( )
 {
     switch ( m_handler->accessTypeBackend )
     {
-    case AccessType::CREATE:
+    case Access::CREATE:
         return adios2::Mode::Write;
-    case AccessType::READ_ONLY:
+    case Access::READ_ONLY:
         return adios2::Mode::Read;
-    case AccessType::READ_WRITE:
+    case Access::READ_WRITE:
         std::cerr << "ADIOS2 does currently not yet implement ReadWrite "
                      "(Append) mode."
                   << "Replacing with Read mode." << std::endl;
@@ -815,7 +815,7 @@ namespace detail
     {
 
         VERIFY_ALWAYS( impl->m_handler->accessTypeBackend !=
-                           AccessType::READ_ONLY,
+                           Access::READ_ONLY,
                        "[ADIOS2] Cannot write attribute in read-only mode." );
         auto pos = impl->setAndGetFilePosition( writable );
         auto file = impl->refreshFileFromParent( writable );
@@ -1099,7 +1099,7 @@ namespace detail
                       adios2::Engine & engine )
     {
         VERIFY_ALWAYS( m_impl->m_handler->accessTypeBackend !=
-                           AccessType::READ_ONLY,
+                           Access::READ_ONLY,
                        "[ADIOS2] Cannot write data in read-only mode." );
 
         auto ptr = std::static_pointer_cast< const T >( bp.param.data ).get( );
@@ -1465,7 +1465,7 @@ namespace detail
 
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
-    openPMD::AccessType at,
+    openPMD::Access at,
     MPI_Comm comm,
     nlohmann::json options )
     : AbstractIOHandler( std::move( path ), at, comm ),
@@ -1477,7 +1477,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(
 
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
-    AccessType at,
+    Access at,
     nlohmann::json options )
     : AbstractIOHandler( std::move( path ), at ),
       m_impl{ this, std::move( options ) }
@@ -1494,10 +1494,10 @@ ADIOS2IOHandler::flush()
 
 #    if openPMD_HAVE_MPI
 ADIOS2IOHandler::ADIOS2IOHandler(
-    std::string path,
-    AccessType at,
-    MPI_Comm comm,
-    nlohmann::json
+        std::string path,
+        Access at,
+        MPI_Comm comm,
+        nlohmann::json
 )
     : AbstractIOHandler( std::move( path ), at, comm )
 {
@@ -1506,9 +1506,9 @@ ADIOS2IOHandler::ADIOS2IOHandler(
 #    endif // openPMD_HAVE_MPI
 
 ADIOS2IOHandler::ADIOS2IOHandler(
-    std::string path,
-    AccessType at,
-    nlohmann::json )
+        std::string path,
+        Access at,
+        nlohmann::json )
     : AbstractIOHandler( std::move( path ), at )
 {
 }

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -350,7 +350,7 @@ void
 CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
                                 Parameter< Operation::CREATE_FILE > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[ADIOS1] Creating a file in read-only mode is not possible.");
 
     if( !writable->written )
@@ -384,7 +384,7 @@ void
 CommonADIOS1IOHandlerImpl::createPath(Writable* writable,
                                 Parameter< Operation::CREATE_PATH > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[ADIOS1] Creating a path in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -417,7 +417,7 @@ void
 CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
                                    Parameter< Operation::CREATE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[ADIOS1] Creating a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -509,7 +509,7 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
     else
         filePath = it->second;
 
-    if( m_handler->accessTypeBackend == AccessType::CREATE )
+    if( m_handler->m_backendAccess == Access::CREATE )
     {
         // called at Series::flush for iterations that has been flushed before
         // this is to make sure to point the Series.m_writer points to this iteration
@@ -702,7 +702,7 @@ void
 CommonADIOS1IOHandlerImpl::deleteFile(Writable* writable,
                                 Parameter< Operation::DELETE_FILE > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[ADIOS1] Deleting a file opened as read only is not possible.");
 
     if( writable->written )
@@ -779,7 +779,7 @@ void
 CommonADIOS1IOHandlerImpl::writeDataset(Writable* writable,
                                   Parameter< Operation::WRITE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[ADIOS1] Writing into a dataset in a file opened as read-only is not possible.");
 
     int64_t fd = GetFileHandle(writable);
@@ -811,7 +811,7 @@ void
 CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
                                     Parameter< Operation::WRITE_ATT > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[ADIOS1] Writing an attribute in a file opened as read only is not possible.");
 
     std::string name = concrete_bp1_file_position(writable);

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -58,7 +58,7 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
         close(f.second);
     m_openReadFileHandles.clear();
 
-    if( this->m_handler->accessTypeBackend != AccessType::READ_ONLY )
+    if( this->m_handler->m_backendAccess != Access::READ_ONLY )
     {
         for( auto& group : m_attributeWrites )
             for( auto& att : group.second )
@@ -336,7 +336,7 @@ ParallelADIOS1IOHandlerImpl::initialize_group(std::string const &name)
 #else
 #   if openPMD_HAVE_MPI
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
-                                                 AccessType at,
+                                                 Access at,
                                                  MPI_Comm comm)
         : AbstractIOHandler(std::move(path), at, comm)
 {
@@ -344,7 +344,7 @@ ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
 }
 #   else
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
-                                                 AccessType at)
+                                                 Access at)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without parallel ADIOS1 support");

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -224,7 +224,7 @@ ParallelADIOS1IOHandlerImpl::init()
 }
 
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
-                                                 AccessType at,
+                                                 Access at,
                                                  MPI_Comm comm)
         : AbstractIOHandler(std::move(path), at, comm),
           m_impl{new ParallelADIOS1IOHandlerImpl(this, comm)}

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -34,57 +34,58 @@ namespace openPMD
 #if openPMD_HAVE_MPI
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-            std::string path,
-            Access accessTypeBackend,
-            Format format,
-            MPI_Comm comm,
-            std::string const & options )
+        std::string path,
+        Access access,
+        Format format,
+        MPI_Comm comm,
+        std::string const & options )
     {
         nlohmann::json optionsJson = nlohmann::json::parse( options );
         switch( format )
         {
             case Format::HDF5:
-                return std::make_shared< ParallelHDF5IOHandler >(path, accessTypeBackend, comm);
+                return std::make_shared< ParallelHDF5IOHandler >( path, access, comm );
             case Format::ADIOS1:
 #   if openPMD_HAVE_ADIOS1
-                return std::make_shared< ParallelADIOS1IOHandler >(path, accessTypeBackend, comm);
+                return std::make_shared< ParallelADIOS1IOHandler >( path, access, comm );
 #   else
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #   endif
             case Format::ADIOS2:
                 return std::make_shared< ADIOS2IOHandler >(
-                    path, accessTypeBackend, comm, std::move( optionsJson ) );
+                    path, access, comm, std::move( optionsJson ) );
             default:
                 throw std::runtime_error(
                     "Unknown file format! Did you specify a file ending?" );
         }
     }
 #endif
+
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-            std::string path,
-            Access accessType,
-            Format format,
-            std::string const & options )
+        std::string path,
+        Access access,
+        Format format,
+        std::string const & options )
     {
         nlohmann::json optionsJson = nlohmann::json::parse( options );
         switch( format )
         {
             case Format::HDF5:
-                return std::make_shared< HDF5IOHandler >(path, accessType);
+                return std::make_shared< HDF5IOHandler >( path, access );
             case Format::ADIOS1:
 #if openPMD_HAVE_ADIOS1
-                return std::make_shared< ADIOS1IOHandler >(path, accessType);
+                return std::make_shared< ADIOS1IOHandler >( path, access );
 #else
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #endif
 #if openPMD_HAVE_ADIOS2
             case Format::ADIOS2:
                 return std::make_shared< ADIOS2IOHandler >(
-                    path, accessType, std::move( optionsJson ) );
+                    path, access, std::move( optionsJson ) );
 #endif // openPMD_HAVE_ADIOS2
             case Format::JSON:
-                return std::make_shared< JSONIOHandler >( path, accessType );
+                return std::make_shared< JSONIOHandler >( path, access );
             default:
                 throw std::runtime_error(
                     "Unknown file format! Did you specify a file ending?" );

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -34,11 +34,11 @@ namespace openPMD
 #if openPMD_HAVE_MPI
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-        std::string path,
-        AccessType accessTypeBackend,
-        Format format,
-        MPI_Comm comm,
-        std::string const & options )
+            std::string path,
+            Access accessTypeBackend,
+            Format format,
+            MPI_Comm comm,
+            std::string const & options )
     {
         nlohmann::json optionsJson = nlohmann::json::parse( options );
         switch( format )
@@ -62,10 +62,10 @@ namespace openPMD
 #endif
     std::shared_ptr< AbstractIOHandler >
     createIOHandler(
-        std::string path,
-        AccessType accessType,
-        Format format,
-        std::string const & options )
+            std::string path,
+            Access accessType,
+            Format format,
+            std::string const & options )
     {
         nlohmann::json optionsJson = nlohmann::json::parse( options );
         switch( format )

--- a/src/IO/DummyIOHandler.cpp
+++ b/src/IO/DummyIOHandler.cpp
@@ -26,7 +26,7 @@
 
 namespace openPMD
 {
-    DummyIOHandler::DummyIOHandler(std::string path, AccessType at)
+    DummyIOHandler::DummyIOHandler(std::string path, Access at)
             : AbstractIOHandler(std::move(path), at)
     { }
 

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -95,7 +95,7 @@ void
 HDF5IOHandlerImpl::createFile(Writable* writable,
                               Parameter< Operation::CREATE_FILE > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Creating a file in read-only mode is not possible.");
 
     if( !writable->written )
@@ -110,7 +110,7 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
         if( !auxiliary::ends_with(name, ".h5") )
             name += ".h5";
         unsigned flags;
-        if( m_handler->accessTypeBackend == AccessType::CREATE )
+        if( m_handler->accessTypeBackend == Access::CREATE )
             flags = H5F_ACC_TRUNC;
         else
             flags = H5F_ACC_EXCL;
@@ -133,7 +133,7 @@ void
 HDF5IOHandlerImpl::createPath(Writable* writable,
                               Parameter< Operation::CREATE_PATH > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Creating a path in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -196,7 +196,7 @@ void
 HDF5IOHandlerImpl::createDataset(Writable* writable,
                                  Parameter< Operation::CREATE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Creating a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -305,7 +305,7 @@ void
 HDF5IOHandlerImpl::extendDataset(Writable* writable,
                                  Parameter< Operation::EXTEND_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Extending a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -373,13 +373,13 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     }
 
     unsigned flags;
-    AccessType at = m_handler->accessTypeBackend;
-    if( at == AccessType::READ_ONLY )
+    Access at = m_handler->accessTypeBackend;
+    if( at == Access::READ_ONLY )
         flags = H5F_ACC_RDONLY;
-    else if( at == AccessType::READ_WRITE || at == AccessType::CREATE )
+    else if( at == Access::READ_WRITE || at == Access::CREATE )
         flags = H5F_ACC_RDWR;
     else
-        throw std::runtime_error("[HDF5] Unknown file AccessType");
+        throw std::runtime_error("[HDF5] Unknown file Access");
     hid_t file_id;
     file_id = H5Fopen(name.c_str(),
                       flags,
@@ -534,7 +534,7 @@ void
 HDF5IOHandlerImpl::deleteFile(Writable* writable,
                               Parameter< Operation::DELETE_FILE > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting a file opened as read only is not possible.");
 
     if( writable->written )
@@ -565,7 +565,7 @@ void
 HDF5IOHandlerImpl::deletePath(Writable* writable,
                               Parameter< Operation::DELETE_PATH > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -609,7 +609,7 @@ void
 HDF5IOHandlerImpl::deleteDataset(Writable* writable,
                                  Parameter< Operation::DELETE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -653,7 +653,7 @@ void
 HDF5IOHandlerImpl::deleteAttribute(Writable* writable,
                                    Parameter< Operation::DELETE_ATT > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting an attribute in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -682,7 +682,7 @@ void
 HDF5IOHandlerImpl::writeDataset(Writable* writable,
                                 Parameter< Operation::WRITE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Writing into a dataset in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);
@@ -768,7 +768,7 @@ void
 HDF5IOHandlerImpl::writeAttribute(Writable* writable,
                                   Parameter< Operation::WRITE_ATT > const& parameters)
 {
-    if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+    if( m_handler->accessTypeBackend == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Writing an attribute in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);
@@ -1570,7 +1570,7 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
 #endif
 
 #if openPMD_HAVE_HDF5
-HDF5IOHandler::HDF5IOHandler(std::string path, AccessType at)
+HDF5IOHandler::HDF5IOHandler(std::string path, Access at)
         : AbstractIOHandler(std::move(path), at),
           m_impl{new HDF5IOHandlerImpl(this)}
 { }
@@ -1583,7 +1583,7 @@ HDF5IOHandler::flush()
     return m_impl->flush();
 }
 #else
-HDF5IOHandler::HDF5IOHandler(std::string path, AccessType at)
+HDF5IOHandler::HDF5IOHandler(std::string path, Access at)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without HDF5 support");

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -95,7 +95,7 @@ void
 HDF5IOHandlerImpl::createFile(Writable* writable,
                               Parameter< Operation::CREATE_FILE > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Creating a file in read-only mode is not possible.");
 
     if( !writable->written )
@@ -110,7 +110,7 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
         if( !auxiliary::ends_with(name, ".h5") )
             name += ".h5";
         unsigned flags;
-        if( m_handler->accessTypeBackend == Access::CREATE )
+        if( m_handler->m_backendAccess == Access::CREATE )
             flags = H5F_ACC_TRUNC;
         else
             flags = H5F_ACC_EXCL;
@@ -133,7 +133,7 @@ void
 HDF5IOHandlerImpl::createPath(Writable* writable,
                               Parameter< Operation::CREATE_PATH > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Creating a path in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -196,7 +196,7 @@ void
 HDF5IOHandlerImpl::createDataset(Writable* writable,
                                  Parameter< Operation::CREATE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Creating a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -305,7 +305,7 @@ void
 HDF5IOHandlerImpl::extendDataset(Writable* writable,
                                  Parameter< Operation::EXTEND_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Extending a dataset in a file opened as read only is not possible.");
 
     if( !writable->written )
@@ -373,7 +373,7 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     }
 
     unsigned flags;
-    Access at = m_handler->accessTypeBackend;
+    Access at = m_handler->m_backendAccess;
     if( at == Access::READ_ONLY )
         flags = H5F_ACC_RDONLY;
     else if( at == Access::READ_WRITE || at == Access::CREATE )
@@ -534,7 +534,7 @@ void
 HDF5IOHandlerImpl::deleteFile(Writable* writable,
                               Parameter< Operation::DELETE_FILE > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting a file opened as read only is not possible.");
 
     if( writable->written )
@@ -565,7 +565,7 @@ void
 HDF5IOHandlerImpl::deletePath(Writable* writable,
                               Parameter< Operation::DELETE_PATH > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -609,7 +609,7 @@ void
 HDF5IOHandlerImpl::deleteDataset(Writable* writable,
                                  Parameter< Operation::DELETE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting a path in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -653,7 +653,7 @@ void
 HDF5IOHandlerImpl::deleteAttribute(Writable* writable,
                                    Parameter< Operation::DELETE_ATT > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Deleting an attribute in a file opened as read only is not possible.");
 
     if( writable->written )
@@ -682,7 +682,7 @@ void
 HDF5IOHandlerImpl::writeDataset(Writable* writable,
                                 Parameter< Operation::WRITE_DATASET > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Writing into a dataset in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);
@@ -768,7 +768,7 @@ void
 HDF5IOHandlerImpl::writeAttribute(Writable* writable,
                                   Parameter< Operation::WRITE_ATT > const& parameters)
 {
-    if( m_handler->accessTypeBackend == Access::READ_ONLY )
+    if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Writing an attribute in a file opened as read only is not possible.");
 
     auto res = m_fileIDs.find(writable);

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -39,7 +39,7 @@ namespace openPMD
 #   endif
 
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
-                                             AccessType at,
+                                             Access at,
                                              MPI_Comm comm)
         : AbstractIOHandler(std::move(path), at, comm),
           m_impl{new ParallelHDF5IOHandlerImpl(this, comm)}
@@ -94,7 +94,7 @@ ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
 #else
 #   if openPMD_HAVE_MPI
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
-                                             AccessType at,
+                                             Access at,
                                              MPI_Comm comm)
         : AbstractIOHandler(std::move(path), at, comm)
 {
@@ -102,7 +102,7 @@ ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
 }
 #   else
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
-                                             AccessType at)
+                                             Access at)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without parallel support and without HDF5 support");

--- a/src/IO/JSON/JSONIOHandler.cpp
+++ b/src/IO/JSON/JSONIOHandler.cpp
@@ -27,8 +27,8 @@ namespace openPMD
     JSONIOHandler::~JSONIOHandler( ) = default;
 
     JSONIOHandler::JSONIOHandler(
-            std::string path,
-            Access at
+        std::string path,
+        Access at
     ) :
         AbstractIOHandler {
             path,

--- a/src/IO/JSON/JSONIOHandler.cpp
+++ b/src/IO/JSON/JSONIOHandler.cpp
@@ -27,8 +27,8 @@ namespace openPMD
     JSONIOHandler::~JSONIOHandler( ) = default;
 
     JSONIOHandler::JSONIOHandler(
-        std::string path,
-        AccessType at
+            std::string path,
+            Access at
     ) :
         AbstractIOHandler {
             path,

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -84,7 +84,7 @@ namespace openPMD
         Parameter< Operation::CREATE_FILE > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
             "[JSON] Creating a file in read-only mode is not possible." );
 
         if( !writable->written )
@@ -100,8 +100,8 @@ namespace openPMD
 
             auto res_pair = getPossiblyExisting( name );
             File shared_name = File( name );
-            VERIFY_ALWAYS( !( m_handler->accessTypeBackend == AccessType::READ_WRITE &&
-                              ( !std::get< 2 >( res_pair ) ||
+            VERIFY_ALWAYS( !(m_handler->accessTypeBackend == Access::READ_WRITE &&
+                             ( !std::get< 2 >( res_pair ) ||
                                 auxiliary::file_exists( fullPath( std::get< 0 >( res_pair ) ) ) ) ),
                 "[JSON] Can only overwrite existing file in CREATE mode." );
 
@@ -203,7 +203,7 @@ namespace openPMD
         Parameter< Operation::CREATE_DATASET > const & parameter
     )
     {
-        if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+        if(m_handler->accessTypeBackend == Access::READ_ONLY )
         {
             throw std::runtime_error( "[JSON] Creating a dataset in a file opened as read only is not possible." );
         }
@@ -238,7 +238,7 @@ namespace openPMD
         Parameter< Operation::EXTEND_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
             "[JSON] Cannot extend a dataset in read-only mode." )
         refreshFileFromParent( writable );
         setAndGetFilePosition( writable );
@@ -368,7 +368,7 @@ namespace openPMD
         Parameter< Operation::DELETE_FILE > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
             "[JSON] Cannot delete files in read-only mode" )
 
         if( !writable->written )
@@ -402,7 +402,7 @@ namespace openPMD
         Parameter< Operation::DELETE_PATH > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
             "[JSON] Cannot delete paths in read-only mode" )
 
         if( !writable->written )
@@ -508,7 +508,7 @@ namespace openPMD
         Parameter< Operation::DELETE_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
             "[JSON] Cannot delete datasets in read-only mode" )
 
         if( !writable->written )
@@ -563,7 +563,7 @@ namespace openPMD
         Parameter< Operation::DELETE_ATT > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
             "[JSON] Cannot delete attributes in read-only mode" )
         if( !writable->written )
         {
@@ -582,7 +582,7 @@ namespace openPMD
         Parameter< Operation::WRITE_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS( m_handler->accessTypeBackend != AccessType::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
             "[JSON] Cannot write data in read-only mode." );
 
         auto pos = setAndGetFilePosition( writable );
@@ -613,7 +613,7 @@ namespace openPMD
         Parameter< Operation::WRITE_ATT > const & parameter
     )
     {
-        if( m_handler->accessTypeBackend == AccessType::READ_ONLY )
+        if(m_handler->accessTypeBackend == Access::READ_ONLY )
         {
             throw std::runtime_error( "[JSON] Creating a dataset in a file opened as read only is not possible." );
         }
@@ -782,8 +782,8 @@ namespace openPMD
 
     std::shared_ptr< JSONIOHandlerImpl::FILEHANDLE >
     JSONIOHandlerImpl::getFilehandle(
-        File fileName,
-        AccessType accessType
+            File fileName,
+            Access accessType
     )
     {
         VERIFY_ALWAYS( fileName.valid( ),
@@ -792,14 +792,14 @@ namespace openPMD
         auto fs = std::make_shared< std::fstream >( );
         switch( accessType )
         {
-            case AccessType::CREATE:
-            case AccessType::READ_WRITE:
+            case Access::CREATE:
+            case Access::READ_WRITE:
                 fs->open(
                     path,
                     std::ios_base::out | std::ios_base::trunc
                 );
                 break;
-            case AccessType::READ_ONLY:
+            case Access::READ_ONLY:
                 fs->open(
                     path,
                     std::ios_base::in
@@ -1085,8 +1085,8 @@ namespace openPMD
         }
         // read from file
         auto fh = getFilehandle(
-            file,
-            AccessType::READ_ONLY
+                file,
+                Access::READ_ONLY
         );
         std::shared_ptr< nlohmann::json >
             res = std::make_shared< nlohmann::json >( );
@@ -1124,8 +1124,8 @@ namespace openPMD
         if( it != m_jsonVals.end( ) )
         {
             auto fh = getFilehandle(
-                filename,
-                AccessType::CREATE
+                    filename,
+                    Access::CREATE
             );
             ( *it->second )["platform_byte_widths"] = platformSpecifics( );
             *fh << *it->second << std::endl;

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -84,7 +84,7 @@ namespace openPMD
         Parameter< Operation::CREATE_FILE > const & parameters
     )
     {
-        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->m_backendAccess != Access::READ_ONLY,
             "[JSON] Creating a file in read-only mode is not possible." );
 
         if( !writable->written )
@@ -100,7 +100,7 @@ namespace openPMD
 
             auto res_pair = getPossiblyExisting( name );
             File shared_name = File( name );
-            VERIFY_ALWAYS( !(m_handler->accessTypeBackend == Access::READ_WRITE &&
+            VERIFY_ALWAYS( !(m_handler->m_backendAccess == Access::READ_WRITE &&
                              ( !std::get< 2 >( res_pair ) ||
                                 auxiliary::file_exists( fullPath( std::get< 0 >( res_pair ) ) ) ) ),
                 "[JSON] Can only overwrite existing file in CREATE mode." );
@@ -203,7 +203,7 @@ namespace openPMD
         Parameter< Operation::CREATE_DATASET > const & parameter
     )
     {
-        if(m_handler->accessTypeBackend == Access::READ_ONLY )
+        if(m_handler->m_backendAccess == Access::READ_ONLY )
         {
             throw std::runtime_error( "[JSON] Creating a dataset in a file opened as read only is not possible." );
         }
@@ -238,7 +238,7 @@ namespace openPMD
         Parameter< Operation::EXTEND_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->m_backendAccess != Access::READ_ONLY,
             "[JSON] Cannot extend a dataset in read-only mode." )
         refreshFileFromParent( writable );
         setAndGetFilePosition( writable );
@@ -368,7 +368,7 @@ namespace openPMD
         Parameter< Operation::DELETE_FILE > const & parameters
     )
     {
-        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->m_backendAccess != Access::READ_ONLY,
             "[JSON] Cannot delete files in read-only mode" )
 
         if( !writable->written )
@@ -402,7 +402,7 @@ namespace openPMD
         Parameter< Operation::DELETE_PATH > const & parameters
     )
     {
-        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->m_backendAccess != Access::READ_ONLY,
             "[JSON] Cannot delete paths in read-only mode" )
 
         if( !writable->written )
@@ -508,7 +508,7 @@ namespace openPMD
         Parameter< Operation::DELETE_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->m_backendAccess != Access::READ_ONLY,
             "[JSON] Cannot delete datasets in read-only mode" )
 
         if( !writable->written )
@@ -563,7 +563,7 @@ namespace openPMD
         Parameter< Operation::DELETE_ATT > const & parameters
     )
     {
-        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->m_backendAccess != Access::READ_ONLY,
             "[JSON] Cannot delete attributes in read-only mode" )
         if( !writable->written )
         {
@@ -582,7 +582,7 @@ namespace openPMD
         Parameter< Operation::WRITE_DATASET > const & parameters
     )
     {
-        VERIFY_ALWAYS(m_handler->accessTypeBackend != Access::READ_ONLY,
+        VERIFY_ALWAYS(m_handler->m_backendAccess != Access::READ_ONLY,
             "[JSON] Cannot write data in read-only mode." );
 
         auto pos = setAndGetFilePosition( writable );
@@ -613,7 +613,7 @@ namespace openPMD
         Parameter< Operation::WRITE_ATT > const & parameter
     )
     {
-        if(m_handler->accessTypeBackend == Access::READ_ONLY )
+        if(m_handler->m_backendAccess == Access::READ_ONLY )
         {
             throw std::runtime_error( "[JSON] Creating a dataset in a file opened as read only is not possible." );
         }
@@ -782,15 +782,15 @@ namespace openPMD
 
     std::shared_ptr< JSONIOHandlerImpl::FILEHANDLE >
     JSONIOHandlerImpl::getFilehandle(
-            File fileName,
-            Access accessType
+        File fileName,
+        Access access
     )
     {
         VERIFY_ALWAYS( fileName.valid( ),
             "[JSON] Tried opening a file that has been overwritten or deleted." )
         auto path = fullPath( std::move( fileName ) );
         auto fs = std::make_shared< std::fstream >( );
-        switch( accessType )
+        switch( access )
         {
             case Access::CREATE:
             case Access::READ_WRITE:
@@ -1085,8 +1085,8 @@ namespace openPMD
         }
         // read from file
         auto fh = getFilehandle(
-                file,
-                Access::READ_ONLY
+            file,
+            Access::READ_ONLY
         );
         std::shared_ptr< nlohmann::json >
             res = std::make_shared< nlohmann::json >( );

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -119,7 +119,7 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     } else
     {
         // operations for create mode
-        if((IOHandler->accessTypeFrontend == Access::CREATE ) &&
+        if((IOHandler->m_frontendAccess == Access::CREATE ) &&
            ( (IOHandler->backendName() == "MPI_ADIOS1") || (IOHandler->backendName() == "ADIOS1") ) )
         {
             auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
@@ -168,7 +168,7 @@ Iteration::flushGroupBased(uint64_t i)
 void
 Iteration::flush()
 {
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
     {
         for( auto& m : meshes )
             m.second.flush(m.first);

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -119,8 +119,8 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
     } else
     {
         // operations for create mode
-        if( ( IOHandler->accessTypeFrontend == AccessType::CREATE ) &&
-            ( (IOHandler->backendName() == "MPI_ADIOS1") || (IOHandler->backendName() == "ADIOS1") ) )
+        if((IOHandler->accessTypeFrontend == Access::CREATE ) &&
+           ( (IOHandler->backendName() == "MPI_ADIOS1") || (IOHandler->backendName() == "ADIOS1") ) )
         {
             auto s = dynamic_cast< Series* >(parent->attributable->parent->attributable);
             Parameter< Operation::OPEN_FILE > fOpen;
@@ -168,7 +168,7 @@ Iteration::flushGroupBased(uint64_t i)
 void
 Iteration::flush()
 {
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
     {
         for( auto& m : meshes )
             m.second.flush(m.first);

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -196,7 +196,7 @@ Mesh::setTimeOffset( float );
 void
 Mesh::flush_impl(std::string const& name)
 {
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
     {
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -196,7 +196,7 @@ Mesh::setTimeOffset( float );
 void
 Mesh::flush_impl(std::string const& name)
 {
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
     {
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -113,7 +113,7 @@ ParticleSpecies::read()
 void
 ParticleSpecies::flush(std::string const& path)
 {
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
     {
         for( auto& record : *this )
             record.second.flush(record.first);

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -113,7 +113,7 @@ ParticleSpecies::read()
 void
 ParticleSpecies::flush(std::string const& path)
 {
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
     {
         for( auto& record : *this )
             record.second.flush(record.first);

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -48,7 +48,7 @@ Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
 void
 Record::flush_impl(std::string const& name)
 {
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
     {
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -48,7 +48,7 @@ Record::setUnitDimension(std::map< UnitDimension, double > const& udim)
 void
 Record::flush_impl(std::string const& name)
 {
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
     {
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -107,7 +107,7 @@ RecordComponent::empty() const
 void
 RecordComponent::flush(std::string const& name)
 {
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
     {
         while( !m_chunks->empty() )
         {

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -107,7 +107,7 @@ RecordComponent::empty() const
 void
 RecordComponent::flush(std::string const& name)
 {
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
     {
         while( !m_chunks->empty() )
         {

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -494,12 +494,12 @@ Series::init(std::shared_ptr< AbstractIOHandler > ioHandler,
     m_filenamePostfix = std::make_shared< std::string >(input->filenamePostfix);
     m_filenamePadding = std::make_shared< int >(input->filenamePadding);
 
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY || IOHandler->accessTypeFrontend == Access::READ_WRITE )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY || IOHandler->m_frontendAccess == Access::READ_WRITE )
     {
         /* Allow creation of values in Containers and setting of Attributes
          * Would throw for Access::READ_ONLY */
-        auto oldType = IOHandler->accessTypeFrontend;
-        auto newType = const_cast< Access* >(&m_writable->IOHandler->accessTypeFrontend);
+        auto oldType = IOHandler->m_frontendAccess;
+        auto newType = const_cast< Access* >(&m_writable->IOHandler->m_frontendAccess);
         *newType = Access::READ_WRITE;
 
         if( input->iterationEncoding == IterationEncoding::fileBased )
@@ -556,7 +556,7 @@ Series::flushFileBased()
     if( iterations.empty() )
         throw std::runtime_error("fileBased output can not be written with no iterations.");
 
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
         for( auto& i : iterations )
             i.second.flush();
     else
@@ -593,7 +593,7 @@ Series::flushFileBased()
 void
 Series::flushGroupBased()
 {
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
         for( auto& i : iterations )
             i.second.flush();
     else
@@ -713,7 +713,7 @@ Series::readFileBased()
     {
         /* Frontend access type might change during Series::read() to allow parameter modification.
          * Backend access type stays unchanged for the lifetime of a Series. */
-        if(IOHandler->accessTypeBackend == Access::READ_ONLY  )
+        if(IOHandler->m_backendAccess == Access::READ_ONLY  )
             throw std::runtime_error("No matching iterations found: " + name());
         else
             std::cerr << "No matching iterations found: " << name() << std::endl;
@@ -724,7 +724,7 @@ Series::readFileBased()
 
     /* Frontend access type might change during Series::read() to allow parameter modification.
      * Backend access type stays unchanged for the lifetime of a Series. */
-    if( paddings.size() > 1u && IOHandler->accessTypeBackend == Access::READ_WRITE )
+    if( paddings.size() > 1u && IOHandler->m_backendAccess == Access::READ_WRITE )
         throw std::runtime_error("Cannot write to a series with inconsistent iteration padding. "
                                  "Please specify '%0<N>T' or open as read-only.");
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -83,7 +83,7 @@ struct Series::ParsedInput
 #if openPMD_HAVE_MPI
 Series::Series(
     std::string const & filepath,
-    AccessType at,
+    Access at,
     MPI_Comm comm,
     std::string const & options )
     : iterations{ Container< Iteration, uint64_t >() }
@@ -98,7 +98,7 @@ Series::Series(
 
 Series::Series(
     std::string const & filepath,
-    AccessType at,
+    Access at,
     std::string const & options )
     : iterations{ Container< Iteration, uint64_t >() }
     , m_iterationEncoding{ std::make_shared< IterationEncoding >() }
@@ -494,13 +494,13 @@ Series::init(std::shared_ptr< AbstractIOHandler > ioHandler,
     m_filenamePostfix = std::make_shared< std::string >(input->filenamePostfix);
     m_filenamePadding = std::make_shared< int >(input->filenamePadding);
 
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY || IOHandler->accessTypeFrontend == AccessType::READ_WRITE )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY || IOHandler->accessTypeFrontend == Access::READ_WRITE )
     {
         /* Allow creation of values in Containers and setting of Attributes
-         * Would throw for AccessType::READ_ONLY */
+         * Would throw for Access::READ_ONLY */
         auto oldType = IOHandler->accessTypeFrontend;
-        auto newType = const_cast< AccessType* >(&m_writable->IOHandler->accessTypeFrontend);
-        *newType = AccessType::READ_WRITE;
+        auto newType = const_cast< Access* >(&m_writable->IOHandler->accessTypeFrontend);
+        *newType = Access::READ_WRITE;
 
         if( input->iterationEncoding == IterationEncoding::fileBased )
             readFileBased();
@@ -509,7 +509,7 @@ Series::init(std::shared_ptr< AbstractIOHandler > ioHandler,
 
         if( iterations.empty() )
         {
-            /* AccessType::READ_WRITE can be used to create a new Series
+            /* Access::READ_WRITE can be used to create a new Series
              * allow setting attributes in that case */
             written = false;
 
@@ -556,7 +556,7 @@ Series::flushFileBased()
     if( iterations.empty() )
         throw std::runtime_error("fileBased output can not be written with no iterations.");
 
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
         for( auto& i : iterations )
             i.second.flush();
     else
@@ -593,7 +593,7 @@ Series::flushFileBased()
 void
 Series::flushGroupBased()
 {
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
         for( auto& i : iterations )
             i.second.flush();
     else
@@ -713,7 +713,7 @@ Series::readFileBased()
     {
         /* Frontend access type might change during Series::read() to allow parameter modification.
          * Backend access type stays unchanged for the lifetime of a Series. */
-        if( IOHandler->accessTypeBackend == AccessType::READ_ONLY  )
+        if(IOHandler->accessTypeBackend == Access::READ_ONLY  )
             throw std::runtime_error("No matching iterations found: " + name());
         else
             std::cerr << "No matching iterations found: " << name() << std::endl;
@@ -724,7 +724,7 @@ Series::readFileBased()
 
     /* Frontend access type might change during Series::read() to allow parameter modification.
      * Backend access type stays unchanged for the lifetime of a Series. */
-    if( paddings.size() > 1u && IOHandler->accessTypeBackend == AccessType::READ_WRITE )
+    if( paddings.size() > 1u && IOHandler->accessTypeBackend == Access::READ_WRITE )
         throw std::runtime_error("Cannot write to a series with inconsistent iteration padding. "
                                  "Please specify '%0<N>T' or open as read-only.");
 }

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -71,7 +71,7 @@ Attributable::getAttribute(std::string const& key) const
 bool
 Attributable::deleteAttribute(std::string const& key)
 {
-    if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
+    if(Access::READ_ONLY == IOHandler->m_frontendAccess )
         throw std::runtime_error("Can not delete an Attribute in a read-only Series.");
 
     auto it = m_attributes->find(key);

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -71,7 +71,7 @@ Attributable::getAttribute(std::string const& key) const
 bool
 Attributable::deleteAttribute(std::string const& key)
 {
-    if( AccessType::READ_ONLY == IOHandler->accessTypeFrontend )
+    if(Access::READ_ONLY == IOHandler->accessTypeFrontend )
         throw std::runtime_error("Can not delete an Attribute in a read-only Series.");
 
     auto it = m_attributes->find(key);

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -42,7 +42,7 @@ PatchRecord::flush_impl(std::string const& path)
 {
     if( this->find(RecordComponent::SCALAR) == this->end() )
     {
-        if( IOHandler->accessTypeFrontend != AccessType::READ_ONLY )
+        if(IOHandler->accessTypeFrontend != Access::READ_ONLY )
             Container< PatchRecordComponent >::flush(path);
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -42,7 +42,7 @@ PatchRecord::flush_impl(std::string const& path)
 {
     if( this->find(RecordComponent::SCALAR) == this->end() )
     {
-        if(IOHandler->accessTypeFrontend != Access::READ_ONLY )
+        if(IOHandler->m_frontendAccess != Access::READ_ONLY )
             Container< PatchRecordComponent >::flush(path);
         for( auto& comp : *this )
             comp.second.flush(comp.first);

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -70,7 +70,7 @@ PatchRecordComponent::PatchRecordComponent()
 void
 PatchRecordComponent::flush(std::string const& name)
 {
-    if( IOHandler->accessTypeFrontend == AccessType::READ_ONLY )
+    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
     {
         while( !m_chunks->empty() )
         {

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -70,7 +70,7 @@ PatchRecordComponent::PatchRecordComponent()
 void
 PatchRecordComponent::flush(std::string const& name)
 {
-    if(IOHandler->accessTypeFrontend == Access::READ_ONLY )
+    if(IOHandler->m_frontendAccess == Access::READ_ONLY )
     {
         while( !m_chunks->empty() )
         {

--- a/src/binding/python/Access.cpp
+++ b/src/binding/python/Access.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller and Franz Poeschel
+/* Copyright 2018-2020 Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -18,17 +18,19 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "openPMD/IO/Access.hpp"
+
+namespace py = pybind11;
+using namespace openPMD;
 
 
-namespace openPMD
-{
-    /** File access mode to use during IO.
-     */
-    enum class AccessType
-    {
-        READ_ONLY,  //!< open series as read-only, fails if series is not found
-        READ_WRITE, //!< open existing series as writable
-        CREATE      //!< create new series and truncate existing (files)
-    }; // AccessType
-} // namespace openPMD
+void init_Access(py::module &m) {
+    py::enum_<Access>(m, "Access")
+        .value("read_only", Access::READ_ONLY)
+        .value("read_write", Access::READ_WRITE)
+        .value("create", Access::CREATE)
+    ;
+}

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -57,14 +57,14 @@ using namespace openPMD;
 void init_Series(py::module &m) {
     py::class_<Series, Attributable>(m, "Series")
 
-        .def(py::init<std::string const&, AccessType, std::string const &>(),
-            py::arg("filepath"), py::arg("access_type"), py::arg("options") = "{}")
+        .def(py::init<std::string const&, Access, std::string const &>(),
+            py::arg("filepath"), py::arg("access"), py::arg("options") = "{}")
 #if openPMD_HAVE_MPI
         .def(py::init([](
-                std::string const& filepath,
-                AccessType at,
-                py::object &comm,
-                std::string const& options){
+                 std::string const& filepath,
+                 Access at,
+                 py::object &comm,
+                 std::string const& options){
             //! TODO perform mpi4py import test and check min-version
             //!       careful: double MPI_Init risk? only import mpi4py.MPI?
             //!       required C-API init? probably just checks:
@@ -113,7 +113,7 @@ void init_Series(py::module &m) {
             return new Series(filepath, at, *mpiCommPtr, options);
         }),
             py::arg("filepath"),
-            py::arg("access_type"),
+            py::arg("access"),
             py::arg("mpi_communicator"),
             py::arg("options") = "{}"
         )

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -32,7 +32,7 @@ namespace py = pybind11;
 
 
 // forward declarations of exposed classes
-void init_AccessType(py::module &);
+void init_Access(py::module &);
 void init_Attributable(py::module &);
 void init_BaseRecord(py::module &);
 void init_BaseRecordComponent(py::module &);
@@ -62,7 +62,7 @@ PYBIND11_MODULE(openpmd_api_cxx, m) {
 
             .. autosummary::
                :toctree: _generate
-               Access_Type
+               Access
                Attributable
                Container
                Dataset
@@ -84,7 +84,7 @@ PYBIND11_MODULE(openpmd_api_cxx, m) {
     )pbdoc";
 
     // note: order from parent to child classes
-    init_AccessType(m);
+    init_Access(m);
     init_UnitDimension(m);
     init_Attributable(m);
     init_Container(m);

--- a/src/binding/python/openpmd_api/__init__.py
+++ b/src/binding/python/openpmd_api/__init__.py
@@ -6,3 +6,6 @@ __version__ = cxx.__version__
 __doc__ = cxx.__doc__
 __license__ = cxx.__license__
 # __author__ = cxx.__author__
+
+# TODO remove in future versions (deprecated)
+Access_Type = Access  # noqa

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -33,7 +33,7 @@ struct TestHelper : public Attributable
 {
     TestHelper()
     {
-        m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
+        m_writable->IOHandler = createIOHandler(".", Access::CREATE, Format::JSON);
         IOHandler = m_writable->IOHandler.get();
     }
 };
@@ -108,7 +108,7 @@ TEST_CASE( "container_default_test", "[auxiliary]")
 {
 #if openPMD_USE_INVASIVE_TESTS
     Container< openPMD::test::S > c = Container< openPMD::test::S >();
-    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
+    c.m_writable->IOHandler = createIOHandler(".", Access::CREATE, Format::JSON);
     c.IOHandler = c.m_writable->IOHandler.get();
 
     REQUIRE(c.empty());
@@ -143,7 +143,7 @@ TEST_CASE( "container_retrieve_test", "[auxiliary]" )
 #if openPMD_USE_INVASIVE_TESTS
     using structure = openPMD::test::structure;
     Container< structure > c = Container< structure >();
-    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
+    c.m_writable->IOHandler = createIOHandler(".", Access::CREATE, Format::JSON);
     c.IOHandler = c.m_writable->IOHandler.get();
 
     structure s;
@@ -220,7 +220,7 @@ TEST_CASE( "container_access_test", "[auxiliary]" )
 #if openPMD_USE_INVASIVE_TESTS
     using Widget = openPMD::test::Widget;
     Container< Widget > c = Container< Widget >();
-    c.m_writable->IOHandler = createIOHandler(".", AccessType::CREATE, Format::JSON);
+    c.m_writable->IOHandler = createIOHandler(".", Access::CREATE, Format::JSON);
     c.IOHandler = c.m_writable->IOHandler.get();
 
     c["1firstWidget"] = Widget(0);

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -143,7 +143,7 @@ TEST_CASE( "attribute_dtype_test", "[core]" )
 TEST_CASE( "output_default_test", "[core]" )
 {
     using IE = IterationEncoding;
-    Series o = Series("./new_openpmd_output_%T.json", AccessType::CREATE);
+    Series o = Series("./new_openpmd_output_%T.json", Access::CREATE);
 
     REQUIRE(o.openPMD() == "1.1.0");
     REQUIRE(o.openPMDextension() == static_cast<uint32_t>(0));
@@ -160,7 +160,7 @@ TEST_CASE( "output_default_test", "[core]" )
 TEST_CASE( "output_constructor_test", "[core]" )
 {
     using IE = IterationEncoding;
-    Series o = Series("./MyCustomOutput.json", AccessType::CREATE);
+    Series o = Series("./MyCustomOutput.json", Access::CREATE);
 
     o.setMeshesPath("customMeshesPath").setParticlesPath("customParticlesPath");
 
@@ -184,7 +184,7 @@ TEST_CASE( "output_constructor_test", "[core]" )
 
 TEST_CASE( "output_modification_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     o.setOpenPMD("1.0.0");
     REQUIRE(o.openPMD() == "1.0.0");
@@ -209,7 +209,7 @@ TEST_CASE( "output_modification_test", "[core]" )
 
 TEST_CASE( "iteration_default_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     Iteration& i = o.iterations[42];
 
@@ -223,7 +223,7 @@ TEST_CASE( "iteration_default_test", "[core]" )
 
 TEST_CASE( "iteration_modification_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     Iteration& i = o.iterations[42];
 
@@ -241,7 +241,7 @@ TEST_CASE( "iteration_modification_test", "[core]" )
 
 TEST_CASE( "particleSpecies_modification_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     auto& particles = o.iterations[42].particles;
     REQUIRE(0 == particles.numAttributes());
@@ -270,7 +270,7 @@ TEST_CASE( "particleSpecies_modification_test", "[core]" )
 
 TEST_CASE( "record_constructor_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     ParticleSpecies ps = o.iterations[42].particles["species"];
     Record& r = ps["record"];
@@ -292,7 +292,7 @@ TEST_CASE( "record_constructor_test", "[core]" )
 
 TEST_CASE( "record_modification_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     auto species = o.iterations[42].particles["species"];
     Record& r = species["position"];
@@ -320,7 +320,7 @@ TEST_CASE( "record_modification_test", "[core]" )
 
 TEST_CASE( "recordComponent_modification_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     ParticleSpecies ps = o.iterations[42].particles["species"];
     Record& r = ps["record"];
@@ -342,7 +342,7 @@ TEST_CASE( "recordComponent_modification_test", "[core]" )
 
 TEST_CASE( "mesh_constructor_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     Mesh &m = o.iterations[42].meshes["E"];
 
@@ -370,7 +370,7 @@ TEST_CASE( "mesh_constructor_test", "[core]" )
 
 TEST_CASE( "mesh_modification_test", "[core]" )
 {
-    Series o = Series("./MyOutput_%T.json", AccessType::CREATE);
+    Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     Mesh &m = o.iterations[42].meshes["E"];
     m["x"];
@@ -410,7 +410,7 @@ TEST_CASE( "mesh_modification_test", "[core]" )
 TEST_CASE( "structure_test", "[core]" )
 {
 #if openPMD_USE_INVASIVE_TESTS
-    Series o = Series("./new_openpmd_output_%T.json", AccessType::CREATE);
+    Series o = Series("./new_openpmd_output_%T.json", Access::CREATE);
 
     REQUIRE(o.IOHandler);
     REQUIRE(o.iterations.IOHandler);
@@ -535,7 +535,7 @@ TEST_CASE( "structure_test", "[core]" )
 
 TEST_CASE( "wrapper_test", "[core]" )
 {
-    Series o = Series("./new_openpmd_output.json", AccessType::CREATE);
+    Series o = Series("./new_openpmd_output.json", Access::CREATE);
 
     o.setOpenPMDextension(42);
     o.setIterationEncoding(IterationEncoding::fileBased);
@@ -655,7 +655,7 @@ TEST_CASE( "wrapper_test", "[core]" )
 
 TEST_CASE( "use_count_test", "[core]" )
 {
-    Series o = Series("./new_openpmd_output.json", AccessType::CREATE);
+    Series o = Series("./new_openpmd_output.json", Access::CREATE);
 
     MeshRecordComponent mrc = o.iterations[1].meshes["E"]["x"];
     mrc.resetDataset(Dataset(determineDatatype<uint16_t>(), {42}));
@@ -679,7 +679,7 @@ TEST_CASE( "use_count_test", "[core]" )
 
 TEST_CASE( "empty_record_test", "[core]" )
 {
-    Series o = Series("./new_openpmd_output.json", AccessType::CREATE);
+    Series o = Series("./new_openpmd_output.json", Access::CREATE);
 
     o.iterations[1].meshes["E"].setComment("No assumption about contained RecordComponents will be made");
     REQUIRE_THROWS_WITH(o.flush(),
@@ -690,7 +690,7 @@ TEST_CASE( "empty_record_test", "[core]" )
 
 TEST_CASE( "zero_extent_component", "[core]" )
 {
-    Series o = Series("./new_openpmd_output.json", AccessType::CREATE);
+    Series o = Series("./new_openpmd_output.json", Access::CREATE);
 
     auto E_x = o.iterations[1].meshes["E"]["x"];
     E_x.setComment("Datasets must contain dimensions.");
@@ -703,10 +703,10 @@ TEST_CASE( "zero_extent_component", "[core]" )
 
 TEST_CASE( "no_file_ending", "[core]" )
 {
-    REQUIRE_THROWS_WITH(Series("./new_openpmd_output", AccessType::CREATE),
+    REQUIRE_THROWS_WITH(Series("./new_openpmd_output", Access::CREATE),
                         Catch::Equals("Unknown file format! Did you specify a file ending?"));
-    REQUIRE_THROWS_WITH(Series("./new_openpmd_output_%T", AccessType::CREATE),
+    REQUIRE_THROWS_WITH(Series("./new_openpmd_output_%T", Access::CREATE),
                         Catch::Equals("Unknown file format! Did you specify a file ending?"));
-    REQUIRE_THROWS_WITH(Series("./new_openpmd_output_%05T", AccessType::CREATE),
+    REQUIRE_THROWS_WITH(Series("./new_openpmd_output_%05T", Access::CREATE),
                         Catch::Equals("Unknown file format! Did you specify a file ending?"));
 }

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -63,7 +63,7 @@ TEST_CASE( "parallel_multi_series_test", "[parallel]" )
             allSeries.emplace_back(
                     std::string("../samples/parallel_multi_open_test_").
                             append(std::to_string(sn)).append(".").append(file_ending),
-                    AccessType::CREATE,
+                    Access::CREATE,
                     MPI_COMM_WORLD
             );
             allSeries.back().iterations[sn].setAttribute("wululu", sn);
@@ -101,7 +101,7 @@ void write_test_zero_extent( bool fileBased, std::string file_ending, bool write
     std::string filePath = "../samples/parallel_write_zero_extent";
     if( fileBased )
         filePath += "_%07T";
-    Series o = Series( filePath.append(".").append(file_ending), AccessType::CREATE, MPI_COMM_WORLD);
+    Series o = Series(filePath.append(".").append(file_ending), Access::CREATE, MPI_COMM_WORLD);
 
     int const max_step = 100;
 
@@ -167,7 +167,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[parallel][hdf5]" )
     uint64_t rank = mpi_rank % 3;
     try
     {
-        Series o = Series("../samples/git-sample/data00000%T.h5", AccessType::READ_ONLY, MPI_COMM_WORLD);
+        Series o = Series("../samples/git-sample/data00000%T.h5", Access::READ_ONLY, MPI_COMM_WORLD);
 
         {
             double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
@@ -220,7 +220,7 @@ TEST_CASE( "hdf5_write_test", "[parallel][hdf5]" )
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_r);
     uint64_t mpi_size = static_cast<uint64_t>(mpi_s);
     uint64_t mpi_rank = static_cast<uint64_t>(mpi_r);
-    Series o = Series("../samples/parallel_write.h5", AccessType::CREATE, MPI_COMM_WORLD);
+    Series o = Series("../samples/parallel_write.h5", Access::CREATE, MPI_COMM_WORLD);
 
     o.setAuthor("Parallel HDF5");
     ParticleSpecies& e = o.iterations[1].particles["e"];
@@ -290,7 +290,7 @@ TEST_CASE( "no_parallel_hdf5", "[parallel][hdf5]" )
 #if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
 TEST_CASE( "adios_write_test", "[parallel][adios]" )
 {
-    Series o = Series("../samples/parallel_write.bp", AccessType::CREATE, MPI_COMM_WORLD);
+    Series o = Series("../samples/parallel_write.bp", Access::CREATE, MPI_COMM_WORLD);
 
     int size{-1};
     int rank{-1};
@@ -350,7 +350,7 @@ TEST_CASE( "hzdr_adios_sample_content_test", "[parallel][adios1]" )
     try
     {
         /* development/huebl/lwfa-bgfield-001 */
-        Series o = Series("../samples/hzdr-sample/bp/checkpoint_%T.bp", AccessType::READ_ONLY, MPI_COMM_WORLD);
+        Series o = Series("../samples/hzdr-sample/bp/checkpoint_%T.bp", Access::READ_ONLY, MPI_COMM_WORLD);
 
         if( o.iterations.count(0) == 1)
         {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -65,7 +65,7 @@ TEST_CASE( "multi_series_test", "[serial]" )
             allSeries.emplace_back(
                 std::string("../samples/multi_open_test_").
                     append(std::to_string(sn)).append(".").append(file_ending),
-                AccessType::CREATE
+                Access::CREATE
             );
             allSeries.back().iterations[sn].setAttribute("wululu", sn);
             allSeries.back().flush();
@@ -97,7 +97,7 @@ empty_dataset_test( std::string file_ending )
 {
     {
         Series series(
-            "../samples/empty_datasets." + file_ending, AccessType::CREATE );
+            "../samples/empty_datasets." + file_ending, Access::CREATE );
 
         auto makeEmpty_dim_7_int =
             series.iterations[ 1 ].meshes[ "rho" ][ "makeEmpty_dim_7_int" ];
@@ -119,7 +119,7 @@ empty_dataset_test( std::string file_ending )
     }
     {
         Series series(
-            "../samples/empty_datasets." + file_ending, AccessType::READ_ONLY );
+            "../samples/empty_datasets." + file_ending, Access::READ_ONLY );
 
         REQUIRE(series.iterations.contains(1));
         REQUIRE(series.iterations.count(1) == 1);
@@ -181,7 +181,7 @@ void constant_scalar(std::string file_ending)
 
     {
         // constant scalar
-        Series s = Series("../samples/constant_scalar." + file_ending, AccessType::CREATE);
+        Series s = Series("../samples/constant_scalar." + file_ending, Access::CREATE);
         auto rho = s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR];
         REQUIRE(s.iterations[1].meshes["rho"].scalar());
         rho.resetDataset(Dataset(Datatype::CHAR, {1, 2, 3}));
@@ -232,7 +232,7 @@ void constant_scalar(std::string file_ending)
     }
 
     {
-        Series s = Series("../samples/constant_scalar." + file_ending, AccessType::READ_ONLY);
+        Series s = Series("../samples/constant_scalar." + file_ending, Access::READ_ONLY);
         REQUIRE(s.iterations[1].meshes.count("rho") == 1);
         REQUIRE(s.iterations[1].meshes["rho"].count(MeshRecordComponent::SCALAR) == 1);
         REQUIRE(s.iterations[1].meshes["rho"][MeshRecordComponent::SCALAR].containsAttribute("shape"));
@@ -316,7 +316,7 @@ TEST_CASE( "flush_without_position_positionOffset", "[serial]" )
         const std::string & file_ending = std::get< 0 >( t );
         Series s = Series(
             "../samples/flush_without_position_positionOffset." + file_ending,
-            AccessType::CREATE );
+            Access::CREATE );
         ParticleSpecies e = s.iterations[ 0 ].particles[ "e" ];
         RecordComponent weighting = e[ "weighting" ][ RecordComponent::SCALAR ];
         weighting.resetDataset( Dataset( Datatype::FLOAT, Extent{ 2, 2 } ) );
@@ -354,7 +354,7 @@ void particle_patches( std::string file_ending )
     uint64_t const num_patches = 2u;
     {
         // constant scalar
-        Series s = Series("../samples/particle_patches." + file_ending, AccessType::CREATE);
+        Series s = Series("../samples/particle_patches." + file_ending, Access::CREATE);
 
         auto e = s.iterations[42].particles["electrons"];
 
@@ -400,7 +400,7 @@ void particle_patches( std::string file_ending )
         e.particlePatches["extent"]["y"].store(1, float(123.));
     }
     {
-        Series s = Series("../samples/particle_patches." + file_ending, AccessType::READ_ONLY);
+        Series s = Series("../samples/particle_patches." + file_ending, Access::READ_ONLY);
 
         auto e = s.iterations[42].particles["electrons"];
 
@@ -442,7 +442,7 @@ void dtype_test(const std::string & backend, bool test_128_bit = true)
     bool test_long_double = test_128_bit || sizeof (long double) <= 8;
     bool test_long_long = test_128_bit || sizeof (long long) <= 8;
     {
-        Series s = Series("../samples/dtype_test." + backend, AccessType::CREATE);
+        Series s = Series("../samples/dtype_test." + backend, Access::CREATE);
 
         char c = 'c';
         s.setAttribute("char", c);
@@ -528,7 +528,7 @@ void dtype_test(const std::string & backend, bool test_128_bit = true)
         }
     }
 
-    Series s = Series("../samples/dtype_test." + backend, AccessType::READ_ONLY);
+    Series s = Series("../samples/dtype_test." + backend, Access::READ_ONLY);
 
     REQUIRE(s.getAttribute("char").get< char >() == 'c');
     REQUIRE(s.getAttribute("uchar").get< unsigned char >() == 'u');
@@ -634,7 +634,7 @@ TEST_CASE( "dtype_test", "[serial]" )
 inline
 void write_test(const std::string & backend)
 {
-    Series o = Series("../samples/serial_write." + backend, AccessType::CREATE);
+    Series o = Series("../samples/serial_write." + backend, Access::CREATE);
 
     ParticleSpecies& e_1 = o.iterations[1].particles["e"];
 
@@ -764,7 +764,7 @@ void fileBased_write_test(const std::string & backend)
         auxiliary::remove_directory("../samples/subdir");
 
     {
-        Series o = Series("../samples/subdir/serial_fileBased_write%08T." + backend, AccessType::CREATE);
+        Series o = Series("../samples/subdir/serial_fileBased_write%08T." + backend, Access::CREATE);
 
         ParticleSpecies& e_1 = o.iterations[1].particles["e"];
 
@@ -847,7 +847,7 @@ void fileBased_write_test(const std::string & backend)
         || auxiliary::directory_exists("../samples/subdir/serial_fileBased_write00000003." + backend)));
 
     {
-        Series o = Series("../samples/subdir/serial_fileBased_write%T." + backend, AccessType::READ_ONLY);
+        Series o = Series("../samples/subdir/serial_fileBased_write%T." + backend, Access::READ_ONLY);
 
         REQUIRE(o.iterations.size() == 5);
         REQUIRE(o.iterations.count(1) == 1);
@@ -918,7 +918,7 @@ void fileBased_write_test(const std::string & backend)
 
     // extend existing series with new step and auto-detection of iteration padding
     {
-        Series o = Series("../samples/subdir/serial_fileBased_write%T." + backend, AccessType::READ_WRITE);
+        Series o = Series("../samples/subdir/serial_fileBased_write%T." + backend, Access::READ_WRITE);
 
         REQUIRE(o.iterations.size() == 5);
         o.iterations[6];
@@ -929,7 +929,7 @@ void fileBased_write_test(const std::string & backend)
 
     // additional iteration with different iteration padding but similar content
     {
-        Series o = Series("../samples/subdir/serial_fileBased_write%01T." + backend, AccessType::READ_WRITE);
+        Series o = Series("../samples/subdir/serial_fileBased_write%01T." + backend, Access::READ_WRITE);
 
         REQUIRE(o.iterations.empty());
 
@@ -949,19 +949,19 @@ void fileBased_write_test(const std::string & backend)
 
     // read back with auto-detection and non-fixed padding
     {
-        Series s = Series("../samples/subdir/serial_fileBased_write%T." + backend, AccessType::READ_ONLY);
+        Series s = Series("../samples/subdir/serial_fileBased_write%T." + backend, Access::READ_ONLY);
         REQUIRE(s.iterations.size() == 7);
     }
 
     // write with auto-detection and in-consistent padding
     {
-        REQUIRE_THROWS_WITH(Series("../samples/subdir/serial_fileBased_write%T." + backend, AccessType::READ_WRITE),
+        REQUIRE_THROWS_WITH(Series("../samples/subdir/serial_fileBased_write%T." + backend, Access::READ_WRITE),
             Catch::Equals("Cannot write to a series with inconsistent iteration padding. Please specify '%0<N>T' or open as read-only."));
     }
 
     // read back with auto-detection and fixed padding
     {
-        Series s = Series("../samples/subdir/serial_fileBased_write%08T." + backend, AccessType::READ_ONLY);
+        Series s = Series("../samples/subdir/serial_fileBased_write%08T." + backend, Access::READ_ONLY);
         REQUIRE(s.iterations.size() == 6);
     }
 }
@@ -977,7 +977,7 @@ TEST_CASE( "fileBased_write_test", "[serial]" )
 inline
 void sample_write_thetaMode(std::string file_ending)
 {
-    Series o = Series(std::string("../samples/thetaMode_%05T.").append(file_ending), AccessType::CREATE);
+    Series o = Series(std::string("../samples/thetaMode_%05T.").append(file_ending), Access::CREATE);
 
     unsigned int const num_modes = 4u;
     unsigned int const num_fields = 1u + (num_modes-1u) * 2u; // the first mode is purely real
@@ -1053,13 +1053,13 @@ inline
 void bool_test(const std::string & backend)
 {
     {
-        Series o = Series("../samples/serial_bool." + backend, AccessType::CREATE);
+        Series o = Series("../samples/serial_bool." + backend, Access::CREATE);
 
         o.setAttribute("Bool attribute (true)", true);
         o.setAttribute("Bool attribute (false)", false);
     }
     {
-        Series o = Series("../samples/serial_bool." + backend, AccessType::READ_ONLY);
+        Series o = Series("../samples/serial_bool." + backend, Access::READ_ONLY);
 
         auto attrs = o.attributes();
         REQUIRE(std::count(attrs.begin(), attrs.end(), "Bool attribute (true)") == 1);
@@ -1080,7 +1080,7 @@ TEST_CASE( "bool_test", "[serial]" )
 inline
 void patch_test(const std::string & backend)
 {
-    Series o = Series("../samples/serial_patch." + backend, AccessType::CREATE);
+    Series o = Series("../samples/serial_patch." + backend, Access::CREATE);
 
     auto e = o.iterations[1].particles["e"];
 
@@ -1117,7 +1117,7 @@ TEST_CASE( "patch_test", "[serial]" )
 inline
 void deletion_test(const std::string & backend)
 {
-    Series o = Series("../samples/serial_deletion." + backend, AccessType::CREATE);
+    Series o = Series("../samples/serial_deletion." + backend, Access::CREATE);
 
 
     o.setAttribute("removed",
@@ -1177,7 +1177,7 @@ void read_missing_throw_test(const std::string & backend)
 {
     try
     {
-        auto s = Series("this/does/definitely/not/exist." + backend, AccessType::READ_ONLY);
+        auto s = Series("this/does/definitely/not/exist." + backend, Access::READ_ONLY);
     }
     catch( ... )
     {
@@ -1197,7 +1197,7 @@ void optional_paths_110_test(const std::string & backend)
     try
     {
         {
-            Series s = Series("../samples/issue-sample/no_fields/data%T." + backend, AccessType::READ_ONLY);
+            Series s = Series("../samples/issue-sample/no_fields/data%T." + backend, Access::READ_ONLY);
             auto attrs = s.attributes();
             REQUIRE(std::count(attrs.begin(), attrs.end(), "meshesPath") == 1);
             REQUIRE(std::count(attrs.begin(), attrs.end(), "particlesPath") == 1);
@@ -1206,7 +1206,7 @@ void optional_paths_110_test(const std::string & backend)
         }
 
         {
-            Series s = Series("../samples/issue-sample/no_particles/data%T." + backend, AccessType::READ_ONLY);
+            Series s = Series("../samples/issue-sample/no_particles/data%T." + backend, Access::READ_ONLY);
             auto attrs = s.attributes();
             REQUIRE(std::count(attrs.begin(), attrs.end(), "meshesPath") == 1);
             REQUIRE(std::count(attrs.begin(), attrs.end(), "particlesPath") == 1);
@@ -1219,7 +1219,7 @@ void optional_paths_110_test(const std::string & backend)
     }
 
     {
-        Series s = Series("../samples/no_meshes_1.1.0_compliant." + backend, AccessType::CREATE);
+        Series s = Series("../samples/no_meshes_1.1.0_compliant." + backend, Access::CREATE);
         auto foo = s.iterations[1].particles["foo"];
         Dataset dset = Dataset(Datatype::DOUBLE, {1});
         foo["position"][RecordComponent::SCALAR].resetDataset(dset);
@@ -1229,14 +1229,14 @@ void optional_paths_110_test(const std::string & backend)
     }
 
     {
-        Series s = Series("../samples/no_particles_1.1.0_compliant." + backend, AccessType::CREATE);
+        Series s = Series("../samples/no_particles_1.1.0_compliant." + backend, Access::CREATE);
         auto foo = s.iterations[1].meshes["foo"];
         Dataset dset = Dataset(Datatype::DOUBLE, {1});
         foo[RecordComponent::SCALAR].resetDataset(dset);
     }
 
     {
-        Series s = Series("../samples/no_meshes_1.1.0_compliant." + backend, AccessType::READ_ONLY);
+        Series s = Series("../samples/no_meshes_1.1.0_compliant." + backend, Access::READ_ONLY);
         auto attrs = s.attributes();
         REQUIRE(std::count(attrs.begin(), attrs.end(), "meshesPath") == 0);
         REQUIRE(std::count(attrs.begin(), attrs.end(), "particlesPath") == 1);
@@ -1245,7 +1245,7 @@ void optional_paths_110_test(const std::string & backend)
     }
 
     {
-        Series s = Series("../samples/no_particles_1.1.0_compliant." + backend, AccessType::READ_ONLY);
+        Series s = Series("../samples/no_particles_1.1.0_compliant." + backend, Access::READ_ONLY);
         auto attrs = s.attributes();
         REQUIRE(std::count(attrs.begin(), attrs.end(), "meshesPath") == 1);
         REQUIRE(std::count(attrs.begin(), attrs.end(), "particlesPath") == 0);
@@ -1266,7 +1266,7 @@ TEST_CASE( "git_hdf5_sample_structure_test", "[serial][hdf5]" )
 #if openPMD_USE_INVASIVE_TESTS
     try
     {
-        Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_ONLY);
+        Series o = Series("../samples/git-sample/data%T.h5", Access::READ_ONLY);
 
         REQUIRE(!o.parent);
         REQUIRE(o.iterations.parent == getWritable(&o));
@@ -1319,7 +1319,7 @@ TEST_CASE( "git_hdf5_sample_attribute_test", "[serial][hdf5]" )
 {
     try
     {
-        Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_ONLY);
+        Series o = Series("../samples/git-sample/data%T.h5", Access::READ_ONLY);
 
         REQUIRE(o.openPMD() == "1.1.0");
         REQUIRE(o.openPMDextension() == 1);
@@ -1568,7 +1568,7 @@ TEST_CASE( "git_hdf5_sample_content_test", "[serial][hdf5]" )
 {
     try
     {
-        Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_ONLY);
+        Series o = Series("../samples/git-sample/data%T.h5", Access::READ_ONLY);
 
         {
             double actual[3][3][3] = {{{-1.9080703683727052e-09, -1.5632650729457964e-10, 1.1497536256399599e-09},
@@ -1618,7 +1618,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
 {
     try
     {
-        Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_ONLY);
+        Series o = Series("../samples/git-sample/data%T.h5", Access::READ_ONLY);
 
         REQUIRE(o.iterations.size() == 5);
         REQUIRE(o.iterations.count(100) == 1);
@@ -1638,7 +1638,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
 
     try
     {
-        Series o = Series("../samples/git-sample/data%08T.h5", AccessType::READ_ONLY);
+        Series o = Series("../samples/git-sample/data%08T.h5", Access::READ_ONLY);
 
         REQUIRE(o.iterations.size() == 5);
         REQUIRE(o.iterations.count(100) == 1);
@@ -1656,7 +1656,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
         return;
     }
 
-    REQUIRE_THROWS_WITH(Series("../samples/git-sample/data%07T.h5", AccessType::READ_ONLY),
+    REQUIRE_THROWS_WITH(Series("../samples/git-sample/data%07T.h5", Access::READ_ONLY),
                         Catch::Equals("No matching iterations found: data%07T"));
 
     try
@@ -1672,7 +1672,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
                 auxiliary::remove_file(file);
 
         {
-            Series o = Series("../samples/git-sample/data%T.h5", AccessType::READ_WRITE);
+            Series o = Series("../samples/git-sample/data%T.h5", Access::READ_WRITE);
 
 #if openPMD_USE_INVASIVE_TESTS
             REQUIRE(*o.m_filenamePadding == 8);
@@ -1702,7 +1702,7 @@ TEST_CASE( "git_hdf5_sample_read_thetaMode", "[serial][hdf5][thetaMode]" )
 {
     try
     {
-        Series o = Series("../samples/git-sample/thetaMode/data%T.h5", AccessType::READ_ONLY);
+        Series o = Series("../samples/git-sample/thetaMode/data%T.h5", Access::READ_ONLY);
 
         REQUIRE(o.iterations.size() == 5);
         REQUIRE(o.iterations.count(100) == 1);
@@ -1770,7 +1770,7 @@ TEST_CASE( "hzdr_hdf5_sample_content_test", "[serial][hdf5]" )
     {
         /* HZDR: /bigdata/hplsim/development/huebl/lwfa-openPMD-062-smallLWFA-h5
          * DOI:10.14278/rodare.57 */
-        Series o = Series("../samples/hzdr-sample/h5/simData_%T.h5", AccessType::READ_ONLY);
+        Series o = Series("../samples/hzdr-sample/h5/simData_%T.h5", Access::READ_ONLY);
 
         REQUIRE(o.openPMD() == "1.0.0");
         REQUIRE(o.openPMDextension() == 1);
@@ -2229,7 +2229,7 @@ TEST_CASE( "hzdr_adios1_sample_content_test", "[serial][adios1]" )
     {
         /* HZDR: /bigdata/hplsim/development/huebl/lwfa-bgfield-001
          * DOI:10.14278/rodare.57 */
-        Series o = Series("../samples/hzdr-sample/bp/checkpoint_%T.bp", AccessType::READ_ONLY);
+        Series o = Series("../samples/hzdr-sample/bp/checkpoint_%T.bp", Access::READ_ONLY);
 
         REQUIRE(o.openPMD() == "1.0.0");
         REQUIRE(o.openPMDextension() == 1);
@@ -2451,7 +2451,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
 )END";
     auto const write = []( std::string const & filename,
                      std::string const & config ) {
-        openPMD::Series series( filename, openPMD::AccessType::CREATE, config );
+        openPMD::Series series( filename, openPMD::Access::CREATE, config );
         auto E_x = series.iterations[ 0 ].meshes[ "E" ][ "x" ];
         E_x.resetDataset(
             openPMD::Dataset( openPMD::Datatype::INT, { 1000 } ) );
@@ -2490,7 +2490,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
 )END";
     auto const read = []( std::string const & filename, std::string const & config ) {
         openPMD::Series series(
-            filename, openPMD::AccessType::READ_ONLY, config );
+            filename, openPMD::Access::READ_ONLY, config );
         auto E_x = series.iterations[ 0 ].meshes[ "E" ][ "x" ];
         REQUIRE( E_x.getDimensionality() == 1 );
         REQUIRE( E_x.getExtent()[ 0 ] == 1000 );

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -47,7 +47,7 @@ class APITest(unittest.TestCase):
                 os.path.join("issue-sample", "no_fields", "data%T.h5"))
         path_to_data = generateTestFilePath(
                 os.path.join("git-sample", "data%T.h5"))
-        mode = io.Access_Type.read_only
+        mode = io.Access.read_only
         self.__field_series = io.Series(path_to_field_data, mode)
         self.__particle_series = io.Series(path_to_particle_data, mode)
         self.__series = io.Series(path_to_data, mode)
@@ -120,7 +120,7 @@ class APITest(unittest.TestCase):
         # write
         series = io.Series(
             "unittest_py_API." + file_ending,
-            io.Access_Type.create
+            io.Access.create
         )
 
         # meta data
@@ -218,7 +218,7 @@ class APITest(unittest.TestCase):
         # read back
         series = io.Series(
             "unittest_py_API." + file_ending,
-            io.Access_Type.read_only
+            io.Access.read_only
         )
 
         self.assertEqual(series.get_attribute("char"), "c")
@@ -318,7 +318,7 @@ class APITest(unittest.TestCase):
         # write
         series = io.Series(
             "unittest_py_constant_API." + file_ending,
-            io.Access_Type.create
+            io.Access.create
         )
 
         ms = series.iterations[0].meshes
@@ -376,7 +376,7 @@ class APITest(unittest.TestCase):
         # read back
         series = io.Series(
             "unittest_py_constant_API." + file_ending,
-            io.Access_Type.read_only
+            io.Access.read_only
         )
 
         ms = series.iterations[0].meshes
@@ -924,7 +924,7 @@ class APITest(unittest.TestCase):
         # get series
         series = io.Series(
             "unittest_py_slice_API." + file_ending,
-            io.Access_Type.create
+            io.Access.create
         )
         i = series.iterations[0]
 
@@ -1104,7 +1104,7 @@ class APITest(unittest.TestCase):
 
         series = io.Series(
             "unittest_py_particle_patches." + file_ending,
-            io.Access_Type.create
+            io.Access.create
         )
         e = series.iterations[42].particles["electrons"]
 
@@ -1149,7 +1149,7 @@ class APITest(unittest.TestCase):
 
         series = io.Series(
             "unittest_py_particle_patches." + file_ending,
-            io.Access_Type.read_only
+            io.Access.read_only
         )
         e = series.iterations[42].particles["electrons"]
 


### PR DESCRIPTION
Rename the user-facing `AccessType`/`Access_Type` enum classes to `Access`.

Rationale: "type" just like "action" are relatively meaningless words and do only add verbosity. One could have gone for "access_mode" or "mode" but `openPMD::Access::READ` is probably clear enough, especially in combination with the only usage in `openPMD::Series`.

The old names are still available as (now undocumented and) deprecated aliases and will be removed in a future version of the library.