### PR TITLE
Add Checks to *dynamic_cast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Other
   - move ``.travis/`` to ``.github/ci/`` #715
   - move example file download scripts to ``share/openPMD/`` #715
 - ``listSeries``: remove unused parameters in try-catch #706
+- safer internal ``*dynamic_cast``s of pointers #745
 
 
 0.11.1-alpha

--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -28,6 +28,7 @@
 #include <adios_types.h>
 
 #include <cstring>
+#include <exception>
 #include <iterator>
 #include <iostream>
 #include <sstream>
@@ -208,7 +209,10 @@ concrete_bp1_file_position(Writable* w)
     std::string pos;
     while( !hierarchy.empty() )
     {
-        pos += std::dynamic_pointer_cast< ADIOS1FilePosition >(hierarchy.top()->abstractFilePosition)->location;
+        auto const tmp_ptr = std::dynamic_pointer_cast< ADIOS1FilePosition >(hierarchy.top()->abstractFilePosition);
+        if( tmp_ptr == nullptr )
+            throw std::runtime_error("Dynamic pointer cast returned a nullptr!");
+        pos += tmp_ptr->location;
         hierarchy.pop();
     }
 

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -22,6 +22,7 @@
 
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/IOTask.hpp"
+#include "openPMD/auxiliary/DerefDynamicCast.hpp"
 
 #include <future>
 
@@ -42,6 +43,8 @@ public:
 
     virtual std::future< void > flush()
     {
+        using namespace auxiliary;
+
         while( !(*m_handler).m_work.empty() )
         {
             IOTask& i = (*m_handler).m_work.front();
@@ -51,58 +54,58 @@ public:
                 {
                     using O = Operation;
                     case O::CREATE_FILE:
-                        createFile(i.writable, *dynamic_cast< Parameter< Operation::CREATE_FILE >* >(i.parameter.get()));
+                        createFile(i.writable, deref_dynamic_cast< Parameter< Operation::CREATE_FILE > >(i.parameter.get()));
                         break;
                     case O::CREATE_PATH:
-                        createPath(i.writable, *dynamic_cast< Parameter< O::CREATE_PATH >* >(i.parameter.get()));
+                        createPath(i.writable, deref_dynamic_cast< Parameter< O::CREATE_PATH > >(i.parameter.get()));
                         break;
                     case O::CREATE_DATASET:
-                        createDataset(i.writable, *dynamic_cast< Parameter< O::CREATE_DATASET >* >(i.parameter.get()));
+                        createDataset(i.writable, deref_dynamic_cast< Parameter< O::CREATE_DATASET > >(i.parameter.get()));
                         break;
                     case O::EXTEND_DATASET:
-                        extendDataset(i.writable, *dynamic_cast< Parameter< O::EXTEND_DATASET >* >(i.parameter.get()));
+                        extendDataset(i.writable, deref_dynamic_cast< Parameter< O::EXTEND_DATASET > >(i.parameter.get()));
                         break;
                     case O::OPEN_FILE:
-                        openFile(i.writable, *dynamic_cast< Parameter< O::OPEN_FILE >* >(i.parameter.get()));
+                        openFile(i.writable, deref_dynamic_cast< Parameter< O::OPEN_FILE > >(i.parameter.get()));
                         break;
                     case O::OPEN_PATH:
-                        openPath(i.writable, *dynamic_cast< Parameter< O::OPEN_PATH >* >(i.parameter.get()));
+                        openPath(i.writable, deref_dynamic_cast< Parameter< O::OPEN_PATH > >(i.parameter.get()));
                         break;
                     case O::OPEN_DATASET:
-                        openDataset(i.writable, *dynamic_cast< Parameter< O::OPEN_DATASET >* >(i.parameter.get()));
+                        openDataset(i.writable, deref_dynamic_cast< Parameter< O::OPEN_DATASET > >(i.parameter.get()));
                         break;
                     case O::DELETE_FILE:
-                        deleteFile(i.writable, *dynamic_cast< Parameter< O::DELETE_FILE >* >(i.parameter.get()));
+                        deleteFile(i.writable, deref_dynamic_cast< Parameter< O::DELETE_FILE > >(i.parameter.get()));
                         break;
                     case O::DELETE_PATH:
-                        deletePath(i.writable, *dynamic_cast< Parameter< O::DELETE_PATH >* >(i.parameter.get()));
+                        deletePath(i.writable, deref_dynamic_cast< Parameter< O::DELETE_PATH > >(i.parameter.get()));
                         break;
                     case O::DELETE_DATASET:
-                        deleteDataset(i.writable, *dynamic_cast< Parameter< O::DELETE_DATASET >* >(i.parameter.get()));
+                        deleteDataset(i.writable, deref_dynamic_cast< Parameter< O::DELETE_DATASET > >(i.parameter.get()));
                         break;
                     case O::DELETE_ATT:
-                        deleteAttribute(i.writable, *dynamic_cast< Parameter< O::DELETE_ATT >* >(i.parameter.get()));
+                        deleteAttribute(i.writable, deref_dynamic_cast< Parameter< O::DELETE_ATT > >(i.parameter.get()));
                         break;
                     case O::WRITE_DATASET:
-                        writeDataset(i.writable, *dynamic_cast< Parameter< O::WRITE_DATASET >* >(i.parameter.get()));
+                        writeDataset(i.writable, deref_dynamic_cast< Parameter< O::WRITE_DATASET > >(i.parameter.get()));
                         break;
                     case O::WRITE_ATT:
-                        writeAttribute(i.writable, *dynamic_cast< Parameter< O::WRITE_ATT >* >(i.parameter.get()));
+                        writeAttribute(i.writable, deref_dynamic_cast< Parameter< O::WRITE_ATT > >(i.parameter.get()));
                         break;
                     case O::READ_DATASET:
-                        readDataset(i.writable, *dynamic_cast< Parameter< O::READ_DATASET >* >(i.parameter.get()));
+                        readDataset(i.writable, deref_dynamic_cast< Parameter< O::READ_DATASET > >(i.parameter.get()));
                         break;
                     case O::READ_ATT:
-                        readAttribute(i.writable, *dynamic_cast< Parameter< O::READ_ATT >* >(i.parameter.get()));
+                        readAttribute(i.writable, deref_dynamic_cast< Parameter< O::READ_ATT > >(i.parameter.get()));
                         break;
                     case O::LIST_PATHS:
-                        listPaths(i.writable, *dynamic_cast< Parameter< O::LIST_PATHS >* >(i.parameter.get()));
+                        listPaths(i.writable, deref_dynamic_cast< Parameter< O::LIST_PATHS > >(i.parameter.get()));
                         break;
                     case O::LIST_DATASETS:
-                        listDatasets(i.writable, *dynamic_cast< Parameter< O::LIST_DATASETS >* >(i.parameter.get()));
+                        listDatasets(i.writable, deref_dynamic_cast< Parameter< O::LIST_DATASETS > >(i.parameter.get()));
                         break;
                     case O::LIST_ATTS:
-                        listAttributes(i.writable, *dynamic_cast< Parameter< O::LIST_ATTS >* >(i.parameter.get()));
+                        listAttributes(i.writable, deref_dynamic_cast< Parameter< O::LIST_ATTS > >(i.parameter.get()));
                         break;
                 }
             } catch (unsupported_data_error&)

--- a/include/openPMD/auxiliary/DerefDynamicCast.hpp
+++ b/include/openPMD/auxiliary/DerefDynamicCast.hpp
@@ -1,0 +1,50 @@
+/* Copyright 2020 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <exception>
+
+
+namespace openPMD
+{
+namespace auxiliary {
+    /** Returns a value reference stored in a dynamically casted pointer
+     *
+     * Safe version of *dynamic_cast< New_Type* >( some_ptr ); This function
+     * will throw as dynamic_cast and will furthermore throw if the result
+     * of the dynamic_cast is a nullptr.
+     *
+     * @tparam New_Type new type to cast to
+     * @tparam Old_Type old type to cast from
+     * @param[in] ptr and input pointer type
+     * @return value reference of a dereferenced, dynamically casted ptr to New_Type*
+     */
+    template<typename New_Type, typename Old_Type>
+    inline New_Type &
+    deref_dynamic_cast(Old_Type *ptr) {
+        auto const tmp_ptr = dynamic_cast< New_Type * >( ptr );
+        if (tmp_ptr == nullptr)
+            throw std::runtime_error("Dynamic cast returned a nullptr!");
+        return *tmp_ptr;
+    }
+
+} // namespace auxiliary
+} // namespace openPMD

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -24,21 +24,23 @@
 #include "openPMD/config.hpp"
 #if openPMD_HAVE_MPI
 
+#include "RandomDatasetFiller.hpp"
 
 #include "openPMD/openPMD.hpp"
+#include "openPMD/benchmark/mpi/MPIBenchmarkReport.hpp"
+#include "openPMD/benchmark/mpi/DatasetFiller.hpp"
+#include "openPMD/benchmark/mpi/BlockSlicer.hpp"
+
 #include <mpi.h>
+
 #include <chrono>
+#include <exception>
 #include <iostream>
 #include <sstream>
 #include <utility>
 #include <vector>
 #include <tuple>
 #include <set>
-#include "openPMD/benchmark/mpi/MPIBenchmarkReport.hpp"
-#include "openPMD/benchmark/mpi/DatasetFiller.hpp"
-#include "openPMD/benchmark/mpi/BlockSlicer.hpp"
-#include "openPMD/Datatype.hpp"
-#include "RandomDatasetFiller.hpp"
 
 
 namespace openPMD
@@ -296,7 +298,10 @@ namespace openPMD
         m_blockSlicer { std::move( blockSlicer ) },
         m_dfp { dfp },
         m_basePath { std::move( basePath ) }
-    {}
+    {
+        if( m_blockSlicer == nullptr )
+            throw std::runtime_error("Argument blockSlicer cannot be a nullptr!");
+    }
 
 
     template< typename DatasetFillerProvider >

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -51,6 +51,7 @@ namespace openPMD {}
 #include "openPMD/IO/Format.hpp"
 
 #include "openPMD/auxiliary/Date.hpp"
+#include "openPMD/auxiliary/DerefDynamicCast.hpp"
 #include "openPMD/auxiliary/Deprecated.hpp"
 #include "openPMD/auxiliary/OutOfRangeMsg.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -23,6 +23,7 @@
 
 #if openPMD_HAVE_ADIOS1
 #   include "openPMD/auxiliary/Filesystem.hpp"
+#   include "openPMD/auxiliary/DerefDynamicCast.hpp"
 #   include "openPMD/auxiliary/Memory.hpp"
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
@@ -77,6 +78,8 @@ ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
 std::future< void >
 ADIOS1IOHandlerImpl::flush()
 {
+    using namespace auxiliary;
+
     auto handler = dynamic_cast< ADIOS1IOHandler* >(m_handler);
     while( !handler->m_setup.empty() )
     {
@@ -87,19 +90,19 @@ ADIOS1IOHandlerImpl::flush()
             {
                 using O = Operation;
                 case O::CREATE_FILE:
-                    createFile(i.writable, *dynamic_cast< Parameter< Operation::CREATE_FILE >* >(i.parameter.get()));
+                    createFile(i.writable, deref_dynamic_cast< Parameter< Operation::CREATE_FILE > >(i.parameter.get()));
                     break;
                 case O::CREATE_PATH:
-                    createPath(i.writable, *dynamic_cast< Parameter< O::CREATE_PATH >* >(i.parameter.get()));
+                    createPath(i.writable, deref_dynamic_cast< Parameter< O::CREATE_PATH > >(i.parameter.get()));
                     break;
                 case O::CREATE_DATASET:
-                    createDataset(i.writable, *dynamic_cast< Parameter< O::CREATE_DATASET >* >(i.parameter.get()));
+                    createDataset(i.writable, deref_dynamic_cast< Parameter< O::CREATE_DATASET > >(i.parameter.get()));
                     break;
                 case O::WRITE_ATT:
-                    writeAttribute(i.writable, *dynamic_cast< Parameter< O::WRITE_ATT >* >(i.parameter.get()));
+                    writeAttribute(i.writable, deref_dynamic_cast< Parameter< O::WRITE_ATT > >(i.parameter.get()));
                     break;
                 case O::OPEN_FILE:
-                    openFile(i.writable, *dynamic_cast< Parameter< O::OPEN_FILE >* >(i.parameter.get()));
+                    openFile(i.writable, deref_dynamic_cast< Parameter< O::OPEN_FILE > >(i.parameter.get()));
                     break;
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS setup queue");
@@ -115,6 +118,8 @@ ADIOS1IOHandlerImpl::flush()
 
     while( !handler->m_work.empty() )
     {
+        using namespace auxiliary;
+
         IOTask& i = handler->m_work.front();
         try
         {
@@ -122,43 +127,43 @@ ADIOS1IOHandlerImpl::flush()
             {
                 using O = Operation;
                 case O::EXTEND_DATASET:
-                    extendDataset(i.writable, *dynamic_cast< Parameter< O::EXTEND_DATASET >* >(i.parameter.get()));
+                    extendDataset(i.writable, deref_dynamic_cast< Parameter< O::EXTEND_DATASET > >(i.parameter.get()));
                     break;
                 case O::OPEN_PATH:
-                    openPath(i.writable, *dynamic_cast< Parameter< O::OPEN_PATH >* >(i.parameter.get()));
+                    openPath(i.writable, deref_dynamic_cast< Parameter< O::OPEN_PATH > >(i.parameter.get()));
                     break;
                 case O::OPEN_DATASET:
-                    openDataset(i.writable, *dynamic_cast< Parameter< O::OPEN_DATASET >* >(i.parameter.get()));
+                    openDataset(i.writable, deref_dynamic_cast< Parameter< O::OPEN_DATASET > >(i.parameter.get()));
                     break;
                 case O::DELETE_FILE:
-                    deleteFile(i.writable, *dynamic_cast< Parameter< O::DELETE_FILE >* >(i.parameter.get()));
+                    deleteFile(i.writable, deref_dynamic_cast< Parameter< O::DELETE_FILE > >(i.parameter.get()));
                     break;
                 case O::DELETE_PATH:
-                    deletePath(i.writable, *dynamic_cast< Parameter< O::DELETE_PATH >* >(i.parameter.get()));
+                    deletePath(i.writable, deref_dynamic_cast< Parameter< O::DELETE_PATH > >(i.parameter.get()));
                     break;
                 case O::DELETE_DATASET:
-                    deleteDataset(i.writable, *dynamic_cast< Parameter< O::DELETE_DATASET >* >(i.parameter.get()));
+                    deleteDataset(i.writable, deref_dynamic_cast< Parameter< O::DELETE_DATASET > >(i.parameter.get()));
                     break;
                 case O::DELETE_ATT:
-                    deleteAttribute(i.writable, *dynamic_cast< Parameter< O::DELETE_ATT >* >(i.parameter.get()));
+                    deleteAttribute(i.writable, deref_dynamic_cast< Parameter< O::DELETE_ATT > >(i.parameter.get()));
                     break;
                 case O::WRITE_DATASET:
-                    writeDataset(i.writable, *dynamic_cast< Parameter< O::WRITE_DATASET >* >(i.parameter.get()));
+                    writeDataset(i.writable, deref_dynamic_cast< Parameter< O::WRITE_DATASET > >(i.parameter.get()));
                     break;
                 case O::READ_DATASET:
-                    readDataset(i.writable, *dynamic_cast< Parameter< O::READ_DATASET >* >(i.parameter.get()));
+                    readDataset(i.writable, deref_dynamic_cast< Parameter< O::READ_DATASET > >(i.parameter.get()));
                     break;
                 case O::READ_ATT:
-                    readAttribute(i.writable, *dynamic_cast< Parameter< O::READ_ATT >* >(i.parameter.get()));
+                    readAttribute(i.writable, deref_dynamic_cast< Parameter< O::READ_ATT > >(i.parameter.get()));
                     break;
                 case O::LIST_PATHS:
-                    listPaths(i.writable, *dynamic_cast< Parameter< O::LIST_PATHS >* >(i.parameter.get()));
+                    listPaths(i.writable, deref_dynamic_cast< Parameter< O::LIST_PATHS > >(i.parameter.get()));
                     break;
                 case O::LIST_DATASETS:
-                    listDatasets(i.writable, *dynamic_cast< Parameter< O::LIST_DATASETS >* >(i.parameter.get()));
+                    listDatasets(i.writable, deref_dynamic_cast< Parameter< O::LIST_DATASETS > >(i.parameter.get()));
                     break;
                 case O::LIST_ATTS:
-                    listAttributes(i.writable, *dynamic_cast< Parameter< O::LIST_ATTS >* >(i.parameter.get()));
+                    listAttributes(i.writable, deref_dynamic_cast< Parameter< O::LIST_ATTS > >(i.parameter.get()));
                     break;
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS work queue");

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -23,6 +23,7 @@
 
 #if openPMD_HAVE_MPI && openPMD_HAVE_ADIOS1
 #   include "openPMD/auxiliary/Filesystem.hpp"
+#   include "openPMD/auxiliary/DerefDynamicCast.hpp"
 #   include "openPMD/auxiliary/Memory.hpp"
 #   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
@@ -101,6 +102,8 @@ ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
 std::future< void >
 ParallelADIOS1IOHandlerImpl::flush()
 {
+    using namespace auxiliary;
+
     auto handler = dynamic_cast< ParallelADIOS1IOHandler* >(m_handler);
     while( !handler->m_setup.empty() )
     {
@@ -111,19 +114,19 @@ ParallelADIOS1IOHandlerImpl::flush()
             {
                 using O = Operation;
                 case O::CREATE_FILE:
-                    createFile(i.writable, *dynamic_cast< Parameter< Operation::CREATE_FILE >* >(i.parameter.get()));
+                    createFile(i.writable, deref_dynamic_cast< Parameter< Operation::CREATE_FILE > >(i.parameter.get()));
                     break;
                 case O::CREATE_PATH:
-                    createPath(i.writable, *dynamic_cast< Parameter< O::CREATE_PATH >* >(i.parameter.get()));
+                    createPath(i.writable, deref_dynamic_cast< Parameter< O::CREATE_PATH > >(i.parameter.get()));
                     break;
                 case O::CREATE_DATASET:
-                    createDataset(i.writable, *dynamic_cast< Parameter< O::CREATE_DATASET >* >(i.parameter.get()));
+                    createDataset(i.writable, deref_dynamic_cast< Parameter< O::CREATE_DATASET > >(i.parameter.get()));
                     break;
                 case O::WRITE_ATT:
-                    writeAttribute(i.writable, *dynamic_cast< Parameter< O::WRITE_ATT >* >(i.parameter.get()));
+                    writeAttribute(i.writable, deref_dynamic_cast< Parameter< O::WRITE_ATT > >(i.parameter.get()));
                     break;
                 case O::OPEN_FILE:
-                    openFile(i.writable, *dynamic_cast< Parameter< O::OPEN_FILE >* >(i.parameter.get()));
+                    openFile(i.writable, deref_dynamic_cast< Parameter< O::OPEN_FILE > >(i.parameter.get()));
                     break;
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS setup queue");
@@ -146,43 +149,43 @@ ParallelADIOS1IOHandlerImpl::flush()
             {
                 using O = Operation;
                 case O::EXTEND_DATASET:
-                    extendDataset(i.writable, *dynamic_cast< Parameter< O::EXTEND_DATASET >* >(i.parameter.get()));
+                    extendDataset(i.writable, deref_dynamic_cast< Parameter< O::EXTEND_DATASET > >(i.parameter.get()));
                     break;
                 case O::OPEN_PATH:
-                    openPath(i.writable, *dynamic_cast< Parameter< O::OPEN_PATH >* >(i.parameter.get()));
+                    openPath(i.writable, deref_dynamic_cast< Parameter< O::OPEN_PATH > >(i.parameter.get()));
                     break;
                 case O::OPEN_DATASET:
-                    openDataset(i.writable, *dynamic_cast< Parameter< O::OPEN_DATASET >* >(i.parameter.get()));
+                    openDataset(i.writable, deref_dynamic_cast< Parameter< O::OPEN_DATASET > >(i.parameter.get()));
                     break;
                 case O::DELETE_FILE:
-                    deleteFile(i.writable, *dynamic_cast< Parameter< O::DELETE_FILE >* >(i.parameter.get()));
+                    deleteFile(i.writable, deref_dynamic_cast< Parameter< O::DELETE_FILE > >(i.parameter.get()));
                     break;
                 case O::DELETE_PATH:
-                    deletePath(i.writable, *dynamic_cast< Parameter< O::DELETE_PATH >* >(i.parameter.get()));
+                    deletePath(i.writable, deref_dynamic_cast< Parameter< O::DELETE_PATH > >(i.parameter.get()));
                     break;
                 case O::DELETE_DATASET:
-                    deleteDataset(i.writable, *dynamic_cast< Parameter< O::DELETE_DATASET >* >(i.parameter.get()));
+                    deleteDataset(i.writable, deref_dynamic_cast< Parameter< O::DELETE_DATASET > >(i.parameter.get()));
                     break;
                 case O::DELETE_ATT:
-                    deleteAttribute(i.writable, *dynamic_cast< Parameter< O::DELETE_ATT >* >(i.parameter.get()));
+                    deleteAttribute(i.writable, deref_dynamic_cast< Parameter< O::DELETE_ATT > >(i.parameter.get()));
                     break;
                 case O::WRITE_DATASET:
-                    writeDataset(i.writable, *dynamic_cast< Parameter< O::WRITE_DATASET >* >(i.parameter.get()));
+                    writeDataset(i.writable, deref_dynamic_cast< Parameter< O::WRITE_DATASET > >(i.parameter.get()));
                     break;
                 case O::READ_DATASET:
-                    readDataset(i.writable, *dynamic_cast< Parameter< O::READ_DATASET >* >(i.parameter.get()));
+                    readDataset(i.writable, deref_dynamic_cast< Parameter< O::READ_DATASET > >(i.parameter.get()));
                     break;
                 case O::READ_ATT:
-                    readAttribute(i.writable, *dynamic_cast< Parameter< O::READ_ATT >* >(i.parameter.get()));
+                    readAttribute(i.writable, deref_dynamic_cast< Parameter< O::READ_ATT > >(i.parameter.get()));
                     break;
                 case O::LIST_PATHS:
-                    listPaths(i.writable, *dynamic_cast< Parameter< O::LIST_PATHS >* >(i.parameter.get()));
+                    listPaths(i.writable, deref_dynamic_cast< Parameter< O::LIST_PATHS > >(i.parameter.get()));
                     break;
                 case O::LIST_DATASETS:
-                    listDatasets(i.writable, *dynamic_cast< Parameter< O::LIST_DATASETS >* >(i.parameter.get()));
+                    listDatasets(i.writable, deref_dynamic_cast< Parameter< O::LIST_DATASETS > >(i.parameter.get()));
                     break;
                 case O::LIST_ATTS:
-                    listAttributes(i.writable, *dynamic_cast< Parameter< O::LIST_ATTS >* >(i.parameter.get()));
+                    listAttributes(i.writable, deref_dynamic_cast< Parameter< O::LIST_ATTS > >(i.parameter.get()));
                     break;
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS work queue");

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -7,6 +7,7 @@
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/auxiliary/DerefDynamicCast.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
@@ -17,10 +18,11 @@
 #include <catch2/catch.hpp>
 
 #include <array>
+#include <exception>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
 
 using namespace openPMD;
 
@@ -40,6 +42,27 @@ struct TestHelper : public Attributable
 } // test
 } // openPMD
 
+
+TEST_CASE( "deref_cast_test", "[auxiliary]" ) {
+    using namespace auxiliary;
+
+    struct A { double m_x; A(double x) : m_x(x){} virtual ~A() = default; };
+    struct B : virtual A { B(double x) : A(x){}};
+    struct C { float m_x; };
+
+    B const value = {123.45};
+    B const * const ptr = &value;
+
+    auto const a = deref_dynamic_cast<A const>(ptr);
+    auto const& ra = deref_dynamic_cast<A const>(ptr);
+    (void)a;
+    (void)ra;
+
+    REQUIRE_THROWS_AS(deref_dynamic_cast<C const>(ptr), std::runtime_error);
+
+    A * const nptr = nullptr;
+    REQUIRE_THROWS_AS(deref_dynamic_cast<B>(nptr), std::runtime_error);
+}
 
 TEST_CASE( "string_test", "[auxiliary]" )
 {


### PR DESCRIPTION
We often use this construct in backend switch-yards:
`*dynamic_cast<New_Type*>( ptr );`.

This is unsafe and has bitten us in the past in the following situations:
- input is an actual `nullptr`
- `dynamic_cast` returns a `nullptr` because the cast failed (result: throw *or* [nullptr](https://en.cppreference.com/w/cpp/language/dynamic_cast)!) and/or a problem with the std library caused the cast to fail #441 #442 #444

This catches the `nullptr` before it gets dereferenced, making problems significantly easier to debug than catching UB.

Fix #471 