### PR TITLE
Python Container: Redundant Move

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ Other
 - ``listSeries``: remove unused parameters in try-catch #706
 - safer internal ``*dynamic_cast``s of pointers #745
 - CMake: subproject inclusion cleanup #751
+- Python: remove redundant move in container #753
 
 
 0.11.1-alpha

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -63,7 +63,8 @@ namespace detail
     >
     py::class_<
         Map,
-        holder_type
+        holder_type,
+        Attributable
     > bind_container(
         py::handle scope,
         std::string const & name,

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -195,7 +195,7 @@ namespace detail
             }
         );
 
-        return std::move(cl);
+        return cl;
     }
 } // namespace detail
 


### PR DESCRIPTION
Remove a redundant move warning (`-Wredundant-move`) seen with Cygwin/GNU 9.3.0