### PR TITLE
CI: ADIOS 2.5.0 & CMake 3.12.0+

### DIFF
--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -55,6 +55,7 @@ packages:
   adios:
     variants: ~zfp ~sz ~lz4 ~blosc
   adios2:
+    version: [2.5.0]
     variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc
   python:
     version: [3.5.5, 3.6.3, 3.7.1, 3.7.2, 3.8.0]

--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -17,21 +17,21 @@ packages:
       perl@5.18.2%clang@11.0.0 arch=darwin-mojave-x86_64: /usr
     buildable: False
   cmake:
-    version: [3.11.0]
+    version: [3.12.0]
     paths:
-      cmake@3.11.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%clang@5.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%clang@8.0.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.11.0
-      cmake@3.11.0%clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
-      cmake@3.11.0%clang@10.0.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
-      cmake@3.11.0%clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.12.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%clang@5.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%clang@8.0.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.12.0%clang@10.0.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.12.0%clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
     version: [1.6.5, 1.10.2, 2.1.1]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   apt: true
   directories:
     - $HOME/.cache/spack
-    - $HOME/.cache/cmake-3.11.0
+    - $HOME/.cache/cmake-3.12.0
     - $HOME/.cache/kcov-35
     - $HOME/Library/Caches/Homebrew
   pip: true
@@ -659,26 +659,26 @@ install:
     fi
   # Configured Spack compilers
   - spack compilers
-  # required dependencies - CMake 3.11.0
+  # required dependencies - CMake 3.12.0
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      if [ ! -f $HOME/.cache/cmake-3.11.0/bin/cmake ]; then
-        wget -O cmake.sh https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.sh &&
-        sh cmake.sh --skip-license --exclude-subdir --prefix=$HOME/.cache/cmake-3.11.0 &&
+      if [ ! -f $HOME/.cache/cmake-3.12.0/bin/cmake ]; then
+        wget -O cmake.sh https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh &&
+        sh cmake.sh --skip-license --exclude-subdir --prefix=$HOME/.cache/cmake-3.12.0 &&
         rm cmake.sh;
       fi;
-      spack install cmake@3.11.0 $CXXSPEC;
+      spack install cmake@3.12.0 $CXXSPEC;
     else
       if [ ! -d /Applications/CMake.app/Contents/ ]; then
-        curl -L -s -o cmake.dmg https://cmake.org/files/v3.11/cmake-3.11.0-Darwin-x86_64.dmg &&
+        curl -L -s -o cmake.dmg https://cmake.org/files/v3.12/cmake-3.12.0-Darwin-x86_64.dmg &&
         yes | hdiutil mount cmake.dmg &&
-        sudo cp -R "/Volumes/cmake-3.11.0-Darwin-x86_64/CMake.app" /Applications &&
+        sudo cp -R "/Volumes/cmake-3.12.0-Darwin-x86_64/CMake.app" /Applications &&
         hdiutil detach /dev/disk1s1 &&
         rm cmake.dmg;
       fi;
-      spack install cmake@3.11.0 $CXXSPEC;
+      spack install cmake@3.12.0 $CXXSPEC;
     fi
   - spack find cmake
-  - spack load cmake@3.11.0 $CXXSPEC
+  - spack load cmake@3.12.0 $CXXSPEC
   # diagnostics: modules created and visible?
   - module av
   - module li

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Bug Fixes
 Other
 """""
 
+- CMake: require version 3.12.0+ #755
 - separate header for export macros #704
 - rename ``AccessType``/``Access_Type`` to ``Access`` #740
 - CI:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 project(openPMD VERSION 0.12.0) # LANGUAGES CXX
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Our manual shows full [read & write examples](https://openpmd-api.readthedocs.io
 ## Dependencies
 
 Required:
-* CMake 3.11.0+
+* CMake 3.12.0+
 * C++11 capable compiler, e.g. g++ 4.8+, clang 3.9+, VS 2015+
 
 Shipped internally in `share/openPMD/thirdParty/`:

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -9,7 +9,7 @@ These are currently:
 Required
 --------
 
-* CMake 3.11.0+
+* CMake 3.12.0+
 * C++11 capable compiler, e.g. g++ 4.8+, clang 3.9+, VS 2015+
 
 Shipped internally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools>38.6", "wheel", "cmake>=3.11.0,<4.0.0", "pybind11>=2.3.0,<3.0.0"]
+requires = ["setuptools>38.6", "wheel", "cmake>=3.12.0,<4.0.0", "pybind11>=2.3.0,<3.0.0"]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError(
-                "CMake 3.11.0+ must be installed to build the following " +
+                "CMake 3.12.0+ must be installed to build the following " +
                 "extensions: " +
                 ", ".join(e.name for e in self.extensions))
 
@@ -29,8 +29,8 @@ class CMakeBuild(build_ext):
             r'version\s*([\d.]+)',
             out.decode()
         ).group(1))
-        if cmake_version < '3.11.0':
-            raise RuntimeError("CMake >= 3.11.0 is required")
+        if cmake_version < '3.12.0':
+            raise RuntimeError("CMake >= 3.12.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
Keep ADIOS2 v2.5.0 for now since 2.6.0 has issues with macOS.

Already bumps our CMake dependency to 3.12.0+ in preparation of #754 (and reflecting the latest change in Spack already).

See: https://github.com/ornladios/ADIOS2/issues/2316