### PR TITLE
Spack: apple-clang

### DIFF
--- a/.github/ci/spack/compilers.yaml
+++ b/.github/ci/spack/compilers.yaml
@@ -49,8 +49,8 @@ compilers:
     paths:
       cc: /usr/lib/llvm-5.0/bin/clang
       cxx: /usr/lib/llvm-5.0/bin/clang++
-      f77: /usr/bin/gfortran-4.9
-      fc: /usr/bin/gfortran-4.9
+      f77: null
+      fc: null
     spec: clang@5.0.0
     target: x86_64
 - compiler:
@@ -168,8 +168,8 @@ compilers:
     paths:
       cc: /usr/bin/clang-8
       cxx: /usr/bin/clang++-8
-      f77: /usr/bin/gfortran-7.4
-      fc: /usr/bin/gfortran-7.4
+      f77: null
+      fc: null
     spec: clang@8.0.0
     target: x86_64
 - compiler:

--- a/.github/ci/spack/compilers.yaml
+++ b/.github/ci/spack/compilers.yaml
@@ -10,7 +10,7 @@ compilers:
       cxx: /usr/bin/clang++
       f77: null
       fc: null
-    spec: clang@9.1.0
+    spec: apple-clang@9.1.0
     target: x86_64
 - compiler:
     environment: {}
@@ -25,7 +25,7 @@ compilers:
       cxx: /usr/bin/clang++
       f77: null
       fc: null
-    spec: clang@10.0.0
+    spec: apple-clang@10.0.0
     target: x86_64
 - compiler:
     environment: {}
@@ -38,7 +38,7 @@ compilers:
       cxx: /usr/bin/clang++
       f77: null
       fc: null
-    spec: clang@11.0.0
+    spec: apple-clang@11.0.0
     target: x86_64
 - compiler:
     environment: {}

--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -12,9 +12,9 @@ packages:
       perl@5.22.4%clang@6.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.26.1%clang@8.0.0 arch=linux-ubuntu18-x86_64: /usr
-      perl@5.18.2%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
-      perl@5.18.2%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr
-      perl@5.18.2%clang@11.0.0 arch=darwin-mojave-x86_64: /usr
+      perl@5.18.2%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
+      perl@5.18.2%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /usr
+      perl@5.18.2%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /usr
     buildable: False
   cmake:
     version: [3.12.0]
@@ -29,9 +29,9 @@ packages:
       cmake@3.12.0%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
       cmake@3.12.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
       cmake@3.12.0%clang@8.0.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
-      cmake@3.12.0%clang@10.0.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
-      cmake@3.12.0%clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.12.0%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.12.0%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
+      cmake@3.12.0%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
     version: [1.6.5, 1.10.2, 2.1.1]
@@ -72,9 +72,9 @@ packages:
       python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
       python@3.6.3%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
       python@3.7.1%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
-      python@3.7.2%clang@9.1.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
-      python@3.7.2%clang@10.0.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
-      python@3.7.2%clang@11.0.0 arch=darwin-mojave-x86_64: /usr/local/opt/python
+      python@3.7.2%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
+      python@3.7.2%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
+      python@3.7.2%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /usr/local/opt/python
     buildable: False
 
   # speed up builds of dependencies
@@ -90,4 +90,4 @@ packages:
     target: ['x86_64']
     providers:
       mpi: [openmpi, mpich]
-    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@8.0.0, clang@9.1.0, clang@10.0.0, clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0, gcc@8.1.0, gcc@9.3.0]
+    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@8.0.0, apple-clang@9.1.0, apple-clang@10.0.0, apple-clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0, gcc@8.1.0, gcc@9.3.0]

--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -36,10 +36,10 @@ packages:
   openmpi:
     version: [1.6.5, 1.10.2, 2.1.1]
     paths:
-      openmpi@1.6.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /usr
-      openmpi@1.6.5%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
-      openmpi@1.6.5%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /usr
-      openmpi@1.6.5%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /usr
+      openmpi@1.6.5%gcc@4.8.5 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
+      openmpi@1.6.5%gcc@4.9.4 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
+      openmpi@1.6.5%gcc@6.5.0 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
+      openmpi@1.6.5%gcc@7.4.0 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
       openmpi@1.10.2%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
       openmpi@2.1.1%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
       openmpi@1.10.2%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -325,7 +325,7 @@ jobs:
       sudo: required
       language: generic
       env:
-        - CXXSPEC="%clang@9.1.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
+        - CXXSPEC="%apple-clang@9.1.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=ON USE_ADIOS2=OFF USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
       before_install:
@@ -339,7 +339,7 @@ jobs:
       sudo: required
       language: generic
       env:
-        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SAMPLES=ON
+        - CXXFLAGS="${CXXFLAGS} -stdlib=libc++" CXXSPEC="%apple-clang@10.0.0" USE_MPI=OFF USE_PYTHON=ON USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
       before_install:
@@ -353,7 +353,7 @@ jobs:
       sudo: required
       language: generic
       env:
-        - CXXSPEC="%clang@11.0.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SAMPLES=ON
+        - CXXSPEC="%apple-clang@11.0.0" USE_MPI=OFF USE_PYTHON=OFF USE_HDF5=ON USE_ADIOS1=OFF USE_ADIOS2=ON USE_SAMPLES=ON
       compiler: clang
       script: *script-cpp-unit
       before_install:


### PR DESCRIPTION
[Spack 0.15.0](https://github.com/spack/spack/releases/tag/v0.15.0) has a unique name for Apple's Clang fork instead of using a version suffix.