### PR TITLE
Travis CI: Add Clang 10.0 on Bionic

### DIFF
--- a/.github/ci/spack/compilers.yaml
+++ b/.github/ci/spack/compilers.yaml
@@ -179,6 +179,19 @@ compilers:
     modules: []
     operating_system: ubuntu18.04
     paths:
+      cc: /usr/bin/clang-10
+      cxx: /usr/bin/clang++-10
+      f77: null
+      fc: null
+    spec: clang@10.0.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu18.04
+    paths:
       cc: /usr/bin/gcc-9
       cxx: /usr/bin/g++-9
       f77: /usr/bin/gfortran-9

--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -12,6 +12,7 @@ packages:
       perl@5.22.4%clang@6.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
       perl@5.26.1%clang@8.0.0 arch=linux-ubuntu18-x86_64: /usr
+      perl@5.26.1%clang@10.0.0 arch=linux-ubuntu18-x86_64: /usr
       perl@5.18.2%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
       perl@5.18.2%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /usr
       perl@5.18.2%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /usr
@@ -29,6 +30,7 @@ packages:
       cmake@3.12.0%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
       cmake@3.12.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
       cmake@3.12.0%clang@8.0.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
+      cmake@3.12.0%clang@10.0.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
       cmake@3.12.0%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
       cmake@3.12.0%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
       cmake@3.12.0%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
@@ -44,6 +46,7 @@ packages:
       openmpi@2.1.1%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
       openmpi@1.10.2%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr
       openmpi@1.10.2%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
+      openmpi@2.1.1%clang@10.0.0 arch=linux-ubuntu18-x86_64: /usr
     buildable: False
   mpich:
     version: [3.3]
@@ -60,6 +63,7 @@ packages:
   python:
     version: [3.5.5, 3.6.3, 3.7.1, 3.7.2, 3.8.0]
     paths:
+      python@3.8.0%clang@10.0.0 arch=linux-ubuntu18-x86_64: /home/travis/virtualenv/python3.8
       python@3.8.0%clang@8.0.0 arch=linux-ubuntu18-x86_64: /home/travis/virtualenv/python3.8
       python@3.8.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.8
       python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
@@ -90,4 +94,4 @@ packages:
     target: ['x86_64']
     providers:
       mpi: [openmpi, mpich]
-    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@8.0.0, apple-clang@9.1.0, apple-clang@10.0.0, apple-clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0, gcc@8.1.0, gcc@9.3.0]
+    compiler: [clang@5.0.0, clang@6.0.0, clang@7.0.0, clang@8.0.0, clang@10.0.0, apple-clang@9.1.0, apple-clang@10.0.0, apple-clang@11.0.0, gcc@4.8.5, gcc@4.9.4, gcc@6.5.0, gcc@7.4.0, gcc@8.1.0, gcc@9.3.0]

--- a/.travis.yml
+++ b/.travis.yml
@@ -255,25 +255,6 @@ jobs:
       before_install: &clang_init
         # FIXME: extra include needed https://bugs.launchpad.net/ubuntu/+source/libc++/+bug/1812133
         - CXX=clang++-6.0 && CC=clang-6.0 && CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -I/usr/include/libcxxabi/"
-    # Clang 7.0.0 + Python 3.8.0 @ Xenial
-    - <<: *test-cpp-unit
-      name: clang@7.0.0 +OMPI +PY@3.8 +H5@1.10.6 +ADIOS1 +ADIOS2 +Release
-      dist: xenial
-      language: python
-      python: "3.8"
-      env:
-        - CXXSPEC="%clang@7.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON HDF5_VERSION=@1.10.6 USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON BUILD_TYPE="Release"
-      compiler: clang
-      addons:
-        apt:
-          <<: *apt_common_sources
-          packages:
-            - *clang_deps
-            - libopenmpi-dev
-            - openmpi-bin
-      script: *script-cpp-unit
-      before_install: &clang_init
-        - CXX=clang++ && CC=clang
     # Clang 7.0.0 + Python 3.7.1 + Address Sanitizer + Undefined Behavior Sanitizer @ Xenial
     - <<: *test-cpp-unit
       name: clang@7.0.0 +OMPI +PY@3.7 +H5 -ADIOS1 +ADIOS2 +ASan +UBSan +STATIC
@@ -317,6 +298,26 @@ jobs:
       script: *script-cpp-unit
       before_install: &clang_init
         - CXX=clang++-8 && CC=clang-8
+    # Clang 10.0.0 + Python 3.8.0 @ Bionic
+    - <<: *test-cpp-unit
+      name: clang@10.0.0 +OMPI +PY@3.8 +H5@1.10.6 +ADIOS1 +ADIOS2 +Release
+      dist: bionic
+      language: python
+      python: "3.8"
+      env:
+        - CXXSPEC="%clang@10.0.0" USE_MPI=ON USE_PYTHON=ON USE_HDF5=ON HDF5_VERSION=@1.10.6 USE_ADIOS1=ON USE_ADIOS2=ON USE_SAMPLES=ON BUILD_TYPE="Release"
+      compiler: clang
+      addons:
+        apt:
+          <<: *apt_common_sources
+          packages: &clang100_bionic_deps
+            - environment-modules
+            - clang-10
+            - libopenmpi-dev
+            - openmpi-bin
+      script: *script-cpp-unit
+      before_install: &clang_init
+        - CXX=clang++-10 && CC=clang-10
     # AppleClang 9.1.0 + Python 3.7.2 @ OSX "highsierra"
     - <<: *test-cpp-unit
       name: AppleClang@9.1.0 -MPI +PY@3.7 +H5 +ADIOS1 -ADIOS2


### PR DESCRIPTION
Transform a Clang 7.0 (Xenial) build into a modern Ubuntu Bionic (18.04) Clang 10.0 build.