### PR TITLE
CI: New Spack External Packages Syntax

### DIFF
--- a/.github/ci/spack/packages.yaml
+++ b/.github/ci/spack/packages.yaml
@@ -1,57 +1,95 @@
 packages:
   perl:
     version: [5.14.0, 5.18.2, 5.22.4, 5.26.2]
-    paths:
-      perl@5.14.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /usr
-      perl@5.14.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /usr
-      perl@5.14.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /usr
-      perl@5.14.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /usr
-      perl@5.22.4%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
-      perl@5.26.2%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
-      perl@5.22.4%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr
-      perl@5.22.4%clang@6.0.0 arch=linux-ubuntu16-x86_64: /usr
-      perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
-      perl@5.26.1%clang@8.0.0 arch=linux-ubuntu18-x86_64: /usr
-      perl@5.26.1%clang@10.0.0 arch=linux-ubuntu18-x86_64: /usr
-      perl@5.18.2%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /usr
-      perl@5.18.2%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /usr
-      perl@5.18.2%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /usr
+    externals:
+    - spec: "perl@5.14.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "perl@5.14.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "perl@5.14.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "perl@5.14.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "perl@5.22.4%gcc@8.1.0 arch=linux-ubuntu16-x86_64"
+      prefix: /usr
+    - spec: "perl@5.26.2%gcc@9.3.0 arch=linux-ubuntu18-x86_64"
+      prefix: /usr
+    - spec: "perl@5.22.4%clang@5.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /usr
+    - spec: "perl@5.22.4%clang@6.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /usr
+    - spec: "perl@5.22.4%clang@7.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /usr
+    - spec: "perl@5.26.1%clang@8.0.0 arch=linux-ubuntu18-x86_64"
+      prefix: /usr
+    - spec: "perl@5.26.1%clang@10.0.0 arch=linux-ubuntu18-x86_64"
+      prefix: /usr
+    - spec: "perl@5.18.2%apple-clang@9.1.0 arch=darwin-highsierra-x86_64"
+      prefix: /usr
+    - spec: "perl@5.18.2%apple-clang@10.0.0 arch=darwin-highsierra-x86_64"
+      prefix: /usr
+    - spec: "perl@5.18.2%apple-clang@11.0.0 arch=darwin-mojave-x86_64"
+      prefix: /usr
     buildable: False
   cmake:
     version: [3.12.0]
-    paths:
-      cmake@3.12.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%clang@5.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%clang@8.0.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%clang@10.0.0 arch=linux-ubuntu18-x86_64: /home/travis/.cache/cmake-3.12.0
-      cmake@3.12.0%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
-      cmake@3.12.0%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /Applications/CMake.app/Contents/
-      cmake@3.12.0%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /Applications/CMake.app/Contents/
+    externals:
+    - spec: "cmake@3.12.0%gcc@4.8.5 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%gcc@4.9.4 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%gcc@6.5.0 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%gcc@7.4.0 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%gcc@8.1.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%clang@5.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%clang@6.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%clang@7.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%clang@8.0.0 arch=linux-ubuntu18-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%clang@10.0.0 arch=linux-ubuntu18-x86_64"
+      prefix: /home/travis/.cache/cmake-3.12.0
+    - spec: "cmake@3.12.0%apple-clang@9.1.0 arch=darwin-highsierra-x86_64"
+      prefix: /Applications/CMake.app/Contents/
+    - spec: "cmake@3.12.0%apple-clang@10.0.0 arch=darwin-highsierra-x86_64"
+      prefix: /Applications/CMake.app/Contents/
+    - spec: "cmake@3.12.0%apple-clang@11.0.0 arch=darwin-mojave-x86_64"
+      prefix: /Applications/CMake.app/Contents/
     buildable: False
   openmpi:
     version: [1.6.5, 1.10.2, 2.1.1]
-    paths:
-      openmpi@1.6.5%gcc@4.8.5 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
-      openmpi@1.6.5%gcc@4.9.4 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
-      openmpi@1.6.5%gcc@6.5.0 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
-      openmpi@1.6.5%gcc@7.4.0 ~wrapper-rpath arch=linux-ubuntu14-x86_64: /usr
-      openmpi@1.10.2%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /usr
-      openmpi@2.1.1%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /usr
-      openmpi@1.10.2%clang@5.0.0 arch=linux-ubuntu16-x86_64: /usr
-      openmpi@1.10.2%clang@7.0.0 arch=linux-ubuntu16-x86_64: /usr
-      openmpi@2.1.1%clang@10.0.0 arch=linux-ubuntu18-x86_64: /usr
+    externals:
+    - spec: "openmpi@1.6.5%gcc@4.8.5 ~wrapper-rpath arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "openmpi@1.6.5%gcc@4.9.4 ~wrapper-rpath arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "openmpi@1.6.5%gcc@6.5.0 ~wrapper-rpath arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "openmpi@1.6.5%gcc@7.4.0 ~wrapper-rpath arch=linux-ubuntu14-x86_64"
+      prefix: /usr
+    - spec: "openmpi@1.10.2%gcc@8.1.0 arch=linux-ubuntu16-x86_64"
+      prefix: /usr
+    - spec: "openmpi@2.1.1%gcc@9.3.0 arch=linux-ubuntu18-x86_64"
+      prefix: /usr
+    - spec: "openmpi@1.10.2%clang@5.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /usr
+    - spec: "openmpi@1.10.2%clang@7.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /usr
+    - spec: "openmpi@2.1.1%clang@10.0.0 arch=linux-ubuntu18-x86_64"
+      prefix: /usr
     buildable: False
   mpich:
     version: [3.3]
-    paths:
-      mpich@3.3%clang@8.0.0 arch=linux-ubuntu18-x86_64: /usr
+    externals:
+    - spec: "mpich@3.3%clang@8.0.0 arch=linux-ubuntu18-x86_64"
+      prefix:: /usr
     buildable: False
   hdf5:
     version: [1.10.1, 1.8.13]
@@ -66,23 +104,39 @@ packages:
     #   Library not loaded: @rpath/libbz2.1.dylib
   python:
     version: [3.5.5, 3.6.3, 3.7.1, 3.7.2, 3.8.0]
-    paths:
-      python@3.8.0%clang@10.0.0 arch=linux-ubuntu18-x86_64: /home/travis/virtualenv/python3.8
-      python@3.8.0%clang@8.0.0 arch=linux-ubuntu18-x86_64: /home/travis/virtualenv/python3.8
-      python@3.8.0%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.8
-      python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
-      python@3.6.3%clang@6.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6
-      python@3.6.3%clang@5.0.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.6
-      python@3.8.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64: /home/travis/virtualenv/python3.8
-      python@3.6.3%gcc@7.4.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
-      python@3.5.5%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
-      python@3.6.3%gcc@4.9.4 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
-      python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.5
-      python@3.6.3%gcc@6.5.0 arch=linux-ubuntu14-x86_64: /home/travis/virtualenv/python3.6
-      python@3.7.1%gcc@8.1.0 arch=linux-ubuntu16-x86_64: /home/travis/virtualenv/python3.7
-      python@3.7.2%apple-clang@9.1.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
-      python@3.7.2%apple-clang@10.0.0 arch=darwin-highsierra-x86_64: /usr/local/opt/python
-      python@3.7.2%apple-clang@11.0.0 arch=darwin-mojave-x86_64: /usr/local/opt/python
+    externals:
+    - spec: "python@3.8.0%clang@10.0.0 arch=linux-ubuntu18-x86_64"
+      prefix: /home/travis/virtualenv/python3.8
+    - spec: "python@3.8.0%clang@8.0.0 arch=linux-ubuntu18-x86_64"
+      prefix: /home/travis/virtualenv/python3.8
+    - spec: "python@3.8.0%clang@7.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/virtualenv/python3.8
+    - spec: "python@3.7.1%clang@7.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/virtualenv/python3.7
+    - spec: "python@3.6.3%clang@6.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/virtualenv/python3.6
+    - spec: "python@3.6.3%clang@5.0.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/virtualenv/python3.6
+    - spec: "python@3.8.0%gcc@9.3.0 arch=linux-ubuntu18-x86_64"
+      prefix: /home/travis/virtualenv/python3.8
+    - spec: "python@3.6.3%gcc@7.4.0 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/virtualenv/python3.6
+    - spec: "python@3.5.5%gcc@6.5.0 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/virtualenv/python3.5
+    - spec: "python@3.6.3%gcc@4.9.4 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/virtualenv/python3.6
+    - spec: "python@3.5.5%gcc@4.8.5 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/virtualenv/python3.5
+    - spec: "python@3.6.3%gcc@6.5.0 arch=linux-ubuntu14-x86_64"
+      prefix: /home/travis/virtualenv/python3.6
+    - spec: "python@3.7.1%gcc@8.1.0 arch=linux-ubuntu16-x86_64"
+      prefix: /home/travis/virtualenv/python3.7
+    - spec: "python@3.7.2%apple-clang@9.1.0 arch=darwin-highsierra-x86_64"
+      prefix: /usr/local/opt/python
+    - spec: "python@3.7.2%apple-clang@10.0.0 arch=darwin-highsierra-x86_64"
+      prefix: /usr/local/opt/python
+    - spec: "python@3.7.2%apple-clang@11.0.0 arch=darwin-mojave-x86_64"
+      prefix: /usr/local/opt/python
     buildable: False
 
   # speed up builds of dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -664,6 +664,10 @@ install:
     fi
   # Configured Spack compilers
   - spack compilers
+  # Add E4S build cache
+  #   https://spack.readthedocs.io/en/latest/binary_caches.html#list-of-popular-build-caches
+  - spack mirror add E4S https://cache.e4s.io || true
+  - spack buildcache keys -it
   # required dependencies - CMake 3.12.0
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       if [ ! -f $HOME/.cache/cmake-3.12.0/bin/cmake ]; then


### PR DESCRIPTION
Adjust to new `packages.yaml` schema for externally registered packages.

Ref.: https://github.com/spack/spack/pull/16526 / https://github.com/spack/spack/pull/17804

Also adds the E4S build cache to potentially speed up re-silvering of the travis build cache.