### PR TITLE
Doxygen 1.8.20: Fix Warning

### DIFF
--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -32,21 +32,6 @@ namespace openPMD
 {
 namespace auxiliary
 {
-std::unique_ptr< void, std::function< void(void*) > >
-allocatePtr(Datatype dtype, Extent const& e);
-
-std::unique_ptr< void, std::function< void(void*) > >
-allocatePtr(Datatype dtype, uint64_t numPoints);
-
-inline std::unique_ptr< void, std::function< void(void*) > >
-allocatePtr(Datatype dtype, Extent const& e)
-{
-  uint64_t numPoints = 1u;
-  for( auto const& dimensionSize : e )
-    numPoints *= dimensionSize;
-  return allocatePtr(dtype, numPoints);
-}
-
 inline std::unique_ptr< void, std::function< void(void*) > >
 allocatePtr(Datatype dtype, uint64_t numPoints)
 {
@@ -139,5 +124,15 @@ allocatePtr(Datatype dtype, uint64_t numPoints)
 
     return std::unique_ptr< void, std::function< void(void*) > >(data, del);
 }
+
+inline std::unique_ptr< void, std::function< void(void*) > >
+allocatePtr(Datatype dtype, Extent const& e)
+{
+    uint64_t numPoints = 1u;
+    for( auto const& dimensionSize : e )
+        numPoints *= dimensionSize;
+    return allocatePtr(dtype, numPoints);
+}
+
 } // auxiliary
 } // openPMD


### PR DESCRIPTION
Fix a warning with Doxygen 1.8.20 by removing forward declarations in a simple header file that also defines the implementation inline.

(This is a falsely triggering Doxygen diagnostics.)
```
openPMD-api/include/openPMD/auxiliary/Memory.hpp:42: error: no matching file member found for 
std::unique_ptr< void, std::function< void(void *) > > openPMD::auxiliary::allocatePtr(openPMD::Datatype dtype, const std::vector &e)
Possible candidates:
 'std::unique_ptr< void, std::function< void(void *) > > allocatePtr(Datatype dtype, Extent const &e)' at line 42 of file openPMD-api/include/openPMD/auxiliary/Memory.hpp
 'std::unique_ptr< void, std::function< void(void *) > > allocatePtr(Datatype dtype, uint64_t numPoints)' at line 51 of file openPMD-api/include/openPMD/auxiliary/Memory.hpp
```