### PR TITLE
openpmd-ls: add -v|--version

### DIFF
--- a/include/openPMD/cli/ls.hpp
+++ b/include/openPMD/cli/ls.hpp
@@ -40,12 +40,27 @@ namespace ls
     {
         std::cout << "Usage: " << program_name << " openPMD-series\n";
         std::cout << "List information about an openPMD data series.\n\n";
-        std::cout << "Options:\n    -h, --help    display this help and exit\n\n";
+        std::cout << "Options:\n";
+        std::cout << "    -h, --help    display this help and exit\n";
+        std::cout << "    -v, --version output version information and exit\n";
+        std::cout << "\n";
         std::cout << "Examples:\n";
         std::cout << "    " << program_name << " ./samples/git-sample/data%T.h5\n";
         std::cout << "    " << program_name << " ./samples/git-sample/data%08T.h5\n";
         std::cout << "    " << program_name << " ./samples/serial_write.json\n";
         std::cout << "    " << program_name << " ./samples/serial_patch.bp\n";
+    }
+
+    inline void
+    print_version( std::string const program_name )
+    {
+        std::cout << program_name << " (openPMD-api) "
+                  << getVersion() << "\n";
+        std::cout << "Copyright 2017-2020 openPMD contributors\n";
+        std::cout << "Authors: Axel Huebl et al.\n";
+        std::cout << "License: LGPLv3+\n";
+        std::cout << "This is free software: you are free to change and redistribute it.\n"
+                     "There is NO WARRANTY, to the extent permitted by law.\n";
     }
 
     /** Run the openpmd-ls command line tool
@@ -63,10 +78,18 @@ namespace ls
             print_help(argv[0]);
             return 0;
         }
-        if (std::string("--help") == argv[1] || std::string("-h") == argv[1]) {
-            print_help(argv[0]);
-            return 0;
+
+        for (int c = 1; c < int(argc); c++) {
+            if (std::string("--help") == argv[c] || std::string("-h") == argv[c]) {
+                print_help(argv[0]);
+                return 0;
+            }
+            if (std::string("--version") == argv[c] || std::string("-v") == argv[c]) {
+                print_version(argv[0]);
+                return 0;
+            }
         }
+
         if (argc > 2) {
             std::cerr << "Too many arguments! See: " << argv[0] << " --help\n";
             return 1;


### PR DESCRIPTION
Add a `-v, --version` option to the `openpmd-ls` CLI tool.