### PR TITLE
ADIOS2: Write/Put In Sync Mode

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1107,7 +1107,8 @@ namespace detail
         adios2::Variable< T > var = m_impl->verifyDataset< T >(
             bp.param.offset, bp.param.extent, IO, bp.name );
 
-        engine.Put( var, ptr );
+        // default is Deferred, and it is error prone
+        engine.Put( var, ptr, adios2::Mode::Sync );
     }
 
     template < typename T >

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1107,7 +1107,7 @@ namespace detail
         adios2::Variable< T > var = m_impl->verifyDataset< T >(
             bp.param.offset, bp.param.extent, IO, bp.name );
 
-        // default is Deferred, which is error prone (as of 2.6.0) and will 
+        // default is Deferred, which is error prone (as of 2.6.0) and will
         // make another copy (memory footprint)
         engine.Put( var, ptr, adios2::Mode::Sync );
     }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1107,7 +1107,8 @@ namespace detail
         adios2::Variable< T > var = m_impl->verifyDataset< T >(
             bp.param.offset, bp.param.extent, IO, bp.name );
 
-        // default is Deferred, and it is error prone
+        // default is Deferred, which is error prone (as of 2.6.0) and will 
+        // make another copy (memory footprint)
         engine.Put( var, ptr, adios2::Mode::Sync );
     }
 


### PR DESCRIPTION
Using the `Sync` mode for now does:
- save an additional memory copy (application memory footprint)?
- has no performance impact currently (as of ADIOS 2.6.0)?
- is more robust than the default deferred mode?

