### PR TITLE
Iteration::close() is MPI-collective

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -87,10 +87,13 @@ public:
      */
     Iteration& setTimeUnitSI(double newTimeUnitSI);
 
-    /**
-     * @brief Close an iteration. No further (backend-propagating) accesses
-     *        may be performed on this iteration.
-     *        A closed iteration may not (yet) be reopened.
+    /** Close an iteration
+     *
+     * No further (backend-propagating) accesses may be performed on this
+     * iteration. A closed iteration may not (yet) be reopened.
+     *
+     * With an MPI-parallel series, close is an MPI-collective operation.
+     *
      * @return Reference to iteration.
      */
     /*


### PR DESCRIPTION
Add more user-facing documentation about the MPI behavior.