### PR TITLE
Docs: Overview Compression ADIOS2

### DIFF
--- a/docs/source/backends/overview.rst
+++ b/docs/source/backends/overview.rst
@@ -13,7 +13,7 @@ Operating Systems  Linux, OSX             Linux, OSX, Windows
 Serial             supported     supported     supported supported
 MPI-parallel       supported     supported     supported no
 Dataset deletion   no            no            supported supported
-Compression        upcoming      upcoming      upcoming  no
+Compression        upcoming      supported     upcoming  no
 Streaming/Staging  not exposed   upcoming      no        no
 Portable Files     limited       awaiting      yes       yes
 PByte-scalable     yes           yes           no        no


### PR DESCRIPTION
Document supported compression in ADIOS2 backend.

Follow-up to #569