### PR TITLE
ICC: Fix Export

### DIFF
--- a/include/openPMD/auxiliary/Export.hpp
+++ b/include/openPMD/auxiliary/Export.hpp
@@ -31,7 +31,7 @@
 #endif
 
 #ifndef OPENPMDAPI_EXPORT_ENUM_CLASS
-#   if defined(__GNUC__) && (__GNUC__ < 6) && !defined(__clang__)
+#   if defined(__GNUC__) && (__GNUC__ < 6) && !defined(__clang__) && !defined(__INTEL_COMPILER)
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43407
 #       define OPENPMDAPI_EXPORT_ENUM_CLASS(ECNAME) enum class ECNAME : OPENPMDAPI_EXPORT unsigned int
 #   else


### PR DESCRIPTION
Do not apply the GCC<6 work-around to Intel 19.* compilers, which breaks our symbol hiding.

Fix #787