### PR TITLE
Clang-Tidy: Rule of Five

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,8 @@
+HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'
 # Future consideration: cppcoreguidelines-*,clang-analyzer-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,readability-*,-clang-diagnostic-unused-command-line-argument,-*-namespace-comment*,-*-braces-around-statements,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-readability-named-parameter
 # FIXME: all performance-* reports
 # FIXME: all cert-* reports
-Checks: -*,bugprone-*,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,modernize-use-override,modernize-use-equals-default
-HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'
+Checks: -*,bugprone-*,cppcoreguidelines-slicing,cppcoreguidelines-special-member-functions,mpi-*,readability-non-const-parameter,modernize-use-override,modernize-use-equals-default
+CheckOptions:
+    - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+      value:           '1'


### PR DESCRIPTION
Add a clang-tidy check that makes sure the rule of zero/five is obeyed.

Core Rule guideline C.21
(Note sure if this clang-tidy check also covers C.20... aka "rule of zero")

https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-special-member-functions.html