### PR TITLE
add comment on lib64

### DIFF
--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -178,6 +178,7 @@ CMake will summarize the install paths for you before the build step.
    # install prefix         |------------|
    export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
    export LD_LIBRARY_PATH=$HOME/somepath/lib:$LD_LIBRARY_PATH
+   # Please be aware that on a 64-bit system `.../lib` might need to be replaced by `.../lib64`.
 
    #                change path to your python MAJOR.MINOR version
    export PYTHONPATH=$HOME/somepath/lib/python3.5/site-packages:$PYTHONPATH

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -181,7 +181,7 @@ CMake will summarize the install paths for you before the build step.
    # Note that one some systems, /lib might need to be replaced with /lib64.
 
    #                change path to your python MAJOR.MINOR version
-   export PYTHONPATH=$HOME/somepath/lib/python3.5/site-packages:$PYTHONPATH
+   export PYTHONPATH=$HOME/somepath/lib/python3.8/site-packages:$PYTHONPATH
 
 Adding those lines to your ``$HOME/.bashrc`` and re-opening your terminal will set them permanently.
 

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -178,7 +178,7 @@ CMake will summarize the install paths for you before the build step.
    # install prefix         |------------|
    export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
    export LD_LIBRARY_PATH=$HOME/somepath/lib:$LD_LIBRARY_PATH
-   # Please be aware that on a 64-bit system `.../lib` might need to be replaced by `.../lib64`.
+   # Note that one some systems, /lib might need to be replaced with /lib64.
 
    #                change path to your python MAJOR.MINOR version
    export PYTHONPATH=$HOME/somepath/lib/python3.5/site-packages:$PYTHONPATH


### PR DESCRIPTION
This pull request adds a brief comment in the installation documentation that informs the user that on a 64-bit system, the library path might be named `lib64`. This solves the issue #792.  