### PR TITLE
add missing python interface (read/write) for machine

### DIFF
--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -143,8 +143,7 @@ Python
 
    series.set_author(
        "Axel Huebl <a.huebl@hzdr.de>")
-   series.set_machine(
-       "Hall Probe 5000, Model 3")
+   series.machine = "Hall Probe 5000, Model 3"
    series.set_attribute(
        "dinner", "Pizza and Coke")
    i.set_attribute(

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -131,8 +131,10 @@ void init_Series(py::module &m) {
         .def("set_particles_path", &Series::setParticlesPath)
         .def_property_readonly("author", &Series::author)
         .def("set_author", &Series::setAuthor)
-        .def_property_readonly("machine", &Series::machine)
-        .def("set_machine", &Series::setMachine)
+        .def_property("machine",
+            &Series::machine,
+            &Series::setMachine,
+            "Indicate the machine or relevant hardware that created the file.")
         .def_property_readonly("software", &Series::software)
         .def("set_software", &Series::setSoftware,
             py::arg("name"), py::arg("version") = std::string("unspecified"))

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -131,6 +131,8 @@ void init_Series(py::module &m) {
         .def("set_particles_path", &Series::setParticlesPath)
         .def_property_readonly("author", &Series::author)
         .def("set_author", &Series::setAuthor)
+        .def_property_readonly("machine", &Series::machine)
+        .def("set_machine", &Series::setMachine)
         .def_property_readonly("software", &Series::software)
         .def("set_software", &Series::setSoftware,
             py::arg("name"), py::arg("version") = std::string("unspecified"))

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -127,6 +127,7 @@ class APITest(unittest.TestCase):
         series.set_software("nonsense")  # with unspecified version
         series.set_software_version("1.2.3")  # deprecated
         series.set_software("openPMD-api-python-tests", "0.42.0")
+        series.machine = "testMachine"
 
         # write one of each supported types
         series.set_attribute("char", 'c')  # string
@@ -252,6 +253,8 @@ class APITest(unittest.TestCase):
             "unittest_py_API." + file_ending,
             io.Access.read_only
         )
+
+        self.assertEqual(series.machine, "testMachine")
 
         self.assertEqual(series.get_attribute("char"), "c")
         self.assertEqual(series.get_attribute("pystring"), "howdy!")


### PR DESCRIPTION
This pull request fixes the issue reported in #794. The getter and setter for `machine` were not defined in the python interface (they work properly in c++). 

