### PR TITLE
Conda: Recommend Fresh Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ spack load -r openpmd-api
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openpmd-api)](https://anaconda.org/conda-forge/openpmd-api)
 
 ```bash
-# optional:            OpenMPI support  =*=mpi_openmpi*
-# optional:              MPICH support  =*=mpi_mpich*
-conda install -c conda-forge openpmd-api
+# optional:                      OpenMPI support  =*=mpi_openmpi*
+# optional:                        MPICH support  =*=mpi_mpich*
+conda create -n openpmd -c conda-forge openpmd-api
+conda activate openpmd
 ```
 
 ### [Brew](https://brew.sh)

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -51,9 +51,10 @@ A package for openPMD-api is available via the `Conda <https://conda.io>`_ packa
 
 .. code-block:: bash
 
-   # optional:            OpenMPI support  =*=mpi_openmpi*
-   # optional:              MPICH support  =*=mpi_mpich*
-   conda install -c conda-forge openpmd-api
+   # optional:                      OpenMPI support  =*=mpi_openmpi*
+   # optional:                        MPICH support  =*=mpi_mpich*
+   conda create -n openpmd -c conda-forge openpmd-api
+   conda activate openpmd
 
 .. _install-brew:
 


### PR DESCRIPTION
Base environments, even the standard one, are these days too far diverged from the conda-forge feedstock to resolve properly. In many scenarios, an old release of openpmd-api will be picked.

Instead, recommend using a new conda environment and installing everything self-consistently in there. Users can add further packages inside it.