### PR TITLE
Be less verbose about missing helper attributes for boolean attributes in ADIOS2 

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -133,7 +133,11 @@ namespace detail
         size_t operator( )( Params &&... );
     };
 
-    Datatype attributeInfo( adios2::IO &, std::string const & attributeName );
+    Datatype
+    attributeInfo(
+        adios2::IO &,
+        std::string const & attributeName,
+        bool verbose );
 } // namespace detail
 
 } // namespace openPMD

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -168,13 +168,20 @@ namespace detail
     }
 
     Datatype
-    attributeInfo( adios2::IO & IO, std::string const & attributeName )
+    attributeInfo(
+        adios2::IO & IO,
+        std::string const & attributeName,
+        bool verbose )
     {
         std::string type = IO.AttributeType( attributeName );
         if( type.empty() )
         {
-            std::cerr << "[ADIOS2] Warning: Attribute with name " << attributeName
-                      << " has no type in backend." << std::endl;
+            if( verbose )
+            {
+                std::cerr << "[ADIOS2] Warning: Attribute with name "
+                          << attributeName << " has no type in backend."
+                          << std::endl;
+            }
             return Datatype::UNDEFINED;
         }
         else

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -805,8 +805,15 @@ namespace detail
         ( std::is_same< T, rep >::value )
         {
             std::string metaAttr = "__is_boolean__" + name;
-            auto type = attributeInfo( IO, "__is_boolean__" + name );
-            if ( type == determineDatatype<rep>() )
+            /*
+             * In verbose mode, attributeInfo will yield a warning if not
+             * finding the requested attribute. Since we expect the attribute
+             * not to be present in many cases (i.e. when it is actually not
+             * a boolean), let's tell attributeInfo to be quiet.
+             */
+            auto type = attributeInfo(
+                IO, "__is_boolean__" + name, /* verbose = */ false );
+            if( type == determineDatatype< rep >() )
             {
                 auto attr = IO.InquireAttribute< rep >( metaAttr );
                 if (attr.Data().size() == 1 && attr.Data()[0] == 1)
@@ -1194,9 +1201,10 @@ namespace detail
                     ba.getEngine( ) );
     }
 
-    void BufferedAttributeRead::run( BufferedActions & ba )
+    void
+    BufferedAttributeRead::run( BufferedActions & ba )
     {
-        auto type = attributeInfo( ba.m_IO, name );
+        auto type = attributeInfo( ba.m_IO, name, /* verbose = */ true );
 
         if ( type == Datatype::UNDEFINED )
         {


### PR DESCRIPTION
Fixes #784.

EDIT: Since boolean types are neither really supported by ADIOS or HDF5.. what about just kicking out `openPMD::Datatype::BOOL`?