### PR TITLE
CI: Replace set-env in Cygwin

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,0 +1,73 @@
+name: Cygwin
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  cmake:
+    runs-on: [windows-2019]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cygwin
+        run: |
+          choco config get cacheLocation
+          choco install --no-progress cygwin
+          echo "C:\tools\cygwin\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+
+          echo "C:\tools\cygwin\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install dependencies
+        shell: cmd
+        run: |
+          C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P cmake,gcc-core,gcc-g++,git,libhdf5-devel,make,python37-devel,python37-numpy,zlib-devel
+      - name: Build
+        shell: cmd
+        run: |
+          mkdir build
+          cd build
+          cmake ../
+          cmake --build . --parallel 2
+      - name: Test
+        shell: cmd
+        run: |
+          cd build
+          ctest
+#          cmake --build . --target install
+
+  wheel:
+    runs-on: [windows-2019]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cygwin
+        run: |
+          choco config get cacheLocation
+          choco install --no-progress cygwin
+          echo "C:\tools\cygwin\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+
+          echo "C:\tools\cygwin\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install dependencies
+        shell: cmd
+        run: |
+          C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P cmake,gcc-core,gcc-g++,git,libhdf5-devel,libuv-devel,make,python37-devel,python37-numpy,python37-pip,python37-wheel,zlib-devel
+      - name: Build
+        shell: cmd
+        run: |
+          python3.7m.exe -m pip install -U pip setuptools wheel
+          python3.7m.exe -m pip install git+https://github.com/ax3l/scikit-build.git@topic-cygwinPlatform
+          python3.7m.exe -m pip wheel --no-build-isolation --no-deps -v .
+      - name: Install
+        shell: cmd
+        run: |
+          python3.7m.exe -m pip install -v *whl
+      - name: Test
+        shell: cmd
+        run: |
+          python3.7m.exe -m openpmd_api.ls --help

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -18,11 +18,8 @@ jobs:
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-      - name: Set Environment
-        shell: cmd
-        run: |
-          echo C:\\tools\\cygwin\\bin > %GITHUB_PATH%
-          echo C:\\tools\\cygwin\\usr\\bin >> %GITHUB_PATH%
+          echo "C:\\tools\\cygwin\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "C:\\tools\\cygwin\\usr\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install dependencies
         shell: cmd
         run: |
@@ -50,11 +47,8 @@ jobs:
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-      - name: Set Environment
-        shell: cmd
-        run: |
-          echo C:\\tools\\cygwin\\bin > %GITHUB_PATH%
-          echo C:\\tools\\cygwin\\usr\\bin >> %GITHUB_PATH%
+          echo "C:\\tools\\cygwin\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "C:\\tools\\cygwin\\usr\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install dependencies
         shell: cmd
         run: |

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -8,11 +8,6 @@ on:
     branches:
       - dev
 
-env:
-  PATH: C:\\tools\\cygwin\\bin;C:\\tools\\cygwin\\usr\\bin;$PATH
-  CC: /usr/bin/c++.exe
-  CXX: /usr/bin/cc
-
 jobs:
   cmake:
     runs-on: [windows-2019]
@@ -23,7 +18,13 @@ jobs:
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-
+      - name: Set Environment
+        shell: cmd
+        run: |
+          echo CC=/usr/bin/cc >> %GITHUB_ENV%
+          echo CXX=/usr/bin/c++.exe >> %GITHUB_ENV%
+          echo C:\\tools\\cygwin\\bin >> %GITHUB_PATH%
+          echo C:\\tools\\cygwin\\usr\\bin >> %GITHUB_PATH%
       - name: Install dependencies
         shell: cmd
         run: |
@@ -51,7 +52,13 @@ jobs:
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-
+      - name: Set Environment
+        shell: cmd
+        run: |
+          echo CC=/usr/bin/cc >> %GITHUB_ENV%
+          echo CXX=/usr/bin/c++.exe >> %GITHUB_ENV%
+          echo C:\\tools\\cygwin\\bin >> %GITHUB_PATH%
+          echo C:\\tools\\cygwin\\usr\\bin >> %GITHUB_PATH%
       - name: Install dependencies
         shell: cmd
         run: |

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -14,23 +14,20 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v2
-      - name: Install cygwin
-        run: |
-          choco config get cacheLocation
-          choco install --no-progress cygwin
-          echo "C:\\tools\\cygwin\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-          echo "C:\\tools\\cygwin\\usr\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install dependencies
-        shell: cmd
         run: |
-          C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P cmake,gcc-core,gcc-g++,git,libhdf5-devel,make,python37-devel,python37-numpy,zlib-devel
+          $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
+          bash.exe -c "pacman-key --init 2>&1"
+          bash.exe -c "pacman-key --populate msys2 2>&1"
+          pacman -S --noconfirm --needed --noprogressbar mingw64/mingw-w64-x86_64-hdf5
+          pacman -S --noconfirm --needed --noprogressbar mingw64/mingw-w64-x86_64-python
+          pacman -S --noconfirm --needed --noprogressbar mingw64/mingw-w64-x86_64-python-numpy
+#          make,python37-devel,python37-numpy,zlib-devel
       - name: Build
         shell: cmd
         run: |
-          mkdir build
-          cd build
-          cmake ../
-          cmake --build . --parallel 2
+          cmake -S . -B build -G "MSYS Makefiles"
+          cmake --build build --parallel 2
       - name: Test
         shell: cmd
         run: |
@@ -43,16 +40,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v2
-      - name: Install cygwin
-        run: |
-          choco config get cacheLocation
-          choco install --no-progress cygwin
-          echo "C:\\tools\\cygwin\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-          echo "C:\\tools\\cygwin\\usr\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Install dependencies
-        shell: cmd
-        run: |
-          C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P cmake,gcc-core,gcc-g++,git,libhdf5-devel,libuv-devel,make,python37-devel,python37-numpy,python37-pip,python37-wheel,zlib-devel
+#      - name: Install dependencies
+#        shell: cmd
+#        run: |
+#          C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P cmake,gcc-core,gcc-g++,git,libhdf5-devel,libuv-devel,make,python37-devel,python37-numpy,python37-pip,python37-wheel,zlib-devel
       - name: Build
         shell: cmd
         run: |

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -12,19 +12,22 @@ jobs:
   cmake:
     runs-on: [windows-2019]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            base-devel
+            gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-hdf5
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-python-numpy
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
-          bash.exe -c "pacman-key --init 2>&1"
-          bash.exe -c "pacman-key --populate msys2 2>&1"
-          pacman -S --noconfirm --needed --noprogressbar mingw64/mingw-w64-x86_64-hdf5
-          pacman -S --noconfirm --needed --noprogressbar mingw64/mingw-w64-x86_64-python
-          pacman -S --noconfirm --needed --noprogressbar mingw64/mingw-w64-x86_64-python-numpy
-#          make,python37-devel,python37-numpy,zlib-devel
       - name: Build
-        shell: cmd
         run: |
           cmake -S . -B build -G "MSYS Makefiles"
           cmake --build build --parallel 2

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -21,9 +21,7 @@ jobs:
       - name: Set Environment
         shell: cmd
         run: |
-          echo CC=/usr/bin/cc >> %GITHUB_ENV%
-          echo CXX=/usr/bin/c++.exe >> %GITHUB_ENV%
-          echo C:\\tools\\cygwin\\bin >> %GITHUB_PATH%
+          echo C:\\tools\\cygwin\\bin > %GITHUB_PATH%
           echo C:\\tools\\cygwin\\usr\\bin >> %GITHUB_PATH%
       - name: Install dependencies
         shell: cmd
@@ -55,9 +53,7 @@ jobs:
       - name: Set Environment
         shell: cmd
         run: |
-          echo CC=/usr/bin/cc >> %GITHUB_ENV%
-          echo CXX=/usr/bin/c++.exe >> %GITHUB_ENV%
-          echo C:\\tools\\cygwin\\bin >> %GITHUB_PATH%
+          echo C:\\tools\\cygwin\\bin > %GITHUB_PATH%
           echo C:\\tools\\cygwin\\usr\\bin >> %GITHUB_PATH%
       - name: Install dependencies
         shell: cmd

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - dev
 
+env:
+  PATH: C:\\tools\\cygwin\\bin;C:\\tools\\cygwin\\usr\\bin;$PATH
+  CC: /usr/bin/c++.exe
+  CXX: /usr/bin/cc
+
 jobs:
   cmake:
     runs-on: [windows-2019]
@@ -18,9 +23,6 @@ jobs:
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-          echo "C:\tools\cygwin\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-
-          echo "C:\tools\cygwin\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install dependencies
         shell: cmd
@@ -49,9 +51,6 @@ jobs:
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-          echo "C:\tools\cygwin\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-
-          echo "C:\tools\cygwin\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install dependencies
         shell: cmd


### PR DESCRIPTION
Use the GitHub Action `env:` keyword instead of the deprecated `set-env` command:
* https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
  * https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
* https://github.community/t/migration-from-deprecated-add-path-on-windows/136265