### PR TITLE
Add Jupyter notebook examples for read_serial and write_serial examples

### DIFF
--- a/examples/2_read_serial.ipynb
+++ b/examples/2_read_serial.ipynb
@@ -1,19 +1,19 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# openPMD-api Read Serial Example"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import openpmd_api as io"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# openPMD-api read_serial example"
    ]
   },
   {
@@ -33,6 +33,7 @@
     }
    ],
    "source": [
+    "# Load a Series\n",
     "series = io.Series(\"../samples/git-sample/data%T.h5\", io.Access.read_only)\n",
     "series"
    ]
@@ -281,12 +282,26 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(-1.60217657e-19)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# printing a scalar value\n",
     "electrons = it.particles[\"electrons\"]\n",
     "charge = electrons[\"charge\"][io.Mesh_Record_Component.SCALAR]\n",
-    "series.flush()\n"
+    "series.flush()\n",
+    "\n",
+    "# And the first electron particle has a charge\n",
+    "charge[0]"
    ]
   },
   {
@@ -297,31 +312,10 @@
     {
      "data": {
       "text/plain": [
-       "array(-1.60217657e-19)"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# And the first electron particle has a charge\n",
-    "charge[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
        "<openPMD.Mesh_Record_Component of dimensionality '3'>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -333,13 +327,34 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[26, 26, 201]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Shape\n",
+    "E_x.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "([26, 26, 201], dtype('float64'))"
+       "dtype('float64')"
       ]
      },
      "execution_count": 17,
@@ -348,8 +363,8 @@
     }
    ],
    "source": [
-    "# Shape and data type\n",
-    "E_x.shape, E_x.dtype"
+    "# data type\n",
+    "E_x.dtype"
    ]
   },
   {
@@ -427,10 +442,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# The files in 'series' are still open until the object is destroyed, on\n",
+    "# which it cleanly flushes and closes all open file handles.\n",
+    "# One can delete the object explicitly (or let it run out of scope) to\n",
+    "# trigger this.\n",
+    "# del series"
+   ]
   }
  ],
  "metadata": {

--- a/examples/2_read_serial.ipynb
+++ b/examples/2_read_serial.ipynb
@@ -276,6 +276,161 @@
     "    for r in it.particles[ps]:\n",
     "        print('\\t', r)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# printing a scalar value\n",
+    "electrons = it.particles[\"electrons\"]\n",
+    "charge = electrons[\"charge\"][io.Mesh_Record_Component.SCALAR]\n",
+    "series.flush()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(-1.60217657e-19)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# And the first electron particle has a charge\n",
+    "charge[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '3'>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "E_x = it.meshes[\"E\"][\"x\"]\n",
+    "E_x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([26, 26, 201], dtype('float64'))"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Shape and data type\n",
+    "E_x.shape, E_x.dtype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[[-75874183.04159331],\n",
+       "        [-75956606.50847568]],\n",
+       "\n",
+       "       [[-84234548.15893488],\n",
+       "        [-48105850.2088511 ]]])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chunk_data = E_x[1:3, 1:3, 1:2]\n",
+    "series.flush()\n",
+    "\n",
+    "#Chunk has been read from disk\n",
+    "# Read chunk contains\n",
+    "chunk_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(26, 26, 201)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_data = E_x.load_chunk()\n",
+    "series.flush()\n",
+    "all_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-10854939.06257274, -13967032.39947386, -12319531.17508235,\n",
+       "       -11579523.18708802, -13373849.85062899])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Full E/x starts with:\"\n",
+    "all_data[0, 0, :5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/3_write_serial.ipynb
+++ b/examples/3_write_serial.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# openPMD-API Write Serial Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openpmd_api as io\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# user input: size of matrix to write, default 3x3\n",
+    "size = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, 3)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# matrix dataset to write with values 0...size*size-1\n",
+    "\n",
+    "#Set up a 2D square array that will be written\n",
+    "data = np.arange(size*size, dtype=np.double).reshape(3, 3)\n",
+    "\n",
+    "data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Attributable with '8' attributes>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# open file for writing\n",
+    "series = io.Series('../samples/3_write_serial_py.h5', io.Access.create)\n",
+    "series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Iteration_Encoding.group_based, 0)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Created an empty Series \n",
+    "series.iteration_encoding, len(series.iterations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rho = series.iterations[1].meshes['rho'][io.Mesh_Record_Component.SCALAR]\n",
+    "rho"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Dataset of rank '2'>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset = io.Dataset(data.dtype, data.shape)\n",
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([3, 3], dtype('float64'))"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Created a Dataset of extent and datatype: \n",
+    "dataset.extent, dataset.dtype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '2'>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rho.reset_dataset(dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the dataset properties for the scalar field rho in iteration 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series.flush()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stored the whole Dataset contents as a single chunk, ready to write content\n",
+    "rho[()] = data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series.flush()\n",
+    "# Now the Dataset content has been fully written"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The files in 'series' are still open until the object is destroyed, on\n",
+    "# which it cleanly flushes and closes all open file handles.\n",
+    "# One can delete the object explicitly (or let it run out of scope) to\n",
+    "# trigger this.\n",
+    "\n",
+    "# del series"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/3a_write_thetaMode_serial.ipynb
+++ b/examples/3a_write_thetaMode_serial.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# opemPMD-api Write thetaMode Serial Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openpmd_api as io\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open file for writing\n",
+    "series = io.Series(\n",
+    "    '../samples/3_write_thetaMode_serial_py.h5',\n",
+    "    io.Access.create\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# configure and setup geometry\n",
+    "num_modes = 5\n",
+    "num_fields = 1 + (num_modes-1) * 2  # the first mode is purely real\n",
+    "N_r = 60\n",
+    "N_z = 200"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write values 0...size-1\n",
+    "E_r_data = np.arange(num_fields*N_r*N_z, dtype=np.double) \\\n",
+    "             .reshape(num_fields, N_r, N_z)\n",
+    "E_t_data = np.arange(num_fields*N_r*N_z, dtype=np.single) \\\n",
+    "             .reshape(num_fields, N_r, N_z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'m=5;imag=+'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geometry_parameters = f'm={num_modes};imag=+'\n",
+    "geometry_parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh record with '0' record components>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "E = series.iterations[0].meshes[\"E\"]\n",
+    "E.set_geometry(io.Geometry.thetaMode)\n",
+    "E.set_geometry_parameters(geometry_parameters)\n",
+    "E.set_data_order(io.Data_Order.C)\n",
+    "E.set_grid_spacing([1.0, 1.0])\n",
+    "E.set_grid_global_offset([0.0, 0.0])\n",
+    "E.set_grid_unit_SI(1.0)\n",
+    "E.set_axis_labels([\"r\", \"z\"])\n",
+    "E.unit_dimension = {io.Unit_Dimension.I: 1.0,\n",
+    "                    io.Unit_Dimension.J: 2.0}\n",
+    "E"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '3'>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# write components: E_z, E_r, E_t\n",
+    "E_z = E[\"z\"]\n",
+    "E_z.unit_SI = 10.\n",
+    "E_z.position = [0.0, 0.5]\n",
+    "#   (modes, r, z) see set_geometry_parameters\n",
+    "E_z.reset_dataset(io.Dataset(io.Datatype.FLOAT, [num_fields, N_r, N_z]))\n",
+    "E_z.make_constant(42.54)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '3'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# write all modes at once (otherwise iterate over modes and first index\n",
+    "E_r = E[\"r\"]\n",
+    "E_r.unit_SI = 10.\n",
+    "E_r.position = [0.5, 0.0]\n",
+    "E_r.reset_dataset(io.Dataset(E_r_data.dtype, E_r_data.shape))\n",
+    "E_r.store_chunk(E_r_data)\n",
+    "\n",
+    "E_r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '3'>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "E_t = E[\"t\"]\n",
+    "E_t.unit_SI = 10.\n",
+    "E_t.position = [0.0, 0.0]\n",
+    "E_t.reset_dataset(io.Dataset(E_t_data.dtype, E_t_data.shape))\n",
+    "E_t.store_chunk(E_t_data)\n",
+    "\n",
+    "E_t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series.flush()\n",
+    "\n",
+    "# The files in 'series' are still open until the object is destroyed, on\n",
+    "# which it cleanly flushes and closes all open file handles.\n",
+    "# One can delete the object explicitly (or let it run out of scope) to\n",
+    "# trigger this.\n",
+    "# del series"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/7_extended_write_serial.ipynb
+++ b/examples/7_extended_write_serial.ipynb
@@ -1,0 +1,597 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# opePMD-api Extended Write Serial Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openpmd_api import Series, Access, Dataset, Mesh_Record_Component, \\\n",
+    "    Unit_Dimension\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SCALAR = Mesh_Record_Component.SCALAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open file for writing\n",
+    "f = Series(\n",
+    "    \"2D_simData_py.h5\",\n",
+    "    Access.create\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Attributable with '10' attributes>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# all required openPMD attributes will be set to reasonable default values\n",
+    "# (all ones, all zeros, empty strings,...)\n",
+    "# manually setting them enforces the openPMD standard\n",
+    "f.set_meshes_path(\"custom_meshes_path\")\n",
+    "f.set_particles_path(\"long_and_very_custom_particles_path\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Attributable with '12' attributes>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# it is possible to add and remove attributes\n",
+    "f.set_comment(\"This is fine and actually encouraged by the standard\")\n",
+    "f.set_attribute(\n",
+    "    \"custom_attribute_name\",\n",
+    "    \"This attribute is manually added and can contain about any datatype \"\n",
+    "    \"you would want\"\n",
+    ")\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# note that removing attributes required by the standard typically makes\n",
+    "# the file unusable for post-processing\n",
+    "f.delete_attribute(\"custom_attribute_name\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# setting attributes can be chained in JS-like syntax for compact code\n",
+    "tmpItObj = f.iterations[1] \\\n",
+    "    .set_time(42.0) \\\n",
+    "    .set_dt(1.0) \\\n",
+    "    .set_time_unit_SI(1.39e-16)\n",
+    "# everything that is accessed with [] should be interpreted as permanent\n",
+    "# storage the objects sunk into these locations are deep copies\n",
+    "f.iterations[2].set_comment(\"This iteration will not appear in any output\")\n",
+    "del f.iterations[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Iteration of at t = '0.000000 s'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# this is a reference to an iteration\n",
+    "reference = f.iterations[1]\n",
+    "reference.set_comment(\"Modifications to a reference will always be visible\"\n",
+    "                      \" in the output\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del reference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# alternatively, a copy may be created and later re-assigned to\n",
+    "# f.iterations[1]\n",
+    "copy = f.iterations[1]  # TODO .copy()\n",
+    "copy.set_comment(\"Modifications to copies will only take effect after you \"\n",
+    "                 \"reassign the copy\")\n",
+    "f.iterations[1] = copy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del copy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f.iterations[1].delete_attribute(\"comment\")\n",
+    "\n",
+    "cur_it = f.iterations[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the underlying concept for numeric data is the openPMD Record\n",
+    "# https://github.com/openPMD/openPMD-standard/blob/upcoming-1.0.1/STANDARD.md#scalar-vector-and-tensor-records\n",
+    "# Meshes are specialized records\n",
+    "cur_it.meshes[\"generic_2D_field\"].unit_dimension = {\n",
+    "    Unit_Dimension.L: -3, Unit_Dimension.M: 1}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh record with '0' record components>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# as this is a reference, it modifies the original resource\n",
+    "lowRez = cur_it.meshes[\"generic_2D_field\"]\n",
+    "lowRez.set_grid_spacing([1, 1]) \\\n",
+    "    .set_grid_global_offset([0, 600])\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# del cur_it.meshes[\"generic_2D_field\"]\n",
+    "cur_it.meshes[\"lowRez_2D_field\"] = lowRez\n",
+    "del lowRez\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# particles are handled very similar\n",
+    "electrons = cur_it.particles[\"electrons\"]\n",
+    "electrons.set_attribute(\n",
+    "    \"NoteWorthyParticleSpeciesProperty\",\n",
+    "    \"Observing this species was a blast.\")\n",
+    "electrons[\"displacement\"].unit_dimension = {Unit_Dimension.M: 1}\n",
+    "electrons[\"displacement\"][\"x\"].unit_SI = 1.e-6\n",
+    "del electrons[\"displacement\"]\n",
+    "electrons[\"weighting\"][SCALAR].make_constant(1.e-5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh record with '0' record components>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mesh = cur_it.meshes[\"lowRez_2D_field\"]\n",
+    "mesh.set_axis_labels([\"x\", \"y\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data is assumed to reside behind a pointer as a contiguous column-major\n",
+    "# array shared data ownership during IO is indicated with a smart pointer\n",
+    "partial_mesh = np.arange(5, dtype=np.double)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '2'>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# before storing record data, you must specify the dataset once per\n",
+    "# component this describes the datatype and shape of data as it should be\n",
+    "# written to disk\n",
+    "d = Dataset(partial_mesh.dtype, extent=[2, 5])\n",
+    "d.set_compression(\"zlib\", 9)\n",
+    "d.set_custom_transform(\"blosc:compressor=zlib,shuffle=bit,lvl=1;nometa\")\n",
+    "mesh[\"x\"].reset_dataset(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "electrons = cur_it.particles[\"electrons\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mpiDims = [4]\n",
+    "partial_particlePos = np.arange(2, dtype=np.float32)\n",
+    "d = Dataset(partial_particlePos.dtype, extent=mpiDims)\n",
+    "electrons[\"position\"][\"x\"].reset_dataset(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "partial_particleOff = np.arange(2, dtype=np.uint)\n",
+    "d = Dataset(partial_particleOff.dtype, mpiDims)\n",
+    "electrons[\"positionOffset\"][\"x\"].reset_dataset(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Base_Record_Component of 'ULONG'>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dset = Dataset(np.dtype(\"uint64\"), extent=[2])\n",
+    "electrons.particle_patches[\"numParticles\"][SCALAR].reset_dataset(dset)\n",
+    "electrons.particle_patches[\"numParticlesOffset\"][SCALAR]. \\\n",
+    "    reset_dataset(dset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Base_Record_Component of 'FLOAT'>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dset = Dataset(partial_particlePos.dtype, extent=[2])\n",
+    "electrons.particle_patches[\"offset\"].set_unit_dimension(\n",
+    "    {Unit_Dimension.L: 1})\n",
+    "electrons.particle_patches[\"offset\"][\"x\"].reset_dataset(dset)\n",
+    "electrons.particle_patches[\"extent\"].set_unit_dimension(\n",
+    "    {Unit_Dimension.L: 1})\n",
+    "electrons.particle_patches[\"extent\"][\"x\"].reset_dataset(dset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# at any point in time you may decide to dump already created output to\n",
+    "# disk note that this will make some operations impossible (e.g. renaming\n",
+    "# files)\n",
+    "f.flush()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chunked Writing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# chunked writing of the final dataset at a time is supported\n",
+    "# this loop writes one row at a time\n",
+    "mesh_x = np.array([\n",
+    "    [1,  3,  5,  7,  9],\n",
+    "    [11, 13, 15, 17, 19]\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "particle_position = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)\n",
+    "particle_position_offset = [0, 1, 2, 3]\n",
+    "for i in [0, 1]:\n",
+    "    for col in [0, 1, 2, 3, 4]:\n",
+    "        partial_mesh[col] = mesh_x[i, col]\n",
+    "\n",
+    "    mesh[\"x\"][i, 0:5] = partial_mesh\n",
+    "    # operations between store and flush MUST NOT modify the pointed-to\n",
+    "    # data\n",
+    "    f.flush()\n",
+    "    # after the flush completes successfully, access to the shared\n",
+    "    # resource is returned to the caller\n",
+    "\n",
+    "    for idx in [0, 1]:\n",
+    "        partial_particlePos[idx] = particle_position[idx + 2*i]\n",
+    "        partial_particleOff[idx] = particle_position_offset[idx + 2*i]\n",
+    "\n",
+    "    numParticlesOffset = 2*i\n",
+    "    numParticles = 2\n",
+    "\n",
+    "    o = numParticlesOffset\n",
+    "    u = numParticles + o\n",
+    "    electrons[\"position\"][\"x\"][o:u] = partial_particlePos\n",
+    "    electrons[\"positionOffset\"][\"x\"][o:u] = partial_particleOff\n",
+    "\n",
+    "    electrons.particle_patches[\"numParticles\"][SCALAR].store(\n",
+    "        i, np.array([numParticles], dtype=np.uint64))\n",
+    "    electrons.particle_patches[\"numParticlesOffset\"][SCALAR].store(\n",
+    "        i, np.array([numParticlesOffset], dtype=np.uint64))\n",
+    "\n",
+    "    electrons.particle_patches[\"offset\"][\"x\"].store(\n",
+    "        i,\n",
+    "        np.array([particle_position[numParticlesOffset]],\n",
+    "                 dtype=np.float32))\n",
+    "    electrons.particle_patches[\"extent\"][\"x\"].store(\n",
+    "        i,\n",
+    "        np.array([\n",
+    "            particle_position[numParticlesOffset + numParticles - 1] -\n",
+    "            particle_position[numParticlesOffset]\n",
+    "        ], dtype=np.float32))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Mesh_Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mesh[\"y\"].reset_dataset(d)\n",
+    "mesh[\"y\"].unit_SI = 4\n",
+    "constant_value = 0.3183098861837907\n",
+    "# for datasets that contain a single unique value, openPMD offers\n",
+    "# constant records\n",
+    "mesh[\"y\"].make_constant(constant_value)\n",
+    "mesh[\"y\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cleanup\n",
+    "import os\n",
+    "os.remove(\"2D_simData_py.h5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The files in 'f' are still open until the object is destroyed, on\n",
+    "# which it cleanly flushes and closes all open file handles.\n",
+    "# One can delete the object explicitly (or let it run out of scope) to\n",
+    "# trigger this.\n",
+    "# del f"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/9_particle_write_serial.ipynb
+++ b/examples/9_particle_write_serial.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# openPMD-api Particle Write Serial Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openpmd_api import Series, Access, Dataset, Mesh_Record_Component, \\\n",
+    "    Unit_Dimension\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "SCALAR = Mesh_Record_Component.SCALAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open file for writing\n",
+    "f = Series(\n",
+    "    \"../samples/7_particle_write_serial_py.h5\",\n",
+    "    Access.create\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Attributable with '10' attributes>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# all required openPMD attributes will be set to reasonable default values\n",
+    "# (all ones, all zeros, empty strings,...)\n",
+    "# manually setting them enforces the openPMD standard\n",
+    "f.set_meshes_path(\"fields\")\n",
+    "f.set_particles_path(\"particles\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# new iteration\n",
+    "cur_it = f.iterations[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.ParticleSpecies>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# particles\n",
+    "electrons = cur_it.particles[\"electrons\"]\n",
+    "electrons.set_attribute(\n",
+    "    \"Electrons... the necessary evil for ion acceleration! \",\n",
+    "    \"Just kidding.\")\n",
+    "\n",
+    "electrons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# let's set a weird user-defined record this time\n",
+    "electrons[\"displacement\"].unit_dimension = {Unit_Dimension.M: 1}\n",
+    "electrons[\"displacement\"][SCALAR].unit_SI = 1.e-6\n",
+    "dset = Dataset(np.dtype(\"float64\"), extent=[2])\n",
+    "electrons[\"displacement\"][SCALAR].reset_dataset(dset)\n",
+    "electrons[\"displacement\"][SCALAR].make_constant(42.43)\n",
+    "# don't like it anymore? remove it with:\n",
+    "# del electrons[\"displacement\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "electrons[\"weighting\"][SCALAR].make_constant(1.e-5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "particlePos_x = np.random.rand(234).astype(np.float32)\n",
+    "particlePos_y = np.random.rand(234).astype(np.float32)\n",
+    "d = Dataset(particlePos_x.dtype, extent=particlePos_x.shape)\n",
+    "electrons[\"position\"][\"x\"].reset_dataset(d)\n",
+    "electrons[\"position\"][\"y\"].reset_dataset(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Record_Component of dimensionality '1'>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "particleOff_x = np.arange(234, dtype=np.uint)\n",
+    "particleOff_y = np.arange(234, dtype=np.uint)\n",
+    "d = Dataset(particleOff_x.dtype, particleOff_x.shape)\n",
+    "electrons[\"positionOffset\"][\"x\"].reset_dataset(d)\n",
+    "electrons[\"positionOffset\"][\"y\"].reset_dataset(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "electrons[\"position\"][\"x\"].store_chunk(particlePos_x)\n",
+    "electrons[\"position\"][\"y\"].store_chunk(particlePos_y)\n",
+    "electrons[\"positionOffset\"][\"x\"].store_chunk(particleOff_x)\n",
+    "electrons[\"positionOffset\"][\"y\"].store_chunk(particleOff_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# at any point in time you may decide to dump already created output to\n",
+    "# disk note that this will make some operations impossible (e.g. renaming\n",
+    "# files)\n",
+    "f.flush()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now the file is closed\n",
+    "# del f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cleanup\n",
+    "import os\n",
+    "os.remove(\"../samples/7_particle_write_serial_py.h5\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/read_serial.ipynb
+++ b/examples/read_serial.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openpmd_api as io"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# openPMD-api read_serial example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Attributable with '10' attributes>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "series = io.Series(\"../samples/git-sample/data%T.h5\", io.Access.read_only)\n",
+    "series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.1.0'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# openPMD standard version\n",
+    "series.openPMD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Attributable with '0' attributes>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The Series contains iterations:\n",
+    "series.iterations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(series.iterations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100\n",
+      "200\n",
+      "300\n",
+      "400\n",
+      "500\n"
+     ]
+    }
+   ],
+   "source": [
+    "# These are their labels\n",
+    "for i in series.iterations:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Iteration of at t = '0.000000 s'>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get an iteration\n",
+    "it = series.iterations[100]\n",
+    "it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<openPMD.Attributable with '6' attributes>,\n",
+       " ['chargeCorrection',\n",
+       "  'currentSmoothing',\n",
+       "  'currentSmoothingParameters',\n",
+       "  'fieldBoundary',\n",
+       "  'fieldSolver',\n",
+       "  'particleBoundary'])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Iteration 100 contains meshes\n",
+    "it.meshes, it.meshes.attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(it)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "E\n",
+      "rho\n"
+     ]
+    }
+   ],
+   "source": [
+    "for m in it.meshes:\n",
+    "    print(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openPMD.Attributable with '0' attributes>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Iteration 100 contains particle species\n",
+    "it.particles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(it.particles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electrons with records:\n",
+      "\t charge\n",
+      "\t mass\n",
+      "\t momentum\n",
+      "\t position\n",
+      "\t positionOffset\n",
+      "\t weighting\n"
+     ]
+    }
+   ],
+   "source": [
+    "for ps in it.particles:\n",
+    "    print(ps, 'with records:')\n",
+    "    for r in it.particles[ps]:\n",
+    "        print('\\t', r)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This translates the `read_serial.py` and `write_serial.py` into Jupyter notebooks. These notebooks are fully evaluated, so they can serve as documentation as well as working tutorial examples. 