### PR TITLE
Fix Series Attributes: Read Defaults

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -25,6 +25,7 @@
 #include "openPMD/IO/AbstractIOHandlerHelper.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/Series.hpp"
+#include "openPMD/version.hpp"
 
 #include <exception>
 #include <iomanip>
@@ -533,24 +534,16 @@ Series::init(std::shared_ptr< AbstractIOHandler > ioHandler,
 void
 Series::initDefaults()
 {
-    std::stringstream openPMDstandard;
-    openPMDstandard << OPENPMD_STANDARD_MAJOR << "."
-                    << OPENPMD_STANDARD_MINOR << "."
-                    << OPENPMD_STANDARD_PATCH;
-    setOpenPMD( openPMDstandard.str() );
-    setOpenPMDextension(0);
-    setAttribute("basePath", std::string(BASEPATH));
-    setDate( auxiliary::getDateString() );
-
-    std::stringstream openPMDapi;
-    openPMDapi << OPENPMDAPI_VERSION_MAJOR << "."
-               << OPENPMDAPI_VERSION_MINOR << "."
-               << OPENPMDAPI_VERSION_PATCH;
-    if( std::string( OPENPMDAPI_VERSION_LABEL ).size() > 0 )
-        openPMDapi << "-" << OPENPMDAPI_VERSION_LABEL;
-    setSoftware( "openPMD-api", openPMDapi.str() );
-
-    // TODO Potentially warn on flush if software and author are not user-provided (defaulted)
+    if( !containsAttribute("openPMD"))
+        setOpenPMD( getStandard() );
+    if( !containsAttribute("openPMDextension"))
+        setOpenPMDextension(0);
+    if( !containsAttribute("basePath"))
+        setAttribute("basePath", std::string(BASEPATH));
+    if( !containsAttribute("date"))
+        setDate( auxiliary::getDateString() );
+    if( !containsAttribute("software"))
+        setSoftware( "openPMD-api", getVersion() );
 }
 
 template< typename IterationsContainer >

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -254,6 +254,8 @@ class APITest(unittest.TestCase):
             io.Access.read_only
         )
 
+        self.assertEqual(series.software, "openPMD-api-python-tests")
+        self.assertEqual(series.software_version, "0.42.0")
         self.assertEqual(series.machine, "testMachine")
 
         self.assertEqual(series.get_attribute("char"), "c")


### PR DESCRIPTION
Do not overwrite attributes of the `Series` object on read with defaults if they are present in the read series.

Fix #798