### PR TITLE
Use ADIOS variables for openPMD attributes

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -78,6 +78,30 @@ jobs:
         export OPENPMD_BP_BACKEND=ADIOS1
         ctest --output-on-failure
 
+  clang5_nopy_ompi_h5_ad2_newLayout_bp3:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Spack Cache
+      uses: actions/cache@v2
+      with: {path: /opt/spack, key: clang5_nopy_ompi_h5_ad1_ad2_bp3 }
+    - name: Install
+      run: |
+        sudo apt-get install clang-5.0 gfortran libopenmpi-dev python3
+        sudo .github/workflows/dependencies/install_spack
+    - name: Build
+      env: {CC: clang-5.0, CXX: clang++-5.0, CXXFLAGS: -Werror -Wno-deprecated-declarations}
+      run: |
+        eval $(spack env activate --sh .github/ci/spack-envs/clang5_nopy_ompi_h5_ad1_ad2_bp3/)
+        spack install
+
+        mkdir build && cd build
+        ../share/openPMD/download_samples.sh && chmod u-w samples/git-sample/*.h5
+        cmake -S .. -B . -DopenPMD_USE_PYTHON=OFF -DopenPMD_USE_MPI=ON -DopenPMD_USE_HDF5=ON -DopenPMD_USE_ADIOS1=OFF -DopenPMD_USE_ADIOS2=ON -DopenPMD_USE_INVASIVE_TESTS=ON
+        cmake --build . --parallel 2
+        export OPENPMD_NEW_ATTRIBUTE_LAYOUT=1
+        ctest --output-on-failure
+
 # TODO
 #  clang6_py36_nompi_h5_ad1_ad2_libcpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ set(IO_SOURCE
         src/IO/JSON/JSONFilePosition.cpp
         src/IO/ADIOS/ADIOS2IOHandler.cpp
         src/IO/ADIOS/ADIOS2Auxiliary.cpp
+        src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
         src/IO/InvalidatableFile.cpp)
 set(IO_ADIOS1_SEQUENTIAL_SOURCE
         src/auxiliary/Filesystem.cpp

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -75,6 +75,29 @@ A good number for substreams is usually the number of contributing nodes divided
 For fine-tuning at extreme scale or for exotic systems, please refer to the ADIOS2 manual and talk to your filesystem admins and the ADIOS2 authors.
 Be aware that extreme-scale I/O is a research topic after all.
 
+Experimental new attribute layout
+---------------------------------
+
+We are experimenting with a breaking change to our layout of openPMD datasets in ADIOS2.
+It is likely that we will in future use ADIOS attributes only for a handful of internal flags.
+Actual openPMD attributes will be modeled by ADIOS variables of the same name.
+In order to distinguish datasets from attributes, datasets will be suffixed by ``/__data__``.
+
+We hope that this will bring several advantages:
+
+* Unlike ADIOS attributes, ADIOS variables are mutable.
+* ADIOS variables are more closely related to the concept of ADIOS steps.
+  An ADIOS variable that is not written to in one step is not seen by the reader.
+  This will bring more manageable amounts of metadata for readers to parse through.
+
+The new layout may be activated **for experimental purposes** in two ways:
+
+* Via the JSON parameter ``adios2.new_attribute_layout = true``.
+* Via the environment variable ``export OPENPMD_NEW_ATTRIBUTE_LAYOUT=1``.
+
+The classical and the new layout are absolutely incompatible with one another.
+The ADIOS2 backend will **not** (yet) automatically recognize the layout that has been used by a writer when reading a dataset.
+
 Selected References
 -------------------
 

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -23,12 +23,15 @@
 
 #include "openPMD/config.hpp"
 #if openPMD_HAVE_ADIOS2
-#include "openPMD/Datatype.hpp"
-#include <adios2.h>
-#include <complex>
-#include <stdexcept>
-#include <utility>
-#include <vector>
+# include "openPMD/Dataset.hpp"
+# include "openPMD/Datatype.hpp"
+
+# include <adios2.h>
+
+# include <complex>
+# include <stdexcept>
+# include <utility>
+# include <vector>
 
 namespace openPMD
 {
@@ -75,16 +78,25 @@ namespace detail
      */
     Datatype fromADIOS2Type( std::string const & dt );
 
+    enum class VariableOrAttribute : unsigned char
+    {
+        Variable,
+        Attribute
+    };
+
     template < typename T > struct AttributeInfoHelper
     {
-        static typename std::vector< T >::size_type
-        getSize( adios2::IO &, std::string const & attributeName );
+        static Extent
+        getSize(
+            adios2::IO &,
+            std::string const & attributeName,
+            VariableOrAttribute );
     };
 
     template < > struct AttributeInfoHelper< std::complex< long double > >
     {
-        static typename std::vector< long double >::size_type
-        getSize( adios2::IO &, std::string const & )
+        static Extent
+        getSize( adios2::IO &, std::string const &, VariableOrAttribute )
         {
             throw std::runtime_error(
                 "[ADIOS2] Internal error: no support for long double complex attribute types" );
@@ -93,14 +105,17 @@ namespace detail
 
     template < typename T > struct AttributeInfoHelper< std::vector< T > >
     {
-        static typename std::vector< T >::size_type
-        getSize( adios2::IO &, std::string const & attributeName );
+        static Extent
+        getSize(
+            adios2::IO &,
+            std::string const & attributeName,
+            VariableOrAttribute );
     };
 
     template < > struct AttributeInfoHelper< std::vector< std::complex< long double > > >
     {
-        static typename std::vector< std::complex< long double > >::size_type
-        getSize( adios2::IO &, std::string const & )
+        static Extent
+        getSize( adios2::IO &, std::string const &, VariableOrAttribute )
         {
             throw std::runtime_error(
                 "[ADIOS2] Internal error: no support for long double complex vector attribute types" );
@@ -110,27 +125,33 @@ namespace detail
     template < typename T, std::size_t n >
     struct AttributeInfoHelper< std::array< T, n > >
     {
-        static typename std::vector< T >::size_type
-        getSize( adios2::IO & IO, std::string const & attributeName )
+        static Extent
+        getSize(
+            adios2::IO & IO,
+            std::string const & attributeName,
+            VariableOrAttribute voa )
         {
-            return AttributeInfoHelper< T >::getSize( IO, attributeName );
+            return AttributeInfoHelper< T >::getSize( IO, attributeName, voa );
         }
     };
 
     template <> struct AttributeInfoHelper< bool >
     {
-        static typename std::vector< bool_representation >::size_type
-        getSize( adios2::IO &, std::string const & attributeName );
+        static Extent
+        getSize(
+            adios2::IO &,
+            std::string const & attributeName,
+            VariableOrAttribute );
     };
 
     struct AttributeInfo
     {
-        template < typename T >
-        typename std::vector< T >::size_type
-        operator( )( adios2::IO &, std::string const & attributeName );
+        template< typename T, typename... Params >
+        Extent
+        operator()( Params &&... );
 
         template < int n, typename... Params >
-        size_t operator( )( Params &&... );
+        Extent operator( )( Params &&... );
     };
 
     /**
@@ -146,7 +167,44 @@ namespace detail
     attributeInfo(
         adios2::IO & IO,
         std::string const & attributeName,
-        bool verbose );
+        bool verbose,
+        VariableOrAttribute = VariableOrAttribute::Attribute );
+
+    template< typename T >
+    struct IsTrivialType
+    {
+        constexpr static bool val = true;
+    };
+
+    template< typename T >
+    struct IsTrivialType< std::vector< T > >
+    {
+        constexpr static bool val = false;
+    };
+
+    template< typename T, size_t n >
+    struct IsTrivialType< std::array< T, n > >
+    {
+        constexpr static bool val = false;
+    };
+
+    template<>
+    struct IsTrivialType< bool >
+    {
+        constexpr static bool val = false;
+    };
+
+    template<>
+    struct IsTrivialType< std::complex< long double > >
+    {
+        constexpr static bool val = false;
+    };
+
+    template<>
+    struct IsTrivialType< std::vector< std::complex< long double > > >
+    {
+        constexpr static bool val = false;
+    };
 } // namespace detail
 
 } // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -1,0 +1,164 @@
+/* Copyright 2020 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "openPMD/config.hpp"
+#if openPMD_HAVE_ADIOS2
+
+#include <adios2.h>
+#include <functional>
+#include <map>
+#include <stddef.h>
+
+#include "openPMD/Datatype.hpp"
+
+namespace openPMD
+{
+namespace detail
+{
+    /**
+     * @brief Pointer to an attribute's data along with its shape.
+     *
+     * @tparam T Underlying attribute data type.
+     */
+    template< typename T >
+    struct AttributeWithShape
+    {
+        adios2::Dims shape;
+        T const * data;
+    };
+
+    /**
+     * Class that is responsible for scheduling and buffering openPMD attribute
+     * loads from ADIOS2, if using ADIOS variables to store openPMD attributes.
+     *
+     * Reasoning: ADIOS variables can be of any shape and size, and ADIOS cannot
+     * know which variables to buffer. While it will preload and buffer scalar
+     * variables, openPMD also stores vector-type attributes which are not
+     * preloaded. Since in Streaming setups, every variable load requires full
+     * communication back to the writer, this can quickly become very expensive.
+     * Hence, do this manually.
+     *
+     */
+    class PreloadAdiosAttributes
+    {
+    public:
+        /**
+         * Internally used struct to store meta information on a buffered
+         * attribute. Public for simplicity (helper struct in the
+         * implementation uses it).
+         */
+        struct AttributeLocation
+        {
+            adios2::Dims shape;
+            size_t offset;
+            Datatype dt;
+            char *destroy = nullptr;
+
+            AttributeLocation() = delete;
+            AttributeLocation( adios2::Dims shape, size_t offset, Datatype dt );
+
+            AttributeLocation( AttributeLocation const & other ) = delete;
+            AttributeLocation &
+            operator=( AttributeLocation const & other ) = delete;
+
+            AttributeLocation( AttributeLocation && other );
+            AttributeLocation & operator=( AttributeLocation && other );
+
+            ~AttributeLocation();
+        };
+
+    private:
+        /*
+         * Allocate one large buffer instead of hundreds of single heap
+         * allocations.
+         * This will comply with alignment requirements, since
+         * std::allocator<char>::allocate() will call the untyped new operator
+         * ::operator new(std::size_t)
+         * https://en.cppreference.com/w/cpp/memory/allocator/allocate
+         */
+        std::vector< char > m_rawBuffer;
+        std::map< std::string, AttributeLocation > m_offsets;
+
+    public:
+        explicit PreloadAdiosAttributes() = default;
+        PreloadAdiosAttributes( PreloadAdiosAttributes const & other ) = delete;
+        PreloadAdiosAttributes &
+        operator=( PreloadAdiosAttributes const & other ) = delete;
+
+        PreloadAdiosAttributes( PreloadAdiosAttributes && other ) = default;
+        PreloadAdiosAttributes &
+        operator=( PreloadAdiosAttributes && other ) = default;
+
+        /**
+         * @brief Schedule attributes for preloading.
+         *
+         * This will invalidate all previously buffered attributes.
+         * This will *not* flush the scheduled loads. This way, attributes can
+         * be loaded along with the next adios2::Engine flush.
+         *
+         * @param IO
+         * @param engine
+         */
+        void
+        preloadAttributes( adios2::IO & IO, adios2::Engine & engine );
+
+        /**
+         * @brief Get an attribute that has been buffered previously.
+         *
+         * @tparam T The underlying primitive datatype of the attribute.
+         *      Will fail if the type found in ADIOS does not match.
+         * @param name The full name of the attribute.
+         * @return Pointer to the buffered attribute along with information on
+         *      the attribute's shape. Valid only until any non-const member
+         *      of PreloadAdiosAttributes is called.
+         */
+        template< typename T >
+        AttributeWithShape< T >
+        getAttribute( std::string const & name ) const;
+    };
+
+    template< typename T >
+    AttributeWithShape< T >
+    PreloadAdiosAttributes::getAttribute( std::string const & name ) const
+    {
+        auto it = m_offsets.find( name );
+        if( it == m_offsets.end() )
+        {
+            throw std::runtime_error(
+                "[ADIOS2] Requested attribute not found: " + name );
+        }
+        AttributeLocation const & location = it->second;
+        if( location.dt != determineDatatype< T >() )
+        {
+            throw std::runtime_error(
+                "[ADIOS2] Wrong datatype for attribute: " + name );
+        }
+        AttributeWithShape< T > res;
+        res.shape = location.shape;
+        res.data =
+            reinterpret_cast< T const * >( &m_rawBuffer[ location.offset ] );
+        return res;
+    }
+} // namespace detail
+} // namespace openPMD
+
+#endif // openPMD_HAVE_ADIOS2

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -1,0 +1,368 @@
+/* Copyright 2020 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openPMD/config.hpp"
+#if openPMD_HAVE_ADIOS2
+
+#include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
+
+#include "openPMD/Datatype.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
+#include "openPMD/auxiliary/StringManip.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <numeric>
+#include <type_traits>
+
+namespace openPMD
+{
+namespace detail
+{
+    namespace
+    {
+        template< typename T, typename = void >
+        struct AttributeTypes;
+
+        template< typename T >
+        struct AttributeTypes<
+            T,
+            typename std::enable_if< IsTrivialType< T >::val >::type >
+        {
+            static size_t
+            alignment()
+            {
+                return alignof( T );
+            }
+
+            static size_t
+            size()
+            {
+                return sizeof( T );
+            }
+
+            static adios2::Dims
+            shape( adios2::IO & IO, std::string const & name )
+            {
+                auto var = IO.InquireVariable< T >( name );
+                if( !var )
+                {
+                    throw std::runtime_error(
+                        "[ADIOS2] Variable not found: " + name );
+                }
+                return var.Shape();
+            }
+
+            static void
+            scheduleLoad(
+                adios2::IO & IO,
+                adios2::Engine & engine,
+                std::string const & name,
+                char * buffer,
+                PreloadAdiosAttributes::AttributeLocation & location )
+            {
+                adios2::Variable< T > var = IO.InquireVariable< T >( name );
+                if( !var )
+                {
+                    throw std::runtime_error(
+                        "[ADIOS2] Variable not found: " + name );
+                }
+                adios2::Dims const & shape = location.shape;
+                adios2::Dims offset( shape.size(), 0 );
+                if( shape.size() > 0 )
+                {
+                    var.SetSelection( { offset, shape } );
+                }
+                T * dest = reinterpret_cast< T * >( buffer );
+                size_t numItems = 1;
+                for( auto extent : shape )
+                {
+                    numItems *= extent;
+                }
+                new( dest ) T[ numItems ]{};
+                location.destroy = buffer;
+                engine.Get( var, dest, adios2::Mode::Deferred );
+            }
+
+            static void attributeLocationDestroy( char *ptr, size_t numItems )
+            {
+                T *destroy = reinterpret_cast< T * >( ptr );
+                for( size_t i = 0; i < numItems; ++i )
+                {
+                    destroy[ i ].~T();
+                }
+            }
+        };
+
+        template< typename T >
+        struct AttributeTypes<
+            T,
+            typename std::enable_if< !IsTrivialType< T >::val >::type >
+        {
+            static size_t
+            alignment()
+            {
+                return 0; // we're not interested in those
+            }
+
+            static size_t
+            size()
+            {
+                return 0; // we're not interested in those
+            }
+
+            template< typename... Args >
+            static adios2::Dims
+            shape( Args &&... )
+            {
+                throw std::runtime_error( "[ADIOS2] Control Flow Error!" );
+            }
+
+            template< typename... Args >
+            static void
+            scheduleLoad( Args &&... )
+            {
+                throw std::runtime_error( "[ADIOS2] Control Flow Error!" );
+            }
+
+            template< typename... Args >
+            static void attributeLocationDestroy( Args &&... )
+            {
+                throw std::runtime_error( "[ADIOS2] Control Flow Error!" );
+            }
+        };
+
+        struct GetAlignment
+        {
+            template< typename T >
+            constexpr size_t
+            operator()() const
+            {
+                return AttributeTypes< T >::alignment();
+            }
+
+            template< unsigned long, typename... Args >
+            constexpr size_t
+            operator()( Args &&... ) const
+            {
+                return 0;
+            }
+        };
+
+        struct GetSize
+        {
+            template< typename T >
+            constexpr size_t
+            operator()() const
+            {
+                return AttributeTypes< T >::size();
+            }
+
+            template< unsigned long, typename... Args >
+            constexpr size_t
+            operator()( Args &&... ) const
+            {
+                return 0;
+            }
+        };
+
+        struct ScheduleLoad
+        {
+            template< typename T, typename... Args >
+            void
+            operator()( Args &&... args )
+            {
+                AttributeTypes< T >::scheduleLoad(
+                    std::forward< Args >( args )... );
+            }
+
+            template< unsigned long, typename... Args >
+            void
+            operator()( Args &&... )
+            {
+                throw std::runtime_error( "[ADIOS2] Unknown datatype." );
+            }
+        };
+
+        struct VariableShape
+        {
+            template< typename T, typename... Args >
+            adios2::Dims
+            operator()( Args &&... args )
+            {
+                return AttributeTypes< T >::shape(
+                    std::forward< Args >( args )... );
+            }
+
+            template< unsigned long n, typename... Args >
+            adios2::Dims
+            operator()( Args &&... )
+            {
+                return {};
+            }
+        };
+
+        struct AttributeLocationDestroy
+        {
+            template< typename T, typename... Args >
+            void operator()( Args &&...args )
+            {
+                return AttributeTypes< T >::attributeLocationDestroy(
+                    std::forward< Args >( args )... );
+            }
+
+            template< unsigned long n, typename... Args >
+            void operator()( Args &&... )
+            {
+            }
+        };
+    } // namespace
+
+    using AttributeLocation = PreloadAdiosAttributes::AttributeLocation;
+
+    AttributeLocation::AttributeLocation(
+        adios2::Dims shape_in, size_t offset_in, Datatype dt_in )
+        : shape( std::move( shape_in ) ), offset( offset_in ), dt( dt_in )
+    {
+    }
+
+    AttributeLocation::AttributeLocation( AttributeLocation && other )
+        : shape{ std::move( other.shape ) }
+        , offset{ std::move( other.offset ) }
+        , dt{ std::move( other.dt ) }
+        , destroy{ std::move( other.destroy ) }
+    {
+        other.destroy = nullptr;
+    }
+
+    AttributeLocation &
+    AttributeLocation::operator=( AttributeLocation && other )
+    {
+        this->shape = std::move( other.shape );
+        this->offset = std::move( other.offset );
+        this->dt = std::move( other.dt );
+        this->destroy = std::move( other.destroy );
+        other.destroy = nullptr;
+        return *this;
+    }
+
+    PreloadAdiosAttributes::AttributeLocation::~AttributeLocation()
+    {
+        /*
+         * If the object has been moved from, this may be empty.
+         * Or else, if no custom destructor has been emplaced.
+         */
+        if( destroy )
+        {
+            size_t length = 1;
+            for( auto ext : shape )
+            {
+                length *= ext;
+            }
+            static AttributeLocationDestroy ald;
+            switchType( dt, ald, destroy, length );
+        }
+    }
+
+    void
+    PreloadAdiosAttributes::preloadAttributes(
+        adios2::IO & IO,
+        adios2::Engine & engine )
+    {
+        m_offsets.clear();
+        std::map< Datatype, std::vector< std::string > > attributesByType;
+        auto addAttribute =
+            [ &attributesByType ]( Datatype dt, std::string name ) {
+                constexpr size_t reserve = 10;
+                auto it = attributesByType.find( dt );
+                if( it == attributesByType.end() )
+                {
+                    it = attributesByType.emplace_hint(
+                        it, dt, std::vector< std::string >() );
+                    it->second.reserve( reserve );
+                }
+                it->second.push_back( std::move( name ) );
+            };
+        // PHASE 1: collect names of available attributes by ADIOS datatype
+        for( auto & variable : IO.AvailableVariables() )
+        {
+            if( auxiliary::ends_with( variable.first, "/__data__" ) )
+            {
+                continue;
+            }
+            // this will give us basic types only, no fancy vectors or similar
+            Datatype dt = fromADIOS2Type( IO.VariableType( variable.first ) );
+            addAttribute( dt, std::move( variable.first ) );
+        }
+
+        // PHASE 2: get offsets for attributes in buffer
+        std::map< Datatype, size_t > offsets;
+        size_t currentOffset = 0;
+        GetAlignment switchAlignment;
+        GetSize switchSize;
+        VariableShape switchShape;
+        for( auto & pair : attributesByType )
+        {
+            size_t alignment = switchType< size_t >( pair.first, switchAlignment );
+            size_t size = switchType< size_t >( pair.first, switchSize );
+            // go to next offset with valid alignment
+            size_t modulus = currentOffset % alignment;
+            if( modulus > 0 )
+            {
+                currentOffset += alignment - modulus;
+            }
+            for( std::string & name : pair.second )
+            {
+                adios2::Dims shape =
+                    switchType< adios2::Dims >( pair.first, switchShape, IO, name );
+                size_t elements = 1;
+                for( auto extent : shape )
+                {
+                    elements *= extent;
+                }
+                m_offsets.emplace(
+                    std::piecewise_construct,
+                    std::forward_as_tuple( std::move( name ) ),
+                    std::forward_as_tuple(
+                        std::move( shape ), currentOffset, pair.first ) );
+                currentOffset += elements * size;
+            }
+        }
+        // now, currentOffset is the number of bytes that we need to allocate
+        // PHASE 3: allocate new buffer and schedule loads
+        m_rawBuffer.resize( currentOffset );
+        ScheduleLoad switchSchedule;
+        for( auto & pair : m_offsets )
+        {
+            switchType(
+                pair.second.dt,
+                switchSchedule,
+                IO,
+                engine,
+                pair.first,
+                &m_rawBuffer[ pair.second.offset ],
+                pair.second );
+        }
+    }
+} // namespace detail
+} // namespace openPMD
+
+#endif // openPMD_HAVE_ADIOS2

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3148,6 +3148,48 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
     bp4_steps( "../samples/bp4steps_no_no.bp", dontUseSteps, dontUseSteps );
     bp4_steps( "../samples/nullcore.bp", nullcore, "" );
     bp4_steps( "../samples/bp4steps_default.bp", "{}", "{}" );
+
+    /*
+     * Do this whole thing once more, but this time use the new attribute
+     * layout.
+     */
+    useSteps = R"(
+    {
+        "adios2": {
+            "new_attribute_layout": true,
+            "engine": {
+                "type": "bp4",
+                "usesteps": true
+            }
+        }
+    }
+    )";
+    dontUseSteps = R"(
+    {
+        "adios2": {
+            "new_attribute_layout": true,
+            "engine": {
+                "type": "bp4",
+                "usesteps": false
+            }
+        }
+    }
+    )";
+    /*
+     * @todo Activate these tests for Windows as soon as we bump the required
+     *       ADIOS2 version to 2.7.0. Read here:
+     *       https://github.com/openPMD/openPMD-api/pull/813#issuecomment-762235260
+     */
+#ifndef _WIN32
+    // sing the yes no song
+    bp4_steps( "../samples/newlayout_bp4steps_yes_yes.bp", useSteps, useSteps );
+    bp4_steps(
+        "../samples/newlayout_bp4steps_no_yes.bp", dontUseSteps, useSteps );
+    bp4_steps(
+        "../samples/newlayout_bp4steps_yes_no.bp", useSteps, dontUseSteps );
+    bp4_steps(
+        "../samples/newlayout_bp4steps_no_no.bp", dontUseSteps, dontUseSteps );
+#endif
 }
 #endif
 


### PR DESCRIPTION
~~Note: Don't get scared at the diff, this is based upon my [topic-streaming](https://github.com/franzpoeschel/openPMD-api/tree/topic-streaming) branch, since many of the issues leading to this PR became obvious only upon implementing streaming mode.
For comparing: https://github.com/franzpoeschel/openPMD-api/compare/topic-streaming...franzpoeschel:topic-adios-variables-for-attributes~~

It has turned out that ADIOS attributes are too restricted to use them for modeling openPMD attributes. ADIOS attributes are independent of ADIOS steps, whereas in openPMD we create new sets of attributes for each iteration (which in our Streaming API are equivalent to ADIOS steps). This is not the preferred way to model scientific data in ADIOS. ADIOS prefers metadata to be setup once only and reuse that  metadata along steps. The mid-term goal might be to investigate a data layout in openPMD that agrees with this concept better. Up until then, the short-term solution is to use ADIOS variables for openPMD attributes.

ADIOS provides a zero-dimensional variable shape called *global single value* for storing scalars, intended for metadata that changes over steps. Since our metadata is not exclusively scalar, we cannot fully rely on those, but need to use regular *global array* variables as well.

In order to distinguish openPMD datasets from openPMD attributes, openPMD datasets will from now on be suffixed by `/__data__`. As an example, an E field created by PIConGPU:
```
int8_t    /data/0/fields/E/axisLabels                                      {3, 2}                                                                           
  string    /data/0/fields/E/dataOrder                                       scalar                                                                           
  string    /data/0/fields/E/fieldSmoothing                                  scalar                                                                           
  string    /data/0/fields/E/geometry                                        scalar                                                                           
  double    /data/0/fields/E/gridGlobalOffset                                {3}    
  float     /data/0/fields/E/gridSpacing                                     {3}   
  double    /data/0/fields/E/gridUnitSI                                      scalar      
  float     /data/0/fields/E/timeOffset                                      scalar
  double    /data/0/fields/E/unitDimension                                   {7}   
  float     /data/0/fields/E/x/__data__                                      {56, 56, 56}
  float     /data/0/fields/E/x/position                                      {3}    
  double    /data/0/fields/E/x/unitSI                                        scalar
  float     /data/0/fields/E/y/__data__                                      {56, 56, 56}
  float     /data/0/fields/E/y/position                                      {3}   
  double    /data/0/fields/E/y/unitSI                                        scalar 
  float     /data/0/fields/E/z/__data__                                      {56, 56, 56}
  float     /data/0/fields/E/z/position                                      {3}    
  double    /data/0/fields/E/z/unitSI                                        scalar
```

For `bpls`, the `-A` switch is now useless for displaying openPMD attributes only without datasets, as a workaround the following regexp may be used: `bpls --regexp '^(.(?!/__data__))*$'`.

TODO/DONE:

- [x]  Feature-complete, yet possibly not fully efficient implementation of openPMD attributes via ADIOS variables.
- [x] A toggle between the old and new ADIOS layout in order to keep this breaking change optional and experimental for a while. (Thinking that this one is going to be ugly..)
- [x] Documentation
- [x] Add a CI test that sets OPENPMD_NEW_ATTRIBUTE_LAYOUT=1
- [x] Wait for #570 to be merged

Reimplementations of things that would come out of the box by using ADIOS attributes:

- [x] Buffered writing at the right times.
- [x] Buffered reading (missing only for `vector<string>` type
- [x] The `vector<string>` type. This one is implemented as a two-dimensional char-array where each line represents a zero-terminated (zero-padded) string. While this works fine as a serialization for openPMD data using ADIOS2, self-descriptiveness is somewhat limited by this approach as the output of `bpls` on such an attribute shows:
```
# new:
  int8_t       /vecString          {3, 8}
    (0,0)    118 101 99 116 111 114
    (0,6)    0 0 111 102 0 0
    (1,4)    0 0 0 0 115 116
    (2,2)    114 105 110 103 115 0
# vs. old:
  string       /vecString                    attr   = {"vector", "of", "strings"}                                                                             
```
**Update:** The `-S` flag on `bpls` solves this:
```
int8_t /vecString {3, 8}
(0,0) "vector"
(1,0) "of"
(2,0) "strings"
```
- [x] Pre-reading attributes upon `adios2::Engine::BeginStep`. Especially in the SST engine, each performed variable read requires communication back to the data source (writing application). Hence, we might want to (lazily) read and buffer attributes (= ADIOS variables without `/__data__` suffix) upon each `BeginStep`.
  **Update:** I've pushed an implementation for this. There are some evil typecasts involved in order to allow buffering everything into one contiguous slab of memory.