### PR TITLE
[WIP] Series: Non-Copyable

### DIFF
--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -69,6 +69,12 @@ public:
         std::string const & filepath,
         Access at,
         std::string const & options = "{}" );
+
+    Series(Series &&) = default;
+
+    /** The meaning of copying a Series is not (yet) defined */
+    Series(Series const &) = delete;
+
     ~Series();
 
     /**

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -82,7 +82,7 @@ class Attributable
 public:
     Attributable();
     Attributable(Attributable const&);
-    Attributable(Attributable&&) = delete;
+    Attributable(Attributable&&) = default;
     virtual ~Attributable() = default;
 
     Attributable& operator=(Attributable const&);

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -542,17 +542,22 @@ TEST_CASE( "structure_test", "[core]" )
 
 TEST_CASE( "wrapper_test", "[core]" )
 {
-    Series o = Series("./new_openpmd_output.json", Access::CREATE);
+    Series o0 = Series("./new_openpmd_output.json", Access::CREATE);
 
-    o.setOpenPMDextension(42);
-    o.setIterationEncoding(IterationEncoding::fileBased);
-    Series copy = o;
+    o0.setOpenPMDextension(42);
+    o0.setIterationEncoding(IterationEncoding::fileBased);
+    // this might be allowed as a handle in the future
+    // Series copy = o0;
+    Series copy = std::move(o0);
     REQUIRE(copy.openPMDextension() == 42);
     REQUIRE(copy.iterationEncoding() == IterationEncoding::fileBased);
     REQUIRE(copy.name() == "new_openpmd_output");
     copy.setOpenPMD("1.2.0");
     copy.setIterationEncoding(IterationEncoding::groupBased);
     copy.setName("other_name");
+
+    Series & o = copy;
+
     REQUIRE(o.openPMD() == "1.2.0");
     REQUIRE(o.iterationEncoding() == IterationEncoding::groupBased);
     REQUIRE(o.name() == "other_name");


### PR DESCRIPTION
Delete the Copy-constructor in Series and add a move-constructor to Series and Attributable. This is a quick-fix for currently inconsistent handle-creation during copy.

Reproducer and long-term strategy as handle: #804

## To Do

- [ ] tests for move constructor in `Attributable` and `Series`
- [ ] entry in `NEWS`
- [ ] Python also affected?