### PR TITLE
JSON configuration on the dataset level

### DIFF
--- a/docs/source/details/adios2.json
+++ b/docs/source/details/adios2.json
@@ -8,10 +8,13 @@
       }
     },
     "dataset": {
-      "operators": [ 
+      "operators": [
         {
-          "type": "bzip2",
-          "parameters": {}
+          "type": "blosc",
+          "parameters": {
+              "clevel": "1",
+              "doshuffle": "BLOSC_BITSHUFFLE"
+          }
         }
       ]
     }

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -19,7 +19,6 @@ Generally, keys of the configuration are *lower case*.
 Parameters that are directly passed through to an external library and not interpreted within openPMD API (e.g. ``adios2.engine.parameters``) are unaffected by this and follow the respective library's conventions.
 
 The configuration string may refer to the complete ``openPMD::Series`` or may additionally be specified per ``openPMD::Dataset``, passed in the respective constructors.
-*A configuration per dataset is currently not yet implemented.*
 This reflects the fact that certain backend-specific parameters may refer to the whole Series (such as storage engines and their parameters) and others refer to actual datasets (such as compression).
 
 For a consistent user interface, backends shall follow the following rules:
@@ -49,11 +48,14 @@ Explanation of the single keys:
   Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for a list of available engines.
 * ``adios2.engine.type``: An associative array of string-formatted engine parameters, passed directly through to ``adios2::IO::SetParameters``.
   Please refer to the official ADIOS2 documentation for the allowable engine parameters.
-* ``adios2.dataset.operators``: (*currently unimplemented* – please use the ``openPMD::Dataset::compression`` for the meantime) This key contains a list of ADIOS2 `operators <https://adios2.readthedocs.io/en/latest/components/components.html#operator>`_, used to enable compression or dataset transformations.
-  Each object in the list has three keys:
+* ``adios2.dataset.operators``: This key contains a list of ADIOS2 `operators <https://adios2.readthedocs.io/en/latest/components/components.html#operator>`_, used to enable compression or dataset transformations.
+  Each object in the list has two keys:
 
   * ``type`` supported ADIOS operator type, e.g. zfp, sz
   * ``parameters`` is an associative map of string parameters for the operator (e.g. compression levels)
+
+Any setting specified under ``adios2.dataset`` is applicable globally as well as on a per-dataset level.
+Any setting under ``adios2.engine`` is applicable globally only.
 
 Other backends
 ^^^^^^^^^^^^^^

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -38,7 +38,7 @@ class Dataset
     friend class RecordComponent;
 
 public:
-    Dataset(Datatype, Extent);
+    Dataset(Datatype, Extent, std::string options = "{}");
 
     Dataset& extend(Extent newExtent);
     Dataset& setChunkSize(Extent const&);

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -51,5 +51,6 @@ public:
     Extent chunkSize;
     std::string compression;
     std::string transform;
+    std::string options = "{}"; //!< backend-dependent JSON configuration
 };
-} // openPMD
+} // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -228,11 +228,11 @@ private:
      * @return first parameter: the operators, second parameters: whether
      * operators have been configured
      */
-    std::pair< std::vector< ParameterizedOperator >, bool >
+    auxiliary::Option< std::vector< ParameterizedOperator > >
     getOperators( auxiliary::TracingJSON config );
 
     // use m_config
-    std::pair< std::vector< ParameterizedOperator >, bool >
+    auxiliary::Option< std::vector< ParameterizedOperator > >
     getOperators();
 
     /*

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -188,8 +188,8 @@ private:
 
     struct ParameterizedOperator
     {
-        adios2::Operator const op;
-        adios2::Params const params;
+        adios2::Operator op;
+        adios2::Params params;
     };
 
     std::vector< ParameterizedOperator > defaultOperators;

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -233,7 +233,7 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_DATASET > : public Abstrac
     Parameter(Parameter const & p) : AbstractParameter(),
         name(p.name), extent(p.extent), dtype(p.dtype),
         chunkSize(p.chunkSize), compression(p.compression),
-        transform(p.transform) {}
+        transform(p.transform), options(p.options) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -248,6 +248,7 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_DATASET > : public Abstrac
     Extent chunkSize = {};
     std::string compression = "";
     std::string transform = "";
+    std::string options = "{}";
 };
 
 template<>

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -26,11 +26,12 @@
 
 namespace openPMD
 {
-Dataset::Dataset(Datatype d, Extent e)
+Dataset::Dataset(Datatype d, Extent e, std::string options_in)
         : extent{e},
           dtype{d},
           rank{static_cast<uint8_t>(e.size())},
-          chunkSize{e}
+          chunkSize{e},
+          options{std::move(options_in)}
 { }
 
 Dataset&

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -271,7 +271,7 @@ void ADIOS2IOHandlerImpl::createDataset(
             auxiliary::TracingJSON datasetConfig( options[ "adios2" ] );
             auto datasetOperators = getOperators( datasetConfig );
 
-            operators = datasetOperators ? datasetOperators.get()
+            operators = datasetOperators ? std::move( datasetOperators.get() )
                                          : defaultOperators;
 
             auto shadow = datasetConfig.invertShadow();

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -92,21 +92,26 @@ ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
         return;
     }
     m_config = std::move( cfg[ "adios2" ] );
-    defaultOperators = getOperators().first;
+    auto operators = getOperators();
+    if( operators )
+    {
+        defaultOperators = std::move( operators.get() );
+    }
 }
 
-std::pair< std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator >, bool >
+auxiliary::Option< std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator > >
 ADIOS2IOHandlerImpl::getOperators( auxiliary::TracingJSON cfg )
 {
+    using ret_t = auxiliary::Option< std::vector< ParameterizedOperator > >;
     std::vector< ParameterizedOperator > res;
     if( !cfg.json().contains( "dataset" ) )
     {
-        return std::make_pair( res, false );
+        return ret_t();
     }
     auto datasetConfig = cfg[ "dataset" ];
     if( !datasetConfig.json().contains( "operators" ) )
     {
-        return std::make_pair( res, false );
+        return ret_t();
     }
     auto _operators = datasetConfig[ "operators" ];
     nlohmann::json const & operators = _operators.json();
@@ -137,10 +142,10 @@ ADIOS2IOHandlerImpl::getOperators( auxiliary::TracingJSON cfg )
         }
     }
     _operators.declareFullyRead();
-    return std::make_pair( res, true );
+    return auxiliary::makeOption( std::move( res ) );
 }
 
-std::pair< std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator >, bool >
+auxiliary::Option< std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator > >
 ADIOS2IOHandlerImpl::getOperators()
 {
     return getOperators( m_config );

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -169,6 +169,7 @@ RecordComponent::flush(std::string const& name)
                 dCreate.chunkSize = m_dataset->chunkSize;
                 dCreate.compression = m_dataset->compression;
                 dCreate.transform = m_dataset->transform;
+                dCreate.options = m_dataset->options;
                 IOHandler->enqueue(IOTask(this, dCreate));
             }
         }

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -88,6 +88,7 @@ PatchRecordComponent::flush(std::string const& name)
             dCreate.chunkSize = getExtent();
             dCreate.compression = m_dataset->compression;
             dCreate.transform = m_dataset->transform;
+            dCreate.options = m_dataset->options;
             IOHandler->enqueue(IOTask(this, dCreate));
         }
 

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -42,6 +42,15 @@ void init_Dataset(py::module &m) {
         }),
             py::arg("dtype"), py::arg("extent")
         )
+        .def(py::init<Datatype, Extent, std::string>(),
+            py::arg("dtype"), py::arg("extent"), py::arg("options")
+        )
+        .def(py::init( [](py::dtype dt, Extent e, std::string options) {
+            auto const d = dtype_from_numpy( dt );
+            return new Dataset{d, e, std::move(options)};
+        }),
+            py::arg("dtype"), py::arg("extent"), py::arg("options")
+        )
 
         .def("__repr__",
             [](const Dataset &d) {
@@ -61,6 +70,7 @@ void init_Dataset(py::module &m) {
         .def_property_readonly("dtype", [](const Dataset &d) {
             return dtype_to_numpy( d.dtype );
         })
+        .def_readwrite("options", &Dataset::options)
     ;
 }
 

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1605,11 +1605,14 @@ class APITest(unittest.TestCase):
   }
 }
 """
+        if not io.variants['adios2']:
+            return
         series = io.Series(
             "../samples/unittest_jsonConfiguredBP3.bp",
             io.Access_Type.create,
             global_config)
         if series.backend != 'ADIOS2':
+            # might happen, if env. var. OPENPMD_BP_BACKEND is used
             return
 
         DS = io.Dataset

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1641,5 +1641,6 @@ class APITest(unittest.TestCase):
             self.assertEqual(chunk_x[i], i)
             self.assertEqual(chunk_y[i], i)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1559,6 +1559,87 @@ class APITest(unittest.TestCase):
         for ext in io.file_extensions:
             self.makeAvailableChunksRoundTrip(ext)
 
+    def testJsonConfigADIOS2(self):
+        global_config = """
+{
+  "adios2": {
+    "engine": {
+      "type": "bp3",
+      "unused": "parameter",
+      "parameters": {
+        "BufferGrowthFactor": "2.0",
+        "Profile": "On"
+      }
+    },
+    "unused": "as well",
+    "dataset": {
+      "operators": [
+        {
+          "type": "blosc",
+          "parameters": {
+              "clevel": "1",
+              "doshuffle": "BLOSC_BITSHUFFLE"
+          }
+        }
+      ]
+    }
+  }
+}
+"""
+        local_config = """
+{
+  "adios2": {
+    "unused": "dataset parameter",
+    "dataset": {
+      "unused": "too",
+      "operators": [
+        {
+          "type": "blosc",
+          "parameters": {
+              "clevel": "3",
+              "doshuffle": "BLOSC_BITSHUFFLE"
+          }
+        }
+      ]
+    }
+  }
+}
+"""
+        series = io.Series(
+            "../samples/unittest_jsonConfiguredBP3.bp",
+            io.Access_Type.create,
+            global_config)
+        if series.backend != 'ADIOS2':
+            return
+
+        DS = io.Dataset
+        data = np.array(range(1000), dtype=np.dtype("double"))
+
+        E_x = series.iterations[0].meshes["E"]["x"]
+        E_x.reset_dataset(DS(np.dtype("double"), [1000]))
+        E_x.store_chunk(data, [0], [1000])
+
+        E_y = series.iterations[0].meshes["E"]["y"]
+        E_y.reset_dataset(DS(np.dtype("double"), [1000], local_config))
+        E_y.store_chunk(data, [0], [1000])
+
+        del series
+
+        read = io.Series(
+            "../samples/unittest_jsonConfiguredBP3.bp",
+            io.Access_Type.read_only,
+            global_config)
+
+        E_x = read.iterations[0].meshes["E"]["x"]
+        chunk_x = E_x.load_chunk([0], [1000])
+        E_y = read.iterations[0].meshes["E"]["x"]
+        chunk_y = E_y.load_chunk([0], [1000])
+
+        read.iterations[0].close()
+
+        for i in range(1000):
+            self.assertEqual(chunk_x[i], i)
+            self.assertEqual(chunk_y[i], i)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a field `std::string openPMD::Dataset::options = "{}"` which may be used to pass options that are specific to backend as well as dataset. Close #688, see there for further description.
Implemented for ADIOS2 compression.

TODO:
- [x] Documentation.