### PR TITLE
Allow reading a file-based series with many iterations without crashing the number of file handles

### DIFF
--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -23,6 +23,9 @@
 #include "openPMD/config.hpp"
 #if openPMD_HAVE_HDF5
 #   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
+
+#   include "openPMD/auxiliary/Option.hpp"
+
 #   include <hdf5.h>
 #   include <unordered_map>
 #   include <unordered_set>
@@ -58,7 +61,7 @@ namespace openPMD
         void listDatasets(Writable*, Parameter< Operation::LIST_DATASETS > &) override;
         void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
 
-        std::unordered_map< Writable*, hid_t > m_fileIDs;
+        std::unordered_map< Writable*, std::string > m_fileNames;
         std::unordered_map< std::string,  hid_t > m_fileNamesWithID;
 
         std::unordered_set< hid_t > m_openFileIDs;
@@ -71,6 +74,14 @@ namespace openPMD
         hid_t m_H5T_CFLOAT;
         hid_t m_H5T_CDOUBLE;
         hid_t m_H5T_CLONG_DOUBLE;
+
+    private:
+        struct File
+        {
+            std::string name;
+            hid_t id;
+        };
+        auxiliary::Option< File > getFile( Writable * );
     }; // HDF5IOHandlerImpl
 #else
     class HDF5IOHandlerImpl

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -271,6 +271,7 @@ OPENPMD_private:
     void readGroupBased();
     void readBase();
     void read();
+    void openIteration( uint64_t index, Iteration iteration );
 
     static constexpr char const * const BASEPATH = "/data/%T/";
 

--- a/include/openPMD/auxiliary/Option.hpp
+++ b/include/openPMD/auxiliary/Option.hpp
@@ -24,6 +24,7 @@
 #include "VariantSrc.hpp"
 
 #include <utility> // std::forward, std::move
+#include <type_traits>
 
 
 namespace openPMD
@@ -162,10 +163,11 @@ namespace auxiliary
     };
 
     template< typename T >
-    Option< T >
+    Option< typename std::decay< T >::type >
     makeOption( T && val )
     {
-        return Option< T >( std::forward< T >( val ) );
+        return Option< typename std::decay< T >::type >(
+            std::forward< T >( val ) );
     }
 } // namespace auxiliary
 } // namespace openPMD

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -326,7 +326,8 @@ ADIOS2IOHandlerImpl::closeFile(
     auto fileIterator = m_files.find( writable );
     if ( fileIterator != m_files.end( ) )
     {
-        fileIterator->second.invalidate( );
+        // do not invalidate the file
+        // it still exists, it is just not open
         auto it = m_fileData.find( fileIterator->second );
         if ( it != m_fileData.end( ) )
         {

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -152,7 +152,7 @@ HDF5IOHandlerImpl::createFile(Writable* writable,
         writable->written = true;
         writable->abstractFilePosition = std::make_shared< HDF5FilePosition >("/");
 
-        m_fileIDs[writable] = id;
+        m_fileNames[writable] = name;
         m_fileNamesWithID[std::move(name)]=id;
         m_openFileIDs.insert(id);
     }
@@ -180,8 +180,8 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
             position = writable->parent;
         else
             position = writable; /* root does not have a parent but might still have to be written */
-        auto res = m_fileIDs.find(position);
-        hid_t node_id = H5Gopen(res->second,
+        File file = getFile( position ).get();
+        hid_t node_id = H5Gopen(file.id,
                                 concrete_h5_file_position(position).c_str(),
                                 H5P_DEFAULT);
         VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path creation");
@@ -217,7 +217,7 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         writable->written = true;
         writable->abstractFilePosition = std::make_shared< HDF5FilePosition >(path);
 
-        m_fileIDs[writable] = res->second;
+        m_fileNames[writable] = file.name;
     }
 }
 
@@ -238,10 +238,9 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
             name = auxiliary::replace_last(name, "/", "");
 
         /* Open H5Object to write into */
-        auto res = m_fileIDs.find(writable);
-        if( res == m_fileIDs.end() )
-            res = m_fileIDs.find(writable->parent);
-        hid_t node_id = H5Gopen(res->second,
+        auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
+        hid_t node_id = H5Gopen(file.id,
                                 concrete_h5_file_position(writable).c_str(),
                                 H5P_DEFAULT);
         VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset creation");
@@ -332,7 +331,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         writable->written = true;
         writable->abstractFilePosition = std::make_shared< HDF5FilePosition >(name);
 
-        m_fileIDs[writable] = res->second;
+        m_fileNames[writable] = file.name;
     }
 }
 
@@ -346,9 +345,9 @@ HDF5IOHandlerImpl::extendDataset(Writable* writable,
     if( !writable->written )
         throw std::runtime_error("[HDF5] Extending an unwritten Dataset is not possible.");
 
-    auto res = m_fileIDs.find(writable->parent);
+    auto file = getFile(writable->parent).get();
     hid_t node_id, dataset_id;
-    node_id = H5Gopen(res->second,
+    node_id = H5Gopen(file.id,
                       concrete_h5_file_position(writable->parent).c_str(),
                       H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset extension");
@@ -383,9 +382,6 @@ void
 HDF5IOHandlerImpl::openFile(Writable* writable,
                             Parameter< Operation::OPEN_FILE > const& parameters)
 {
-    //TODO check if file already open
-    //not possible with current implementation
-    //quick idea - map with filenames as key
     if( !auxiliary::directory_exists(m_handler->directory) )
         throw no_such_file_error("[HDF5] Supplied directory is not valid: " + m_handler->directory);
 
@@ -393,17 +389,12 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     if( !auxiliary::ends_with(name, ".h5") )
         name += ".h5";
 
-    // this segment of name/id  checking is a quick attempt to address
-    // the above TODO.  More  work needs to be done on efficiency at the Series.flush() call
-    // with regard  to iteration management
+    // this may (intentionally) overwrite
+    m_fileNames[ writable ] = name;
+
+    // check if file already open
     auto search = m_fileNamesWithID.find(name);
     if (search != m_fileNamesWithID.end()) {
-      auto search2 = m_fileIDs.find(writable);
-      if (search2 != m_fileIDs.end())  {
-          if (m_fileIDs[writable] ==  m_fileNamesWithID[name])
-              return;
-      }
-      m_fileIDs[writable] = m_fileNamesWithID[name];
       return;
     }
 
@@ -425,9 +416,6 @@ HDF5IOHandlerImpl::openFile(Writable* writable,
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< HDF5FilePosition >("/");
 
-    m_fileIDs.erase(writable);
-    m_fileIDs.insert({writable, file_id});
-
     m_fileNamesWithID.erase(name);
     m_fileNamesWithID.insert({std::move(name), file_id});
     m_openFileIDs.insert(file_id);
@@ -438,38 +426,20 @@ HDF5IOHandlerImpl::closeFile(
     Writable * writable,
     Parameter< Operation::CLOSE_FILE > const & )
 {
-    auto fileID_it = m_fileIDs.find( writable );
-    if( fileID_it == m_fileIDs.end() )
+    auto optionalFile = getFile( writable );
+    if( ! optionalFile )
     {
         throw std::runtime_error(
             "[HDF5] Trying to close a file that is not "
             "present in the backend" );
         return;
     }
-    hid_t fileID = fileID_it->second;
-    H5Fclose( fileID );
-    m_openFileIDs.erase( fileID );
-    m_fileIDs.erase( fileID_it );
+    File file = optionalFile.get();
+    H5Fclose( file.id );
+    m_openFileIDs.erase( file.id );
+    m_fileNames.erase( writable );
 
-    /* std::unordered_map::erase:
-     * References and iterators to the erased elements are invalidated. Other
-     * iterators and references are not invalidated.
-     */
-    using iter_t = decltype( m_fileNamesWithID )::iterator;
-    std::vector< iter_t > deleteMe;
-    deleteMe.reserve( 1 ); // should normally suffice
-    for( auto it = m_fileNamesWithID.begin(); it != m_fileNamesWithID.end();
-         ++it )
-    {
-        if( it->second == fileID )
-        {
-            deleteMe.push_back( it );
-        }
-    }
-    for( auto iterator : deleteMe )
-    {
-        m_fileNamesWithID.erase( iterator );
-    }
+   m_fileNamesWithID.erase( file.name );
 }
 
 void
@@ -477,9 +447,9 @@ HDF5IOHandlerImpl::openPath(
     Writable * writable,
     Parameter< Operation::OPEN_PATH > const & parameters )
 {
-    auto res = m_fileIDs.find(writable->parent);
+    File file = getFile(writable->parent).get();
     hid_t node_id, path_id;
-    node_id = H5Gopen(res->second,
+    node_id = H5Gopen(file.id,
                       concrete_h5_file_position(writable->parent).c_str(),
                       H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path opening");
@@ -505,17 +475,17 @@ HDF5IOHandlerImpl::openPath(
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< HDF5FilePosition >(path);
 
-    m_fileIDs.erase(writable);
-    m_fileIDs.insert({writable, res->second});
+    m_fileNames.erase(writable);
+    m_fileNames.insert({writable, file.name});
 }
 
 void
 HDF5IOHandlerImpl::openDataset(Writable* writable,
                                Parameter< Operation::OPEN_DATASET > & parameters)
 {
-    auto res = m_fileIDs.find(writable->parent);
+    File file = getFile( writable->parent ).get();
     hid_t node_id, dataset_id;
-    node_id = H5Gopen(res->second,
+    node_id = H5Gopen(file.id,
                       concrete_h5_file_position(writable->parent).c_str(),
                       H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset opening");
@@ -610,7 +580,7 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< HDF5FilePosition >(name);
 
-    m_fileIDs[writable] = res->second;
+    m_fileNames[writable] = file.name;
 }
 
 void
@@ -622,7 +592,7 @@ HDF5IOHandlerImpl::deleteFile(Writable* writable,
 
     if( writable->written )
     {
-        hid_t file_id = m_fileIDs[writable];
+        hid_t file_id = getFile( writable ).get().id;
         herr_t status = H5Fclose(file_id);
         VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 file during file deletion");
 
@@ -639,7 +609,7 @@ HDF5IOHandlerImpl::deleteFile(Writable* writable,
         writable->abstractFilePosition.reset();
 
         m_openFileIDs.erase(file_id);
-        m_fileIDs.erase(writable);
+        m_fileNames.erase(writable);
         m_fileNamesWithID.erase(name);
     }
 }
@@ -664,10 +634,9 @@ HDF5IOHandlerImpl::deletePath(Writable* writable,
          * Ugly hack: H5Ldelete can't delete "."
          *            Work around this by deleting from the parent
          */
-        auto res = m_fileIDs.find(writable);
-        if( res == m_fileIDs.end() )
-            res = m_fileIDs.find(writable->parent);
-        hid_t node_id = H5Gopen(res->second,
+        auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
+        hid_t node_id = H5Gopen(file.id,
                                 concrete_h5_file_position(writable->parent).c_str(),
                                 H5P_DEFAULT);
         VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path deletion");
@@ -684,7 +653,7 @@ HDF5IOHandlerImpl::deletePath(Writable* writable,
         writable->written = false;
         writable->abstractFilePosition.reset();
 
-        m_fileIDs.erase(writable);
+        m_fileNames.erase(writable);
     }
 }
 
@@ -708,10 +677,9 @@ HDF5IOHandlerImpl::deleteDataset(Writable* writable,
          * Ugly hack: H5Ldelete can't delete "."
          *            Work around this by deleting from the parent
          */
-        auto res = m_fileIDs.find(writable);
-        if( res == m_fileIDs.end() )
-            res = m_fileIDs.find(writable->parent);
-        hid_t node_id = H5Gopen(res->second,
+        auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
+        hid_t node_id = H5Gopen(file.id,
                                 concrete_h5_file_position(writable->parent).c_str(),
                                 H5P_DEFAULT);
         VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset deletion");
@@ -728,7 +696,7 @@ HDF5IOHandlerImpl::deleteDataset(Writable* writable,
         writable->written = false;
         writable->abstractFilePosition.reset();
 
-        m_fileIDs.erase(writable);
+        m_fileNames.erase(writable);
     }
 }
 
@@ -744,10 +712,9 @@ HDF5IOHandlerImpl::deleteAttribute(Writable* writable,
         std::string name = parameters.name;
 
         /* Open H5Object to delete in */
-        auto res = m_fileIDs.find(writable);
-        if( res == m_fileIDs.end() )
-            res = m_fileIDs.find(writable->parent);
-        hid_t node_id = H5Oopen(res->second,
+        auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
+        hid_t node_id = H5Oopen(file.id,
                                 concrete_h5_file_position(writable).c_str(),
                                 H5P_DEFAULT);
         VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during attribute deletion");
@@ -768,13 +735,12 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
     if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Writing into a dataset in a file opened as read only is not possible.");
 
-    auto res = m_fileIDs.find(writable);
-    if( res == m_fileIDs.end() )
-        res = m_fileIDs.find(writable->parent);
+    auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
 
     hid_t dataset_id, filespace, memspace;
     herr_t status;
-    dataset_id = H5Dopen(res->second,
+    dataset_id = H5Dopen(file.id,
                          concrete_h5_file_position(writable).c_str(),
                          H5P_DEFAULT);
     VERIFY(dataset_id >= 0, "[HDF5] Internal error: Failed to open HDF5 dataset during dataset write");
@@ -855,7 +821,7 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
     status = H5Dclose(dataset_id);
     VERIFY(status == 0, "[HDF5] Internal error: Failed to close dataset " + concrete_h5_file_position(writable) + " during dataset write");
 
-    m_fileIDs[writable] = res->second;
+    m_fileNames[writable] = file.name;
 }
 
 void
@@ -865,11 +831,10 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
     if( m_handler->m_backendAccess == Access::READ_ONLY )
         throw std::runtime_error("[HDF5] Writing an attribute in a file opened as read only is not possible.");
 
-    auto res = m_fileIDs.find(writable);
-    if( res == m_fileIDs.end() )
-        res = m_fileIDs.find(writable->parent);
+    auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
     hid_t node_id, attribute_id;
-    node_id = H5Oopen(res->second,
+    node_id = H5Oopen(file.id,
                       concrete_h5_file_position(writable).c_str(),
                       H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 object during attribute write");
@@ -1129,19 +1094,18 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
     status = H5Oclose(node_id);
     VERIFY(status == 0, "[HDF5] Internal error: Failed to close " + concrete_h5_file_position(writable) + " during attribute write");
 
-    m_fileIDs[writable] = res->second;
+    m_fileNames[writable] = file.name;
 }
 
 void
 HDF5IOHandlerImpl::readDataset(Writable* writable,
                                Parameter< Operation::READ_DATASET > & parameters)
 {
-    auto res = m_fileIDs.find(writable);
-    if( res == m_fileIDs.end() )
-        res = m_fileIDs.find(writable->parent);
+    auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
     hid_t dataset_id, memspace, filespace;
     herr_t status;
-    dataset_id = H5Dopen(res->second,
+    dataset_id = H5Dopen(file.id,
                          concrete_h5_file_position(writable).c_str(),
                          H5P_DEFAULT);
     VERIFY(dataset_id >= 0, "[HDF5] Internal error: Failed to open HDF5 dataset during dataset read");
@@ -1229,13 +1193,12 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
     if( !writable->written )
         throw std::runtime_error("[HDF5] Internal error: Writable not marked written during attribute read");
 
-    auto res = m_fileIDs.find(writable);
-    if( res == m_fileIDs.end() )
-        res = m_fileIDs.find(writable->parent);
+    auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
 
     hid_t obj_id, attr_id;
     herr_t status;
-    obj_id = H5Oopen(res->second,
+    obj_id = H5Oopen(file.id,
                      concrete_h5_file_position(writable).c_str(),
                      H5P_DEFAULT);
     VERIFY(obj_id >= 0, "[HDF5] Internal error: Failed to open HDF5 object during attribute read");
@@ -1651,10 +1614,9 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
     if( !writable->written )
         throw std::runtime_error("[HDF5] Internal error: Writable not marked written during path listing");
 
-    auto res = m_fileIDs.find(writable);
-    if( res == m_fileIDs.end() )
-        res = m_fileIDs.find(writable->parent);
-    hid_t node_id = H5Gopen(res->second,
+    auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
+    hid_t node_id = H5Gopen(file.id,
                             concrete_h5_file_position(writable).c_str(),
                             H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path listing");
@@ -1686,10 +1648,9 @@ HDF5IOHandlerImpl::listDatasets(Writable* writable,
     if( !writable->written )
         throw std::runtime_error("[HDF5] Internal error: Writable not marked written during dataset listing");
 
-    auto res = m_fileIDs.find(writable);
-    if( res == m_fileIDs.end() )
-        res = m_fileIDs.find(writable->parent);
-    hid_t node_id = H5Gopen(res->second,
+    auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
+    hid_t node_id = H5Gopen(file.id,
                             concrete_h5_file_position(writable).c_str(),
                             H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during dataset listing");
@@ -1720,11 +1681,10 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
     if( !writable->written )
         throw std::runtime_error("[HDF5] Internal error: Writable not marked written during attribute listing");
 
-    auto res = m_fileIDs.find(writable);
-    if( res == m_fileIDs.end() )
-        res = m_fileIDs.find(writable->parent);
+    auto res = getFile( writable );
+        File file = res ? res.get() : getFile( writable->parent ).get();
     hid_t node_id;
-    node_id = H5Oopen(res->second,
+    node_id = H5Oopen(file.id,
                       concrete_h5_file_position(writable).c_str(),
                       H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during attribute listing");
@@ -1763,6 +1723,26 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
 
     status = H5Oclose(node_id);
     VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 object during attribute listing");
+}
+
+auxiliary::Option< HDF5IOHandlerImpl::File >
+HDF5IOHandlerImpl::getFile( Writable * writable )
+{
+    using namespace auxiliary;
+    auto it = m_fileNames.find( writable );
+    if( it == m_fileNames.end() )
+    {
+        return Option< File >();
+    }
+    auto it2 = m_fileNamesWithID.find( it->second );
+    if( it2 == m_fileNamesWithID.end() )
+    {
+        return Option< File >();
+    }
+    File res;
+    res.name = it->second;
+    res.id = it2->second;
+    return makeOption( std::move( res ) );
 }
 #endif
 

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -315,7 +315,8 @@ namespace openPMD
         if ( fileIterator != m_files.end( ) )
         {
             putJsonContents( fileIterator->second );
-            fileIterator->second.invalidate( );
+            // do not invalidate the file
+            // it still exists, it is just not open
             m_files.erase( fileIterator );
         }
     }

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -223,18 +223,7 @@ Iteration::flushFileBased(std::string const& filename, uint64_t i)
 
         // operations for read/read-write mode
         /* open file */
-        Parameter< Operation::OPEN_FILE > fOpen;
-        fOpen.name = filename;
-        IOHandler->enqueue(IOTask(s, fOpen));
-
-        /* open basePath */
-        Parameter< Operation::OPEN_PATH > pOpen;
-        pOpen.path = auxiliary::replace_first(s->basePath(), "%T/", "");
-        IOHandler->enqueue(IOTask(&s->iterations, pOpen));
-
-        /* open iteration path */
-        pOpen.path = std::to_string(i);
-        IOHandler->enqueue(IOTask(this, pOpen));
+        s->openIteration( i, *this );
     }
 
     flush();

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -557,7 +557,7 @@ Series::flushFileBased( IterationsContainer && iterationsToFlush )
     if( IOHandler->m_frontendAccess == Access::READ_ONLY )
         for( auto & i : iterationsToFlush )
         {
-            bool dirtyRecursive = i.second.dirtyRecursive();
+            bool const dirtyRecursive = i.second.dirtyRecursive();
             if( *i.second.m_closed == Iteration::CloseStatus::ClosedInBackend )
             {
                 // file corresponding with the iteration has previously been
@@ -599,7 +599,7 @@ Series::flushFileBased( IterationsContainer && iterationsToFlush )
         bool allDirty = dirty();
         for( auto & i : iterationsToFlush )
         {
-            bool dirtyRecursive = i.second.dirtyRecursive();
+            bool const dirtyRecursive = i.second.dirtyRecursive();
             if( *i.second.m_closed == Iteration::CloseStatus::ClosedInBackend )
             {
                 // file corresponding with the iteration has previously been

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1025,9 +1025,11 @@ void
 Series::openIteration( uint64_t index, Iteration iteration )
 {
     // open the iteration's file again
-    std::stringstream name( "" );
-    name << std::setw( *m_filenamePadding ) << std::setfill( '0' ) << index;
-    std::string filename = *m_filenamePrefix + name.str() + *m_filenamePostfix;
+    std::stringstream nameBuilder( "" );
+    nameBuilder << std::setw( *m_filenamePadding ) << std::setfill( '0' )
+                << index;
+    std::string filename =
+        *m_filenamePrefix + nameBuilder.str() + *m_filenamePostfix;
 
     Parameter< Operation::OPEN_FILE > fOpen;
     fOpen.name = filename;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -557,12 +557,13 @@ Series::flushFileBased( IterationsContainer && iterationsToFlush )
     if( IOHandler->m_frontendAccess == Access::READ_ONLY )
         for( auto & i : iterationsToFlush )
         {
+            bool dirtyRecursive = i.second.dirtyRecursive();
             if( *i.second.m_closed == Iteration::CloseStatus::ClosedInBackend )
             {
                 // file corresponding with the iteration has previously been
                 // closed and fully flushed
                 // verify that there have been no further accesses
-                if( i.second.dirtyRecursive() )
+                if( dirtyRecursive )
                 {
                     throw std::runtime_error(
                         "[Series] Detected illegal access to iteration that "
@@ -570,6 +571,36 @@ Series::flushFileBased( IterationsContainer && iterationsToFlush )
                 }
                 continue;
             }
+            /*
+             * Opening a file is expensive, so let's do it only if necessary.
+             * Necessary if:
+             * 1. The iteration itself has been changed somewhere.
+             * 2. Or the Series has been changed globally in a manner that
+             *    requires adapting all iterations.
+             */
+            if( !dirtyRecursive && !this->dirty() )
+            {
+                continue;
+            }
+
+            // open the iteration's file again
+            std::stringstream iteration( "" );
+            iteration << std::setw( *m_filenamePadding ) << std::setfill( '0' )
+                      << i.first;
+            std::string filename =
+                *m_filenamePrefix + iteration.str() + *m_filenamePostfix;
+            Parameter< Operation::OPEN_FILE > fOpen;
+            fOpen.name = filename;
+            IOHandler->enqueue( IOTask( this, fOpen ) );
+
+            /* open base path */
+            Parameter< Operation::OPEN_PATH > pOpen;
+            pOpen.path = auxiliary::replace_first( basePath(), "%T/", "" );
+            IOHandler->enqueue( IOTask( &iterations, pOpen ) );
+            /* open iteration path */
+            pOpen.path = std::to_string( i.first );
+            IOHandler->enqueue( IOTask( &i.second, pOpen ) );
+
             i.second.flush();
             if( *i.second.m_closed == Iteration::CloseStatus::ClosedInFrontend )
             {
@@ -584,6 +615,7 @@ Series::flushFileBased( IterationsContainer && iterationsToFlush )
         bool allDirty = dirty();
         for( auto & i : iterationsToFlush )
         {
+            bool dirtyRecursive = i.second.dirtyRecursive();
             if( *i.second.m_closed == Iteration::CloseStatus::ClosedInBackend )
             {
                 // file corresponding with the iteration has previously been
@@ -595,12 +627,24 @@ Series::flushFileBased( IterationsContainer && iterationsToFlush )
                         "[Series] Closed iteration has not been written. This "
                         "is an internal error.");
                 }
-                if( i.second.dirtyRecursive() )
+                if( dirtyRecursive )
                 {
                     throw std::runtime_error(
                         "[Series] Detected illegal access to iteration that "
                         "has been closed previously." );
                 }
+                continue;
+            }
+
+            /*
+             * Opening a file is expensive, so let's do it only if necessary.
+             * Necessary if:
+             * 1. The iteration itself has been changed somewhere.
+             * 2. Or the Series has been changed globally in a manner that
+             *    requires adapting all iterations.
+             */
+            if( !dirtyRecursive && !this->dirty() )
+            {
                 continue;
             }
             /* as there is only one series,
@@ -751,6 +795,7 @@ void
 Series::readFileBased()
 {
     Parameter< Operation::OPEN_FILE > fOpen;
+    Parameter< Operation::CLOSE_FILE > fClose;
     Parameter< Operation::READ_ATT > aRead;
 
     if( !auxiliary::directory_exists(IOHandler->directory) )
@@ -810,6 +855,8 @@ Series::readFileBased()
                 throw std::runtime_error("Unexpected Attribute datatype for 'iterationFormat'");
 
             read();
+            IOHandler->enqueue(IOTask(this, fClose));
+            IOHandler->flush();
         }
     }
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -39,7 +39,7 @@ write_and_read_many_iterations( std::string const & ext )
     Series write( filename, Access::CREATE );
     for( unsigned int i = 0; i < nIterations; ++i )
     {
-        std::cout << "Putting iteration " << i << std::endl;
+        // std::cout << "Putting iteration " << i << std::endl;
         Iteration it = write.iterations[ i ];
         auto E_x = it.meshes[ "E" ][ "x" ];
         E_x.resetDataset( ds );
@@ -50,7 +50,7 @@ write_and_read_many_iterations( std::string const & ext )
     Series read( filename, Access::READ_ONLY );
     for( auto iteration : read.iterations )
     {
-        std::cout << "Reading iteration " << iteration.first << std::endl;
+        // std::cout << "Reading iteration " << iteration.first << std::endl;
         auto E_x = iteration.second.meshes[ "E" ][ "x" ];
         auto chunk = E_x.loadChunk< float >( { 0 }, { 10 } );
         iteration.second.close();

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -26,6 +26,60 @@
 
 using namespace openPMD;
 
+namespace {
+    // only needed until we require C++14 and newer (201402L+)
+    template<typename T, typename... Args>
+    std::unique_ptr<T> my_make_unique(Args&&... args) {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+}
+
+void
+write_and_read_many_iterations( std::string const & ext )
+{
+    constexpr unsigned int nIterations = 1000;
+    std::string filename = "../samples/many_iterations/many_iterations_%T." + ext;
+
+    std::vector< float > data( 10 );
+    std::iota( data.begin(), data.end(), 0. );
+    Dataset ds{ Datatype::FLOAT, { 10 } };
+
+    Series write( filename, Access::CREATE );
+    for( unsigned int i = 0; i < nIterations; ++i )
+    {
+        std::cout << "Putting iteration " << i << std::endl;
+        Iteration it = write.iterations[ i ];
+        auto E_x = it.meshes[ "E" ][ "x" ];
+        E_x.resetDataset( ds );
+        E_x.storeChunk( data, { 0 }, { 10 } );
+        it.close();
+    }
+
+    Series read( filename, Access::READ_ONLY );
+    for( auto iteration : read.iterations )
+    {
+        std::cout << "Reading iteration " << iteration.first << std::endl;
+        auto E_x = iteration.second.meshes[ "E" ][ "x" ];
+        auto chunk = E_x.loadChunk< float >( { 0 }, { 10 } );
+        iteration.second.close();
+
+        auto array = chunk.get();
+        for( size_t i = 0; i < 10; ++i )
+        {
+            REQUIRE( array[ i ] == float( i ) );
+        }
+    }
+}
+
+TEST_CASE( "write_and_read_many_iterations", "[serial]" )
+{
+    if( auxiliary::directory_exists( "../samples/many_iterations" ) )
+        auxiliary::remove_directory( "../samples/many_iterations" );
+    for( auto const & t : getFileExtensions() )
+    {
+        write_and_read_many_iterations( t );
+    }
+}
 
 TEST_CASE( "multi_series_test", "[serial]" )
 {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -26,14 +26,6 @@
 
 using namespace openPMD;
 
-namespace {
-    // only needed until we require C++14 and newer (201402L+)
-    template<typename T, typename... Args>
-    std::unique_ptr<T> my_make_unique(Args&&... args) {
-        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-    }
-}
-
 void
 write_and_read_many_iterations( std::string const & ext )
 {


### PR DESCRIPTION
Issue first brought up [here](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3434#issuecomment-729555373) by @cbontoiu.

The openPMD API already allows *writing* a file-based Series with arbitrarily many iterations by using `Iteration::close()` after finishing the write operation. So far, *reading* such a Series was not possible on a system with limited number of allowed file handles per process: The openPMD API would during parsing open all files, but never close a single file handle. This PR closes a parsed iteration directly after parsing. After reading an iteration, a user will need to `Iteration::close()` the iteration again in order to give the file handle back to the system.

Some reorganization was necessary for this in the HDF5 backend, since that backend previously stored the explicit HDF5 file handle for each `Writable` object. Since closing and reopening a file changes the handle, the HDF5 backend will now only store file names for each such object and keep a map from file names to active file handles.

This is a quick fix and more sophisticated methods such as the following are **not** implemented:
* Keeping a stack of open file handles and automatically closing old handles if a certain threshold is reached.
* Lazy parsing of iterations: Only parse an iteration upon `Series.iterations.operator[]()`. This would reduce the number of file accesses while opening a `Series` and drastically speed up this process in general.
* Allow reopening an iteration that a user has explicitly `Iteration::close()`d. Currently, the openPMD API is allowed to close and reopen iterations (which is, what this PR implements). Users are not (yet).

EDIT: Do we have sufficiently fine-grained control over the CI containers to allow setting ulimits to a low number? I don't really want to go overboard with the tests for this one…