### PR TITLE
Python: 3.6 - 3.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Other
 """""
 
 - switch to C++14 #825
+- Python: support 3.6 - 3.9 #828
 - Docs:
 
   - Release cibuildwheel example #775

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,7 @@ if(openPMD_USE_PYTHON STREQUAL AUTO)
                        "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}' "
                        "is NOT supported. Set for example "
                        "-DPYTHON_EXECUTABLE=$(which python3) "
-                       "to use 3.5+.")
+                       "to use 3.6+.")
     endif()
 elseif(openPMD_USE_PYTHON)
     if(openPMD_USE_INTERNAL_PYBIND11)
@@ -286,7 +286,7 @@ elseif(openPMD_USE_PYTHON)
                             "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}' "
                             "is NOT supported. Set for example "
                             "-DPYTHON_EXECUTABLE=$(which python3) "
-                            "to use 3.5+.")
+                            "to use 3.6+.")
     endif()
 else()
     set(openPMD_HAVE_PYTHON FALSE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM       quay.io/pypa/manylinux2010_x86_64 as build-env
 # FROM       quay.io/pypa/manylinux1_x86_64 as build-env
 ENV        DEBIAN_FRONTEND noninteractive
 
-# Python 3.5-3.8 via "35m 36m 37m 38"
-ARG        PY_VERSIONS="35m 36m 37m 38"
+# Python 3.6-3.9 via "36m 37m 38 39"
+ARG        PY_VERSIONS="36m 37m 38 39"
 
 # static libs need relocatable symbols for linking to shared python lib
 ENV        CFLAGS="-fPIC ${CFLAGS}"
@@ -175,18 +175,19 @@ RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io
 RUN        python3 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
-# test in fresh env: Debian:Stretch + Python 3.5
-FROM       debian:stretch
+# test in fresh env: Debian:Bullseye + Python 3.9
+FROM       debian:bullseye
 ENV        DEBIAN_FRONTEND noninteractive
-COPY --from=build-env /wheelhouse/openPMD_api-*-cp35-cp35m-manylinux2010_x86_64.whl .
+COPY --from=build-env /wheelhouse/openPMD_api-*-cp39-cp39-manylinux2010_x86_64.whl .
 RUN        apt-get update \
-           && apt-get install -y --no-install-recommends python3 python3-pip \
+           && apt-get install -y --no-install-recommends python3.9 python3-distutils ca-certificates curl \
            && rm -rf /var/lib/apt/lists/*
-RUN        python3 --version \
-           && python3 -m pip install -U pip \
-           && python3 -m pip install openPMD_api-*-cp35-cp35m-manylinux2010_x86_64.whl
-RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-RUN        python3 -m openpmd_api.ls --help
+RUN        python3.9 --version \
+           && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+           && python3.9 get-pip.py \
+           && python3.9 -m pip install openPMD_api-*-cp39-cp39-manylinux2010_x86_64.whl
+RUN        python3.9 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
+RUN        python3.9 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ RUN        curl -sLo hdf5-1.10.5.tar.gz https://support.hdfgroup.org/ftp/HDF5/re
            && make install
 
 # avoid picking up a static libpthread in adios (also: those libs lack -fPIC)
-RUN        rm /usr/lib64/libpthread.a /usr/lib64/libm.a /usr/lib64/librt.a
+RUN        rm -f /usr/lib64/libpthread.a /usr/lib64/libm.a /usr/lib64/librt.a
+RUN        rm -f /usr/lib/libpthread.a   /usr/lib/libm.a   /usr/lib/librt.a
 
 RUN        curl -sLo c-blosc-1.15.0.tar.gz https://github.com/Blosc/c-blosc/archive/v1.15.0.tar.gz \
            && file c-blosc*.tar.gz \
@@ -68,10 +69,6 @@ RUN        curl -sLo adios2-2.6.0.tar.gz https://github.com/ornladios/ADIOS2/arc
            && file adios2*.tar.gz \
            && tar -xzf adios2*.tar.gz \
            && rm adios2*.tar.gz \
-           && cd ADIOS2-* \
-           && curl -sLo adios2-static.patch https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/1828.patch \
-           && patch -p1 < adios2-static.patch \
-           && cd .. \
            && mkdir build-ADIOS2 \
            && cd build-ADIOS2 \
            && PY_TARGET=${PY_VERSIONS%% *} \
@@ -136,9 +133,10 @@ RUN        python3 --version \
            && python3 -m pip install openPMD_api-*-cp37-cp37m-manylinux2010_x86_64.whl
 RUN        find / -name "openpmd*"
 RUN        ls -hal /usr/local/lib/python3.7/dist-packages/
+RUN        ls -hal /usr/local/lib/python3.7/dist-packages/openpmd_api/
 # RUN        ls -hal /usr/local/lib/python3.7/dist-packages/.libsopenpmd_api
 # RUN        objdump -x /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so | grep RPATH
-RUN        ldd /usr/local/lib/python3.7/dist-packages/openpmd_api.cpython-37m-x86_64-linux-gnu.so
+RUN        ldd /usr/local/lib/python3.7/dist-packages/openpmd_api/openpmd_api_cxx.cpython-37m-x86_64-linux-gnu.so
 RUN        python3 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
 RUN        python3 -m openpmd_api.ls --help
 RUN        openpmd-ls --help

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,7 @@ Upgrade Guide
 -----------
 
 Building openPMD-api now requires a compiler that supports C++14 or newer.
+Supported Python version are now 3.6 to 3.9.
 
 
 0.12.0-alpha

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.5 - 3.8
-  * pybind 2.4.3+
+  * Python 3.6 - 3.9
+  * pybind11 2.4.3+
   * numpy 1.15+
   * mpi4py 2.1+
 

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -39,7 +39,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.5 - 3.8
+  * Python 3.6 - 3.9
   * pybind11 2.4.3+
   * numpy 1.15+
   * mpi4py 2.1+

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ setup(
     cmdclass=dict(build_ext=CMakeBuild),
     # scripts=['openpmd-ls'],
     zip_safe=False,
-    python_requires='>=3.5, <3.9',
+    python_requires='>=3.6, <3.10',
     # tests_require=['pytest'],
     install_requires=install_requires,
     # see: src/bindings/python/cli
@@ -192,10 +192,10 @@ setup(
         'Topic :: Database :: Front-Ends',
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         ('License :: OSI Approved :: '
          'GNU Lesser General Public License v3 or later (LGPLv3+)'),
     ],

--- a/share/openPMD/thirdParty/pybind11/tools/pybind11Tools.cmake
+++ b/share/openPMD/thirdParty/pybind11/tools/pybind11Tools.cmake
@@ -12,7 +12,7 @@ if(NOT PYBIND11_PYTHON_VERSION)
   set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling modules")
 endif()
 
-set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4)
+set(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6)
 find_package(PythonLibsNew ${PYBIND11_PYTHON_VERSION} REQUIRED)
 
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
Add support for Python 3.9, drop support for 3.5 (end-of-life since 9/2020).

Notes:
- we already ship Python 3.9 via conda-forge for the latest release
- theoretically, CPython 3.9.0 has a bug on macOS and does not work with pybind11. pybind11 2.6.0 ships a work-around and CPython 3.9.0 on conda-forge as well as release CPython 3.9.1 will ship a fix: https://bugs.python.org/issue42015 https://github.com/python/cpython/pull/22670
- we already test Python 3.9 on CI (macOS builds from homebrew, with CPython 3.9.0_2)