### PR TITLE
Resizable Datasets

### DIFF
--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -40,6 +40,14 @@ class Dataset
 public:
     Dataset(Datatype, Extent, std::string options = "{}");
 
+    /**
+     * @brief Constructor that sets the datatype to undefined.
+     *
+     * Helpful for resizing datasets, since datatypes need not be given twice.
+     *
+     */
+    Dataset( Extent );
+
     Dataset& extend(Extent newExtent);
     Dataset& setChunkSize(Extent const&);
     Dataset& setCompression(std::string const&, uint8_t const);

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -281,8 +281,7 @@ template<>
 struct OPENPMDAPI_EXPORT Parameter< Operation::EXTEND_DATASET > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(),
-        name(p.name), extent(p.extent) {}
+    Parameter(Parameter const & p) : AbstractParameter(), extent(p.extent) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -291,7 +290,6 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::EXTEND_DATASET > : public Abstrac
             new Parameter< Operation::EXTEND_DATASET >(*this));
     }
 
-    std::string name = "";
     Extent extent = {};
 };
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -100,7 +100,26 @@ public:
 
     RecordComponent& setUnitSI(double);
 
-    RecordComponent& resetDataset(Dataset);
+    /**
+     * @brief Declare the dataset's type and extent.
+     *
+     * Calling this again after flushing will require resizing the dataset.
+     * Support for this depends on the backend.
+     * Unsupported are:
+     * * Changing the datatype.
+     * * Shrinking any dimension's extent.
+     * * Changing the number of dimensions.
+     *
+     * Backend support for resizing datasets:
+     * * JSON: Supported
+     * * ADIOS1: Unsupported
+     * * ADIOS2: Supported as of ADIOS2 2.7.0
+     * * HDF5: (Currently) unsupported.
+     *   Will be probably supported as soon as chunking is supported in HDF5.
+     *
+     * @return RecordComponent&
+     */
+    RecordComponent & resetDataset( Dataset );
 
     uint8_t getDimensionality() const;
     Extent getExtent() const;
@@ -196,6 +215,10 @@ OPENPMD_protected:
     std::shared_ptr< std::queue< IOTask > > m_chunks;
     std::shared_ptr< Attribute > m_constantValue;
     std::shared_ptr< bool > m_isEmpty = std::make_shared< bool >( false );
+    // User has extended the dataset, but the EXTEND task must yet be flushed
+    // to the backend
+    std::shared_ptr< bool > m_hasBeenExtended =
+        std::make_shared< bool >( false );
 
 private:
     void flush(std::string const&);

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -34,8 +34,12 @@ Dataset::Dataset(Datatype d, Extent e, std::string options_in)
           options{std::move(options_in)}
 { }
 
-Dataset&
-Dataset::extend(Extent newExtents)
+Dataset::Dataset( Extent e ) : Dataset( Datatype::UNDEFINED, std::move( e ) )
+{
+}
+
+Dataset &
+Dataset::extend( Extent newExtents )
 {
     if( newExtents.size() != rank )
         throw std::runtime_error("Dimensionality of extended Dataset must match the original dimensionality");


### PR DESCRIPTION
~~Based on [topic-available-chunks](https://github.com/openPMD/openPMD-api/pull/802) since that one will be merged soon anyway.~~
Based on #927 since this requires ADIOS 2.7.0, see [here](https://github.com/ax3l/openPMD-api/compare/adios-2.7.0...franzpoeschel:topic-resizable-datasets) for the diff.

Motivation: For some simulations, it is impossible to know at the beginning of writing an iteration's data e.g. the number of particles to expect until the end of the iteration. Hence, an iteration's datasets need to be resized while writing the iteration.

Hence, allow calling `RecordComponent::resetDataset` multiple times with multiple dimensions.

- This does not (yet) allow turning (1) empty (2) constant (3) array-form datasets into one another. This would be much trickier to implement and is not really necessary for the use cases above. 
    EDIT: empty and constant record components can now be turned into one another and extending the extents of any of those two is fully supported.
- [x]  →Throw exceptions if empty/constant datasets are turned into an array-formed one. Other directions are already tested.
- The frontend does not compare the new extent to the old extent in any form whatsoever. Supporting (1) shrinking or (2) changing the dimensionality is the decision of the backend. Growing should generally be supported.

TODO:
- [x] Documentation
- [x] Implementation in the frontend.
- [x] ADIOS2: ~~Apparently, the ADIOS2 semantics for resizing datasets are targeted for a different use case: `Variable<T>::SetShape` does nothing to a variable within the same ADIOS step. So, the ADIOS semantics for resizing datasets are for a use case that we have been supporting for a long time anyway (by creating new datasets for each iteration): Having different-sized datasets across steps/iterations. Unless I'm missing something, implementing this in ADIOS2 is currently not possible. Within the same step, ADIOS2 will currently fully ignore the resizing and any write operation to any of the extended places.~~ https://github.com/ornladios/ADIOS2/pull/2545 fixes this. This means, we'll need to wait for ADIOS 2.7.0 to merge this PR. **This is also the reason for the failing tests.**
- [x] JSON
- [x] HDF5. ~~There is already an old implementation of resizing datasets in there, it's just never been used and I'll need to check whether it works.~~ HDF5 only allows this when writing with chunked storage #406. So I suppose that this one is postponed until we implement writing chunked storage in HDF5. `HDF5IOHandlerImpl::extendDataset` will now throw an exception that gives notice of this.