### PR TITLE
Turn off Statistics (Min/Max) in ADIOS2 backend

### DIFF
--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -33,11 +33,15 @@ environment variable                  default    description
 ``OPENPMD_BP_BACKEND``                ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ===================================== ========== ================================================================================
 
-Please refer to the `ADIOS2 manual, section 5.1 <https://media.readthedocs.org/pdf/adios2/latest/adios2.pdf>`_ for details on I/O tuning.
+Please refer to the `ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for details on I/O tuning.
 
 In case the ADIOS2 backend was not compiled but only the deprecated :ref:`ADIOS1 backend <backends-adios1>`, the default of ``OPENPMD_BP_BACKEND`` will fall back to ``ADIOS1``.
 Be advised that ADIOS1 only supports ``.bp`` files up to the internal version BP3, while ADIOS2 supports BP3, BP4 and later formats.
 
+Notice that the ADIOS2 backend is alternatively configurable via :ref:`JSON parameters <backendconfig>`.
+
+Due to performance considerations, the ADIOS2 backend configures ADIOS2 not to compute any dataset statistics (Min/Max) by default.
+Statistics may be activated by setting the :ref:`JSON parameter <backendconfig>` ``adios2.engine.parameters.StatsLevel = "1"``.
 
 Best Practice at Large Scale
 ----------------------------

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1330,7 +1330,18 @@ namespace detail
                     "SubStreams", std::to_string( num_substreams ) );
             }
         }
-#endif
+#    endif
+        if( notYetConfigured( "StatsLevel" ) )
+        {
+            /*
+             * Switch those off by default since they are expensive to compute
+             * and we don't read them anyway.
+             * No environement variable for this one, can still be switched
+             * on via JSON though.
+             * Default is "1".
+             */
+            m_IO.SetParameter( "StatsLevel", "0" );
+        }
     }
 
     adios2::Engine &


### PR DESCRIPTION
As documented [here](https://adios2.readthedocs.io/en/latest/engines/engines.html), ADIOS2 will produce statistics for variables by default. This is a time-intensive procedure and we don't use the information anyway, so we override this and turn it off.

If a user really wants these, they can be turned on again via JSON. The statistics cannot be accessed via openPMD, but some people may be loading data manually via ADIOS2.

Some little time measurements: I ran a single-threaded simulation with PIConGPU, producing per data dump between 14 and 17GB of data (dumping every 50 time steps for 400 steps in total).
 *  With statistics: 6 minutes, 31 seconds
 *  Without: 6 minutes, 4 seconds

That is a speedup of nearly half a minute.

Also, replace a dead link in the documentation while I'm at it.