### PR TITLE
Fix: Win ClangCL

### DIFF
--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -615,7 +615,7 @@ isSame( openPMD::Datatype const d, openPMD::Datatype const e )
     return false;
 }
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__clang__)
 #define OPENPMD_TEMPLATE_OPERATOR operator
 #else
 #define OPENPMD_TEMPLATE_OPERATOR template operator


### PR DESCRIPTION
Do not apply a MSVC work-around for Clang on Windows (ClangCl).

Seen with https://github.com/ECP-WarpX/WarpX/pull/1541