### PR TITLE
Explicitly record close status if temporarily closing

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -149,8 +149,10 @@ private:
         Open,             //!< Iteration has not been closed
         ClosedInFrontend, /*!< Iteration has been closed, but task has not yet
                                been propagated to the backend */
-        ClosedInBackend   /*!< Iteration has been closed and task has been
+        ClosedInBackend,  /*!< Iteration has been closed and task has been
                                propagated to the backend */
+        ClosedTemporarily /*!< Iteration has been closed internally and may
+                               be reopened later */
     };
 
     /*

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -113,7 +113,32 @@ Iteration::close( bool _flush )
     {
         setAttribute< bool_type >( "closed", 1u );
     }
-    *m_closed = CloseStatus::ClosedInFrontend;
+    // update close status
+    switch( *m_closed )
+    {
+        case CloseStatus::Open:
+        case CloseStatus::ClosedInFrontend:
+            *m_closed = CloseStatus::ClosedInFrontend;
+            break;
+        case CloseStatus::ClosedTemporarily:
+            // should we bother to reopen?
+            if( dirtyRecursive() )
+            {
+                // let's reopen
+                *m_closed = CloseStatus::ClosedInFrontend;
+            }
+            else
+            {
+                // don't reopen
+                *m_closed = CloseStatus::ClosedInBackend;
+            }
+            break;
+        case CloseStatus::ClosedInBackend:
+            // just keep it like it is
+            break;
+        default:
+            throw std::runtime_error( "Unreachable!" );
+    }
     if( _flush )
     {
         /* Find the root point [Series] of this file,


### PR DESCRIPTION
PR #822 introduced logic to close an iteration temporarily in file-based iteration layout.
I noticed two issues:
* The method `Series::flushFileBased` will not close iterations that are not dirty. Fix that.
* Iterations did not store whether they were temporarily closed. This led to issues on the streaming branch with double closing. Let's make that explicit in `Iteration::m_closed`.