### PR TITLE
Determinize destruction order of files in ADIOS2

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -109,7 +109,7 @@ public:
     );
 
 
-    ~ADIOS2IOHandlerImpl( ) override = default;
+    ~ADIOS2IOHandlerImpl() override;
 
     std::future< void > flush( ) override;
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -84,6 +84,36 @@ ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(
     init( std::move( cfg ) );
 }
 
+ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
+{
+    /*
+     * m_fileData is an unordered_map indexed by pointer addresses
+     * to the fileState member of InvalidatableFile.
+     * This means that destruction order is nondeterministic.
+     * Let's determinize it (necessary if computing in parallel).
+     */
+    using file_t = std::unique_ptr< detail::BufferedActions >;
+    std::vector< file_t > sorted;
+    sorted.reserve( m_fileData.size() );
+    for( auto & pair : m_fileData )
+    {
+        sorted.push_back( std::move( pair.second ) );
+    }
+    m_fileData.clear();
+    std::sort(
+        sorted.begin(),
+        sorted.end(),
+        []( auto const & left, auto const & right ) {
+            return left->m_file <= right->m_file;
+        } );
+    // run the destructors
+    for( auto & file : sorted )
+    {
+        // std::unique_ptr interface
+        file.reset();
+    }
+}
+
 void
 ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
 {


### PR DESCRIPTION
See https://github.com/ornladios/ADIOS2/issues/2533.

Interestingly, ADIOS 2.6.0 had no issue when closing different engines in different orders across different ranks.
Current master has issues with that, so this PR determinizes destruction order.