### PR TITLE
CI: Windows on GH Actions (MSVC, Clang)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -125,8 +125,10 @@ before_build:
 
 build_script:
   - cmd: cmake --build . --config %CONFIGURATION%
+  - cmd: ctest -V -C %CONFIGURATION%
   - cmd: cmake --build . --config %CONFIGURATION% --target install
+# note: running ctest after install seems to fail...
 
 test_script:
-  - cmd: ctest -V -C %CONFIGURATION%
   - cmd: python -c "import openpmd_api; print(openpmd_api.__version__); print(openpmd_api.variants)"
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,6 +47,9 @@ jobs:
         if errorlevel 1 exit 1
         cmake --build . --config Release --parallel 2
         if errorlevel 1 exit 1
+        
+        dumpbin /dependents D:\a\openPMD-api\openPMD-api\build\lib\site-packages\openpmd_api\openpmd_api_cxx.cp39-win_amd64.pyd
+        
         ctest -V --output-on-failure --build-config Release
         if errorlevel 1 exit 1
         cmake --build . --config Release --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,53 @@
+name: windows
+
+on: [push, pull_request]
+
+jobs:
+  build_win_msvc:
+    name: MSVC w/o MPI
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Test
+      run: |
+        $erroractionpreference = "stop"
+        md build
+        cd build
+        powershell.exe ..\share\openPMD\download_samples.ps1
+        cmake .. `
+              -DCMAKE_BUILD_TYPE=Debug    `
+              -DCMAKE_VERBOSE_MAKEFILE=ON
+        cmake --build . --config Debug --parallel 2
+        if (-not $?) { throw "CMake build failed" }
+        ctest -V --output-on-failure --build-config Debug
+        if (-not $?) { throw "CTest failed" }
+        cmake --build . --config Debug --target install
+        if (-not $?) { throw "CMake install failed" }
+
+  build_win_clang:
+    name: Clang w/o MPI
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - name: Build & Test
+      shell: cmd
+      run: |
+        md build
+        cd build
+        Powershell.exe -File ..\share\openPMD\download_samples.ps1
+        if errorlevel 1 exit 1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        cmake ..                            ^
+              -G "Ninja"                    ^
+              -DCMAKE_C_COMPILER=clang-cl   ^
+              -DCMAKE_CXX_COMPILER=clang-cl ^
+              -DCMAKE_BUILD_TYPE=Release    ^
+              -DCMAKE_VERBOSE_MAKEFILE=ON
+        if errorlevel 1 exit 1
+        cmake --build . --config Release --parallel 2
+        if errorlevel 1 exit 1
+        ctest -V --output-on-failure --build-config Release
+        if errorlevel 1 exit 1
+        cmake --build . --config Release --target install
+        if errorlevel 1 exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,6 +952,12 @@ if(openPMD_BUILD_TESTING)
         ${MPIEXEC_NUMPROC_FLAG} 2
     )
 
+    # preserve Windows environment for runtime tests
+    if(WIN32)
+        string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
+        string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
+    endif()
+
     # do we have openPMD-example-datasets?
     if(EXISTS "${openPMD_BINARY_DIR}/samples/git-sample/")
         set(EXAMPLE_DATA_FOUND ON)
@@ -1014,17 +1020,10 @@ if(openPMD_BUILD_TESTING)
                         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
                 )
                 if(WIN32)
-                    string(REGEX REPLACE "/" "\\\\" WIN_BUILD_PYDIR ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
-                    string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-                    string(REGEX REPLACE "/" "\\\\" WIN_LIB_BINDIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-                    string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
-                    string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
-                    message(STATUS "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n")
-                    message(STATUS "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}")
                     set_property(TEST Unittest.py
                         PROPERTY ENVIRONMENT
-                            "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n"
-                            "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}"
+                            "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:openPMD>>\;${WIN_PATH}\n"
+                            "PYTHONPATH=$<SHELL_PATH:${CMAKE_PYTHON_OUTPUT_DIRECTORY}>\;${WIN_PYTHONPATH}"
                     )
                 else()
                     set_tests_properties(Unittest.py
@@ -1095,17 +1094,10 @@ if(openPMD_BUILD_TESTING)
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
             if(WIN32)
-                string(REGEX REPLACE "/" "\\\\" WIN_BUILD_PYDIR ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
-                string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-                string(REGEX REPLACE "/" "\\\\" WIN_LIB_BINDIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-                string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
-                string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
-                message(STATUS "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n")
-                message(STATUS "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}")
                 set_property(TEST CLI.py.help.${pymodulename}
                     PROPERTY ENVIRONMENT
-                        "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n"
-                        "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}"
+                        "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:openPMD>>\;${WIN_PATH}\n"
+                        "PYTHONPATH=$<SHELL_PATH:${CMAKE_PYTHON_OUTPUT_DIRECTORY}>\;${WIN_PYTHONPATH}"
                 )
             else()
                 set_tests_properties(CLI.py.help.${pymodulename}
@@ -1147,17 +1139,10 @@ if(openPMD_BUILD_TESTING)
                         )
                     endif()
                     if(WIN32)
-                        string(REGEX REPLACE "/" "\\\\" WIN_BUILD_PYDIR ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
-                        string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-                        string(REGEX REPLACE "/" "\\\\" WIN_LIB_BINDIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-                        string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
-                        string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
-                        message(STATUS "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n")
-                        message(STATUS "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}")
                         set_property(TEST Example.py.${examplename}
                             PROPERTY ENVIRONMENT
-                                "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n"
-                                "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}"
+                                "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:openPMD>>\;${WIN_PATH}\n"
+                                "PYTHONPATH=$<SHELL_PATH:${CMAKE_PYTHON_OUTPUT_DIRECTORY}>\;${WIN_PYTHONPATH}"
                         )
                     else()
                         set_tests_properties(Example.py.${examplename}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,11 +639,14 @@ if(openPMD_HAVE_PYTHON)
     set_target_properties(openPMD.py PROPERTIES
         ARCHIVE_OUTPUT_NAME openpmd_api_cxx
         LIBRARY_OUTPUT_NAME openpmd_api_cxx
-        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
-        PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
-        COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
+        # note: we append an empty generator expression $<0:> to avoid a suffix
+        # of the config type on multi-config generators (VS and XCode)
+        # https://cmake.org/cmake/help/latest/prop_tgt/ARCHIVE_OUTPUT_DIRECTORY.html
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api$<0:>
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api$<0:>
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api$<0:>
+        PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api$<0:>
+        COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api$<0:>
     )
     add_custom_command(TARGET openPMD.py POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -1011,19 +1014,22 @@ if(openPMD_BUILD_TESTING)
                         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
                 )
                 if(WIN32)
-                    string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BASEDIR ${openPMD_BINARY_DIR})
+                    string(REGEX REPLACE "/" "\\\\" WIN_BUILD_PYDIR ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
                     string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+                    string(REGEX REPLACE "/" "\\\\" WIN_LIB_BINDIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
                     string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
                     string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
+                    message(STATUS "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n")
+                    message(STATUS "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}")
                     set_property(TEST Unittest.py
                         PROPERTY ENVIRONMENT
-                            "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
-                            "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+                            "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n"
+                            "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}"
                     )
                 else()
                     set_tests_properties(Unittest.py
                         PROPERTIES ENVIRONMENT
-                            "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+                            "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
                     )
                 endif()
             endif()
@@ -1089,15 +1095,22 @@ if(openPMD_BUILD_TESTING)
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
             if(WIN32)
+                string(REGEX REPLACE "/" "\\\\" WIN_BUILD_PYDIR ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
+                string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+                string(REGEX REPLACE "/" "\\\\" WIN_LIB_BINDIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+                string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
+                string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
+                message(STATUS "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n")
+                message(STATUS "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}")
                 set_property(TEST CLI.py.help.${pymodulename}
                     PROPERTY ENVIRONMENT
-                        "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
-                        "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+                        "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n"
+                        "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}"
                 )
             else()
                 set_tests_properties(CLI.py.help.${pymodulename}
                     PROPERTIES ENVIRONMENT
-                        "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+                        "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
                 )
             endif()
         endforeach()
@@ -1134,19 +1147,22 @@ if(openPMD_BUILD_TESTING)
                         )
                     endif()
                     if(WIN32)
-                        string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BASEDIR ${openPMD_BINARY_DIR})
+                        string(REGEX REPLACE "/" "\\\\" WIN_BUILD_PYDIR ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
                         string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+                        string(REGEX REPLACE "/" "\\\\" WIN_LIB_BINDIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
                         string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
                         string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
+                        message(STATUS "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n")
+                        message(STATUS "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}")
                         set_property(TEST Example.py.${examplename}
                             PROPERTY ENVIRONMENT
-                                "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
-                                "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+                                "PATH=${WIN_BUILD_BINDIR}\;${WIN_LIB_BINDIR}\;${WIN_PATH}\n"
+                                "PYTHONPATH=${WIN_BUILD_PYDIR}\;${WIN_PYTHONPATH}"
                         )
                     else()
                         set_tests_properties(Example.py.${examplename}
                             PROPERTIES ENVIRONMENT
-                                "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+                                "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
                         )
                     endif()
                 endif()


### PR DESCRIPTION
Add two new builds on GH Actions: MSVC and Clang on Windows.

Clang on Windows support depends on #839