### PR TITLE
CI: Update LGTM packages

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,4 +5,4 @@ extraction:
         - openmpi-bin
         - libopenmpi-dev
         - libhdf5-openmpi-dev
-        - libadios-dev  # this is OpenMPI-enabled, explicit name on disco+
+        - libadios-openmpi-dev


### PR DESCRIPTION
Looks like LGTM recently updated their Ubuntu Image, so we can now select the MPI-variant with its new name.
  https://packages.ubuntu.com/focal/libadios-openmpi-dev