### PR TITLE
Explicitly set SubStreams for available_chunks parallel test

### DIFF
--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -299,9 +299,27 @@ available_chunks_test( std::string file_ending )
         mpi_size{ static_cast< unsigned >( r_mpi_size ) };
     std::string name = "../samples/available_chunks." + file_ending;
 
+    std::stringstream parameters;
+    parameters << R"END(
+{
+    "adios2":
+    {
+        "engine":
+        {
+            "type": "bp4",
+            "parameters":
+            {
+                "NumAggregators":)END"
+                << "\"" << std::to_string(mpi_size) << "\""  << R"END(
+            }
+        }
+    }
+}
+)END";
+
     std::vector< int > data{ 2, 4, 6, 8 };
     {
-        Series write( name, Access::CREATE, MPI_COMM_WORLD );
+        Series write( name, Access::CREATE, MPI_COMM_WORLD, parameters.str() );
         Iteration it0 = write.iterations[ 0 ];
         auto E_x = it0.meshes[ "E" ][ "x" ];
         E_x.resetDataset( { Datatype::INT, { mpi_size, 4 } } );

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -299,6 +299,10 @@ available_chunks_test( std::string file_ending )
         mpi_size{ static_cast< unsigned >( r_mpi_size ) };
     std::string name = "../samples/available_chunks." + file_ending;
 
+    /*
+     * ADIOS2 assigns writerIDs to blocks in a BP file by id of the substream
+     * (aggregator). So, use one aggregator per MPI rank to test this feature.
+     */
     std::stringstream parameters;
     parameters << R"END(
 {


### PR DESCRIPTION
ADIOS2 BP engines assign a chunk's `writerID` by its containing subfile. Since ADIOS 2.7 will no longer use one substream per process by default, this breaks our parallel `available_chunks_test`. This prepares the openPMD API for ADIOS 2.7.

Given that the writer ID apparently has only an indirect relation to the writing MPI rank, we should maybe rename `WrittenChunkInfo::mpi_rank` to something more generic?

Also, should we maybe expose some rudimentary JSON editing helpers? Passing this parameter is rather ugly atm.. 