### PR TITLE
Test Case: FBPIC Empty HDF5

### DIFF
--- a/share/openPMD/download_samples.ps1
+++ b/share/openPMD/download_samples.ps1
@@ -17,3 +17,9 @@ Expand-Archive no_fields.zip -DestinationPath samples\issue-sample\
 Invoke-WebRequest https://github.com/yt-project/yt/files/1542670/no_particles.zip -OutFile no_particles.zip
 Expand-Archive no_particles.zip -DestinationPath samples\issue-sample\
 Remove-Item *.zip
+
+# Ref.: https://github.com/openPMD/openPMD-viewer/issues/296
+Invoke-WebRequest https://github.com/openPMD/openPMD-viewer/files/5655027/diags.zip -OutFile empty_alternate_fbpic.zip
+Expand-Archive empty_alternate_fbpic.zip
+Move-Item -Path empty_alternate_fbpic\diags\hdf5\data00000050.h5 samples\issue-sample\empty_alternate_fbpic.h5
+Remove-Item -Recurse -Force empty_alternate_fbpic*

--- a/share/openPMD/download_samples.sh
+++ b/share/openPMD/download_samples.sh
@@ -20,3 +20,9 @@ curl -sOL https://github.com/yt-project/yt/files/1542670/no_particles.zip
 unzip no_particles.zip
 mv no_particles samples/issue-sample/
 rm -rf no_fields.zip no_particles.zip
+
+# Ref.: https://github.com/openPMD/openPMD-viewer/issues/296
+curl -sOL https://github.com/openPMD/openPMD-viewer/files/5655027/diags.zip
+unzip diags.zip
+mv diags/hdf5/data00000050.h5 samples/issue-sample/empty_alternate_fbpic.h5
+rm -rf diags.zip diags

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1263,12 +1263,16 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
     obj_id = H5Oopen(file.id,
                      concrete_h5_file_position(writable).c_str(),
                      H5P_DEFAULT);
-    VERIFY(obj_id >= 0, "[HDF5] Internal error: Failed to open HDF5 object during attribute read");
+    VERIFY(obj_id >= 0, std::string("[HDF5] Internal error: Failed to open HDF5 object '") +
+        concrete_h5_file_position(writable).c_str() + "' during attribute read");
     std::string const & attr_name = parameters.name;
     attr_id = H5Aopen(obj_id,
                       attr_name.c_str(),
                       H5P_DEFAULT);
-    VERIFY(attr_id >= 0, "[HDF5] Internal error: Failed to open HDF5 attribute during attribute read");
+    VERIFY(attr_id >= 0,
+        std::string("[HDF5] Internal error: Failed to open HDF5 attribute '") +
+        attr_name + "' (" +
+        concrete_h5_file_position(writable).c_str() + ") during attribute read");
 
     hid_t attr_type, attr_space;
     attr_type = H5Aget_type(attr_id);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -196,7 +196,7 @@ RecordComponent::readBase()
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 
-    if( constant() )
+    if( constant() && !empty() )
     {
         aRead.name = "value";
         IOHandler->enqueue(IOTask(this, aRead));

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1632,8 +1632,31 @@ void optional_paths_110_test(const std::string & backend)
     }
 }
 
-
 #if openPMD_HAVE_HDF5
+TEST_CASE( "empty_alternate_fbpic", "[serial][hdf5]" )
+{
+    // Ref.: https://github.com/openPMD/openPMD-viewer/issues/296
+    try
+    {
+        {
+            Series s = Series("../samples/issue-sample/empty_alternate_fbpic.h5", Access::READ_ONLY);
+            REQUIRE(s.iterations.contains(50));
+            REQUIRE(s.iterations[50].particles.contains("electrons"));
+            REQUIRE(s.iterations[50].particles["electrons"].contains("momentum"));
+            REQUIRE(s.iterations[50].particles["electrons"]["momentum"].contains("x"));
+            auto empty_rc = s.iterations[50].particles["electrons"]["momentum"]["x"];
+
+            REQUIRE(empty_rc.empty());
+            REQUIRE(empty_rc.getDimensionality() == 1);
+            REQUIRE(empty_rc.getExtent() == Extent{0});
+            REQUIRE(isSame(empty_rc.getDatatype(), determineDatatype< double >()));
+        }
+    } catch (no_such_file_error& e)
+    {
+        std::cerr << "issue sample not accessible. (" << e.what() << ")\n";
+    }
+}
+
 TEST_CASE( "available_chunks_test_hdf5", "[serial][json]" )
 {
     /*


### PR DESCRIPTION
FBPIC writes solely to HDF5 and chooses to write a variable with zero 1D extent for zero particles. Let's test this case.
(ref.: https://github.com/openPMD/openPMD-viewer/issues/296)

Note: we cannot create such a file with the API on the fly, and don't need to, since we use the more portable "constant record component for empty" approach that works with all file formats. So I am just adding another sample file to our tests from the above linked issue.

Note2: Printing the file with `h5dump` and `h5ls` looks good, but I noticed the FBPIC style causes issues with `h5repack`. 