### PR TITLE
Variable-Based iteration layout

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -32,6 +32,7 @@
 #include "openPMD/auxiliary/Option.hpp"
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/config.hpp"
+#include "openPMD/IterationEncoding.hpp"
 
 #if openPMD_HAVE_ADIOS2
 #    include <adios2.h>
@@ -224,6 +225,7 @@ public:
 
 private:
     adios2::ADIOS m_ADIOS;
+    IterationEncoding m_iterationEncoding = IterationEncoding::groupBased;
     /**
      * The ADIOS2 engine type, to be passed to adios2::IO::SetEngine
      */
@@ -1367,7 +1369,7 @@ class ADIOS2IOHandler : public AbstractIOHandler
 {
 #if openPMD_HAVE_ADIOS2
 
-friend class ADIOS2IOHandlerImpl;
+    friend class ADIOS2IOHandlerImpl;
 
 private:
     ADIOS2IOHandlerImpl m_impl;
@@ -1386,7 +1388,7 @@ public:
         }
         catch( ... )
         {
-            std::cerr << "[~ADIOS2IOHandler] An error occurred." << std::endl;
+             std::cerr << "[~ADIOS2IOHandler] An error occurred." << std::endl;
         }
     }
 

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -225,6 +225,10 @@ public:
 
 private:
     adios2::ADIOS m_ADIOS;
+    /*
+     * If the iteration encoding is variableBased, we default to using the
+     * 2021_02_09 schema since it allows mutable attributes.
+     */
     IterationEncoding m_iterationEncoding = IterationEncoding::groupBased;
     /**
      * The ADIOS2 engine type, to be passed to adios2::IO::SetEngine
@@ -1369,7 +1373,7 @@ class ADIOS2IOHandler : public AbstractIOHandler
 {
 #if openPMD_HAVE_ADIOS2
 
-    friend class ADIOS2IOHandlerImpl;
+friend class ADIOS2IOHandlerImpl;
 
 private:
     ADIOS2IOHandlerImpl m_impl;

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -241,6 +241,7 @@ public:
    *
    * The operation should overwrite existing file positions, even when the Writable was already marked written.
    * The path parameters.path may contain multiple levels (e.g. first/second/third/). This path should be relative (i.e. it should not start with a slash "/").
+   * The number of levels may be zero, i.e. parameters.path may be an empty string.
    * The Writables file position should correspond to the complete opened path (i.e. first/second/third/ should be assigned to the Writables file position).
    * The Writable should be marked written when the operation completes successfully.
    */

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -25,6 +25,7 @@
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/ChunkInfo.hpp"
 #include "openPMD/Dataset.hpp"
+#include "openPMD/IterationEncoding.hpp"
 
 #include <memory>
 #include <map>
@@ -108,7 +109,8 @@ template<>
 struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_FILE > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {}
+    Parameter(Parameter const & p) :
+        AbstractParameter(), name(p.name), encoding(p.encoding) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -118,13 +120,15 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_FILE > : public AbstractPa
     }
 
     std::string name = "";
+    IterationEncoding encoding = IterationEncoding::groupBased;
 };
 
 template<>
 struct OPENPMDAPI_EXPORT Parameter< Operation::OPEN_FILE > : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const & p) : AbstractParameter(), name(p.name) {}
+    Parameter(Parameter const & p) :
+        AbstractParameter(), name(p.name), encoding(p.encoding) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -134,6 +138,7 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::OPEN_FILE > : public AbstractPara
     }
 
     std::string name = "";
+    IterationEncoding encoding = IterationEncoding::groupBased;
 };
 
 template<>

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -138,6 +138,11 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::OPEN_FILE > : public AbstractPara
     }
 
     std::string name = "";
+    /*
+     * The backends might need to ensure availability of certain features
+     * for some iteration encodings, e.g. availability of ADIOS steps for
+     * variableBased encoding.
+     */
     IterationEncoding encoding = IterationEncoding::groupBased;
 };
 

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -181,7 +181,7 @@ private:
      * logic for an iteration.
      *
      */
-    void read();
+    void read( std::string path, bool reread = false );
     void readFileBased( std::string filePath, std::string const & groupPath );
     void readGroupBased( std::string const & groupPath );
     void read_impl( std::string const & groupPath );

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -156,9 +156,25 @@ private:
 
     struct DeferredParseAccess
     {
+        /**
+         * The group path within /data containing this iteration.
+         * Example: "1" for iteration 1, "" in variable-based iteration
+         * encoding.
+         */
         std::string path;
+        /**
+         * The iteration index as accessed by the user in series.iterations[i]
+         */
         uint64_t iteration = 0;
+        /**
+         * If this iteration is part of a Series with file-based layout.
+         * (Group- and variable-based parsing shares the same code logic.)
+         */
         bool fileBased = false;
+        /**
+         * If fileBased == true, the file name (without file path) of the file
+         * containing this iteration.
+         */
         std::string filename;
     };
 
@@ -179,11 +195,15 @@ private:
      * allow for those different control flows.
      * Finally, read_impl() is called which contains the common parsing
      * logic for an iteration.
+     * 
+     * reread() reads again an Iteration that has been previously read.
+     * Calling it on an Iteration not yet parsed is an error.
      *
      */
-    void read( std::string path, bool reread = false );
+    void read();
+    void reread( std::string const & path );
     void readFileBased( std::string filePath, std::string const & groupPath );
-    void readGroupBased( std::string const & groupPath );
+    void readGorVBased( std::string const & groupPath );
     void read_impl( std::string const & groupPath );
 
     /**

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -156,13 +156,15 @@ private:
 
     struct DeferredParseAccess
     {
-        std::string index;
+        std::string path;
+        uint64_t iteration = 0;
         bool fileBased = false;
         std::string filename;
     };
 
     void flushFileBased(std::string const&, uint64_t);
     void flushGroupBased(uint64_t);
+    void flushVariableBased(uint64_t);
     void flush();
     void deferParseAccess( DeferredParseAccess );
     /*

--- a/include/openPMD/IterationEncoding.hpp
+++ b/include/openPMD/IterationEncoding.hpp
@@ -31,7 +31,7 @@ namespace openPMD
  */
 enum class IterationEncoding
 {
-    fileBased, groupBased
+    fileBased, groupBased, variableBased
 };
 
 std::ostream&

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -286,18 +286,17 @@ private:
     bool dirtyRecursive() const;
 
 protected:
-    /**
-     * Make sure to parse a RecordComponent only once.
-     */
-    std::shared_ptr< bool > hasBeenRead = std::make_shared< bool >( false );
+
     /**
      * The same std::string that the parent class would pass as parameter to
      * RecordComponent::flush().
      * This is stored only upon RecordComponent::flush() if
      * AbstractIOHandler::flushLevel is set to FlushLevel::SkeletonOnly
      * (for use by the Span<T>-based overload of RecordComponent::storeChunk()).
+     * @todo Merge functionality with ownKeyInParent?
      */
     std::shared_ptr< std::string > m_name = std::make_shared< std::string >();
+
 }; // RecordComponent
 } // namespace openPMD
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -260,6 +260,9 @@ public:
      */
     IterationEncoding iterationEncoding() const;
     /** Set the <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series">encoding style</A> for multiple iterations in this series.
+     * A preview on the <A HREF="https://github.com/openPMD/openPMD-standard/pull/250">openPMD 2.0 variable-based iteration encoding</A> can be activated with this call.
+     * Making full use of the variable-based iteration encoding requires (1) explicit support by the backend (available only in ADIOS2) and (2) use of the openPMD streaming API.
+     * In other backends and without the streaming API, only one iteration/snapshot may be written in the variable-based encoding, making this encoding a good choice for single-snapshot data dumps.
      *
      * @param   iterationEncoding   Desired <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series">encoding style</A> for multiple iterations in this series.
      * @return  Reference to modified series.

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -342,13 +342,20 @@ OPENPMD_private:
 
     std::unique_ptr< ParsedInput > parseInput(std::string);
     void init(std::shared_ptr< AbstractIOHandler >, std::unique_ptr< ParsedInput >);
-    void initDefaults();
+    void initDefaults( IterationEncoding );
     std::future< void > flush_impl(
         iterations_iterator begin,
         iterations_iterator end,
         FlushLevel );
     void flushFileBased( iterations_iterator begin, iterations_iterator end );
-    void flushGroupBased( iterations_iterator begin, iterations_iterator end );
+    /*
+     * Group-based and variable-based iteration layouts share a lot of logic
+     * (realistically, the variable-based iteration layout only throws out
+     *  one layer in the hierarchy).
+     * As a convention, methods that deal with both layouts are called
+     * .*GorVBased, short for .*GroupOrVariableBased
+     */
+    void flushGorVBased( iterations_iterator begin, iterations_iterator end );
     void flushMeshesPath();
     void flushParticlesPath();
     void readFileBased( );
@@ -361,7 +368,7 @@ OPENPMD_private:
      * as of yet. Such a facility will be required upon implementing things such
      * as resizable datasets.
      */
-    void readGroupBased( bool init = true );
+    void readGorVBased( bool init = true );
     void readBase();
     std::string iterationFilename( uint64_t i );
     void openIteration( uint64_t index, Iteration iteration );

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -364,9 +364,6 @@ OPENPMD_private:
      * Note on re-parsing of a Series:
      * If init == false, the parsing process will seek for new
      * Iterations/Records/Record Components etc.
-     * Re-parsing of objects that have already been parsed is not implemented
-     * as of yet. Such a facility will be required upon implementing things such
-     * as resizable datasets.
      */
     void readGorVBased( bool init = true );
     void readBase();

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -215,7 +215,7 @@ OPENPMD_protected:
     std::vector< std::string > myPath() const;
 
     void flushAttributes();
-    void readAttributes();
+    void readAttributes( bool reread = false );
 
     /** Retrieve the value of a floating point Attribute of user-defined precision with ensured type-safety.
      *

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -215,7 +215,24 @@ OPENPMD_protected:
     std::vector< std::string > myPath() const;
 
     void flushAttributes();
-    void readAttributes( bool reread = false );
+    enum ReadMode {
+        /**
+         * Don't read an attribute from the backend if it has been previously
+         * read.
+         */
+        IgnoreExisting,
+        /**
+         * Read all the attributes that the backend has to offer and override
+         * if it has been read previously.
+         */
+        OverrideExisting,
+        /**
+         * Remove all attributes that have been read previously and read
+         * everything that the backend currently has to offer.
+         */
+        FullyReread
+    };
+    void readAttributes( ReadMode );
 
     /** Retrieve the value of a floating point Attribute of user-defined precision with ensured type-safety.
      *

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -326,6 +326,14 @@ OPENPMD_protected:
 
     std::shared_ptr< InternalContainer > m_container;
 
+    /**
+     * This class wraps a Container and forwards operator[]() and at() to it.
+     * It remembers the keys used for accessing. Upon going out of scope, all
+     * keys not yet accessed are removed from the Container.
+     * Note that the container is stored by non-owning reference, thus
+     * requiring that the original Container stay in scope while using this
+     * class.
+     */
     class EraseStaleEntries
     {
         std::set< key_type > m_accessedKeys;

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -23,10 +23,12 @@
 #include "openPMD/backend/Attributable.hpp"
 
 #include <initializer_list>
-#include <type_traits>
-#include <stdexcept>
 #include <map>
+#include <set>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 // expose private and protected members for invasive testing
 #ifndef OPENPMD_protected
@@ -106,13 +108,15 @@ class Container : public LegacyAttributable
     static_assert(
         std::is_base_of< AttributableImpl, T >::value,
         "Type of container element must be derived from Writable");
-    using InternalContainer = T_container;
 
     friend class Iteration;
     friend class ParticleSpecies;
     friend class internal::SeriesData;
     friend class SeriesImpl;
     friend class Series;
+
+protected:
+    using InternalContainer = T_container;
 
 public:
     using key_type = typename InternalContainer::key_type;
@@ -321,6 +325,64 @@ OPENPMD_protected:
     }
 
     std::shared_ptr< InternalContainer > m_container;
+
+    class EraseStaleEntries
+    {
+        std::set< key_type > m_accessedKeys;
+        /*
+         * Note: Putting a copy here leads to weird bugs due to destructors
+         * being called too eagerly upon destruction.
+         * Should be avoidable by extending the frontend redesign to the
+         * Container class template
+         * (https://github.com/openPMD/openPMD-api/pull/886)
+         */
+        Container & m_originalContainer;
+
+    public:
+        explicit EraseStaleEntries( Container & container_in )
+            : m_originalContainer( container_in )
+        {
+        }
+
+        template< typename K >
+        mapped_type & operator[]( K && k )
+        {
+            m_accessedKeys.insert( k ); // copy
+            return m_originalContainer[ std::forward< K >( k ) ];
+        }
+
+        template< typename K >
+        mapped_type & at( K && k )
+        {
+            m_accessedKeys.insert( k ); // copy
+            return m_originalContainer.at( std::forward< K >( k ) );
+        }
+
+        ~EraseStaleEntries()
+        {
+            auto & map = *m_originalContainer.m_container;
+            using iterator_t = typename InternalContainer::const_iterator;
+            std::vector< iterator_t > deleteMe;
+            deleteMe.reserve( map.size() - m_accessedKeys.size() );
+            for( iterator_t it = map.begin(); it != map.end(); ++it )
+            {
+                auto lookup = m_accessedKeys.find( it->first );
+                if( lookup == m_accessedKeys.end() )
+                {
+                    deleteMe.push_back( it );
+                }
+            }
+            for( auto & it : deleteMe )
+            {
+                map.erase( it );
+            }
+        }
+    };
+
+    EraseStaleEntries eraseStaleEntries()
+    {
+        return EraseStaleEntries( *this );
+    }
 };
 
 } // openPMD

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -75,7 +75,6 @@ OPENPMD_private:
     void read();
 
     std::shared_ptr< std::queue< IOTask > > m_chunks;
-    std::shared_ptr< bool > hasBeenRead = std::make_shared< bool >( false );
 
     /**
      * @brief Check recursively whether this RecordComponent is dirty.

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -95,6 +95,9 @@ ADIOS1IOHandlerImpl::flush()
                 case O::CREATE_PATH:
                     createPath(i.writable, deref_dynamic_cast< Parameter< O::CREATE_PATH > >(i.parameter.get()));
                     break;
+                case O::OPEN_PATH:
+                    openPath(i.writable, deref_dynamic_cast< Parameter< O::OPEN_PATH > >(i.parameter.get()));
+                    break;
                 case O::CREATE_DATASET:
                     createDataset(i.writable, deref_dynamic_cast< Parameter< O::CREATE_DATASET > >(i.parameter.get()));
                     break;
@@ -128,9 +131,6 @@ ADIOS1IOHandlerImpl::flush()
                 using O = Operation;
                 case O::EXTEND_DATASET:
                     extendDataset(i.writable, deref_dynamic_cast< Parameter< O::EXTEND_DATASET > >(i.parameter.get()));
-                    break;
-                case O::OPEN_PATH:
-                    openPath(i.writable, deref_dynamic_cast< Parameter< O::OPEN_PATH > >(i.parameter.get()));
                     break;
                 case O::CLOSE_PATH:
                     closePath(i.writable, deref_dynamic_cast< Parameter< O::CLOSE_PATH > >(i.parameter.get()));
@@ -243,6 +243,7 @@ ADIOS1IOHandler::enqueue(IOTask const& i)
     {
         case Operation::CREATE_FILE:
         case Operation::CREATE_PATH:
+        case Operation::OPEN_PATH:
         case Operation::CREATE_DATASET:
         case Operation::OPEN_FILE:
         case Operation::WRITE_ATT:

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -677,10 +677,13 @@ CommonADIOS1IOHandlerImpl::openPath(
 {
     /* Sanitize path */
     std::string path = parameters.path;
-    if( auxiliary::starts_with(path, '/') )
-        path = auxiliary::replace_first(path, "/", "");
-    if( !auxiliary::ends_with(path, '/') )
-        path += '/';
+    if( !path.empty() )
+    {
+        if( auxiliary::starts_with(path, '/') )
+            path = auxiliary::replace_first(path, "/", "");
+        if( !auxiliary::ends_with(path, '/') )
+            path += '/';
+    }
 
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< ADIOS1FilePosition >(path);

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -119,6 +119,9 @@ ParallelADIOS1IOHandlerImpl::flush()
                 case O::CREATE_PATH:
                     createPath(i.writable, deref_dynamic_cast< Parameter< O::CREATE_PATH > >(i.parameter.get()));
                     break;
+                case O::OPEN_PATH:
+                    openPath(i.writable, deref_dynamic_cast< Parameter< O::OPEN_PATH > >(i.parameter.get()));
+                    break;
                 case O::CREATE_DATASET:
                     createDataset(i.writable, deref_dynamic_cast< Parameter< O::CREATE_DATASET > >(i.parameter.get()));
                     break;
@@ -150,9 +153,6 @@ ParallelADIOS1IOHandlerImpl::flush()
                 using O = Operation;
                 case O::EXTEND_DATASET:
                     extendDataset(i.writable, deref_dynamic_cast< Parameter< O::EXTEND_DATASET > >(i.parameter.get()));
-                    break;
-                case O::OPEN_PATH:
-                    openPath(i.writable, deref_dynamic_cast< Parameter< O::OPEN_PATH > >(i.parameter.get()));
                     break;
                 case O::CLOSE_PATH:
                     closePath(i.writable, deref_dynamic_cast< Parameter< O::CLOSE_PATH > >(i.parameter.get()));
@@ -265,6 +265,7 @@ ParallelADIOS1IOHandler::enqueue(IOTask const& i)
     {
         case Operation::CREATE_FILE:
         case Operation::CREATE_PATH:
+        case Operation::OPEN_PATH:
         case Operation::CREATE_DATASET:
         case Operation::OPEN_FILE:
         case Operation::WRITE_ATT:

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -528,19 +528,23 @@ HDF5IOHandlerImpl::openPath(
 
     /* Sanitize path */
     std::string path = parameters.path;
-    if( auxiliary::starts_with(path, '/') )
-        path = auxiliary::replace_first(path, "/", "");
-    if( !auxiliary::ends_with(path, '/') )
-        path += '/';
+    if( !path.empty() )
+    {
+        if( auxiliary::starts_with(path, '/') )
+            path = auxiliary::replace_first(path, "/", "");
+        if( !auxiliary::ends_with(path, '/') )
+            path += '/';
+        path_id = H5Gopen(node_id,
+                        path.c_str(),
+                        H5P_DEFAULT);
+        VERIFY(path_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path opening");
 
-    path_id = H5Gopen(node_id,
-                      path.c_str(),
-                      H5P_DEFAULT);
-    VERIFY(path_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during path opening");
+        herr_t status;
+        status = H5Gclose(path_id);
+        VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during path opening");
+    }
 
     herr_t status;
-    status = H5Gclose(path_id);
-    VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during path opening");
     status = H5Gclose(node_id);
     VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group during path opening");
 

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -445,7 +445,7 @@ void Iteration::read_impl( std::string const & groupPath )
         pOpen.path = s->meshesPath();
         IOHandler()->enqueue(IOTask(&meshes, pOpen));
 
-        meshes.readAttributes();
+        meshes.readAttributes( ReadMode::FullyReread );
 
         auto map = meshes.eraseStaleEntries();
 
@@ -510,7 +510,7 @@ void Iteration::read_impl( std::string const & groupPath )
         pOpen.path = s->particlesPath();
         IOHandler()->enqueue(IOTask(&particles, pOpen));
 
-        particles.readAttributes();
+        particles.readAttributes( ReadMode::FullyReread );
 
         /* obtain all particle species */
         pList.paths->clear();
@@ -532,7 +532,7 @@ void Iteration::read_impl( std::string const & groupPath )
         particles.dirty() = false;
     }
 
-    readAttributes();
+    readAttributes( ReadMode::FullyReread );
 }
 
 AdvanceStatus

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -334,13 +334,8 @@ void Iteration::deferParseAccess( DeferredParseAccess dr )
         auxiliary::makeOption< DeferredParseAccess >( std::move( dr ) );
 }
 
-void Iteration::read( std::string path, bool reread )
+void Iteration::read()
 {
-    if( reread )
-    {
-        read_impl( path );
-        return;
-    }
     if( !m_deferredParseAccess->has_value() )
     {
         return;
@@ -352,10 +347,21 @@ void Iteration::read( std::string path, bool reread )
     }
     else
     {
-        readGroupBased( deferred.path );
+        readGorVBased( deferred.path );
     }
     // reset this thing
     *m_deferredParseAccess = auxiliary::Option< DeferredParseAccess >();
+}
+
+void Iteration::reread( std::string const & path )
+{
+    if( m_deferredParseAccess->has_value() )
+    {
+        throw std::runtime_error(
+            "[Iteration] Internal control flow error: Trying to reread an "
+            "iteration that has not yet been read for its first time." );
+    }
+    read_impl( path );
 }
 
 void Iteration::readFileBased(
@@ -368,7 +374,7 @@ void Iteration::readFileBased(
     read_impl( groupPath );
 }
 
-void Iteration::readGroupBased( std::string const & groupPath )
+void Iteration::readGorVBased( std::string const & groupPath )
 {
 
     read_impl(groupPath );
@@ -687,7 +693,7 @@ void Iteration::runDeferredParseAccess()
     *newAccess = Access::READ_WRITE;
     try
     {
-        read( "", false );
+        read();
     }
     catch( ... )
     {

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -334,8 +334,13 @@ void Iteration::deferParseAccess( DeferredParseAccess dr )
         auxiliary::makeOption< DeferredParseAccess >( std::move( dr ) );
 }
 
-void Iteration::read()
+void Iteration::read( std::string path, bool reread )
 {
+    if( reread )
+    {
+        read_impl( path );
+        return;
+    }
     if( !m_deferredParseAccess->has_value() )
     {
         return;
@@ -679,7 +684,7 @@ void Iteration::runDeferredParseAccess()
     *newAccess = Access::READ_WRITE;
     try
     {
-        read();
+        read( "", false );
     }
     catch( ... )
     {

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -447,6 +447,8 @@ void Iteration::read_impl( std::string const & groupPath )
 
         meshes.readAttributes();
 
+        auto map = meshes.eraseStaleEntries();
+
         /* obtain all non-scalar meshes */
         IOHandler()->enqueue(IOTask(&meshes, pList));
         IOHandler()->flush();
@@ -454,7 +456,7 @@ void Iteration::read_impl( std::string const & groupPath )
         Parameter< Operation::LIST_ATTS > aList;
         for( auto const& mesh_name : *pList.paths )
         {
-            Mesh& m = meshes[mesh_name];
+            Mesh& m = map[mesh_name];
             pOpen.path = mesh_name;
             aList.attributes->clear();
             IOHandler()->enqueue(IOTask(&m, pOpen));
@@ -484,7 +486,7 @@ void Iteration::read_impl( std::string const & groupPath )
         Parameter< Operation::OPEN_DATASET > dOpen;
         for( auto const& mesh_name : *dList.datasets )
         {
-            Mesh& m = meshes[mesh_name];
+            Mesh& m = map[mesh_name];
             dOpen.name = mesh_name;
             IOHandler()->enqueue(IOTask(&m, dOpen));
             IOHandler()->flush();
@@ -515,9 +517,10 @@ void Iteration::read_impl( std::string const & groupPath )
         IOHandler()->enqueue(IOTask(&particles, pList));
         IOHandler()->flush();
 
+        auto map = particles.eraseStaleEntries();
         for( auto const& species_name : *pList.paths )
         {
-            ParticleSpecies& p = particles[species_name];
+            ParticleSpecies& p = map[species_name];
             pOpen.path = species_name;
             IOHandler()->enqueue(IOTask(&p, pOpen));
             IOHandler()->flush();

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -271,7 +271,7 @@ Iteration::flushVariableBased( uint64_t i )
         Parameter< Operation::OPEN_PATH > pOpen;
         pOpen.path = "";
         IOHandler()->enqueue( IOTask( this, pOpen ) );
-        this->setAttribute( "__step__", i );
+        this->setAttribute( "snapshot", i );
     }
 
     flush();

--- a/src/IterationEncoding.cpp
+++ b/src/IterationEncoding.cpp
@@ -34,6 +34,9 @@ openPMD::operator<<(std::ostream& os, openPMD::IterationEncoding const& ie)
         case openPMD::IterationEncoding::groupBased:
             os << "groupBased";
             break;
+        case openPMD::IterationEncoding::variableBased:
+            os << "variableBased";
+            break;
     }
     return os;
 }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -343,11 +343,6 @@ Mesh::read()
         for( auto const& component : *pList.paths )
         {
             MeshRecordComponent& rc = (*this)[component];
-            if ( *rc.hasBeenRead )
-            {
-                dirty() = false;
-                continue;
-            }
             pOpen.path = component;
             IOHandler()->enqueue(IOTask(&rc, pOpen));
             *rc.m_isConstant = true;
@@ -362,11 +357,6 @@ Mesh::read()
         for( auto const& component : *dList.datasets )
         {
             MeshRecordComponent & rc = ( *this )[ component ];
-            if( *rc.hasBeenRead )
-            {
-                dirty() = false;
-                continue;
-            }
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush();

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -379,7 +379,7 @@ Mesh::read()
 
     readBase();
 
-    readAttributes();
+    readAttributes( ReadMode::FullyReread );
 }
 } // openPMD
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -247,14 +247,6 @@ Mesh::flush_impl(std::string const& name)
 void
 Mesh::read()
 {
-    /*
-     * @todo This is a proof-of-concept on how we need to rework our re-parsing
-     * procedures. Goals when parsing an iteration again:
-     * 1. Old handles must survive
-     * 2. Map entries that cannot be found any more must perish.
-     * @todo This approach will kill references that users may have to mapped
-     * components, so improve that.
-     */
     auto map = eraseStaleEntries();
 
     using DT = Datatype;

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -123,7 +123,7 @@ ParticleSpecies::read()
         }
     }
 
-    readAttributes();
+    readAttributes( ReadMode::FullyReread );
 }
 
 namespace

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -42,6 +42,8 @@ ParticleSpecies::read()
     IOHandler()->enqueue(IOTask(this, pList));
     IOHandler()->flush();
 
+    auto map = eraseStaleEntries();
+
     Parameter< Operation::OPEN_PATH > pOpen;
     Parameter< Operation::LIST_ATTS > aList;
     bool hasParticlePatches = false;
@@ -55,7 +57,7 @@ ParticleSpecies::read()
             particlePatches.read();
         } else
         {
-            Record& r = (*this)[record_name];
+            Record& r = map[record_name];
             pOpen.path = record_name;
             aList.attributes->clear();
             IOHandler()->enqueue(IOTask(&r, pOpen));
@@ -68,7 +70,8 @@ ParticleSpecies::read()
             auto shape = std::find(att_begin, att_end, "shape");
             if( value != att_end && shape != att_end )
             {
-                RecordComponent& rc = r[RecordComponent::SCALAR];
+                auto scalarMap = r.eraseStaleEntries();
+                RecordComponent& rc = scalarMap[RecordComponent::SCALAR];
                 rc.parent() = r.parent();
                 IOHandler()->enqueue(IOTask(&rc, pOpen));
                 IOHandler()->flush();
@@ -94,11 +97,12 @@ ParticleSpecies::read()
     for( auto const& record_name : *dList.datasets )
     {
         try {
-            Record& r = (*this)[record_name];
+            Record& r = map[record_name];
             dOpen.name = record_name;
             IOHandler()->enqueue(IOTask(&r, dOpen));
             IOHandler()->flush();
-            RecordComponent& rc = r[RecordComponent::SCALAR];
+            auto scalarMap = r.eraseStaleEntries();
+            RecordComponent& rc = scalarMap[RecordComponent::SCALAR];
             rc.parent() = r.parent();
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush();

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -68,7 +68,8 @@ SeriesIterator::SeriesIterator( Series series )
             openIteration();
             status = it->second.beginStep();
             break;
-        default:
+        case IterationEncoding::groupBased:
+        case IterationEncoding::variableBased:
             /*
              * In group-based iteration layout, we have definitely already had
              * access to the file until now. Better to begin a step right away,
@@ -105,7 +106,8 @@ SeriesIterator & SeriesIterator::operator++()
     switch( series.iterationEncoding() )
     {
         using IE = IterationEncoding;
-    case IE::groupBased: {
+    case IE::groupBased:
+    case IE::variableBased: {
         // since we are in group-based iteration layout, it does not
         // matter which iteration we begin a step upon
         AdvanceStatus status = currentIteration.beginStep();

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -110,11 +110,6 @@ Record::read()
         for( auto const& component : *pList.paths )
         {
             RecordComponent& rc = (*this)[component];
-            if ( *rc.hasBeenRead )
-            {
-                dirty() = false;
-                continue;
-            }
             pOpen.path = component;
             IOHandler()->enqueue(IOTask(&rc, pOpen));
             *rc.m_isConstant = true;
@@ -129,10 +124,6 @@ Record::read()
         for( auto const& component : *dList.datasets )
         {
             RecordComponent & rc = ( *this )[ component ];
-            if( *rc.hasBeenRead )
-            {
-                continue;
-            }
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush();

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -136,7 +136,7 @@ Record::read()
 
     readBase();
 
-    readAttributes();
+    readAttributes( ReadMode::FullyReread );
 }
 
 template <>

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -370,7 +370,7 @@ RecordComponent::readBase()
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 
-    readAttributes();
+    readAttributes( ReadMode::FullyReread );
 }
 
 bool

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -33,7 +33,8 @@
 
 namespace openPMD
 {
-// we must instantiate this somewhere even if it is constexpr
+// We need to instantiate this somewhere otherwise there might be linker issues
+// despite this thing actually being constepxr
 constexpr char const * const RecordComponent::SCALAR;
 
 RecordComponent::RecordComponent()

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -256,13 +256,7 @@ RecordComponent::flush(std::string const& name)
 void
 RecordComponent::read()
 {
-    if ( *hasBeenRead )
-    {
-        dirty() = false;
-        return;
-    }
     readBase();
-    *hasBeenRead = true;
 }
 
 void

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -948,8 +948,8 @@ void SeriesImpl::readOneIterationFileBased( std::string const & filePath )
         throw std::runtime_error("Unknown openPMD version - " + version);
     IOHandler()->enqueue(IOTask(&series.iterations, pOpen));
 
-    readAttributes();
-    series.iterations.readAttributes();
+    readAttributes( ReadMode::IgnoreExisting );
+    series.iterations.readAttributes(ReadMode::OverrideExisting );
 }
 
 void
@@ -1017,11 +1017,11 @@ SeriesImpl::readGorVBased( bool do_init )
         throw std::runtime_error("Unknown openPMD version - " + version);
     IOHandler()->enqueue(IOTask(&series.iterations, pOpen));
 
-    readAttributes();
+    readAttributes( ReadMode::IgnoreExisting );
     /*
      * __step__ changes over steps, so reread that.
      */
-    series.iterations.readAttributes( /* reread = */ true );
+    series.iterations.readAttributes( ReadMode::OverrideExisting );
     /* obtain all paths inside the basepath (i.e. all iterations) */
     Parameter< Operation::LIST_PATHS > pList;
     IOHandler()->enqueue(IOTask(&series.iterations, pList));

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -389,25 +389,11 @@ SeriesImpl::parseInput(std::string filepath)
 
     input->format = determineFormat(input->name);
 
-    // first, check for file-based iteration layout
     std::regex pattern("(.*)%(0[[:digit:]]+)?T(.*)");
     std::smatch regexMatch;
     std::regex_match(input->name, regexMatch, pattern);
     if( regexMatch.empty() )
-    {
-        // now check for variable-based iteration layout
-        pattern = "(.*)%V(\\.[^.]+)";
-        std::regex_match( input->name, regexMatch, pattern );
-        if( regexMatch.empty() )
-        {
-            input->iterationEncoding = IterationEncoding::groupBased;
-        }
-        else
-        {
-            input->iterationEncoding = IterationEncoding::variableBased;
-            input->name = regexMatch[1].str() + regexMatch[2].str();
-        }
-    }
+        input->iterationEncoding = IterationEncoding::groupBased;
     else if( regexMatch.size() == 4 )
     {
         input->iterationEncoding = IterationEncoding::fileBased;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -910,12 +910,15 @@ void SeriesImpl::readOneIterationFileBased( std::string const & filePath )
         }
         else if( encoding == "variableBased" )
         {
-            // @todo should we throw? test this path
-            series.m_iterationEncoding = IterationEncoding::variableBased;
-            std::cerr << "Series constructor called with iteration "
-                            "regex '%T' suggests loading a "
-                        << "time series with fileBased iteration "
-                            "encoding. Loaded file is variableBased.\n";
+            /*
+             * Unlike if the file were group-based, this one doesn't work
+             * at all since the group paths are different.
+             */
+            throw std::runtime_error(
+                "Series constructor called with iteration "
+                "regex '%T' suggests loading a "
+                "time series with fileBased iteration "
+                "encoding. Loaded file is variableBased." );
         }
         else
             throw std::runtime_error(
@@ -1043,7 +1046,7 @@ SeriesImpl::readGorVBased( bool do_init )
             {
                 pOpen.path = path;
                 IOHandler()->enqueue( IOTask( &i, pOpen ) );
-                i.read( path, /* reread = */ true );
+                i.reread( path );
             }
         }
         else

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1043,13 +1043,13 @@ SeriesImpl::readGorVBased( bool do_init )
 
     auto readSingleIteration =
         [&series, &pOpen, this]
-        (uint64_t index, std::string path)
+        (uint64_t index, std::string path, bool guardClosed )
     {
         if( series.iterations.contains( index ) )
         {
             // maybe re-read
             auto & i = series.iterations.at( index );
-            if( i.closedByWriter() )
+            if( guardClosed && i.closedByWriter() )
             {
                 return;
             }
@@ -1057,7 +1057,7 @@ SeriesImpl::readGorVBased( bool do_init )
             {
                 pOpen.path = path;
                 IOHandler()->enqueue( IOTask( &i, pOpen ) );
-                i.read();
+                i.read( path, /* reread = */ true );
             }
         }
         else
@@ -1087,7 +1087,7 @@ SeriesImpl::readGorVBased( bool do_init )
         for( auto const & it : *pList.paths )
         {
             uint64_t index = std::stoull( it );
-            readSingleIteration( index, it );
+            readSingleIteration( index, it, true );
         }
         break;
     case IterationEncoding::variableBased:
@@ -1099,7 +1099,7 @@ SeriesImpl::readGorVBased( bool do_init )
                 .getAttribute( "__step__" )
                 .get< uint64_t >();
         }
-        readSingleIteration( index, "" );
+        readSingleIteration( index, "", false );
         break;
     }
     }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1019,7 +1019,7 @@ SeriesImpl::readGorVBased( bool do_init )
 
     readAttributes( ReadMode::IgnoreExisting );
     /*
-     * __step__ changes over steps, so reread that.
+     * 'snapshot' changes over steps, so reread that.
      */
     series.iterations.readAttributes( ReadMode::OverrideExisting );
     /* obtain all paths inside the basepath (i.e. all iterations) */
@@ -1079,10 +1079,10 @@ SeriesImpl::readGorVBased( bool do_init )
     case IterationEncoding::variableBased:
     {
         uint64_t index = 0;
-        if( series.iterations.containsAttribute( "__step__" ) )
+        if( series.iterations.containsAttribute( "snapshot" ) )
         {
             index = series.iterations
-                .getAttribute( "__step__" )
+                .getAttribute( "snapshot" )
                 .get< uint64_t >();
         }
         readSingleIteration( index, "", false );

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -186,21 +186,31 @@ AttributableImpl::flushAttributes()
 }
 
 void
-AttributableImpl::readAttributes()
+AttributableImpl::readAttributes( bool reread )
 {
     Parameter< Operation::LIST_ATTS > aList;
     IOHandler()->enqueue(IOTask(this, aList));
     IOHandler()->flush();
     std::vector< std::string > written_attributes = attributes();
 
-    /* std::set_difference requires sorted ranges */
-    std::sort(aList.attributes->begin(), aList.attributes->end());
-    std::sort(written_attributes.begin(), written_attributes.end());
-
     std::set< std::string > tmpAttributes;
-    std::set_difference(aList.attributes->begin(), aList.attributes->end(),
-                        written_attributes.begin(), written_attributes.end(),
-                        std::inserter(tmpAttributes, tmpAttributes.begin()));
+    if( reread )
+    {
+        tmpAttributes = std::set< std::string >(
+            aList.attributes->begin(),
+            aList.attributes->end() );
+    }
+    else
+    {
+        /* std::set_difference requires sorted ranges */
+        std::sort(aList.attributes->begin(), aList.attributes->end());
+        std::sort(written_attributes.begin(), written_attributes.end());
+
+        std::set_difference(
+            aList.attributes->begin(), aList.attributes->end(),
+            written_attributes.begin(), written_attributes.end(),
+            std::inserter(tmpAttributes, tmpAttributes.begin()));
+    }
 
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -241,6 +241,29 @@ AttributableImpl::readAttributes( ReadMode mode )
             continue;
         }
         Attribute a(*aRead.resource);
+
+        auto guardUnitDimension =
+            [ this ]( std::string const & key, auto vector )
+        {
+            if( key == "unitDimension" )
+            {
+                // Some backends may report the wrong type when reading
+                if( vector.size() != 7 )
+                {
+                    throw std::runtime_error(
+                        "[Attributable] "
+                        "Unexpected datatype for unitDimension." );
+                }
+                std::array< double, 7 > arr;
+                std::copy_n( vector.begin(), 7, arr.begin() );
+                setAttribute( key, std::move( arr ) );
+            }
+            else
+            {
+                setAttribute( key, std::move( vector ) );
+            }
+        };
+
         switch( *aRead.dtype )
         {
             case DT::CHAR:
@@ -325,13 +348,13 @@ AttributableImpl::readAttributes( ReadMode mode )
                 setAttribute(att, a.get< std::vector< unsigned long long > >());
                 break;
             case DT::VEC_FLOAT:
-                setAttribute(att, a.get< std::vector< float > >());
+                guardUnitDimension( att, a.get< std::vector< float > >() );
                 break;
             case DT::VEC_DOUBLE:
-                setAttribute(att, a.get< std::vector< double > >());
+                guardUnitDimension( att, a.get< std::vector< double > >() );
                 break;
             case DT::VEC_LONG_DOUBLE:
-                setAttribute(att, a.get< std::vector< long double > >());
+                guardUnitDimension( att, a.get< std::vector< long double > >() );
                 break;
             case DT::VEC_CFLOAT:
                 setAttribute(att, a.get< std::vector< std::complex< float > > >());

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -32,11 +32,6 @@ MeshRecordComponent::MeshRecordComponent()
 void
 MeshRecordComponent::read()
 {
-    if ( *hasBeenRead )
-    {
-        dirty() = false;
-        return;
-    }
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;
 
@@ -60,7 +55,6 @@ MeshRecordComponent::read()
         throw std::runtime_error( "Unexpected Attribute datatype for 'position'");
 
     readBase();
-    *hasBeenRead = true;
 }
 
 template< typename T >

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -115,7 +115,7 @@ PatchRecordComponent::read()
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 
-    readAttributes(); // this will set dirty() = false
+    readAttributes( ReadMode::FullyReread ); // this will set dirty() = false
 }
 
 bool

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -105,12 +105,6 @@ PatchRecordComponent::flush(std::string const& name)
 void
 PatchRecordComponent::read()
 {
-    if ( *hasBeenRead )
-    {
-        dirty() = false;
-        return;
-    }
-
     Parameter< Operation::READ_ATT > aRead;
 
     aRead.name = "unitSI";
@@ -122,8 +116,6 @@ PatchRecordComponent::read()
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 
     readAttributes(); // this will set dirty() = false
-
-    *hasBeenRead = true;
 }
 
 bool

--- a/src/binding/python/IterationEncoding.cpp
+++ b/src/binding/python/IterationEncoding.cpp
@@ -31,5 +31,6 @@ void init_IterationEncoding(py::module &m) {
     py::enum_<IterationEncoding>(m, "Iteration_Encoding")
         .value("file_based", IterationEncoding::fileBased)
         .value("group_based", IterationEncoding::groupBased)
+        .value("step_based", IterationEncoding::variableBased)
     ;
 }

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -846,7 +846,7 @@ TEST_CASE( "hipace_like_write", "[parallel]" )
 #if openPMD_HAVE_ADIOS2 && openPMD_HAVE_MPI
 
 void
-adios2_streaming()
+adios2_streaming( bool variableBasedLayout )
 {
     int size{ -1 };
     int rank{ -1 };
@@ -870,6 +870,11 @@ adios2_streaming()
         // write
         Series writeSeries(
             "../samples/adios2_stream.sst", Access::CREATE );
+        if( variableBasedLayout )
+        {
+            writeSeries.setIterationEncoding(
+                IterationEncoding::variableBased );
+        }
         auto iterations = writeSeries.writeIterations();
         for( size_t i = 0; i < 10; ++i )
         {
@@ -940,7 +945,8 @@ adios2_streaming()
 
 TEST_CASE( "adios2_streaming", "[pseudoserial][adios2]" )
 {
-    adios2_streaming();
+    adios2_streaming( true );
+    adios2_streaming( false );
 }
 
 TEST_CASE( "parallel_adios2_json_config", "[parallel][adios2]" )

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3503,6 +3503,7 @@ variableBasedSeries( std::string const & file )
     constexpr Extent::value_type extent = 1000;
     {
         Series writeSeries( file, Access::CREATE );
+        writeSeries.setIterationEncoding( IterationEncoding::variableBased );
         REQUIRE(
             writeSeries.iterationEncoding() == IterationEncoding::variableBased );
         if( writeSeries.backend() == "ADIOS1" )
@@ -3531,8 +3532,7 @@ variableBasedSeries( std::string const & file )
         }
     }
 
-    REQUIRE( auxiliary::directory_exists(
-        auxiliary::replace_last( file, "%V", "" ) ) );
+    REQUIRE( auxiliary::directory_exists( file ) );
 
     {
         Series readSeries(
@@ -3595,7 +3595,7 @@ variableBasedSeries( std::string const & file )
 
 TEST_CASE( "variableBasedSeries", "[serial][adios2]" )
 {
-    variableBasedSeries( "../samples/variableBasedSeries%V.bp" );
+    variableBasedSeries( "../samples/variableBasedSeries.bp" );
 }
 #endif
 


### PR DESCRIPTION
~~Based on [topic-adios-variables-for-attributes](https://github.com/franzpoeschel/openPMD-api/tree/topic-adios-variables-for-attributes) since "variable attributes" are needed for this.
For comparing the changes: https://github.com/franzpoeschel/openPMD-api/compare/topic-adios-variables-for-attributes...franzpoeschel:topic-stepbased~~

This adds a third iteration layout to the openPMD API: Next to file-based and group-based, a step-based layout.

Idea: ADIOS prefers consuming data in steps. Until now, the openPMD API created entirely new datasets for each iteration, while ADIOS(2) actually allows to reuse datasets across steps. A simple dataset may now look like this in ADIOS2:


```
  string    /basePath                        scalar
  uint64_t  /data/__step__                   10*scalar
  uint8_t   /data/closed                     10*scalar
  double    /data/dt                         10*scalar
  int8_t    /data/meshes/E/axisLabels        10*{1, 2}
  string    /data/meshes/E/dataOrder         10*scalar
  string    /data/meshes/E/geometry          10*scalar
  double    /data/meshes/E/gridGlobalOffset  10*{1}
  double    /data/meshes/E/gridSpacing       10*{1}
  double    /data/meshes/E/gridUnitSI        10*scalar
  float     /data/meshes/E/timeOffset        10*scalar
  double    /data/meshes/E/unitDimension     10*{7}
  int32_t   /data/meshes/E/x/__data__        10*{1000}
  double    /data/meshes/E/x/position        10*{1}
  double    /data/meshes/E/x/unitSI          10*scalar
  int32_t   /data/meshes/E/y/__data__        10*{__}
  double    /data/meshes/E/y/position        10*{1}
  double    /data/meshes/E/y/unitSI          10*scalar
  double    /data/time                       10*scalar
  double    /data/timeUnitSI                 10*scalar
  string    /date                            scalar
  string    /iterationEncoding               scalar
  string    /iterationFormat                 scalar
  string    /meshesPath                      scalar
  string    /openPMD                         scalar
  uint32_t  /openPMDextension                scalar
  string    /software                        scalar
  string    /softwareVersion                 scalar
```

This helps controlling the amount of metadata by reusing attributes and variables across steps.

TODO:

- [x] Remove `currentIteration` group and merge contents with layer above.
      EDIT: See comment below, there are pros and cons and this should be discussed first.
- [x] Merge [topic-adios-variables-for-attributes](https://github.com/franzpoeschel/openPMD-api/tree/topic-adios-variables-for-attributes) before this.
- [x] Merge #938 before this
- [x] CI failures are because I made the use of steps the default behavior for the new schema and there are bugs in ADIOS2 2.6.0 that prevent that. So, merge this only after bumping the required version to ADIOS2 2.7.0.
- [x] Documentation
- [x] More thorough testing
- [x] Formalize this in the openPMD standard: https://github.com/openPMD/openPMD-standard/pull/250
- [x] `iterationFormat` and similar attributes
- [x] Use something like `data%V.bp` for automatic recognition of the iteration layout?
- [x] test that changing extents (shapes) over time work for meshes & particles
    Update: Doesn't work at the moment. I know the reason, need to find a way to fix it.
    Update: I've reordered the PRs, this is now based on #938 (lazy parsing). In lazy parsing mode, this now works. In eager parsing, parsing is done before any step is opened and datasets are not (yet) re-parsed. Fix that.
    Update: Both should be working now.
- [x] Naming: rename `__step__` to `snapshot` (see https://github.com/openPMD/openPMD-standard/issues/148)
- [ ] Expose iteration encoding as JSON option – maybe postpone to a more thorough JSON PR
- [x] Guarantee removal of stale content when reparsing