### PR TITLE
Python: Properties in Series, Mesh, ...

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,8 +3,8 @@
 Upgrade Guide
 =============
 
-0.13.0-beta
------------
+0.13.0
+------
 
 Building openPMD-api now requires a compiler that supports C++14 or newer.
 Supported Python version are now 3.6 to 3.9.
@@ -27,6 +27,18 @@ The old setter function (``set_data_order``) and read-only property (``data_orde
 
 Note: we recommend using ``'C'`` order since version 2 of the openPMD-standard will simplify this option to ``'C'``, too.
 For Fortran-ordered indices, please just invert the attributes ``axis_labels``, ``grid_spacing`` and ``grid_global_offset`` accordingly.
+
+The ``Iteration`` functions ``time``, ``dt`` and ``time_unit_SI`` have been replaced with read-write properties of the same name, essentially without the ``()``-access.
+``set_time``, ``set_dt`` and ``set_time_unit_SI`` are now deprecated and will be removed in future versions of the library.
+
+The already existing read-only ``Series`` properties ``openPMD``, ``openPMD_extension``, ``base_path``, ``meshes_path``, ``particles_path``, ``particles_path``, ``author``, ``date``, ``iteration_encoding``, ``iteration_format`` and ``name`` are now declared as read-write properties.
+``set_openPMD``, ``set_openPMD_extension``, ``set_base_path``, ``set_meshes_path``, ``set_particles_path``, ``set_author``, ``set_date``, ``set_iteration_encoding``, ``set_iteration_format`` and ``set_name`` are now deprecated and will be removed in future versions of the library.
+
+The already existing read-only ``Mesh`` properties ``geometry``, ``geometry_parameters``, ``axis_labels``, ``grid_spacing``, ``grid_global_offset`` and ``grid_unit_SI`` are now declared as read-write properties.
+``set_geometry``, ``set_geometry_parameters``, ``set_axis_labels``, ``set_grid_spacing``, ``set_grid_global_offset`` and ``set_grid_unit_SI`` are now deprecated and will be removed in future versions of the library.
+
+The already existing read-only ``Attributable`` property ``comment`` is now declared as read-write properties.
+``set_comment`` is now deprecated and will be removed in future versions of the library.
 
 
 0.12.0-alpha

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -128,7 +128,7 @@ C++14
 .. code-block:: cpp
 
    series.setAuthor(
-       "Axel Huebl <a.huebl@hzdr.de>");
+       "Axel Huebl <axelhuebl@lbl.gov>");
    series.setMachine(
        "Hall Probe 5000, Model 3");
    series.setAttribute(
@@ -141,8 +141,8 @@ Python
 
 .. code-block:: python3
 
-   series.set_author(
-       "Axel Huebl <a.huebl@hzdr.de>")
+   series.author = \
+       "Axel Huebl <axelhuebl@lbl.gov>"
    series.machine = "Hall Probe 5000, Model 3"
    series.set_attribute(
        "dinner", "Pizza and Coke")

--- a/examples/3a_write_thetaMode_serial.py
+++ b/examples/3a_write_thetaMode_serial.py
@@ -32,12 +32,12 @@ if __name__ == "__main__":
     geometry_parameters = "m={0};imag=+".format(num_modes)
 
     E = series.iterations[0].meshes["E"]
-    E.set_geometry(io.Geometry.thetaMode)
-    E.set_geometry_parameters(geometry_parameters)
-    E.set_grid_spacing([1.0, 1.0])
-    E.set_grid_global_offset([0.0, 0.0])
-    E.set_grid_unit_SI(1.0)
-    E.set_axis_labels(["r", "z"])
+    E.geometry = io.Geometry.thetaMode
+    E.geometry_parameters = geometry_parameters
+    E.grid_spacing = [1.0, 1.0]
+    E.grid_global_offset = [0.0, 0.0]
+    E.grid_unit_SI = 1.0
+    E.axis_labels = ["r", "z"]
     E.data_order = "C"
     E.unit_dimension = {io.Unit_Dimension.I: 1.0,
                         io.Unit_Dimension.J: 2.0}
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     E_z = E["z"]
     E_z.unit_SI = 10.
     E_z.position = [0.0, 0.5]
-    #   (modes, r, z) see set_geometry_parameters
+    #   (modes, r, z) see geometry_parameters
     E_z.reset_dataset(io.Dataset(io.Datatype.FLOAT, [num_fields, N_r, N_z]))
     E_z.make_constant(42.54)
 

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -23,12 +23,12 @@ if __name__ == "__main__":
 
     # all required openPMD attributes will be set to reasonable default values
     # (all ones, all zeros, empty strings,...)
-    # manually setting them enforces the openPMD standard
-    f.set_meshes_path("custom_meshes_path")
-    f.set_particles_path("long_and_very_custom_particles_path")
+    # but one can also set customized values
+    f.meshes_path = "custom_meshes_path"
+    f.particles_path = "long_and_very_custom_particles_path"
 
     # it is possible to add and remove attributes
-    f.set_comment("This is fine and actually encouraged by the standard")
+    f.comment = "This is fine and actually encouraged by the standard"
     f.set_attribute(
         "custom_attribute_name",
         "This attribute is manually added and can contain about any datatype "
@@ -38,27 +38,27 @@ if __name__ == "__main__":
     # the file unusable for post-processing
     f.delete_attribute("custom_attribute_name")
 
-    # setting attributes can be chained in JS-like syntax for compact code
-    tmpItObj = f.iterations[1] \
-        .set_time(42.0) \
-        .set_dt(1.0) \
-        .set_time_unit_SI(1.39e-16)
+    # attributes are read-write properties
+    tmpItObj = f.iterations[1]
+    tmpItObj.time = 42.0
+    tmpItObj.dt = 1.0
+    tmpItObj.time_unit_SI = 1.39e-16
     # everything that is accessed with [] should be interpreted as permanent
     # storage the objects sunk into these locations are deep copies
-    f.iterations[2].set_comment("This iteration will not appear in any output")
+    f.iterations[2].comment = "This iteration will not appear in any output"
     del f.iterations[2]
 
     # this is a reference to an iteration
     reference = f.iterations[1]
-    reference.set_comment("Modifications to a reference will always be visible"
-                          " in the output")
+    reference.comment = "Modifications to a reference will always be visible" \
+                        " in the output"
     del reference
 
     # alternatively, a copy may be created and later re-assigned to
     # f.iterations[1]
     copy = f.iterations[1]  # TODO .copy()
-    copy.set_comment("Modifications to copies will only take effect after you "
-                     "reassign the copy")
+    copy.comment = "Modifications to copies will only take effect after you " \
+                   "reassign the copy"
     f.iterations[1] = copy
     del copy
 
@@ -74,8 +74,8 @@ if __name__ == "__main__":
 
     # as this is a reference, it modifies the original resource
     lowRez = cur_it.meshes["generic_2D_field"]
-    lowRez.set_grid_spacing([1, 1]) \
-        .set_grid_global_offset([0, 600])
+    lowRez.grid_spacing = [1, 1]
+    lowRez.grid_global_offset = [0, 600]
 
     # del cur_it.meshes["generic_2D_field"]
     cur_it.meshes["lowRez_2D_field"] = lowRez
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     electrons["weighting"][SCALAR].make_constant(1.e-5)
 
     mesh = cur_it.meshes["lowRez_2D_field"]
-    mesh.set_axis_labels(["x", "y"])
+    mesh.axis_labels = ["x", "y"]
 
     # data is assumed to reside behind a pointer as a contiguous column-major
     # array shared data ownership during IO is indicated with a smart pointer
@@ -123,11 +123,11 @@ if __name__ == "__main__":
         reset_dataset(dset)
 
     dset = Dataset(partial_particlePos.dtype, extent=[2])
-    electrons.particle_patches["offset"].set_unit_dimension(
-        {Unit_Dimension.L: 1})
+    electrons.particle_patches["offset"].unit_dimension = \
+        {Unit_Dimension.L: 1}
     electrons.particle_patches["offset"]["x"].reset_dataset(dset)
-    electrons.particle_patches["extent"].set_unit_dimension(
-        {Unit_Dimension.L: 1})
+    electrons.particle_patches["extent"].unit_dimension = \
+        {Unit_Dimension.L: 1}
     electrons.particle_patches["extent"]["x"].reset_dataset(dset)
 
     # at any point in time you may decide to dump already created output to

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -23,9 +23,9 @@ if __name__ == "__main__":
 
     # all required openPMD attributes will be set to reasonable default values
     # (all ones, all zeros, empty strings,...)
-    # manually setting them enforces the openPMD standard
-    f.set_meshes_path("fields")
-    f.set_particles_path("particles")
+    # but one can also set domain-specific values
+    f.meshes_path = "fields"
+    f.particles_path = "particles"
 
     # new iteration
     cur_it = f.iterations[0]

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -342,7 +342,8 @@ void init_Attributable(py::module &m) {
 
         // @todo _ipython_key_completions_ if we find a way to add a [] interface
 
-        .def_property_readonly("comment", &Attributable::comment)
+        .def_property("comment", &Attributable::comment, &Attributable::setComment)
+        // TODO remove in future versions (deprecated)
         .def("set_comment", &Attributable::setComment)
     ;
 

--- a/src/binding/python/ChunkInfo.cpp
+++ b/src/binding/python/ChunkInfo.cpp
@@ -39,8 +39,8 @@ void init_Chunk(py::module &m) {
                     + std::to_string(c.offset.size()) + "'>";
             }
         )
-        .def_readonly("offset", &ChunkInfo::offset)
-        .def_readonly("extent", &ChunkInfo::extent)
+        .def_readwrite("offset", &ChunkInfo::offset)
+        .def_readwrite("extent", &ChunkInfo::extent)
     ;
     py::class_<WrittenChunkInfo, ChunkInfo>(m, "WrittenChunkInfo")
         .def(py::init<Offset, Extent>(),
@@ -53,9 +53,9 @@ void init_Chunk(py::module &m) {
                     + std::to_string(c.offset.size()) + "'>";
             }
         )
-        .def_readonly("offset",   &WrittenChunkInfo::offset   )
-        .def_readonly("extent",   &WrittenChunkInfo::extent   )
-        .def_readonly("mpi_rank", &WrittenChunkInfo::mpi_rank )
+        .def_readwrite("offset",   &WrittenChunkInfo::offset   )
+        .def_readwrite("extent",   &WrittenChunkInfo::extent   )
+        .def_readwrite("mpi_rank", &WrittenChunkInfo::mpi_rank )
     ;
 }
 

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -39,21 +39,23 @@ void init_Iteration(py::module &m) {
             }
         )
 
-        .def("time", &Iteration::time<float>)
-        .def("time", &Iteration::time<double>)
-        .def("time", &Iteration::time<long double>)
+        .def_property("time", &Iteration::time<float>, &Iteration::setTime<float>)
+        .def_property("time", &Iteration::time<double>, &Iteration::setTime<double>)
+        .def_property("time", &Iteration::time<long double>, &Iteration::setTime<long double>)
+        .def_property("dt", &Iteration::dt<float>, &Iteration::setDt<float>)
+        .def_property("dt", &Iteration::dt<double>, &Iteration::setDt<double>)
+        .def_property("dt", &Iteration::dt<long double>, &Iteration::setDt<long double>)
+        .def_property("time_unit_SI", &Iteration::timeUnitSI, &Iteration::setTimeUnitSI)
+        .def("close", &Iteration::close, py::arg("flush") = true)
+
+        // TODO remove in future versions (deprecated)
         .def("set_time", &Iteration::setTime<float>)
         .def("set_time", &Iteration::setTime<double>)
         .def("set_time", &Iteration::setTime<long double>)
-        .def("dt", &Iteration::dt<float>)
-        .def("dt", &Iteration::dt<double>)
-        .def("dt", &Iteration::dt<long double>)
         .def("set_dt", &Iteration::setDt<float>)
         .def("set_dt", &Iteration::setDt<double>)
         .def("set_dt", &Iteration::setDt<long double>)
-        .def("time_unit_SI", &Iteration::timeUnitSI)
         .def("set_time_unit_SI", &Iteration::setTimeUnitSI)
-        .def("close", &Iteration::close, py::arg("flush") = true)
 
         .def_readwrite("meshes", &Iteration::meshes,
             py::return_value_policy::reference,

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -47,34 +47,33 @@ void init_Mesh(py::module &m) {
             &Mesh::setUnitDimension,
             python::doc_unit_dimension)
 
-        .def_property_readonly("geometry", &Mesh::geometry)
-        .def("set_geometry", &Mesh::setGeometry)
-        .def_property_readonly("geometry_parameters", &Mesh::geometryParameters)
-        .def("set_geometry_parameters", &Mesh::setGeometryParameters)
+        .def_property("geometry", &Mesh::geometry, &Mesh::setGeometry)
+        .def_property("geometry_parameters", &Mesh::geometryParameters, &Mesh::setGeometryParameters)
         .def_property("data_order",
               [](Mesh const & mesh){ return static_cast< char >(mesh.dataOrder()); },
               [](Mesh & mesh, char d){ mesh.setDataOrder(Mesh::DataOrder(d)); },
               "Data Order of the Mesh (deprecated and set to C in openPMD 2)"
         )
-        .def_property_readonly("axis_labels", &Mesh::axisLabels)
-        .def("set_axis_labels", &Mesh::setAxisLabels)
-        .def_property_readonly("grid_spacing", &Mesh::gridSpacing<float>)
-        .def_property_readonly("grid_spacing", &Mesh::gridSpacing<double>)
-        .def_property_readonly("grid_spacing", &Mesh::gridSpacing<long double>)
-        .def("set_grid_spacing", &Mesh::setGridSpacing<float>)
-        .def("set_grid_spacing", &Mesh::setGridSpacing<double>)
-        .def("set_grid_spacing", &Mesh::setGridSpacing<long double>)
-        .def_property_readonly("grid_global_offset", &Mesh::gridGlobalOffset)
-        .def("set_grid_global_offset", &Mesh::setGridGlobalOffset)
-        .def_property_readonly("grid_unit_SI", &Mesh::gridUnitSI)
-        .def("set_grid_unit_SI", &Mesh::setGridUnitSI)
+        .def_property("axis_labels", &Mesh::axisLabels, &Mesh::setAxisLabels)
+        .def_property("grid_spacing", &Mesh::gridSpacing<float>, &Mesh::setGridSpacing<float>)
+        .def_property("grid_spacing", &Mesh::gridSpacing<double>, &Mesh::setGridSpacing<double>)
+        .def_property("grid_spacing", &Mesh::gridSpacing<long double>, &Mesh::setGridSpacing<long double>)
+        .def_property("grid_global_offset", &Mesh::gridGlobalOffset, &Mesh::setGridGlobalOffset)
+        .def_property("grid_unit_SI", &Mesh::gridUnitSI, &Mesh::setGridUnitSI)
         .def_property("time_offset", &Mesh::timeOffset<float>, &Mesh::setTimeOffset<float>)
         .def_property("time_offset", &Mesh::timeOffset<double>, &Mesh::setTimeOffset<double>)
         .def_property("time_offset", &Mesh::timeOffset<long double>, &Mesh::setTimeOffset<long double>)
 
         // TODO remove in future versions (deprecated)
         .def("set_unit_dimension", &Mesh::setUnitDimension)
-
+        .def("set_geometry", &Mesh::setGeometry)
+        .def("set_geometry_parameters", &Mesh::setGeometryParameters)
+        .def("set_axis_labels", &Mesh::setAxisLabels)
+        .def("set_grid_spacing", &Mesh::setGridSpacing<float>)
+        .def("set_grid_spacing", &Mesh::setGridSpacing<double>)
+        .def("set_grid_spacing", &Mesh::setGridSpacing<long double>)
+        .def("set_grid_global_offset", &Mesh::setGridGlobalOffset)
+        .def("set_grid_unit_SI", &Mesh::setGridUnitSI)
     ;
 
     py::enum_<Mesh::Geometry>(m, "Geometry")

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -142,18 +142,12 @@ void init_Series(py::module &m) {
         )
 #endif
 
-        .def_property_readonly("openPMD", &Series::openPMD)
-        .def("set_openPMD", &Series::setOpenPMD)
-        .def_property_readonly("openPMD_extension", &Series::openPMDextension)
-        .def("set_openPMD_extension", &Series::setOpenPMDextension)
-        .def_property_readonly("base_path", &Series::basePath)
-        .def("set_base_path", &Series::setBasePath)
-        .def_property_readonly("meshes_path", &Series::meshesPath)
-        .def("set_meshes_path", &Series::setMeshesPath)
-        .def_property_readonly("particles_path", &Series::particlesPath)
-        .def("set_particles_path", &Series::setParticlesPath)
-        .def_property_readonly("author", &Series::author)
-        .def("set_author", &Series::setAuthor)
+        .def_property("openPMD", &Series::openPMD, &Series::setOpenPMD)
+        .def_property("openPMD_extension", &Series::openPMDextension, &Series::setOpenPMDextension)
+        .def_property("base_path", &Series::basePath, &Series::setBasePath)
+        .def_property("meshes_path", &Series::meshesPath, &Series::setMeshesPath)
+        .def_property("particles_path", &Series::particlesPath, &Series::setParticlesPath)
+        .def_property("author", &Series::author, &Series::setAuthor)
         .def_property("machine",
             &Series::machine,
             &Series::setMachine,
@@ -168,17 +162,25 @@ void init_Series(py::module &m) {
         })
         // softwareDependencies
         // machine
-        .def_property_readonly("date", &Series::date)
-        .def("set_date", &Series::setDate)
-        .def_property_readonly("iteration_encoding", &Series::iterationEncoding)
-        .def("set_iteration_encoding", &Series::setIterationEncoding)
-        .def_property_readonly("iteration_format", &Series::iterationFormat)
-        .def("set_iteration_format", &Series::setIterationFormat)
-        .def_property_readonly("name", &Series::name)
-        .def("set_name", &Series::setName)
+        .def_property("date", &Series::date, &Series::setDate)
+        .def_property("iteration_encoding", &Series::iterationEncoding, &Series::setIterationEncoding)
+        .def_property("iteration_format", &Series::iterationFormat, &Series::setIterationFormat)
+        .def_property("name", &Series::name, &Series::setName)
         .def("flush", &Series::flush)
 
         .def_property_readonly("backend", &Series::backend)
+
+        // TODO remove in future versions (deprecated)
+        .def("set_openPMD", &Series::setOpenPMD)
+        .def("set_openPMD_extension", &Series::setOpenPMDextension)
+        .def("set_base_path", &Series::setBasePath)
+        .def("set_meshes_path", &Series::setMeshesPath)
+        .def("set_particles_path", &Series::setParticlesPath)
+        .def("set_author", &Series::setAuthor)
+        .def("set_date", &Series::setDate)
+        .def("set_iteration_encoding", &Series::setIterationEncoding)
+        .def("set_iteration_format", &Series::setIterationFormat)
+        .def("set_name", &Series::setName)
 
         .def_readwrite("iterations", &Series::iterations,
             py::return_value_policy::reference,


### PR DESCRIPTION
Modernize read-write property syntax in Python for Series, Mesh, Iteration, ChunkInfo, Attributable.

Besides for `Iteration`, all changes are not breaking compared to the 0.12.0 release (but deprecate the setters).