### PR TITLE
Rename WrittenChunkInfo.mpi_rank -> WrittenChunkInfo.sourceID

### DIFF
--- a/include/openPMD/ChunkInfo.hpp
+++ b/include/openPMD/ChunkInfo.hpp
@@ -51,19 +51,23 @@ struct ChunkInfo
  * data producing application.
  * Produced by BaseRecordComponent::availableChunk.
  *
- * Carries along the usual chunk meta info also the rank from which
- * it was written.
- * If not specified explicitly, the rank will be assumed to be 0.
+ * Carries along the usual chunk meta info also the ID for the data source from
+ * which the chunk is received.
+ * Examples for this include the writing MPI rank in streaming setups or the
+ * subfile containing the chunk.
+ * If not specified explicitly, the sourceID will be assumed to be 0.
+ * This information will vary between different backends and should be used
+ * for optimization purposes only.
  */
 struct WrittenChunkInfo : ChunkInfo
 {
-    unsigned int mpi_rank = 0; //!< the MPI rank of the writing process
+    unsigned int sourceID = 0; //!< ID of the data source containing the chunk
 
+    explicit WrittenChunkInfo() = default;
     /*
      * If rank is smaller than zero, will be converted to zero.
      */
-    explicit WrittenChunkInfo() = default;
-    WrittenChunkInfo( Offset, Extent, int mpi_rank );
+    WrittenChunkInfo( Offset, Extent, int sourceID );
     WrittenChunkInfo( Offset, Extent );
 
     bool

--- a/src/ChunkInfo.cpp
+++ b/src/ChunkInfo.cpp
@@ -36,9 +36,9 @@ ChunkInfo::operator==( ChunkInfo const & other ) const
 WrittenChunkInfo::WrittenChunkInfo(
     Offset offset_in,
     Extent extent_in,
-    int mpi_rank_in )
+    int sourceID_in )
     : ChunkInfo( std::move( offset_in ), std::move( extent_in ) )
-    , mpi_rank( mpi_rank_in < 0 ? 0 : mpi_rank_in )
+    , sourceID( sourceID_in < 0 ? 0 : sourceID_in )
 {
 }
 
@@ -50,7 +50,7 @@ WrittenChunkInfo::WrittenChunkInfo( Offset offset_in, Extent extent_in )
 bool
 WrittenChunkInfo::operator==( WrittenChunkInfo const & other ) const
 {
-    return this->mpi_rank == other.mpi_rank &&
+    return this->sourceID == other.sourceID &&
         this->ChunkInfo::operator==( other );
 }
 } // namespace openPMD

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -366,7 +366,7 @@ namespace openPMD
                         e.push_back( entry );
                     }
                     res.emplace_back(
-                        std::move( o ), std::move( e ), chunk.mpi_rank );
+                        std::move( o ), std::move( e ), chunk.sourceID );
                 }
             }
             return res;

--- a/src/binding/python/ChunkInfo.cpp
+++ b/src/binding/python/ChunkInfo.cpp
@@ -55,7 +55,7 @@ void init_Chunk(py::module &m) {
         )
         .def_readwrite("offset",   &WrittenChunkInfo::offset   )
         .def_readwrite("extent",   &WrittenChunkInfo::extent   )
-        .def_readwrite("mpi_rank", &WrittenChunkInfo::mpi_rank )
+        .def_readwrite("source_id", &WrittenChunkInfo::sourceID )
     ;
 }
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -343,9 +343,9 @@ available_chunks_test( std::string file_ending )
         {
             REQUIRE(
                 chunk.offset ==
-                Offset{ static_cast< unsigned >( chunk.mpi_rank ), 0 } );
+                Offset{ static_cast< unsigned >( chunk.sourceID ), 0 } );
             REQUIRE( chunk.extent == Extent{ 1, 4 } );
-            ranks.emplace_back( chunk.mpi_rank );
+            ranks.emplace_back( chunk.sourceID );
         }
         std::sort( ranks.begin(), ranks.end() );
         for( size_t i = 0; i < ranks.size(); ++i )

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1609,6 +1609,8 @@ class APITest(unittest.TestCase):
 
         chunks = read.iterations[0].meshes["E"]["x"].available_chunks()
         chunks = sorted(chunks, key=lambda chunk: chunk.offset)
+        for chunk in chunks:
+            self.assertEqual(chunk.source_id, 0)
         # print("EXTENSION:", ext)
         # for chunk in chunks:
         #     print("{} -- {}".format(chunk.offset, chunk.extent))


### PR DESCRIPTION
The old naming is misleading. `WrittenChunkInfo.mpi_rank` should not be used to reconstruct MPI ranks that wrote the chunks since the information will vary depending on the backend in use. It should be applied for optimizing parallel chunk loading patterns.

TODO
- [x] Merge #859 first.