### PR TITLE
Fix ADIOS1: Iteration::open()

### DIFF
--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -557,12 +557,15 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
     if( m_groups.find(filePath) == m_groups.end() )
         m_groups[filePath] = initialize_group(name);
 
-    ADIOS_FILE* f = open_read(name);
+    if( m_openReadFileHandles.find(filePath) == m_openReadFileHandles.end() )
+    {
+        ADIOS_FILE* f = open_read(name);
+        m_openReadFileHandles[filePath] = f;
+    }
 
     writable->written = true;
     writable->abstractFilePosition = std::make_shared< ADIOS1FilePosition >("/");
 
-    m_openReadFileHandles[filePath] = f;
     m_filePaths[writable] = filePath;
     m_existsOnDisk[filePath] = true;
 }

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -626,8 +626,7 @@ file_based_write_read( std::string file_ending )
         Series read( name, Access::READ_ONLY, MPI_COMM_WORLD );
         Iteration it = read.iterations[ 30 ];
         it.open(); // collective
-        bool isAdios1 = read.backend() == "MPI_ADIOS1"; // FIXME: this is an ADIOS1 backend bug
-        if( mpi_rank == 0 || isAdios1 ) // non-collective branch (unless ADIOS1)
+        if( mpi_rank == 0 ) // non-collective branch
         {
             auto E_x = it.meshes["E"]["x"];
             auto data = E_x.loadChunk< double >();


### PR DESCRIPTION
Prepare the support for `Iteration::open()` for following non-collective, parallel reads for ADIOS1.

Follow-up to #862 fixing ADIOS1 in #856