### PR TITLE
FindPython.cmake: Development.Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,8 +248,15 @@ endif()
 # TODO: Check if ADIOS2 is parallel when openPMD_HAVE_MPI is ON
 
 # external library: pybind11 (optional)
+set(_PY_DEV_MODULE Development.Module)
+if(CMAKE_VERSION VERSION_LESS 3.18.0)
+    # over-specification needed for CMake<3.18
+    #   https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
+    #   https://cmake.org/cmake/help/v3.18/module/FindPython.html
+    set(_PY_DEV_MODULE Development)
+endif()
 if(openPMD_USE_PYTHON STREQUAL AUTO)
-    find_package(Python 3.6.0 COMPONENTS Interpreter Development)
+    find_package(Python 3.6.0 COMPONENTS Interpreter ${_PY_DEV_MODULE})
     if(Python_FOUND)
         if(openPMD_USE_INTERNAL_PYBIND11)
             add_subdirectory("${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/pybind11")
@@ -268,7 +275,7 @@ if(openPMD_USE_PYTHON STREQUAL AUTO)
         set(openPMD_HAVE_PYTHON FALSE)
     endif()
 elseif(openPMD_USE_PYTHON)
-    find_package(Python COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python COMPONENTS Interpreter ${_PY_DEV_MODULE} REQUIRED)
     if(openPMD_USE_INTERNAL_PYBIND11)
         add_subdirectory("${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/pybind11")
         set(openPMD_HAVE_PYTHON TRUE)


### PR DESCRIPTION
On one of our primary release channels, PyPA wheels for pip, we rely on manylinux2010 images. Those images do not ship Python Development libraries.

We never needed them, since they are only needed if one develops against the (C)Python libs themselves, e.g. when embedding the Python Interpreter. Unfortunately, only CMake 3.18.0+ provides the according `Development.Module` sub-target to search for narrower dependencies.

On Python release channels (pip wheels build in manylinux2010 images, conda-forge) we pull in a recent CMake anyway, so there is no need to bump the overall requirements from CMake 3.15 to 3.18 just yet.