### PR TITLE
LGTM: Fix C++

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,5 @@
+# docs:
+#   https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html#example-of-complete-lgtmyml-file
 extraction:
   cpp:
     prepare:
@@ -6,3 +8,5 @@ extraction:
         - libopenmpi-dev
         - libhdf5-openmpi-dev
         - libadios-openmpi-dev
+    after_prepare: # make sure lgtm.com doesn't call setup.py (for which they use a python2 atm)
+      - rm -f setup.py

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,9 +4,21 @@ extraction:
   cpp:
     prepare:
       packages:
+        - cmake
         - openmpi-bin
         - libopenmpi-dev
         - libhdf5-openmpi-dev
         - libadios-openmpi-dev
     after_prepare: # make sure lgtm.com doesn't call setup.py (for which they use a python2 atm)
       - rm -f setup.py
+      - python -m pip install --upgrade pip
+      - python -m pip install --upgrade wheel
+      - python -m pip install --upgrade cmake
+      - export CMAKE="$HOME/.local/bin/cmake"
+    configure:
+      command:
+        - $CMAKE -S . -B build
+    index:
+      build_command:
+        - $CMAKE --build build -j 2
+


### PR DESCRIPTION
For some reason, in cpp mode the setup.py is called and contrary to LGTM defaults it uses python2 for it.

(LGTM currently runs on Ubuntu Eoan.)