### PR TITLE
CI: Brew Returns Non-Zero If Already Installed

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -119,9 +119,9 @@ jobs:
       run: |
         rm -rf /usr/local/bin/2to3
         brew update
-        brew install adios2
-        brew install hdf5-mpi
-        brew install python
+        brew install adios2 || true
+        brew install hdf5-mpi || true
+        brew install python || true
     - name: Build
       env: {CXXFLAGS: -Werror -Wno-deprecated-declarations, MACOSX_DEPLOYMENT_TARGET: 10.9}
       # C++11 & 14 support in macOS 10.9+


### PR DESCRIPTION
Homebrew has the unusual behavior to return a non-zero error code in `brew install` if the package is already installed. Since the base image in CI is somewhat fluid and also the status that `brew update` leaves is very dynamic, we just change this ourselves now to be a non-error.