### PR TITLE
Ensure that a Series is not dirtyRecursive() after reading

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -333,6 +333,7 @@ Mesh::read()
             MeshRecordComponent& rc = (*this)[component];
             if ( *rc.hasBeenRead )
             {
+                dirty() = false;
                 continue;
             }
             pOpen.path = component;
@@ -351,6 +352,7 @@ Mesh::read()
             MeshRecordComponent & rc = ( *this )[ component ];
             if( *rc.hasBeenRead )
             {
+                dirty() = false;
                 continue;
             }
             dOpen.name = component;

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -103,6 +103,7 @@ Record::read()
             RecordComponent& rc = (*this)[component];
             if ( *rc.hasBeenRead )
             {
+                dirty() = false;
                 continue;
             }
             pOpen.path = component;

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -189,6 +189,7 @@ RecordComponent::read()
 {
     if ( *hasBeenRead )
     {
+        dirty() = false;
         return;
     }
     readBase();

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -34,6 +34,7 @@ MeshRecordComponent::read()
 {
     if ( *hasBeenRead )
     {
+        dirty() = false;
         return;
     }
     using DT = Datatype;


### PR DESCRIPTION
Reading routines (i.e. anything triggered by `Series::read()` should mark `dirty() = false` on all objects in the openPMD hierarchy. Re-reading a Series in streaming mode takes some shortcuts, and I previously forgot ensuring that any object is not dirty when taking such a shortcut.

@ax3l first noticed this while using `openpmd-ls` on the output of `3_write_serial.cpp`.
```
> openpmd-ls ../samples/3_write_serial.h5
[…]
number of iterations: 1 (groupBased)
  all iterations: 1 [~Series] An error occurred: [Series] Illegal access to iteration 1 that has been closed previously.
An error occurred while opening the specified openPMD series!
[Series] Illegal access to iteration 1 that has been closed previously.
```
This should fix that.