### PR TITLE
Fix: listSeries & Iteration::close()

### DIFF
--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -195,7 +195,21 @@ Iteration::open()
 bool
 Iteration::closed() const
 {
-    return *m_closed != CloseStatus::Open;
+    switch( *m_closed )
+    {
+        case CloseStatus::Open:
+        /*
+         * Temporarily closing a file is something that the openPMD API
+         * does for optimization purposes.
+         * Logically to the user, it is still open.
+         */
+        case CloseStatus::ClosedTemporarily:
+            return false;
+        case CloseStatus::ClosedInFrontend:
+        case CloseStatus::ClosedInBackend:
+            return true;
+    }
+    throw std::runtime_error( "Unreachable!" );
 }
 
 bool

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1073,9 +1073,15 @@ Series::advance(
     {
         *iteration.m_closed = oldCloseStatus;
     }
-    else if( oldCloseStatus == Iteration::CloseStatus::ClosedInBackend )
+    else if(
+        oldCloseStatus == Iteration::CloseStatus::ClosedInBackend &&
+        *m_iterationEncoding == IterationEncoding::fileBased )
     {
-        // all is well, nothing to do
+        /*
+         * In file-based iteration encoding, we want to avoid accidentally
+         * opening an iteration's file by beginning a step on it.
+         * So, return now.
+         */
         return AdvanceStatus::OK;
     }
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -61,9 +61,8 @@ write_and_read_many_iterations( std::string const & ext ) {
         }
     }
 
-    // FIXME
-    //Series list( filename, Access::READ_ONLY );
-    //helper::listSeries( list );
+    Series list( filename, Access::READ_ONLY );
+    helper::listSeries( list );
 }
 
 TEST_CASE( "write_and_read_many_iterations", "[serial]" )
@@ -264,11 +263,10 @@ close_iteration_test( std::string file_ending )
         REQUIRE_THROWS( read.flush() );
     }
 
-    // FIXME
-    //{
-    //    Series list{ name, Access::READ_ONLY };
-    //    helper::listSeries( list );
-    //}
+    {
+        Series list{ name, Access::READ_ONLY };
+        helper::listSeries( list );
+    }
 }
 
 TEST_CASE( "close_iteration_test", "[serial]" )


### PR DESCRIPTION
Fix calls of `listSeries` on files that used `Iteration::close()` during creation.