### PR TITLE
JSON Complex Datatype Read

### DIFF
--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -281,7 +281,21 @@ namespace openPMD
         {
             throw std::runtime_error( "[JSON] The specified location contains no valid dataset" );
         }
-        j["data"] = initializeNDArray( parameters.extent );
+        switch( stringToDatatype( j[ "datatype" ].get< std::string >() ) )
+        {
+            case Datatype::CFLOAT:
+            case Datatype::CDOUBLE:
+            case Datatype::CLONG_DOUBLE:
+            {
+                auto complexExtent = parameters.extent;
+                complexExtent.push_back( 2 );
+                j["data"] = initializeNDArray( complexExtent );
+                break;
+            }
+            default:
+                j["data"] = initializeNDArray( parameters.extent );
+                break;
+        }
         writable->written = true;
 
     }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1081,8 +1081,6 @@ void test_complex(const std::string & backend) {
         o.flush();
     }
 
-    //! @todo clarify that complex data is not N+1 data in JSON
-    if( backend != "json" )
     {
         Series i = Series("../samples/serial_write_complex." + backend, Access::READ_ONLY);
         REQUIRE(i.getAttribute("lifeIsComplex").get< std::complex<double> >() == std::complex<double>(4.56, 7.89));
@@ -1107,7 +1105,6 @@ void test_complex(const std::string & backend) {
         }
     }
 
-    if( backend != "json" ) //! @todo clarify that complex data is not N+1 data in JSON
     {
         Series list{ "../samples/serial_write_complex." + backend, Access::READ_ONLY };
         helper::listSeries( list );


### PR DESCRIPTION
Add support to read back complex data back with the JSON backend.
Follow-up to #639

- [x] add recognition in the JSON backend that `COMPLEX` datatypes in JSON are not N+1 data