### PR TITLE
Support Null engine in ADIOS2

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -209,7 +209,8 @@ ADIOS2IOHandlerImpl::fileSuffix() const
     // so we don't add it
     static std::map< std::string, std::string > endings{
         { "sst", "" }, { "staging", "" }, { "bp4", ".bp" },
-        { "bp3", ".bp" },  { "file", ".bp" },     { "hdf5", ".h5" }
+        { "bp3", ".bp" },  { "file", ".bp" },     { "hdf5", ".h5" },
+        { "null", ".null" }
     };
     auto it = endings.find( m_engineType );
     if( it != endings.end() )
@@ -1529,7 +1530,7 @@ namespace detail
     void BufferedActions::configure_IO(ADIOS2IOHandlerImpl& impl){
         ( void )impl;
         static std::set< std::string > streamingEngines = {
-            "sst", "insitumpi", "inline", "staging"
+            "sst", "insitumpi", "inline", "staging", "null"
         };
         static std::set< std::string > fileEngines = {
             "bp4", "bp3", "hdf5", "file"
@@ -1576,7 +1577,8 @@ namespace detail
                 {
                     throw std::runtime_error(
                         "[ADIOS2IOHandler] Unknown engine type. Please choose "
-                        "one out of [sst, staging, bp4, bp3, hdf5, file]" );
+                        "one out of "
+                        "[sst, staging, bp4, bp3, hdf5, file, null]" );
                     // not listing unsupported engines
                 }
             }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2940,6 +2940,32 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
   }
 }
 )END";
+    std::string writeConfigNull = R"END(
+{
+  "adios2": {
+    "engine": {
+      "type": "null",
+      "unused": "parameter",
+      "parameters": {
+        "BufferGrowthFactor": "2.0",
+        "Profile": "On"
+      }
+    },
+    "unused": "as well",
+    "dataset": {
+      "operators": [
+        {
+          "type": "blosc",
+          "parameters": {
+              "clevel": "1",
+              "doshuffle": "BLOSC_BITSHUFFLE"
+          }
+        }
+      ]
+    }
+  }
+}
+)END";
     std::string datasetConfig = R"END(
 {
   "adios2": {
@@ -2978,6 +3004,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
     };
     write( "../samples/jsonConfiguredBP4.bp", writeConfigBP4 );
     write( "../samples/jsonConfiguredBP3.bp", writeConfigBP3 );
+    write( "../samples/jsonConfiguredNull.bp", writeConfigNull );
 
     // BP3 engine writes files, BP4 writes directories
     REQUIRE(


### PR DESCRIPTION
The ADIOS2 backend only allows ADIOS2 engines that are explicitly supported by us. Add the `null` engine to that list, @guj needs it for performance testing.