### PR TITLE
CMake: Prefix Test/CLI/Example Switches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,11 +97,26 @@ cmake_dependent_option(BUILD_SHARED_LIBS
 )
 mark_as_advanced(BUILD_SHARED_LIBS)
 
+# Testing logic with possibility to overwrite on a project basis in superbuilds
 include(CTest)
-# automatically defines: BUILD_TESTING, default is ON
+mark_as_advanced(BUILD_TESTING) # automatically defined, default: ON
+if(DEFINED BUILD_TESTING)
+    set(openPMD_BUILD_TESTING_DEFAULT ${BUILD_TESTING})
+else()
+    set(openPMD_BUILD_TESTING_DEFAULT ON)
+endif()
+option(openPMD_BUILD_TESTING "Build the openPMD tests"
+    ${openPMD_BUILD_TESTING_DEFAULT})
 
-option(BUILD_CLI_TOOLS "Build the command line tools" ON)
-option(BUILD_EXAMPLES  "Build the examples" ON)
+# deprecated: backwards compatibility to <= 0.13.*
+if(NOT DEFINED BUILD_CLI_TOOLS)
+    set(BUILD_CLI_TOOLS ON)
+endif()
+if(NOT DEFINED BUILD_EXAMPLES)
+    set(BUILD_EXAMPLES ON)
+endif()
+option(openPMD_BUILD_CLI_TOOLS "Build the command line tools" ${BUILD_CLI_TOOLS})
+option(openPMD_BUILD_EXAMPLES  "Build the examples" ${BUILD_EXAMPLES})
 
 
 # Dependencies ################################################################
@@ -381,7 +396,7 @@ endif()
 target_link_libraries(openPMD PUBLIC openPMD::thirdparty::mpark_variant)
 
 # Catch2 for unit tests
-if(BUILD_TESTING)
+if(openPMD_BUILD_TESTING)
     add_library(openPMD::thirdparty::Catch2 INTERFACE IMPORTED)
     if(openPMD_USE_INTERNAL_CATCH)
         target_include_directories(openPMD::thirdparty::Catch2 SYSTEM INTERFACE
@@ -653,7 +668,7 @@ if(openPMD_USE_INVASIVE_TESTS)
     endif()
 endif()
 
-if(BUILD_TESTING)
+if(openPMD_BUILD_TESTING)
     # compile Catch2 implementation part separately
     add_library(CatchRunner test/CatchRunner.cpp)  # Always MPI_Init with Serial Fallback
     add_library(CatchMain   test/CatchMain.cpp)    # Serial only
@@ -886,7 +901,7 @@ endif()
 
 # Tests #######################################################################
 #
-if(BUILD_TESTING)
+if(openPMD_BUILD_TESTING)
     enable_testing()
 
     # OpenMPI root guard: https://github.com/open-mpi/ompi/issues/4451
@@ -1062,7 +1077,7 @@ if(BUILD_TESTING)
                             ${openPMD_SOURCE_DIR}/examples/${examplename}.py
                             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
                 )
-                if(BUILD_TESTING)
+                if(openPMD_BUILD_TESTING)
                     if(${examplename} MATCHES "^.*_parallel$")
                         if(openPMD_HAVE_MPI AND MPI4PY_RETURN EQUAL 0)
                             # see https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html
@@ -1140,7 +1155,7 @@ else()
 endif()
 message("  CLI Tools: ${BUILD_CLI_TOOLS}")
 message("  Examples: ${BUILD_EXAMPLES}")
-message("  Testing: ${BUILD_TESTING}")
+message("  Testing: ${openPMD_BUILD_TESTING}")
 message("  Invasive Tests: ${openPMD_USE_INVASIVE_TESTS}")
 message("  Internal VERIFY: ${openPMD_USE_VERIFY}")
 message("  Build Options:")

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ RUN        ls /opt/python/
 
 ENV        HDF5_USE_STATIC_LIBRARIES=ON \
            ADIOS_USE_STATIC_LIBS=ON \
-           BUILD_TESTING=OFF \
-           BUILD_EXAMPLES=OFF
+           openPMD_BUILD_TESTING=OFF \
+           openPMD_BUILD_EXAMPLES=OFF
 
 # build matrix
 RUN        cd /opt/src; \
@@ -104,8 +104,8 @@ RUN        cd /opt/src; \
 #               -DPython_ROOT_DIR=$(which /opt/python/cp${PY_TARGET}-cp${PY_TARGET}m) \
 #               -DHDF5_USE_STATIC_LIBRARIES=ON \
 #               -DBUILD_SHARED_LIBS=OFF \
-#               -DBUILD_TESTING=OFF \
-#               -DBUILD_EXAMPLES=OFF \
+#               -DopenPMD_BUILD_TESTING=OFF \
+#               -DopenPMD_BUILD_EXAMPLES=OFF \
 #               /opt/src \
 #           && make
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,13 @@ By default, the `Release` version is built.
 In order to build with debug symbols, pass `-DCMAKE_BUILD_TYPE=Debug` to your `cmake` command.
 
 By default, tests, examples and command line tools are built.
-In order to skip building those, pass `-DBUILD_TESTING=OFF`, `-DBUILD_EXAMPLES=OFF`, or `-DBUILD_CLI_TOOLS=OFF` to your `cmake` command.
+In order to skip building those, pass ``OFF`` to these ``cmake`` options:
+
+| CMake Option              | Values     | Description              |
+|---------------------------|------------|--------------------------|
+| `openPMD_BUILD_TESTING`   | **ON**/OFF | Build tests              |
+| `openPMD_BUILD_EXAMPLES`  | **ON**/OFF | Build examples           |
+| `openPMD_BUILD_CLI_TOOLS` | **ON**/OFF | Build command-line tools |
 
 ## Linking to your project
 
@@ -310,9 +316,9 @@ Just replace the `add_subdirectory` call with:
 ```cmake
 include(FetchContent)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-set(BUILD_CLI_TOOLS OFF)
-set(BUILD_EXAMPLES OFF)
-set(BUILD_TESTING OFF)
+set(openPMD_BUILD_CLI_TOOLS OFF)
+set(openPMD_BUILD_EXAMPLES OFF)
+set(openPMD_BUILD_TESTING OFF)
 set(openPMD_INSTALL ${BUILD_SHARED_LIBS})  # e.g. only install if used as shared library
 set(openPMD_USE_PYTHON OFF)
 FetchContent_Declare(openPMD

--- a/Singularity
+++ b/Singularity
@@ -45,7 +45,7 @@ Supported frontends are C++11 and Python3.
         -DopenPMD_USE_ADIOS1=ON  \
         -DopenPMD_USE_ADIOS2=OFF \
         -DopenPMD_USE_PYTHON=ON  \
-        -DBUILD_TESTING=OFF      \
+        -DopenPMD_BUILD_TESTING=OFF       \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DCMAKE_INSTALL_PYTHONDIR=lib/python3.6/dist-packages
     make

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -39,7 +39,7 @@ The following options switch between static and shared builds and control if dep
 ============================== =============== ==================================================
 CMake Option                   Values          Description
 ============================== =============== ==================================================
-``BUILD_SHARED_LIBS``          **ON**/OFF      Build the C++ API as shared library
+``openPMD_BUILD_SHARED_LIBS``  **ON**/OFF      Build the C++ API as shared library
 ``HDF5_USE_STATIC_LIBRARIES``  ON/**OFF**      Require static HDF5 library
 ``ADIOS_USE_STATIC_LIBS``      ON/**OFF**      Require static ADIOS1 library
 ============================== =============== ==================================================
@@ -78,4 +78,12 @@ Tests, Examples and Command Line Tools
 --------------------------------------
 
 By default, tests, examples and command line tools are built.
-In order to skip building those, pass ``-DBUILD_TESTING=OFF``, ``-DBUILD_EXAMPLES=OFF``, or ``-DBUILD_CLI_TOOLS=OFF`` to your ``cmake`` command.
+In order to skip building those, pass ``OFF`` to these ``cmake`` options:
+
+============================== =============== ==================================================
+CMake Option                   Values          Description
+============================== =============== ==================================================
+``openPMD_BUILD_TESTING``      **ON**/OFF      Build tests
+``openPMD_BUILD_EXAMPLES``     **ON**/OFF      Build examples
+``openPMD_BUILD_CLI_TOOLS``    **ON**/OFF      Build command-line tools
+============================== =============== ==================================================

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,12 @@ class CMakeBuild(build_ext):
             # variants
             '-DopenPMD_USE_MPI:BOOL=' + openPMD_USE_MPI,
             # skip building cli tools, examples & tests
-            '-DBUILD_CLI_TOOLS:BOOL=OFF',  # note: provided as console scripts
-            '-DBUILD_EXAMPLES:BOOL=' + BUILD_EXAMPLES,
-            '-DBUILD_TESTING:BOOL=' + BUILD_TESTING,
+            #   note: CLI tools provided as console scripts
+            '-DopenPMD_BUILD_CLI_TOOLS:BOOL=OFF',
+            '-DopenPMD_BUILD_EXAMPLES:BOOL=' + BUILD_EXAMPLES,
+            '-DopenPMD_BUILD_TESTING:BOOL=' + BUILD_TESTING,
             # static/shared libs
-            '-DBUILD_SHARED_LIBS:BOOL=' + BUILD_SHARED_LIBS,
+            '-DopenPMD_BUILD_SHARED_LIBS:BOOL=' + BUILD_SHARED_LIBS,
             '-DHDF5_USE_STATIC_LIBRARIES:BOOL=' + HDF5_USE_STATIC_LIBRARIES,
             '-DADIOS_USE_STATIC_LIBS:BOOL=' + ADIOS_USE_STATIC_LIBS,
             # Unix: rpath to current dir when packaged
@@ -121,9 +122,17 @@ with open('./README.md', encoding='utf-8') as f:
 openPMD_USE_MPI = os.environ.get('openPMD_USE_MPI', 'OFF')
 HDF5_USE_STATIC_LIBRARIES = os.environ.get('HDF5_USE_STATIC_LIBRARIES', 'OFF')
 ADIOS_USE_STATIC_LIBS = os.environ.get('ADIOS_USE_STATIC_LIBS', 'OFF')
+# deprecated: backwards compatibility to <= 0.13.*
 BUILD_SHARED_LIBS = os.environ.get('BUILD_SHARED_LIBS', 'OFF')
 BUILD_TESTING = os.environ.get('BUILD_TESTING', 'OFF')
 BUILD_EXAMPLES = os.environ.get('BUILD_EXAMPLES', 'OFF')
+# end deprecated
+BUILD_SHARED_LIBS = os.environ.get('openPMD_BUILD_SHARED_LIBS',
+                                   BUILD_SHARED_LIBS)
+BUILD_TESTING = os.environ.get('openPMD_BUILD_TESTING',
+                               BUILD_TESTING)
+BUILD_EXAMPLES = os.environ.get('openPMD_BUILD_EXAMPLES',
+                                BUILD_EXAMPLES)
 
 # https://cmake.org/cmake/help/v3.0/command/if.html
 if openPMD_USE_MPI.upper() in ['1', 'ON', 'YES', 'TRUE', 'YES']:


### PR DESCRIPTION
Add `openPMD_` project prefixes to test, CLI and example build options.

This enables us to run a superbuild project with testing enabled but not building and running openPMD-api tests in it.