### PR TITLE
[WIP] Parallel HDF5: 4MB Alignment & Buffer

### DIFF
--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -25,7 +25,7 @@ The following environment variables control HDF5 I/O behavior at runtime.
 environment variable                  default   description
 ===================================== ========= ====================================================================================
 ``OPENPMD_HDF5_INDEPENDENT``          ``ON``    Sets the MPI-parallel transfer mode to collective (``OFF``) or independent (``ON``).
-``OPENPMD_HDF5_ALIGNMENT``            ``1``     Tuning parameter for parallel I/O, choose an alignment which is a multiple of the disk block size.
+``OPENPMD_HDF5_ALIGNMENT``            ``ABC``   Tuning parameter for parallel I/O, choose an alignment which is a multiple of the disk block size.
 ``OPENPMD_HDF5_CHUNKS``               ``auto``  Defaults for ``H5Pset_chunk``: ``"auto"`` (heuristic) or ``"none"`` (no chunking).
 ``H5_COLL_API_SANITY_CHECK``          unset     Set to ``1`` to perform an ``MPI_Barrier`` inside each meta-data operation.
 ===================================== ========= ====================================================================================

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -21,14 +21,14 @@ Backend-Specific Controls
 
 The following environment variables control HDF5 I/O behavior at runtime.
 
-===================================== ========= ====================================================================================
-environment variable                  default   description
-===================================== ========= ====================================================================================
-``OPENPMD_HDF5_INDEPENDENT``          ``ON``    Sets the MPI-parallel transfer mode to collective (``OFF``) or independent (``ON``).
-``OPENPMD_HDF5_ALIGNMENT``            ``ABC``   Tuning parameter for parallel I/O, choose an alignment which is a multiple of the disk block size.
-``OPENPMD_HDF5_CHUNKS``               ``auto``  Defaults for ``H5Pset_chunk``: ``"auto"`` (heuristic) or ``"none"`` (no chunking).
-``H5_COLL_API_SANITY_CHECK``          unset     Set to ``1`` to perform an ``MPI_Barrier`` inside each meta-data operation.
-===================================== ========= ====================================================================================
+===================================== =========== ====================================================================================
+environment variable                  default     description
+===================================== =========== ====================================================================================
+``OPENPMD_HDF5_INDEPENDENT``          ``ON``      Sets the MPI-parallel transfer mode to collective (``OFF``) or independent (``ON``).
+``OPENPMD_HDF5_ALIGNMENT``            ``4194304`` Tuning parameter for parallel I/O, choose an alignment which is a multiple of the disk block size.
+``OPENPMD_HDF5_CHUNKS``               ``auto``    Defaults for ``H5Pset_chunk``: ``"auto"`` (heuristic) or ``"none"`` (no chunking).
+``H5_COLL_API_SANITY_CHECK``          unset       Set to ``1`` to perform an ``MPI_Barrier`` inside each meta-data operation.
+===================================== =========== ====================================================================================
 
 ``OPENPMD_HDF5_INDEPENDENT``: by default, we implement MPI-parallel data ``storeChunk`` (write) and ``loadChunk`` (read) calls as `none-collective MPI operations <https://www.mpi-forum.org/docs/mpi-2.2/mpi22-report/node87.htm#Node87>`_.
 Attribute writes are always collective in parallel HDF5.
@@ -53,6 +53,8 @@ Selected References
 -------------------
 
 * GitHub issue `#554 <https://github.com/openPMD/openPMD-api/pull/554>`_
+
+* GitHub libSplash issue `#108 <https://github.com/ComputationalRadiationPhysics/libSplash/issues/108>`_
 
 * Axel Huebl, Rene Widera, Felix Schmitt, Alexander Matthes, Norbert Podhorszki, Jong Youl Choi, Scott Klasky, and Michael Bussmann.
   *On the Scalability of Data Reduction Techniques in Current and Upcoming HPC Systems from an Application Perspective,*

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -85,11 +85,16 @@ A full configuration of the HDF5 backend:
 All keys found under ``hdf5.dataset`` are applicable globally (future: as well as per dataset).
 Explanation of the single keys:
 
-* ``adios2.dataset.chunks``: This key contains options for data chunking via `H5Pset_chunk <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_chunk.htm>`__.
+* ``hdf5.dataset.chunks``: This key contains options for data chunking via `H5Pset_chunk <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_chunk.htm>`__.
   The default is ``"auto"`` for a heuristic.
   ``"none"`` can be used to disable chunking.
   Chunking generally improves performance and only needs to be disabled in corner-cases, e.g. when heavily relying on independent, parallel I/O that non-collectively declares data records.
 
+* ``hdf5.alignment``: This key contains options for file alignment via `H5Pset_alignment <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_alignment.htm>`__ and cache sizes.
+  The contained keys are ``"size"`` as a string in bytes and ``"threshold"``, also as a string in bytes.
+  The default values are set by the environment variable ``OPENPMD_HDF5_ALIGNMENT`` unless overwritten here.
+  If only ``"size"`` is provided, the ``"threshold"`` will be set to ``"0"`` automatically (align all values).
+  Values of ``"1``" for both options equals no alignment.
 
 Other backends
 ^^^^^^^^^^^^^^

--- a/docs/source/details/json.json
+++ b/docs/source/details/json.json
@@ -2,6 +2,10 @@
   "hdf5": {
     "dataset": {
       "chunks": "auto"
+    },
+    "alignment": {
+      "size": "4194304",
+      "threshold": "0"
     }
   }
 }

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -77,9 +77,14 @@ namespace openPMD
         hid_t m_H5T_CDOUBLE;
         hid_t m_H5T_CLONG_DOUBLE;
 
-    private:
+    protected:
         auxiliary::TracingJSON m_config;
+        //! dataset chunking
         std::string m_chunks = "auto";
+        //! 1: no alignment >1: alignment in bytes
+        hsize_t m_alignment = 1;
+        //! 0: all aligned, 1: no aligned, >1: threshold in bytes
+        hsize_t m_threshold = 1;
         struct File
         {
             std::string name;


### PR DESCRIPTION
FS blocksize:
```
stat -fc %s .
```

Tried those options on Cori (Scratch and CFS): 8_benchmark case with `-w`, KNL partition, WarpX-like MPI-rank placement.
modules: ... `darshan/3.1.7` `gcc/8.3.0` `cray-mpich/7.7.10` `cray-hdf5-parallel/1.10.5.2` ...

Scratch: 1MB recommended blocksize (confusingly, `stat -fc %s <dir>` reports 4KiB)
CFS: 16 MB blocksize (with 4MiB subblocks)

Support quote:
> blocksize is a quirky parameter for parallel file systems because between your compute node and the actual block devices are a bunch of network and RAID layers that have their own magic sizes.  Some arcane knowledge is required

Sets medium [striping](https://docs.nersc.gov/performance/io/lustre/).
**Note:** for proper ADIOS2 timings, keep the small default striping (it creates subfiles that should not be heavily striped); for proper HDF5 timings, enable striping (single output file that should be heavily striped).

For HDF5, we can also try [T3PIO](https://github.com/ComputationalRadiationPhysics/libSplash/issues/108) `MPI_Info` hints again.

[cori.sbatch.txt](https://github.com/openPMD/openPMD-api/files/5817775/cori.sbatch.txt)

### Cori: Darshan Logs

```bash
# MPICH statistics collection
export MPICH_MPIIO_STATS=1
export MPICH_MPIIO_HINTS_DISPLAY=1
export MPICH_MPIIO_TIMERS=1

# Darshan extended trace (dxt) logs
export DARSHAN_DISABLE_SHARED_REDUCTION=1
export DXT_ENABLE_IO_TRACE=4

# work-around needed
export LD_PRELOAD=/global/common/cori_cle7/software/darshan/3.1.7/lib/libdarshan.so

// srun

# disable work-around
unset LD_PRELOAD
```