### PR TITLE
Weak scaling in benchmark example

### DIFF
--- a/docs/source/usage/benchmarks.rst
+++ b/docs/source/usage/benchmarks.rst
@@ -6,14 +6,14 @@ Benchmarks
 Parallel benchmark 8
 --------------------
 
-Build based on the helper functions in the :ref:`benchmark utilities <utilities-benchmark>`_, this benchmark executes a simple parallel read-write test.
+Build based on the helper functions in the :ref:`benchmark utilities <utilities-benchmark>`, this benchmark executes a simple parallel read-write test.
 
-In particular, this test case writes and reads a 4D array of type ``long``, sliced 1D along the first dimension.
+In particular, this test case writes and reads a 4D array of type ``uint64_t``, sliced 1D along the first dimension.
 
 .. code-block:: cpp
 
    openPMD::Extent total{
-       100 * scale_up, // slices along or this axis?
+       100 * scale_up, // sliced along this axis over MPI ranks
        100,
        100,
        10

--- a/docs/source/usage/benchmarks.rst
+++ b/docs/source/usage/benchmarks.rst
@@ -8,19 +8,19 @@ Parallel benchmark 8
 
 Build based on the helper functions in the :ref:`benchmark utilities <utilities-benchmark>`_, this benchmark executes a simple parallel read-write test.
 
-In particular, this test case writes and reads a 4D array of type ..., sliced 1D along the ... dimension.
+In particular, this test case writes and reads a 4D array of type ``long``, sliced 1D along the first dimension.
 
 .. code-block:: cpp
 
    openPMD::Extent total{
-       100 * scale_up, // slices along or this...?
+       100 * scale_up, // slices along or this axis?
        100,
        100,
-       10 // or this axis?
+       10
    };
 
-That means in the strong-scaling case, always ... GB of data are produced.
-In the weak-scaling case, the data scales as :math:`N * ... \mathrm{GiB}` with :math:`N` as the number of participating MPI ranks.
+The benchmark writes 10 iterations, meaning that in the strong-scaling case, always around 3/4 GB of data are produced.
+In the weak-scaling case, the data scales as :math:`N * 3/4 \mathrm{GiB}` with :math:`N` as the number of participating MPI ranks.
 
 By default, the benchmarks executes as strong-scaling unless the ``-w``/``--weak`` option is passed as a command-line argument to the executable.
 

--- a/docs/source/usage/benchmarks.rst
+++ b/docs/source/usage/benchmarks.rst
@@ -3,6 +3,28 @@
 Benchmarks
 ==========
 
+Parallel benchmark 8
+--------------------
+
+Build based on the helper functions in the :ref:`benchmark utilities <utilities-benchmark>`_, this benchmark executes a simple parallel read-write test.
+
+In particular, this test case writes and reads a 4D array of type ..., sliced 1D along the ... dimension.
+
+.. code-block:: cpp
+
+   openPMD::Extent total{
+       100 * scale_up, // slices along or this...?
+       100,
+       100,
+       10 // or this axis?
+   };
+
+That means in the strong-scaling case, always ... GB of data are produced.
+In the weak-scaling case, the data scales as :math:`N * ... \mathrm{GiB}` with :math:`N` as the number of participating MPI ranks.
+
+By default, the benchmarks executes as strong-scaling unless the ``-w``/``--weak`` option is passed as a command-line argument to the executable.
+
+
 Parallel benchmarks 8a & 8b
 ---------------------------
 

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -80,7 +80,7 @@ int main(
     // multiple different benchmark runs with different datatypes,
     // given that you provide it with an appropriate DatasetFillerProvider
     // (template parameter of the Benchmark class).
-    using type = long int;
+    using type = uint64_t;
 #if openPMD_HAVE_ADIOS1 || openPMD_HAVE_ADIOS2 || openPMD_HAVE_HDF5
     openPMD::Datatype dt = openPMD::determineDatatype<type>();
 #endif

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -32,10 +32,14 @@ int main(
     openPMD::Datatype dt = openPMD::determineDatatype<type>();
 #endif
 
+
+    int rank, size;
+    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+    MPI_Comm_size( MPI_COMM_WORLD, &size );
     // Total (in this case 4D) dataset across all MPI ranks.
     // Will be the same for all configured benchmarks.
     openPMD::Extent total{
-        100,
+        100 * unsigned( size ),
         100,
         100,
         10
@@ -104,11 +108,6 @@ int main(
     auto res =
         benchmark.runBenchmark<std::chrono::high_resolution_clock>();
 
-    int rank;
-    MPI_Comm_rank(
-        MPI_COMM_WORLD,
-        &rank
-    );
     if( rank == 0 )
     {
         for( auto it = res.durations.begin();

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -8,9 +8,38 @@
 #endif
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 
 #if openPMD_HAVE_MPI
+inline void
+print_help( std::string const program_name )
+{
+    std::cout << "Usage: " << program_name << "\n";
+    std::cout << "Run a simple parallel write and read benchmark.\n\n";
+    std::cout << "Options:\n";
+    std::cout << "    -w, --weak    run a weak scaling (default: strong scaling)\n";
+    std::cout << "    -h, --help    display this help and exit\n";
+    std::cout << "    -v, --version output version information and exit\n";
+    std::cout << "\n";
+    std::cout << "Examples:\n";
+    std::cout << "    " << program_name << " --weak  # for a weak-scaling\n";
+    std::cout << "    " << program_name << "  # for a strong scaling\n";
+}
+
+inline void
+print_version( std::string const program_name )
+{
+    std::cout << program_name << " (openPMD-api) "
+              << openPMD::getVersion() << "\n";
+    std::cout << "Copyright 2017-2021 openPMD contributors\n";
+    std::cout << "Authors: Franz Poeschel, Axel Huebl et al.\n";
+    std::cout << "License: LGPLv3+\n";
+    std::cout << "This is free software: you are free to change and redistribute it.\n"
+                 "There is NO WARRANTY, to the extent permitted by law.\n";
+}
+
 int main(
     int argc,
     char *argv[]
@@ -21,6 +50,30 @@ int main(
         &argc,
         &argv
     );
+
+    // CLI parsing
+    std::vector< std::string > str_argv;
+    for( int i = 0; i < argc; ++i ) str_argv.emplace_back( argv[i] );
+    bool weak_scaling = false;
+
+    for (int c = 1; c < int(argc); c++) {
+        if (std::string("--help") == argv[c] || std::string("-h") == argv[c]) {
+            print_help(argv[0]);
+            return 0;
+        }
+        if (std::string("--version") == argv[c] || std::string("-v") == argv[c]) {
+            print_version(argv[0]);
+            return 0;
+        }
+        if (std::string("--weak") == argv[c] || std::string("-w") == argv[c]) {
+            weak_scaling = true;
+        }
+    }
+
+    if (argc > 2) {
+        std::cerr << "Too many arguments! See: " << argv[0] << " --help\n";
+        return 1;
+    }
 
     // For simplicity, use only one datatype in this benchmark.
     // Note that a single Benchmark object can be used to configure
@@ -36,10 +89,12 @@ int main(
     int rank, size;
     MPI_Comm_rank( MPI_COMM_WORLD, &rank );
     MPI_Comm_size( MPI_COMM_WORLD, &size );
+    const unsigned scale_up = weak_scaling ? unsigned( size ) : 1u;
+
     // Total (in this case 4D) dataset across all MPI ranks.
     // Will be the same for all configured benchmarks.
     openPMD::Extent total{
-        100 * unsigned( size ),
+        100 * scale_up,
         100,
         100,
         10


### PR DESCRIPTION
So far, the `8_benchmark_parallel.cpp` examples writes a fixed-size dataset of ~3/4GB independent of MPI size. This PR multiplies that size by the `MPI_size` to achieve weak scaling.

TODO:
- [ ] Let users choose the size per rank via command line arguments?