### PR TITLE
Add openpmd-pipe.py command line tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,6 +663,9 @@ set(openPMD_TEST_NAMES
 set(openPMD_CLI_TOOL_NAMES
     ls
 )
+set(openPMD_PYTHON_CLI_TOOL_NAMES
+    pipe
+)
 set(openPMD_PYTHON_CLI_MODULE_NAMES ${openPMD_CLI_TOOL_NAMES})
 # examples
 set(openPMD_EXAMPLE_NAMES
@@ -881,6 +884,16 @@ if(openPMD_INSTALL)
         install(TARGETS openPMD.py
             DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/openpmd_api
         )
+        if(openPMD_BUILD_CLI_TOOLS)
+            foreach(toolname ${openPMD_PYTHON_CLI_TOOL_NAMES})
+                install(
+                    FILES ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
+                    DESTINATION ${CMAKE_INSTALL_BINDIR}
+                    RENAME openpmd-${toolname}.py
+                    PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+                )
+            endforeach()
+        endif()
     endif()
     install(DIRECTORY "${openPMD_SOURCE_DIR}/include/openPMD"
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -1079,6 +1092,21 @@ if(openPMD_BUILD_TESTING)
         endif()
     endif()
 
+    function(test_set_pythonpath test_name)
+        if(WIN32)
+            set_property(TEST ${test_name}
+                PROPERTY ENVIRONMENT
+                    "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
+                    "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+            )
+        else()
+            set_tests_properties(${test_name}
+                PROPERTIES ENVIRONMENT
+                    "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+            )
+        endif()
+    endfunction()
+
     # Python CLI Modules
     if(openPMD_HAVE_PYTHON)
         # (Note that during setuptools install, these are furthermore installed as
@@ -1088,19 +1116,74 @@ if(openPMD_BUILD_TESTING)
                  COMMAND ${Python_EXECUTABLE} -m openpmd_api.${pymodulename} --help
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
-            if(WIN32)
-                set_property(TEST CLI.py.help.${pymodulename}
-                    PROPERTY ENVIRONMENT
-                        "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
-                        "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+            test_set_pythonpath(CLI.py.help.${pymodulename})
+        endforeach()
+    endif()
+
+    # Python-based command line tools
+    if(openPMD_BUILD_CLI_TOOLS AND openPMD_HAVE_PYTHON)
+        # all tools must provide a "--help"
+        # The custom target ensures that the file is copied to the build dir
+        # anew if the source file changes (and not only if openPMD.py is rebuilt)
+        add_custom_target(openPMD.py.cliTools)
+        add_dependencies(openPMD.py openPMD.py.cliTools)
+        foreach(toolname ${openPMD_PYTHON_CLI_TOOL_NAMES})
+            add_custom_command(TARGET openPMD.py.cliTools POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy
+                        ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
+                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname}.py
+            )
+            add_test(NAME CLI.help.${toolname}.py
+                COMMAND ${Python_EXECUTABLE}
+                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname}.py --help
+                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            )
+            test_set_pythonpath(CLI.help.${toolname}.py)
+        endforeach()
+
+        # openpmd-pipe.py test
+        if( openPMD_HAVE_HDF5
+            AND (openPMD_HAVE_ADIOS2 OR openPMD_HAVE_ADIOS1)
+            AND EXAMPLE_DATA_FOUND
+        )
+            if( openPMD_HAVE_MPI )
+                set(MPI_TEST_EXE
+                    ${MPIEXEC_EXECUTABLE}
+                    ${MPI_ALLOW_ROOT}
+                    #${MPIEXEC_NUMPROC_FLAG} 2
+                )
+                add_test(NAME CLI.pipe.py
+                    COMMAND sh -c
+                        "${MPI_TEST_EXE} ${Python_EXECUTABLE}                      \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            --infile ../samples/git-sample/thetaMode/data%T.h5     \
+                            --outfile ../samples/git-sample/thetaMode/data%T.bp;   \
+                                                                                   \
+                            ${Python_EXECUTABLE}                                   \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            --infile ../samples/git-sample/thetaMode/data%T.bp     \
+                            --outfile ../samples/git-sample/thetaMode/data%T.json  \
+                        "
+                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
                 )
             else()
-                set_tests_properties(CLI.py.help.${pymodulename}
-                    PROPERTIES ENVIRONMENT
-                        "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+                add_test(NAME CLI.pipe.py
+                    COMMAND sh -c
+                        "${Python_EXECUTABLE}                                      \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            --infile ../samples/git-sample/thetaMode/data%T.h5     \
+                            --outfile ../samples/git-sample/thetaMode/data%T.bp;   \
+                                                                                   \
+                            ${Python_EXECUTABLE}                                   \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            --infile ../samples/git-sample/thetaMode/data%T.bp     \
+                            --outfile ../samples/git-sample/thetaMode/data%T.json  \
+                        "
+                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
                 )
             endif()
-        endforeach()
+            test_set_pythonpath(CLI.pipe.py)
+        endif()
     endif()
 
     # Python Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,7 +889,7 @@ if(openPMD_INSTALL)
                 install(
                     FILES ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
                     DESTINATION ${CMAKE_INSTALL_BINDIR}
-                    RENAME openpmd-${toolname}.py
+                    RENAME openpmd-${toolname}
                     PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                 )
             endforeach()
@@ -1131,17 +1131,17 @@ if(openPMD_BUILD_TESTING)
             add_custom_command(TARGET openPMD.py.cliTools POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy
                         ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
-                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname}.py
+                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname}
             )
             add_test(NAME CLI.help.${toolname}.py
                 COMMAND ${Python_EXECUTABLE}
-                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname}.py --help
+                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname} --help
                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
             test_set_pythonpath(CLI.help.${toolname}.py)
         endforeach()
 
-        # openpmd-pipe.py test
+        # openpmd-pipe (python) test
         if( openPMD_HAVE_HDF5
             AND (openPMD_HAVE_ADIOS2 OR openPMD_HAVE_ADIOS1)
             AND EXAMPLE_DATA_FOUND
@@ -1155,12 +1155,12 @@ if(openPMD_BUILD_TESTING)
                 add_test(NAME CLI.pipe.py
                     COMMAND sh -c
                         "${MPI_TEST_EXE} ${Python_EXECUTABLE}                      \
-                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
                             --infile ../samples/git-sample/thetaMode/data%T.h5     \
                             --outfile ../samples/git-sample/thetaMode/data%T.bp;   \
                                                                                    \
                             ${Python_EXECUTABLE}                                   \
-                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
                             --infile ../samples/git-sample/thetaMode/data%T.bp     \
                             --outfile ../samples/git-sample/thetaMode/data%T.json  \
                         "
@@ -1170,12 +1170,12 @@ if(openPMD_BUILD_TESTING)
                 add_test(NAME CLI.pipe.py
                     COMMAND sh -c
                         "${Python_EXECUTABLE}                                      \
-                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
                             --infile ../samples/git-sample/thetaMode/data%T.h5     \
                             --outfile ../samples/git-sample/thetaMode/data%T.bp;   \
                                                                                    \
                             ${Python_EXECUTABLE}                                   \
-                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe.py      \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
                             --infile ../samples/git-sample/thetaMode/data%T.bp     \
                             --outfile ../samples/git-sample/thetaMode/data%T.json  \
                         "

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -21,19 +21,18 @@
 #pragma once
 
 #include <array>
+#include <climits>
+#include <complex>
 #include <cstdint>
 #include <iosfwd>
-#include <memory>
-#include <type_traits>
-#include <vector>
-#include <tuple>
-#include <climits>
 #include <map>
+#include <memory>
 #include <stdexcept>
 #include <string>
-#include <complex>
-
-
+#include <tuple>
+#include <type_traits>
+#include <utility> // std::declval
+#include <vector>
 
 namespace openPMD
 {
@@ -765,6 +764,182 @@ ReturnType switchType( Datatype dt, Action action, Args &&... args )
     case Datatype::UNDEFINED:
         return action.OPENPMD_TEMPLATE_OPERATOR( )< 0 >(
             std::forward< Args >( args )... );
+    default:
+        throw std::runtime_error(
+            "Internal error: Encountered unknown datatype (switchType) ->" +
+            std::to_string( static_cast< int >( dt ) ) );
+    }
+}
+
+namespace detail
+{
+// std::void_t is C++17
+template< typename >
+using void_t = void;
+
+/*
+ * Check whether class T has a member "errorMsg" of type std::string.
+ * Used to give helpful compile-time error messages with static_assert
+ * down in CallUndefinedDatatype.
+ */
+template< typename T, typename = void >
+struct HasErrorMessageMember
+{
+    static constexpr bool value = false;
+};
+
+template< typename T >
+struct HasErrorMessageMember<
+    T,
+    typename std::enable_if< std::is_same<
+        std::remove_cv_t< std::remove_reference_t< decltype( T::errorMsg ) > >,
+        std::string >::value >::type >
+{
+    static constexpr bool value = true;
+};
+
+/**
+ * Purpose of this struct is to detect at compile time whether
+ * Action::template operator()\<0\>() exists. If yes, call
+ * Action::template operator()\<n\>() with the passed arguments.
+ * If not, throw an error.
+ *
+ * @tparam n As in switchType().
+ * @tparam ReturnType As in switchType().
+ * @tparam Action As in switchType().
+ * @tparam Dummy For SFINAE, set to void.
+ * @tparam Args As in switchType().
+ */
+template<
+    unsigned n,
+    typename ReturnType,
+    typename Action,
+    typename Dummy,
+    typename... Args >
+struct CallUndefinedDatatype
+{
+    static ReturnType call( Action action, Args &&... )
+    {
+        static_assert(
+            HasErrorMessageMember< Action >::value,
+            "[switchType] Action needs either an errorMsg member of type "
+            "std::string or operator()<unsigned>() overloads." );
+        throw std::runtime_error(
+            "[" + action.errorMsg + "] Unknown Datatype." );
+    }
+};
+
+template< unsigned n, typename ReturnType, typename Action, typename... Args >
+struct CallUndefinedDatatype<
+    n,
+    ReturnType,
+    Action,
+    // check whether `action.template operator()<0>(args...)` is callable
+    void_t< decltype(
+        std::declval< Action >().OPENPMD_TEMPLATE_OPERATOR() < 0 >(
+            std::forward< Args >( std::declval< Args >() )... ) ) >,
+    Args... >
+{
+    static ReturnType call( Action action, Args &&... args )
+    {
+        return action.OPENPMD_TEMPLATE_OPERATOR()< n >(
+            std::forward< Args >( args )... );
+    }
+};
+}
+
+/**
+ * Generalizes switching over an openPMD datatype.
+ *
+ * Will call the functor passed
+ * to it using the C++ internal datatype corresponding to the openPMD datatype
+ * as template parameter for the templated <operator()>().
+ * Ignores vector and array types.
+ *
+ * @tparam ReturnType The functor's return type.
+ * @tparam Action The functor's type.
+ * @tparam Args The functors argument types.
+ * @param dt The openPMD datatype.
+ * @param action The functor.
+ * @param args The functor's arguments.
+ * @return The return value of the functor, when calling its <operator()>() with
+ * the passed arguments and the template parameter type corresponding to the
+ * openPMD type.
+ */
+template< typename Action, typename... Args >
+auto switchNonVectorType( Datatype dt, Action action, Args &&... args )
+    -> decltype(
+        action.OPENPMD_TEMPLATE_OPERATOR() < char >
+        ( std::forward< Args >( args )... ) )
+{
+    using ReturnType = decltype(
+        action.OPENPMD_TEMPLATE_OPERATOR() < char >
+        ( std::forward< Args >( args )... ) );
+    switch( dt )
+    {
+    case Datatype::CHAR:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< char >(
+            std::forward< Args >( args )... );
+    case Datatype::UCHAR:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned char >(
+            std::forward< Args >( args )... );
+    case Datatype::SHORT:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< short >(
+            std::forward< Args >( args )... );
+    case Datatype::INT:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< int >(
+            std::forward< Args >( args )... );
+    case Datatype::LONG:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< long >(
+            std::forward< Args >( args )... );
+    case Datatype::LONGLONG:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< long long >(
+            std::forward< Args >( args )... );
+    case Datatype::USHORT:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned short >(
+            std::forward< Args >( args )... );
+    case Datatype::UINT:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned int >(
+            std::forward< Args >( args )... );
+    case Datatype::ULONG:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned long >(
+            std::forward< Args >( args )... );
+    case Datatype::ULONGLONG:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned long long >(
+            std::forward< Args >( args )... );
+    case Datatype::FLOAT:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< float >(
+            std::forward< Args >( args )... );
+    case Datatype::DOUBLE:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< double >(
+            std::forward< Args >( args )... );
+    case Datatype::LONG_DOUBLE:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< long double >(
+            std::forward< Args >( args )... );
+    case Datatype::CFLOAT:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< std::complex< float > >(
+            std::forward< Args >( args )... );
+    case Datatype::CDOUBLE:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< std::complex< double > >(
+            std::forward< Args >( args )... );
+    case Datatype::CLONG_DOUBLE:
+        return action
+            .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
+                std::forward< Args >( args )... );
+    case Datatype::STRING:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< std::string >(
+            std::forward< Args >( args )... );
+    case Datatype::BOOL:
+        return action.OPENPMD_TEMPLATE_OPERATOR()< bool >(
+            std::forward< Args >( args )... );
+    case Datatype::DATATYPE:
+        return detail::CallUndefinedDatatype<
+            1000, ReturnType, Action, void, Args &&... >::
+            call( std::move( action ), std::forward< Args >( args )... );
+    case Datatype::UNDEFINED:
+        return detail::
+            CallUndefinedDatatype< 0, ReturnType, Action, void, Args &&... >::
+                call( std::move( action ), std::forward< Args >( args )... );
     default:
         throw std::runtime_error(
             "Internal error: Encountered unknown datatype (switchType) ->" +

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -811,14 +811,14 @@ struct HasErrorMessageMember<
  * @tparam n As in switchType().
  * @tparam ReturnType As in switchType().
  * @tparam Action As in switchType().
- * @tparam Dummy For SFINAE, set to void.
+ * @tparam Placeholder For SFINAE, set to void.
  * @tparam Args As in switchType().
  */
 template<
     int n,
     typename ReturnType,
     typename Action,
-    typename Dummy,
+    typename Placeholder,
     typename... Args >
 struct CallUndefinedDatatype
 {

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -28,6 +28,7 @@
 #include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
 
+#include <algorithm>
 #include <array>
 #include <complex>
 #include <string>
@@ -259,30 +260,98 @@ bool setAttributeFromBufferInfo(
 
 struct SetAttributeFromObject
 {
+    std::string errorMsg = "Attributable.set_attribute()";
+
     template< typename RequestedType >
     bool operator()(
         Attributable & attr,
         std::string const& key,
         py::object& obj )
     {
-        return attr.setAttribute< RequestedType >( key, obj.cast< RequestedType >() );
-    }
-    template< unsigned, typename... Args >
-    bool operator()( Args&&... )
-    {
-        throw std::runtime_error( "[setAttribute] Unknown datatype." );
+        if( std::string( py::str( obj.get_type() ) ) == "<class 'list'>" )
+        {
+            using ListType = std::vector< RequestedType >;
+            return attr.setAttribute< ListType >( key, obj.cast< ListType >() );
+        }
+        else
+        {
+            return attr.setAttribute< RequestedType >(
+                key, obj.cast< RequestedType >() );
+        }
     }
 };
 
+template<>
+bool SetAttributeFromObject::operator()< double >(
+    Attributable & attr, std::string const & key, py::object & obj )
+{
+    if( std::string( py::str( obj.get_type() ) ) == "<class 'list'>" )
+    {
+        using ListType = std::vector< double >;
+        using ArrayType = std::array< double, 7 >;
+        ListType const & asVector = obj.cast< ListType >();
+        if( asVector.size() == 7 && key == "unitDimension" )
+        {
+            ArrayType asArray;
+            std::copy_n( asVector.begin(), 7, asArray.begin() );
+            return attr.setAttribute< ArrayType >( key, asArray );
+        }
+        else
+        {
+            return attr.setAttribute< ListType >( key, asVector );
+        }
+    }
+    else
+    {
+        return attr.setAttribute< double >( key, obj.cast< double >() );
+    }
+}
+
+template<>
+bool SetAttributeFromObject::operator()< bool >(
+    Attributable & attr, std::string const & key, py::object & obj )
+{
+    return attr.setAttribute< bool >( key, obj.cast< bool >() );
+}
+
+template<>
+bool SetAttributeFromObject::operator()< char >(
+    Attributable & attr, std::string const & key, py::object & obj )
+{
+    if( std::string( py::str( obj.get_type() ) ) == "<class 'list'>" )
+    {
+        using ListChar = std::vector< char >;
+        using ListString = std::vector< std::string >;
+        try
+        {
+            return attr.setAttribute< ListString >(
+                key, obj.cast< ListString >() );
+        }
+        catch( const py::cast_error & )
+        {
+            return attr.setAttribute< ListChar >( key, obj.cast< ListChar >() );
+        }
+    }
+    else if( std::string( py::str( obj.get_type() ) ) == "<class 'str'>" )
+    {
+        return attr.setAttribute< std::string >(
+            key, obj.cast< std::string >() );
+    }
+    else
+    {
+        return attr.setAttribute< char >( key, obj.cast< char >() );
+    }
+}
+
 bool setAttributeFromObject(
     Attributable & attr,
-    std::string const& key,
-    py::object& obj,
-    std::string const& datatype
-) {
-    Datatype requestedDatatype = stringToDatatype( datatype );
+    std::string const & key,
+    py::object & obj,
+    pybind11::dtype datatype )
+{
+    Datatype requestedDatatype = dtype_from_numpy( datatype );
     static SetAttributeFromObject safo;
-    return switchType< bool >( requestedDatatype, safo, attr, key, obj );
+    return switchNonVectorType( requestedDatatype, safo, attr, key, obj );
 }
 
 void init_Attributable(py::module &m) {
@@ -321,7 +390,7 @@ void init_Attributable(py::module &m) {
                 Attributable & attr,
                 std::string const& key,
                 py::object& obj,
-                std::string const& datatype )
+                pybind11::dtype datatype )
         {
             return setAttributeFromObject( attr, key, obj, datatype );
         },
@@ -375,9 +444,9 @@ void init_Attributable(py::module &m) {
             return v.getResource();
             // TODO instead of returning lists, return all arrays (ndim > 0) as numpy arrays?
         })
-        .def("get_attribute_type", []( Attributable & attr, std::string const& key ) {
+        .def("get_attribute_dtype", []( Attributable & attr, std::string const& key ) {
             auto v = attr.getAttribute(key);
-            return datatypeToString(v.dtype);
+            return dtype_to_numpy(v.dtype);
         })
         .def("delete_attribute", &Attributable::deleteAttribute)
         .def("contains_attribute", &Attributable::containsAttribute)

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <array>
 #include <complex>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -444,9 +445,14 @@ void init_Attributable(py::module &m) {
             return v.getResource();
             // TODO instead of returning lists, return all arrays (ndim > 0) as numpy arrays?
         })
-        .def("get_attribute_dtype", []( Attributable & attr, std::string const& key ) {
-            auto v = attr.getAttribute(key);
-            return dtype_to_numpy(v.dtype);
+        .def_property_readonly("attribute_dtypes", []( Attributable const & attributable ) {
+            std::map< std::string, pybind11::dtype > dtypes;
+            for( auto const & attr : attributable.attributes() )
+            {
+                dtypes[ attr ] =
+                    dtype_to_numpy( attributable.getAttribute( attr ).dtype );
+            }
+            return dtypes;
         })
         .def("delete_attribute", &Attributable::deleteAttribute)
         .def("contains_attribute", &Attributable::containsAttribute)

--- a/src/binding/python/openpmd_api/pipe/__init__.py
+++ b/src/binding/python/openpmd_api/pipe/__init__.py
@@ -185,7 +185,7 @@ class pipe:
                 "Internal error: Trying to copy mismatching types")
         for key in src.attributes:
             attr = src.get_attribute(key)
-            attr_type = src.get_attribute_type(key)
+            attr_type = src.get_attribute_dtype(key)
             dest.set_attribute(key, attr, attr_type)
         container_types = [
             io.Mesh_Container, io.Particle_Container, io.ParticleSpecies,

--- a/src/binding/python/openpmd_api/pipe/__init__.py
+++ b/src/binding/python/openpmd_api/pipe/__init__.py
@@ -1,0 +1,287 @@
+"""
+This file is part of the openPMD-api.
+
+This module provides functions that are wrapped into sys.exit(...()) calls by
+the setuptools (setup.py) "entry_points" -> "console_scripts" generator.
+
+Copyright 2021 openPMD contributors
+Authors: Franz Poeschel
+License: LGPLv3+
+"""
+from .. import openpmd_api_cxx as io
+import argparse
+import sys  # sys.stderr.write
+
+# MPI is an optional dependency
+try:
+    from mpi4py import MPI
+    HAVE_MPI = True
+except ImportError:
+    HAVE_MPI = False
+
+debug = False
+
+
+class FallbackMPICommunicator:
+    def __init__(self):
+        self.size = 1
+        self.rank = 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="""
+openPMD Pipe.
+
+This tool connects an openPMD-based data source with an openPMD-based data sink
+and forwards all data from source to sink.
+Possible uses include conversion of data from one backend to another one
+or multiplexing the data path in streaming setups.
+Parallelization with MPI is optionally possible and is done automatically
+as soon as the mpi4py package is found and this tool is called in an MPI
+context. In that case, each dataset will be equally sliced along the dimension
+with the largest extent.""")
+
+    parser.add_argument('--infile', type=str, help='In file')
+    parser.add_argument('--outfile', type=str, help='Out file')
+    parser.add_argument('--inconfig',
+                        type=str,
+                        default='{}',
+                        help='JSON config for the in file')
+    parser.add_argument('--outconfig',
+                        type=str,
+                        default='{}',
+                        help='JSON config for the out file')
+
+    return parser.parse_args()
+
+
+class Chunk:
+    """
+    A Chunk is an n-dimensional hypercube, defined by an offset and an extent.
+    Offset and extent must be of the same dimensionality (Chunk.__len__).
+    """
+    def __init__(self, offset, extent):
+        assert (len(offset) == len(extent))
+        self.offset = offset
+        self.extent = extent
+
+    def __len__(self):
+        return len(self.offset)
+
+    def slice1D(self, mpi_rank, mpi_size, dimension=None):
+        """
+        Slice this chunk into mpi_size hypercubes along one of its
+        n dimensions. The dimension is given through the 'dimension'
+        parameter. If None, the dimension with the largest extent on
+        this hypercube is automatically picked.
+        Returns the mpi_rank'th of the sliced chunks.
+        """
+        if dimension is None:
+            # pick that dimension which has the highest count of items
+            dimension = 0
+            maximum = self.extent[0]
+            for k, v in enumerate(self.extent):
+                if v > maximum:
+                    dimension = k
+        assert (dimension < len(self))
+        # no offset
+        assert (self.offset == [0 for _ in range(len(self))])
+        offset = [0 for _ in range(len(self))]
+        stride = self.extent[dimension] // mpi_size
+        rest = self.extent[dimension] % mpi_size
+
+        # local function f computes the offset of a rank
+        # for more equal balancing, we want the start index
+        # at the upper gaussian bracket of (N/n*rank)
+        # where N the size of the dataset in dimension dim
+        # and n the MPI size
+        # for avoiding integer overflow, this is the same as:
+        # (N div n)*rank + round((N%n)/n*rank)
+        def f(rank):
+            res = stride * rank
+            padDivident = rest * rank
+            pad = padDivident // mpi_size
+            if pad * mpi_size < padDivident:
+                pad += 1
+            return res + pad
+
+        offset[dimension] = f(mpi_rank)
+        extent = self.extent.copy()
+        if mpi_rank >= mpi_size - 1:
+            extent[dimension] -= offset[dimension]
+        else:
+            extent[dimension] = f(mpi_rank + 1) - offset[dimension]
+        return Chunk(offset, extent)
+
+
+class particle_patch_load:
+    """
+    A deferred load/store operation for a particle patch.
+    Our particle-patch API requires that users pass a concrete value for
+    storing, even if the actual write operation occurs much later at
+    series.flush().
+    So, unlike other record components, we cannot call .store_chunk() with
+    a buffer that has not yet been filled, but must wait until the point where
+    we actual have the data at hand already.
+    In short: calling .store() must be deferred, until the data has been fully
+    read from the sink.
+    This class stores the needed parameters to .store().
+    """
+    def __init__(self, data, dest):
+        self.data = data
+        self.dest = dest
+
+    def run(self):
+        for index, item in enumerate(self.data):
+            self.dest.store(index, item)
+
+
+class pipe:
+    """
+    Represents the configuration of one "pipe" pass.
+    """
+    def __init__(self, infile, outfile, inconfig, outconfig, comm):
+        self.infile = infile
+        self.outfile = outfile
+        self.inconfig = inconfig
+        self.outconfig = outconfig
+        self.comm = comm
+
+    def run(self):
+        if self.comm.size == 1:
+            print("Opening data source")
+            sys.stdout.flush()
+            inseries = io.Series(self.infile, io.Access.read_only,
+                                 self.inconfig)
+            print("Opening data sink")
+            sys.stdout.flush()
+            outseries = io.Series(self.outfile, io.Access.create,
+                                  self.outconfig)
+            print("Opened input and output")
+            sys.stdout.flush()
+        else:
+            print("Opening data source on rank {}.".format(self.comm.rank))
+            sys.stdout.flush()
+            inseries = io.Series(self.infile, io.Access.read_only, self.comm,
+                                 self.inconfig)
+            print("Opening data sink on rank {}.".format(self.comm.rank))
+            sys.stdout.flush()
+            outseries = io.Series(self.outfile, io.Access.create, self.comm,
+                                  self.outconfig)
+            print("Opened input and output on rank {}.".format(self.comm.rank))
+            sys.stdout.flush()
+        self.__copy(inseries, outseries)
+
+    def __copy(self, src, dest, current_path="/data/"):
+        """
+        Worker method.
+        Copies data from src to dest. May represent any point in the openPMD
+        hierarchy, but src and dest must both represent the same layer.
+        """
+        if (type(src) != type(dest)
+                and not isinstance(src, io.IndexedIteration)
+                and not isinstance(dest, io.Iteration)):
+            raise RuntimeError(
+                "Internal error: Trying to copy mismatching types")
+        for key in src.attributes:
+            attr = src.get_attribute(key)
+            attr_type = src.get_attribute_type(key)
+            dest.set_attribute(key, attr, attr_type)
+        container_types = [
+            io.Mesh_Container, io.Particle_Container, io.ParticleSpecies,
+            io.Record, io.Mesh, io.Particle_Patches, io.Patch_Record
+        ]
+        if isinstance(src, io.Series):
+            # main loop: read iterations of src, write to dest
+            write_iterations = dest.write_iterations()
+            for in_iteration in src.read_iterations():
+                if self.comm.rank == 0:
+                    print("Iteration {0} contains {1} meshes:".format(
+                        in_iteration.iteration_index,
+                        len(in_iteration.meshes)))
+                    for m in in_iteration.meshes:
+                        print("\t {0}".format(m))
+                    print("")
+                    print(
+                        "Iteration {0} contains {1} particle species:".format(
+                            in_iteration.iteration_index,
+                            len(in_iteration.particles)))
+                    for ps in in_iteration.particles:
+                        print("\t {0}".format(ps))
+                        print("With records:")
+                        for r in in_iteration.particles[ps]:
+                            print("\t {0}".format(r))
+                out_iteration = write_iterations[in_iteration.iteration_index]
+                sys.stdout.flush()
+                self.__particle_patches = []
+                self.__copy(
+                    in_iteration, out_iteration,
+                    current_path + str(in_iteration.iteration_index) + "/")
+                in_iteration.close()
+                for patch_load in self.__particle_patches:
+                    patch_load.run()
+                out_iteration.close()
+                self.__particle_patches.clear()
+                sys.stdout.flush()
+        elif isinstance(src, io.Record_Component):
+            shape = src.shape
+            offset = [0 for _ in shape]
+            dtype = src.dtype
+            dest.reset_dataset(io.Dataset(dtype, shape))
+            if src.empty:
+                # empty record component automatically created by
+                # dest.reset_dataset()
+                pass
+            elif src.constant:
+                dest.make_constant(src.get_attribute("value"))
+            else:
+                chunk = Chunk(offset, shape)
+                local_chunk = chunk.slice1D(self.comm.rank, self.comm.size)
+                if debug:
+                    end = local_chunk.offset.copy()
+                    for i in range(len(end)):
+                        end[i] += local_chunk.extent[i]
+                    print("{}\t{}/{}:\t{} -- {}".format(
+                        current_path, self.comm.rank, self.comm.size,
+                        local_chunk.offset, end))
+                chunk = src.load_chunk(local_chunk.offset, local_chunk.extent)
+                dest.store_chunk(chunk, local_chunk.offset, local_chunk.extent)
+        elif isinstance(src, io.Patch_Record_Component):
+            dest.reset_dataset(io.Dataset(src.dtype, src.shape))
+            if self.comm.rank == 0:
+                self.__particle_patches.append(
+                    particle_patch_load(src.load(), dest))
+        elif isinstance(src, io.Iteration):
+            self.__copy(src.meshes, dest.meshes, current_path + "meshes/")
+            self.__copy(src.particles, dest.particles,
+                        current_path + "particles/")
+        elif any([
+                isinstance(src, container_type)
+                for container_type in container_types
+        ]):
+            for key in src:
+                self.__copy(src[key], dest[key], current_path + key + "/")
+            if isinstance(src, io.ParticleSpecies):
+                self.__copy(src.particle_patches, dest.particle_patches)
+        else:
+            raise RuntimeError("Unknown openPMD class: " + str(src))
+
+
+def main():
+    args = parse_args()
+    if not args.infile or not args.outfile:
+        print("Please specify parameters --infile and --outfile.")
+        sys.exit(1)
+    if (HAVE_MPI):
+        run_pipe = pipe(args.infile, args.outfile, args.inconfig,
+                        args.outconfig, MPI.COMM_WORLD)
+    else:
+        run_pipe = pipe(args.infile, args.outfile, args.inconfig,
+                        args.outconfig, FallbackMPICommunicator())
+
+    run_pipe.run()
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit()

--- a/src/binding/python/openpmd_api/pipe/__init__.py
+++ b/src/binding/python/openpmd_api/pipe/__init__.py
@@ -183,9 +183,10 @@ class pipe:
                 and not isinstance(dest, io.Iteration)):
             raise RuntimeError(
                 "Internal error: Trying to copy mismatching types")
+        attribute_dtypes = src.attribute_dtypes
         for key in src.attributes:
             attr = src.get_attribute(key)
-            attr_type = src.get_attribute_dtype(key)
+            attr_type = attribute_dtypes[key]
             dest.set_attribute(key, attr, attr_type)
         container_types = [
             io.Mesh_Container, io.Particle_Container, io.ParticleSpecies,

--- a/src/binding/python/openpmd_api/pipe/__main__.py
+++ b/src/binding/python/openpmd_api/pipe/__main__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+This file is part of the openPMD-api.
+
+This module provides functions that are wrapped into sys.exit(...()) calls by
+the setuptools (setup.py) "entry_points" -> "console_scripts" generator.
+
+Copyright 2021 openPMD contributors
+Authors: Franz Poeschel
+License: LGPLv3+
+"""
+from . import main
+import sys
+
+if __name__ == "__main__":
+    main()
+    sys.exit()

--- a/src/cli/pipe.py
+++ b/src/cli/pipe.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+This file is part of the openPMD-api.
+
+This module provides functions that are wrapped into sys.exit(...()) calls by
+the setuptools (setup.py) "entry_points" -> "console_scripts" generator.
+
+Copyright 2021 openPMD contributors
+Authors: Franz Poeschel
+License: LGPLv3+
+"""
+import openpmd_api.pipe as pipe
+import sys
+
+if __name__ == "__main__":
+    pipe.main()
+    sys.exit()


### PR DESCRIPTION
This adds a little Python-based command line tool that can pipe data from a source to a sink.
Also adds handling of attributes by explicit datatype to the Python API to make generic attribute writing safe.

Possible uses:
* Converting openPMD-based data from one backend to another one.
* Multiplexing in staging setups

### TODO
- [x] Documentation
- [x] Cleanup
- [x] Testing: Resulting files must again be convertible using `openpmd-pipe`
- [x] Integration into the build system
- [x] Switch to a serial mode if MPI is not configured
- [x] Particle Patches
- [x] rebase after #912 was merged