### PR TITLE
support null core instead of null

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1530,7 +1530,7 @@ namespace detail
     void BufferedActions::configure_IO(ADIOS2IOHandlerImpl& impl){
         ( void )impl;
         static std::set< std::string > streamingEngines = {
-            "sst", "insitumpi", "inline", "staging", "null"
+            "sst", "insitumpi", "inline", "staging", "nullcore"
         };
         static std::set< std::string > fileEngines = {
             "bp4", "bp3", "hdf5", "file"

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -210,7 +210,7 @@ ADIOS2IOHandlerImpl::fileSuffix() const
     static std::map< std::string, std::string > endings{
         { "sst", "" }, { "staging", "" }, { "bp4", ".bp" },
         { "bp3", ".bp" },  { "file", ".bp" },     { "hdf5", ".h5" },
-        { "null", ".null" }
+        { "nullcore", ".nullcore" }
     };
     auto it = endings.find( m_engineType );
     if( it != endings.end() )

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3078,6 +3078,11 @@ bp4_steps( std::string const & file, std::string const & options_write, std::str
         }
     }
 
+    if( options_read.empty() )
+    {
+        return;
+    }
+
     Series readSeries( file, Access::READ_ONLY, options_read );
 
     size_t last_iteration_index = 0;
@@ -3109,6 +3114,16 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
         }
     }
     )";
+    std::string nullcore = R"(
+    {
+        "adios2": {
+            "engine": {
+                "type": "bp4",
+                "usesteps": true
+            }
+        }
+    }
+    )";
     std::string dontUseSteps = R"(
     {
         "adios2": {
@@ -3124,7 +3139,8 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
     bp4_steps( "../samples/bp4steps_no_yes.bp", dontUseSteps, useSteps );
     bp4_steps( "../samples/bp4steps_yes_no.bp", useSteps, dontUseSteps );
     bp4_steps( "../samples/bp4steps_no_no.bp", dontUseSteps, dontUseSteps );
-    bp4_steps("../samples/bp4steps_default.bp", "{}", "{}");
+    bp4_steps( "../samples/nullcore.bp", nullcore, "" );
+    bp4_steps( "../samples/bp4steps_default.bp", "{}", "{}" );
 }
 #endif
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2944,7 +2944,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
 {
   "adios2": {
     "engine": {
-      "type": "null",
+      "type": "nullcore",
       "unused": "parameter",
       "parameters": {
         "BufferGrowthFactor": "2.0",


### PR DESCRIPTION
The NullCore engine is recommended in ADIOS, instead of Null Engine.