### PR TITLE
Check whether particlePatches are dirty

### DIFF
--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -305,6 +305,7 @@ BaseRecord< T_elem >::flush(std::string const& name)
         throw std::runtime_error("A Record can not be written without any contained RecordComponents: " + name);
 
     this->flush_impl(name);
+    this->dirty() = false;
 }
 
 template< typename T_elem >

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -49,6 +49,7 @@ class PatchRecordComponent : public BaseRecordComponent
     friend
     class Container;
 
+    template< typename > friend class BaseRecord;
     friend class ParticlePatches;
     friend class PatchRecord;
 
@@ -74,6 +75,17 @@ OPENPMD_private:
     void read();
 
     std::shared_ptr< std::queue< IOTask > > m_chunks;
+
+    /**
+     * @brief Check recursively whether this RecordComponent is dirty.
+     *        It is dirty if any attribute or dataset is read from or written to
+     *        the backend.
+     *
+     * @return true If dirty.
+     * @return false Otherwise.
+     */
+    bool
+    dirtyRecursive() const;
 }; // PatchRecordComponent
 
 template< typename T >

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -75,6 +75,7 @@ OPENPMD_private:
     void read();
 
     std::shared_ptr< std::queue< IOTask > > m_chunks;
+    std::shared_ptr< bool > hasBeenRead = std::make_shared< bool >( false );
 
     /**
      * @brief Check recursively whether this RecordComponent is dirty.

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -74,6 +74,9 @@ ParticlePatches::read()
         prc.written() = false;
         prc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
         prc.written() = true;
+
+        pr.dirty() = false;
+        prc.read();
     }
 }
 } // openPMD

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -106,6 +106,16 @@ ParticleSpecies::read()
     readAttributes();
 }
 
+namespace
+{
+    bool flushParticlePatches( ParticlePatches const & particlePatches )
+    {
+        return particlePatches.find("numParticles") != particlePatches.end()
+            && particlePatches.find("numParticlesOffset") != particlePatches.end()
+            && particlePatches.size() >= 3;
+    }
+}
+
 void
 ParticleSpecies::flush(std::string const& path)
 {
@@ -129,9 +139,7 @@ ParticleSpecies::flush(std::string const& path)
         for( auto& record : *this )
             record.second.flush(record.first);
 
-        if( particlePatches.find("numParticles") != particlePatches.end()
-            && particlePatches.find("numParticlesOffset") != particlePatches.end()
-            && particlePatches.size() >= 3 )
+        if( flushParticlePatches( particlePatches ) )
         {
             particlePatches.flush("particlePatches");
             for( auto& patch : particlePatches )
@@ -154,11 +162,14 @@ ParticleSpecies::dirtyRecursive() const
             return true;
         }
     }
-    for( auto const & pair : particlePatches )
+    if( flushParticlePatches( particlePatches ) )
     {
-        if( pair.second.dirtyRecursive() )
+        for( auto const & pair : particlePatches )
         {
-            return true;
+            if( pair.second.dirtyRecursive() )
+            {
+                return true;
+            }
         }
     }
     return false;

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -154,6 +154,13 @@ ParticleSpecies::dirtyRecursive() const
             return true;
         }
     }
+    for( auto const & pair : particlePatches )
+    {
+        if( pair.second.dirtyRecursive() )
+        {
+            return true;
+        }
+    }
     return false;
 }
 } // namespace openPMD

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -93,5 +93,6 @@ PatchRecord::read()
         prc.written() = true;
         prc.read();
     }
+    dirty() = false;
 }
 } // openPMD

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -105,6 +105,12 @@ PatchRecordComponent::flush(std::string const& name)
 void
 PatchRecordComponent::read()
 {
+    if ( *hasBeenRead )
+    {
+        dirty() = false;
+        return;
+    }
+
     Parameter< Operation::READ_ATT > aRead;
 
     aRead.name = "unitSI";
@@ -116,6 +122,8 @@ PatchRecordComponent::read()
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 
     readAttributes();
+
+    *hasBeenRead = true;
 }
 
 bool

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -117,4 +117,14 @@ PatchRecordComponent::read()
 
     readAttributes();
 }
+
+bool
+PatchRecordComponent::dirtyRecursive() const
+{
+    if( this->dirty() )
+    {
+        return true;
+    }
+    return !m_chunks->empty();
+}
 } // openPMD

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -121,7 +121,7 @@ PatchRecordComponent::read()
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 
-    readAttributes();
+    readAttributes(); // this will set dirty() = false
 
     *hasBeenRead = true;
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -681,7 +681,7 @@ void particle_patches( std::string file_ending )
     uint64_t const num_patches = 2u;
     {
         // constant scalar
-        Series s = Series("../samples/particle_patches." + file_ending, Access::CREATE);
+        Series s = Series("../samples/particle_patches%T." + file_ending, Access::CREATE);
 
         auto e = s.iterations[42].particles["electrons"];
 
@@ -727,7 +727,7 @@ void particle_patches( std::string file_ending )
         e.particlePatches["extent"]["y"].store(1, float(123.));
     }
     {
-        Series s = Series("../samples/particle_patches." + file_ending, Access::READ_ONLY);
+        Series s = Series("../samples/particle_patches%T." + file_ending, Access::READ_ONLY);
 
         auto e = s.iterations[42].particles["electrons"];
 


### PR DESCRIPTION
Fix for #907. `::dirtyRecursive()` ignored particle patches, leading to skipped flushes.
We should do a minor release soon including this one since this makes restarting from openPMD impossible in PIConGPU.

TODO:
- [x] Add a test for this