### PR TITLE
CI: Ubuntu-latest -> 20.04

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   style:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Non-ASCII Characters
@@ -19,7 +19,7 @@ jobs:
         python3 -m flake8 --exclude=thirdParty .
 
   static-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: pyflakes
@@ -28,7 +28,7 @@ jobs:
         python3 -m pyflakes docs/ examples/ test/ setup.py
 
   documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: s-weigand/setup-conda@v1


### PR DESCRIPTION
Removes a warning:

Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see
https://github.com/actions/virtual-environments/issues/1816