### PR TITLE
Python: store_chunk(temporary)

### DIFF
--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -27,13 +27,14 @@
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/binding/python/Numpy.hpp"
 
-#include <complex>
-#include <string>
 #include <algorithm>
-#include <tuple>
-#include <iostream>
+#include <complex>
 #include <cstdint>
+#include <cstring>
 #include <exception>
+#include <iostream>
+#include <string>
+#include <tuple>
 
 namespace py = pybind11;
 using namespace openPMD;
@@ -279,44 +280,55 @@ store_chunk(RecordComponent & r, py::array & a, Offset const & offset, Extent co
         throw py::index_error(
             "strides in chunk are inefficient, not implemented!");
     // @todo in order to implement stride handling, one needs to
-    //       loop over the input data strides during write below,
-    //       also data might not be owned!
+    //       loop over the input data strides during write below
+
+    // check: did the user pass a temporary buffer? In that case, we copy as we
+    //        do in the shared_ptr API for C++
+    // note: there might be a corner-case if the user passes a temporary via
+    //       additional wrapper function calls here. We can cover this by
+    //       increasing the Py_SET_REFCNT of a ourselves and reducing it after
+    //       flush(), but that's too complicated/exotic to handle for now.
+    // yeah, every call adds a +1
+    // so here it's 3 (temporary) or >=4 (regular external var)
+    const bool copy = a.ref_count() <= 3 ? true : false;
+
+    void* data = a.mutable_data();
+    auto store_data = [ &r, &data, &offset, &extent, &copy ]( auto cxxtype ){
+        using CXXType = decltype(cxxtype);
+        if( copy ) {
+            size_t num_elements = 1u;
+            for( auto const& si : extent )
+                num_elements *= si;
+            std::shared_ptr< CXXType > data_copy( new CXXType[num_elements],
+                                                  [](CXXType const *p) { delete[] p; } );
+            std::memcpy( data_copy.get(), data, num_elements * sizeof(CXXType) );
+            r.storeChunk( data_copy, offset, extent );
+        }
+        else
+            r.storeChunk( shareRaw( (CXXType*)data ), offset, extent );
+    };
 
     // store
     auto const dtype = dtype_from_numpy( a.dtype() );
-    if( dtype == Datatype::CHAR )
-        r.storeChunk( shareRaw( (char*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::UCHAR )
-        r.storeChunk( shareRaw( (unsigned char*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::SHORT )
-        r.storeChunk( shareRaw( (short*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::INT )
-        r.storeChunk( shareRaw( (int*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::LONG )
-       r.storeChunk( shareRaw( (long*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::LONGLONG )
-        r.storeChunk( shareRaw( (long long*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::USHORT )
-        r.storeChunk( shareRaw( (unsigned short*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::UINT )
-        r.storeChunk( shareRaw( (unsigned int*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::ULONG )
-        r.storeChunk( shareRaw( (unsigned long*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::ULONGLONG )
-        r.storeChunk( shareRaw( (unsigned long long*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::LONG_DOUBLE )
-        r.storeChunk( shareRaw( (long double*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::DOUBLE )
-        r.storeChunk( shareRaw( (double*)a.mutable_data() ), offset, extent );
-    else if( dtype == Datatype::FLOAT )
-        r.storeChunk( shareRaw( (float*)a.mutable_data() ), offset, extent );
+    if( dtype == Datatype::CHAR ) store_data( char() );
+    else if( dtype == Datatype::UCHAR ) store_data( (unsigned char)0 );
+    else if( dtype == Datatype::SHORT ) store_data( short() );
+    else if( dtype == Datatype::INT ) store_data( int() );
+    else if( dtype == Datatype::LONG ) store_data( long() );
+    else if( dtype == Datatype::LONGLONG ) store_data( (long long)0 );
+    else if( dtype == Datatype::USHORT ) store_data( (unsigned short)0 );
+    else if( dtype == Datatype::UINT ) store_data( (unsigned int)0 );
+    else if( dtype == Datatype::ULONG ) store_data( (unsigned long)0 );
+    else if( dtype == Datatype::ULONGLONG ) store_data( (unsigned long long)0 );
+    else if( dtype == Datatype::LONG_DOUBLE ) store_data( (long double)0 );
+    else if( dtype == Datatype::DOUBLE ) store_data( double() );
+    else if( dtype == Datatype::FLOAT ) store_data( float() );
 /* @todo
 .value("STRING", Datatype::STRING)
 .value("VEC_STRING", Datatype::VEC_STRING)
 .value("ARR_DBL_7", Datatype::ARR_DBL_7)
 */
-    else if( dtype == Datatype::BOOL )
-        r.storeChunk( shareRaw( (bool*)a.mutable_data() ), offset, extent );
+    else if( dtype == Datatype::BOOL ) store_data( bool() );
     else
         throw std::runtime_error(
             std::string("Datatype '") +

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1657,7 +1657,10 @@ class APITest(unittest.TestCase):
         )
 
         r_E_x = read.iterations[0].meshes["E"]["x"]
-        # self.assertEqual(len(r_E_x.available_chunks()), 2) # oddly, "1"
+        if read.backend == 'ADIOS2':
+            self.assertEqual(len(r_E_x.available_chunks()), 2)
+        else:
+            self.assertEqual(len(r_E_x.available_chunks()), 1)
         r_d = r_E_x[()]
         read.flush()
 


### PR DESCRIPTION
Fix #833

- [x] Test: Store a temporary array that is garbage collected after the call. (note: does not yet trigger a fail...)
- [x] fix `store_chunk`

Note: there is no in-memory overload for `load_chunk` yet exposed in Python.