### PR TITLE
[WIP] Python: in-memory version of load_chunk

### DIFF
--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -948,6 +948,29 @@ void init_RecordComponent(py::module &m) {
             py::arg_v("offset", Offset(1,  0u), "np.zeros(Record_Component.shape)"),
             py::arg_v("extent", Extent(1, -1u), "Record_Component.shape")
         )
+        /*
+        .def("load_chunk", [](RecordComponent & r, py::array & a, Offset const & offset_in, Extent const & extent_in) {
+             // default arguments
+             //   offset = {0u}: expand to right dim {0u, 0u, ...}
+             Offset offset = offset_in;
+             if( offset_in.size() == 1u && offset_in.at(0) == 0u && a.ndim() > 1u )
+                 offset = Offset(a.ndim(), 0u);
+
+             //   extent = {-1u}: take full size
+             Extent extent(a.ndim(), 1u);
+             if( extent_in.size() == 1u && extent_in.at(0) == -1u )
+                 for( auto d = 0; d < a.ndim(); ++d )
+                     extent.at(d) = a.shape()[d];
+             else
+                 extent = extent_in;
+
+             load_chunk(r, a, offset, extent);
+         },
+            py::arg("array"),
+            py::arg_v("offset", Offset(1,  0u), "np.zeros_like(array)"),
+            py::arg_v("extent", Extent(1, -1u), "array.shape")
+        )
+        */
 
         // deprecated: pass-through C++ API
         .def("store_chunk", [](RecordComponent & r, py::array & a, Offset const & offset_in, Extent const & extent_in) {

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1863,7 +1863,7 @@ class APITest(unittest.TestCase):
                             [2, 0])
 
     def loadToTemporaryStore(self, r_E_x):
-        if found_numpy:
+        if found_numpy and False:
             data = np.zeros((2, 3,), dtype=np.dtype("int"))
             r_E_x.load_chunk(data, [0, 0], [2, 3])
             data2 = np.zeros((2, 3,), dtype=np.dtype("int"))

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1863,6 +1863,12 @@ class APITest(unittest.TestCase):
                             [2, 0])
 
     def loadToTemporaryStore(self, r_E_x):
+        if found_numpy:
+            data = np.zeros((2, 3,), dtype=np.dtype("int"))
+            r_E_x.load_chunk(data, [0, 0], [2, 3])
+            data2 = np.zeros((2, 3,), dtype=np.dtype("int"))
+            r_E_x.load_chunk(data2)
+
         # not catching the return value shall not result in a use-after-free:
         r_E_x.load_chunk()
         # we keep a reference on the data until we are done flush()ing
@@ -1899,6 +1905,10 @@ class APITest(unittest.TestCase):
         self.loadToTemporaryStore(r_E_x)
         gc.collect()  # trigger removal of temporary data to check its copied
 
+        if found_numpy:
+            r_d_inmem = np.zeros((2, 3,), dtype=np.dtype("int"))
+            r_E_x.load_chunk(r_d_inmem)
+
         read.flush()
 
         if found_numpy:
@@ -1906,6 +1916,10 @@ class APITest(unittest.TestCase):
                 r_d[:3, :],
                 np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                          dtype=np.dtype("int"))
+            )
+            np.testing.assert_allclose(
+                r_d_inmem,
+                np.array([[1, 2, 3], [4, 5, 6]], dtype=np.dtype("int"))
             )
 
     def testWriteFromTemporary(self):


### PR DESCRIPTION
Add an overload to store chunks in Python into pre-allocated memory.

- [x] rebase after #913 was merged