### PR TITLE
HDF5: Empiric for Optimal Chunk Size

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -43,7 +43,7 @@ jobs:
         python3 -m pip install -U numpy
         sudo .github/workflows/dependencies/install_spack
     - name: Build
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror -Wno-deprecated-declarations}
+      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror -Wno-deprecated-declarations, OPENPMD_HDF5_CHUNKS: none}
       run: |
         eval $(spack env activate --sh .github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad1_ad2/)
         spack install
@@ -51,8 +51,15 @@ jobs:
         mkdir build && cd build
         ../share/openPMD/download_samples.sh && chmod u-w samples/git-sample/*.h5
         export LDFLAGS="${LDFLAGS} -fsanitize=address,undefined -shared-libsan"
-        CXXFLAGS="${CXXFLAGS} -fsanitize=address,undefined -shared-libsan"
-        CXXFLAGS="${CXXFLAGS}" cmake -S .. -B . -DopenPMD_USE_MPI=ON -DopenPMD_USE_PYTHON=ON -DopenPMD_USE_HDF5=ON -DopenPMD_USE_ADIOS2=ON -DopenPMD_USE_ADIOS1=ON -DopenPMD_USE_INVASIVE_TESTS=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+        export CXXFLAGS="${CXXFLAGS} -fsanitize=address,undefined -shared-libsan"
+        cmake -S .. -B .                  \
+          -DopenPMD_USE_MPI=ON            \
+          -DopenPMD_USE_PYTHON=ON         \
+          -DopenPMD_USE_HDF5=ON           \
+          -DopenPMD_USE_ADIOS2=ON         \
+          -DopenPMD_USE_ADIOS1=ON         \
+          -DopenPMD_USE_INVASIVE_TESTS=ON \
+          -DCMAKE_VERBOSE_MAKEFILE=ON
         cmake --build . --parallel 2
         export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         export LSAN_OPTIONS=suppressions="$SOURCEPATH/.github/ci/sanitizer/clang/Leak.supp"

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -26,6 +26,7 @@ environment variable                  default   description
 ===================================== ========= ====================================================================================
 ``OPENPMD_HDF5_INDEPENDENT``          ``ON``    Sets the MPI-parallel transfer mode to collective (``OFF``) or independent (``ON``).
 ``OPENPMD_HDF5_ALIGNMENT``            ``1``     Tuning parameter for parallel I/O, choose an alignment which is a multiple of the disk block size.
+``OPENPMD_HDF5_CHUNKS``               ``auto``  Defaults for ``H5Pset_chunk``: ``"auto"`` (heuristic) or ``"none"`` (no chunking).
 ``H5_COLL_API_SANITY_CHECK``          unset     Set to ``1`` to perform an ``MPI_Barrier`` inside each meta-data operation.
 ===================================== ========= ====================================================================================
 
@@ -39,6 +40,9 @@ Please refer to the `HDF5 manual, function H5Pset_dxpl_mpio <https://support.hdf
 According to the `HDF5 documentation <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_alignment.htm>`_:
 *For MPI IO and other parallel systems, choose an alignment which is a multiple of the disk block size.*
 On Lustre filesystems, according to the `NERSC documentation <https://www.nersc.gov/users/training/online-tutorials/introduction-to-scientific-i-o/?start=5>`_, it is advised to set this to the Lustre stripe size. In addition, ORNL Summit GPFS users are recommended to set the alignment value to 16777216(16MB).
+
+``OPENPMD_HDF5_CHUNKS`` This sets defaults for data chunking via `H5Pset_chunk <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_chunk.htm>`__.
+Chunking generally improves performance and only needs to be disabled in corner-cases, e.g. when heavily relying on independent, parallel I/O that non-collectively declares data records.
 
 ``H5_COLL_API_SANITY_CHECK``: this is a HDF5 control option for debugging parallel I/O logic (API calls).
 Debugging a parallel program with that option enabled can help to spot bugs such as collective MPI-calls that are not called by all participating MPI ranks.

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -74,6 +74,23 @@ Explanation of the single keys:
 Any setting specified under ``adios2.dataset`` is applicable globally as well as on a per-dataset level.
 Any setting under ``adios2.engine`` is applicable globally only.
 
+HDF5
+^^^^
+
+A full configuration of the HDF5 backend:
+
+.. literalinclude:: hdf5.json
+   :language: json
+
+All keys found under ``hdf5.dataset`` are applicable globally (future: as well as per dataset).
+Explanation of the single keys:
+
+* ``adios2.dataset.chunks``: This key contains options for data chunking via `H5Pset_chunk <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_chunk.htm>`__.
+  The default is ``"auto"`` for a heuristic.
+  ``"none"`` can be used to disable chunking.
+  Chunking generally improves performance and only needs to be disabled in corner-cases, e.g. when heavily relying on independent, parallel I/O that non-collectively declares data records.
+
+
 Other backends
 ^^^^^^^^^^^^^^
 

--- a/docs/source/details/json.json
+++ b/docs/source/details/json.json
@@ -1,0 +1,7 @@
+{
+  "hdf5": {
+    "dataset": {
+      "chunks": "auto"
+    }
+  }
+}

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -66,7 +66,7 @@ namespace openPMD
      * @param[in] typeSize size of each element in bytes
      * @return array for resulting chunk dimensions
      */
-    inline std::vector< hsize_t >
+    std::vector< hsize_t >
     getOptimalChunkDims( std::vector< hsize_t > const dims,
                          size_t const typeSize );
 } // namespace openPMD

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller, Felix Schmitt, Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -34,7 +34,6 @@
 
 namespace openPMD
 {
-#if openPMD_HAVE_HDF5
     struct GetH5DataType
     {
         std::unordered_map< std::string, hid_t > m_userTypes;
@@ -54,5 +53,20 @@ namespace openPMD
     std::string
     concrete_h5_file_position(Writable* w);
 
-#endif
+    /** Computes the chunk dimensions for a dataset.
+     *
+     * Chunk dimensions are selected to create chunks sizes between
+     * 64KByte and 4MB. Smaller chunk sizes are inefficient due to overhead,
+     * larger chunks do not map well to file system blocks and striding.
+     *
+     * Chunk dimensions are less or equal to dataset dimensions and do
+     * not need to be a factor of the respective dataset dimension.
+     *
+     * @param[in] dims dimensions of dataset to get chunk dims for
+     * @param[in] typeSize size of each element in bytes
+     * @return array for resulting chunk dimensions
+     */
+    inline std::vector< hsize_t >
+    getOptimalChunkDims( std::vector< hsize_t > const dims,
+                         size_t const typeSize );
 } // namespace openPMD

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -22,6 +22,8 @@
 
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
+#include <nlohmann/json.hpp>
+
 #include <future>
 #include <memory>
 #include <string>
@@ -34,7 +36,7 @@ class HDF5IOHandlerImpl;
 class HDF5IOHandler : public AbstractIOHandler
 {
 public:
-    HDF5IOHandler(std::string path, Access);
+    HDF5IOHandler(std::string path, Access, nlohmann::json config);
     ~HDF5IOHandler() override;
 
     std::string backendName() const override { return "HDF5"; }

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -79,6 +79,7 @@ namespace openPMD
 
     private:
         auxiliary::TracingJSON m_config;
+        std::string m_chunks = "auto";
         struct File
         {
             std::string name;

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -24,6 +24,7 @@
 #if openPMD_HAVE_HDF5
 #   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 
+#   include "openPMD/auxiliary/JSON.hpp"
 #   include "openPMD/auxiliary/Option.hpp"
 
 #   include <hdf5.h>
@@ -38,7 +39,7 @@ namespace openPMD
     class HDF5IOHandlerImpl : public AbstractIOHandlerImpl
     {
     public:
-        HDF5IOHandlerImpl(AbstractIOHandler*);
+        HDF5IOHandlerImpl(AbstractIOHandler*, nlohmann::json config);
         ~HDF5IOHandlerImpl() override;
 
         void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) override;
@@ -77,6 +78,7 @@ namespace openPMD
         hid_t m_H5T_CLONG_DOUBLE;
 
     private:
+        auxiliary::TracingJSON m_config;
         struct File
         {
             std::string name;

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -23,6 +23,8 @@
 #include "openPMD/config.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
+#include <nlohmann/json.hpp>
+
 #include <future>
 #include <memory>
 #include <string>
@@ -36,9 +38,10 @@ namespace openPMD
     {
     public:
     #if openPMD_HAVE_MPI
-        ParallelHDF5IOHandler(std::string path, Access, MPI_Comm);
+        ParallelHDF5IOHandler(
+            std::string path, Access, MPI_Comm, nlohmann::json config);
     #else
-        ParallelHDF5IOHandler(std::string path, Access);
+        ParallelHDF5IOHandler(std::string path, Access, nlohmann::json config);
     #endif
         ~ParallelHDF5IOHandler() override;
 

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
@@ -27,6 +27,7 @@
 #   include <mpi.h>
 #   if openPMD_HAVE_HDF5
 #       include "openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp"
+#       include <nlohmann/json.hpp>
 #   endif
 #endif
 
@@ -37,7 +38,8 @@ namespace openPMD
     class ParallelHDF5IOHandlerImpl : public HDF5IOHandlerImpl
     {
     public:
-        ParallelHDF5IOHandlerImpl(AbstractIOHandler*, MPI_Comm);
+        ParallelHDF5IOHandlerImpl(
+            AbstractIOHandler*, MPI_Comm, nlohmann::json config);
         ~ParallelHDF5IOHandlerImpl() override;
 
         MPI_Comm m_mpiComm;

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -46,7 +46,7 @@ namespace openPMD
         {
             case Format::HDF5:
                 return std::make_shared< ParallelHDF5IOHandler >(
-                    path, access, comm, std::move( optionsJson ) );
+                    path, access, comm, std::move( options ) );
             case Format::ADIOS1:
 #   if openPMD_HAVE_ADIOS1
                 return std::make_shared< ParallelADIOS1IOHandler >( path, access, comm );
@@ -82,7 +82,7 @@ namespace openPMD
         {
             case Format::HDF5:
                 return std::make_shared< HDF5IOHandler >(
-                    path, access, std::move( optionsJson ) );
+                    path, access, std::move( options ) );
             case Format::ADIOS1:
 #if openPMD_HAVE_ADIOS1
                 return std::make_shared< ADIOS1IOHandler >( path, access );

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -45,7 +45,8 @@ namespace openPMD
         switch( format )
         {
             case Format::HDF5:
-                return std::make_shared< ParallelHDF5IOHandler >( path, access, comm );
+                return std::make_shared< ParallelHDF5IOHandler >(
+                    path, access, comm, std::move( optionsJson ) );
             case Format::ADIOS1:
 #   if openPMD_HAVE_ADIOS1
                 return std::make_shared< ParallelADIOS1IOHandler >( path, access, comm );
@@ -80,7 +81,8 @@ namespace openPMD
         switch( format )
         {
             case Format::HDF5:
-                return std::make_shared< HDF5IOHandler >( path, access );
+                return std::make_shared< HDF5IOHandler >(
+                    path, access, std::move( optionsJson ) );
             case Format::ADIOS1:
 #if openPMD_HAVE_ADIOS1
                 return std::make_shared< ADIOS1IOHandler >( path, access );

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -97,9 +97,8 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
             auto datasetConfig = m_config[ "dataset" ];
             if( datasetConfig.json().contains( "chunks" ) )
             {
-                m_chunks = datasetConfig.json()[ "chunks" ];
+                m_chunks = datasetConfig[ "chunks" ].json().get< std::string >();
             }
-            datasetConfig.declareFullyRead();
         }
         if( m_chunks != "auto" && m_chunks != "none" )
         {

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -102,14 +102,16 @@ ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
 #   if openPMD_HAVE_MPI
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
                                              Access at,
-                                             MPI_Comm comm)
+                                             MPI_Comm comm,
+                                             nlohmann::json /* config */)
         : AbstractIOHandler(std::move(path), at, comm)
 {
     throw std::runtime_error("openPMD-api built without HDF5 support");
 }
 #   else
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
-                                             Access at)
+                                             Access at,
+                                             nlohmann::json /* config */)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without parallel support and without HDF5 support");

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -38,11 +38,10 @@ namespace openPMD
 #       define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif
 
-ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
-                                             Access at,
-                                             MPI_Comm comm)
+ParallelHDF5IOHandler::ParallelHDF5IOHandler(
+    std::string path, Access at, MPI_Comm comm, nlohmann::json config )
         : AbstractIOHandler(std::move(path), at, comm),
-          m_impl{new ParallelHDF5IOHandlerImpl(this, comm)}
+          m_impl{new ParallelHDF5IOHandlerImpl(this, comm, std::move(config))}
 { }
 
 ParallelHDF5IOHandler::~ParallelHDF5IOHandler() = default;
@@ -53,9 +52,9 @@ ParallelHDF5IOHandler::flush()
     return m_impl->flush();
 }
 
-ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(AbstractIOHandler* handler,
-                                                     MPI_Comm comm)
-        : HDF5IOHandlerImpl{handler},
+ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
+    AbstractIOHandler* handler, MPI_Comm comm, nlohmann::json config )
+        : HDF5IOHandlerImpl{handler, std::move(config)},
           m_mpiComm{comm},
           m_mpiInfo{MPI_INFO_NULL} /* MPI 3.0+: MPI_INFO_ENV */
 {

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -764,6 +764,19 @@ hipace_like_write( std::string file_ending )
     // the iterations we want to write
     std::vector< int > iterations = { 10, 30, 50, 70 };
 
+    // Parallel HDF5 + chunking does not work with independent IO pattern
+    bool const isHDF5 = file_ending == "h5";
+    std::string options = "{}";
+    if( isHDF5 )
+        options = R"(
+        {
+          "hdf5": {
+            "dataset": {
+              "chunks": "none"
+            }
+          }
+        })";
+
     // MPI communicator meta-data and file name
     int i_mpi_rank{ -1 }, i_mpi_size{ -1 };
     MPI_Comm_rank( MPI_COMM_WORLD, &i_mpi_rank );
@@ -785,7 +798,7 @@ hipace_like_write( std::string file_ending )
         [](precision d) -> precision { return std::sin( d * 2.0 * 3.1415 / 20. ); });
 
     // open a parallel series
-    Series series( name, Access::CREATE, MPI_COMM_WORLD );
+    Series series( name, Access::CREATE, MPI_COMM_WORLD, options );
     series.setIterationEncoding( IterationEncoding::groupBased );
     series.flush();
 


### PR DESCRIPTION
This ports a prior empirical algorithm from libSplash to determine an optimal (large) chunk size for an HDF5 dataset based on its datatype and global extent.

Original implementation by Felix Schmitt @f-schmitt (ZIH, TU Dresden) in [libSplash](https://github.com/ComputationalRadiationPhysics/libSplash).

Original source:
- https://github.com/ComputationalRadiationPhysics/libSplash/blob/v1.7.0/src/DCDataSet.cpp
- https://github.com/ComputationalRadiationPhysics/libSplash/blob/v1.7.0/src/include/splash/core/DCHelper.hpp

Close #406
Related to #898 (improve HDF5 baseline performance)
Required for #510: basis to extend resizable data sets (#829) to HDF5

### To Do

- [x] pass tests
- [x] measure performance ([h5chunks_cori.sbatch.txt](https://github.com/openPMD/openPMD-api/files/6640943/h5chunks_cori.sbatch.txt))
  - Cori seems to be still slow, also when playing further with `OPENPMD_HDF5_INDEPENDENT="OFF"` and `OPENPMD_HDF5_ALIGNMENT="1048576"` for our `8_benchmark_parallel -w` benchmark
- [x] measure filesize overhead

Sample & bin directory `du -hs bin samples` with:
| `OPENPMD_HDF5_CHUNKS` | size |
|--|--|
| "auto"/*unset* | 13M + 1.6G |
| "none" | 11M + 1.6G |

on my laptop (4KiB blocksize).

With `"auto"` the `MPI.8_benchmark_parallel` test is significantly slower. Changing the 4D test to 3D brings the difference down to about 20% slowdown #1010. (Maybe the 4th, 10-element dimension is sub-ideal for chunking?)

# Follow-Ups
- [ ] allow definition on a per-dataset basis
- [ ] allow passing user-defined per-dataset Byte arrays for chunks