### PR TITLE
Wheels: 0.13.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'src'
-        ref: '0.13.1'
+        ref: '0.13.2'
 
     - uses: actions/checkout@v2
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.13.1"
+    - OPENPMD_GIT_REF="0.13.2"
 
     # (1,2,3) Skip building for Python 2.7 & 3.5 on all platforms
     # (4) GNU 7.3.1 & MPark.Variant 1.4.0 on i686:


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.13.2 release.