### PR TITLE
License Header: Update 2021

### DIFF
--- a/.github/workflows/source/buildDoxygen
+++ b/.github/workflows/source/buildDoxygen
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020 Axel Huebl
+# Copyright 2020-2021 Axel Huebl
 #
 # License: LGPLv3+
 

--- a/.github/workflows/source/hasEOLwhiteSpace
+++ b/.github/workflows/source/hasEOLwhiteSpace
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2020 Axel Huebl
+# Copyright 2016-2021 Axel Huebl
 #
 # License: LGPLv3+
 

--- a/.github/workflows/source/hasNonASCII
+++ b/.github/workflows/source/hasNonASCII
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2020 Axel Huebl
+# Copyright 2016-2021 Axel Huebl
 #
 # License: LGPLv3+
 

--- a/.github/workflows/source/hasTabs
+++ b/.github/workflows/source/hasTabs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2020 Axel Huebl
+# Copyright 2016-2021 Axel Huebl
 #
 # License: LGPLv3+
 

--- a/examples/1_structure.cpp
+++ b/examples/1_structure.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2018-2020 openPMD contributors
+Copyright 2018-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/examples/2a_read_thetaMode_serial.cpp
+++ b/examples/2a_read_thetaMode_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/examples/2a_read_thetaMode_serial.py
+++ b/examples/2a_read_thetaMode_serial.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2020 openPMD contributors
+Copyright 2020-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2018-2020 openPMD contributors
+Copyright 2018-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/examples/3a_write_thetaMode_serial.cpp
+++ b/examples/3a_write_thetaMode_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/examples/3a_write_thetaMode_serial.py
+++ b/examples/3a_write_thetaMode_serial.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2020 openPMD contributors
+Copyright 2020-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/examples/4_read_parallel.py
+++ b/examples/4_read_parallel.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2019-2020 openPMD contributors
+Copyright 2019-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2019-2020 openPMD contributors
+Copyright 2019-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2018-2020 openPMD contributors
+Copyright 2018-2021 openPMD contributors
 Authors: Axel Huebl, Fabian Koller
 License: LGPLv3+
 """

--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Junmin Gu, Axel Huebl
+/* Copyright 2020-2021 Junmin Gu, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/examples/8b_benchmark_read_parallel.cpp
+++ b/examples/8b_benchmark_read_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Junmin Gu, Axel Huebl
+/* Copyright 2020-2021 Junmin Gu, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -2,7 +2,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2019-2020 openPMD contributors
+Copyright 2019-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/include/openPMD/ChunkInfo.hpp
+++ b/include/openPMD/ChunkInfo.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Franz Poeschel, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Fabian Koller
+/* Copyright 2018-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS1FilePosition.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1FilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel.
+/* Copyright 2017-2021 Franz Poeschel.
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS2FilePosition.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2FilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2021 Fabian Koller and Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2021 Fabian Koller and Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractFilePosition.hpp
+++ b/include/openPMD/IO/AbstractFilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Fabian Koller
+/* Copyright 2018-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2021 Fabian Koller and Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/DummyIOHandler.hpp
+++ b/include/openPMD/IO/DummyIOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/Format.hpp
+++ b/include/openPMD/IO/Format.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5FilePosition.hpp
+++ b/include/openPMD/IO/HDF5/HDF5FilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/InvalidatableFile.hpp
+++ b/include/openPMD/IO/InvalidatableFile.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/JSON/JSONFilePosition.hpp
+++ b/include/openPMD/IO/JSON/JSONFilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel
+/* Copyright 2017-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/JSON/JSONIOHandler.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel
+/* Copyright 2017-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel
+/* Copyright 2017-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IterationEncoding.hpp
+++ b/include/openPMD/IterationEncoding.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/UnitDimension.hpp
+++ b/include/openPMD/UnitDimension.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Date.hpp
+++ b/include/openPMD/auxiliary/Date.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/DerefDynamicCast.hpp
+++ b/include/openPMD/auxiliary/DerefDynamicCast.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Environment.hpp
+++ b/include/openPMD/auxiliary/Environment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel, Axel Huebl
+/* Copyright 2018-2021 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Export.hpp
+++ b/include/openPMD/auxiliary/Export.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Filesystem.hpp
+++ b/include/openPMD/auxiliary/Filesystem.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Fabian Koller
+/* Copyright 2018-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/JSON.hpp
+++ b/include/openPMD/auxiliary/JSON.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Option.hpp
+++ b/include/openPMD/auxiliary/Option.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/OutOfRangeMsg.hpp
+++ b/include/openPMD/auxiliary/OutOfRangeMsg.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Axel Huebl
+/* Copyright 2017-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/ShareRaw.hpp
+++ b/include/openPMD/auxiliary/ShareRaw.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Franz Poeschel
+/* Copyright 2017-2021 Fabian Koller, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Unused.hpp
+++ b/include/openPMD/auxiliary/Unused.hpp
@@ -1,5 +1,5 @@
 
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Variant.hpp
+++ b/include/openPMD/auxiliary/Variant.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/VariantSrc.hpp
+++ b/include/openPMD/auxiliary/VariantSrc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2002 Axel Huebl
+/* Copyright 2002-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/MemoryProfiler.hpp
+++ b/include/openPMD/benchmark/MemoryProfiler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Junmin Gu
+/* Copyright 2020-2021 Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/Timer.hpp
+++ b/include/openPMD/benchmark/Timer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Junmin Gu
+/* Copyright 2020-2021 Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/BlockSlicer.hpp
+++ b/include/openPMD/benchmark/mpi/BlockSlicer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/DatasetFiller.hpp
+++ b/include/openPMD/benchmark/mpi/DatasetFiller.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/OneDimensionalBlockSlicer.hpp
+++ b/include/openPMD/benchmark/mpi/OneDimensionalBlockSlicer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/RandomDatasetFiller.hpp
+++ b/include/openPMD/benchmark/mpi/RandomDatasetFiller.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/binding/python/UnitDimension.hpp
+++ b/include/openPMD/binding/python/UnitDimension.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/binding/python/Variant.hpp
+++ b/include/openPMD/binding/python/Variant.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/cli/ls.hpp
+++ b/include/openPMD/cli/ls.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -56,7 +56,7 @@ namespace ls
     {
         std::cout << program_name << " (openPMD-api) "
                   << getVersion() << "\n";
-        std::cout << "Copyright 2017-2020 openPMD contributors\n";
+        std::cout << "Copyright 2017-2021 openPMD contributors\n";
         std::cout << "Authors: Axel Huebl et al.\n";
         std::cout << "License: LGPLv3+\n";
         std::cout << "This is free software: you are free to change and redistribute it.\n"

--- a/include/openPMD/config.hpp.in
+++ b/include/openPMD/config.hpp.in
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl
+/* Copyright 2019-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/helper/list_series.hpp
+++ b/include/openPMD/helper/list_series.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl
+/* Copyright 2019-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/version.hpp
+++ b/include/openPMD/version.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/ChunkInfo.cpp
+++ b/src/ChunkInfo.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel.
+/* Copyright 2017-2021 Franz Poeschel.
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel, Fabian Koller and Axel Huebl
+/* Copyright 2017-2021 Franz Poeschel, Fabian Koller and Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/DummyIOHandler.cpp
+++ b/src/IO/DummyIOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/HDF5/HDF5Auxiliary.cpp
+++ b/src/IO/HDF5/HDF5Auxiliary.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Fabian Koller
+/* Copyright 2018-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/InvalidatableFile.cpp
+++ b/src/IO/InvalidatableFile.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel.
+/* Copyright 2017-2021 Franz Poeschel.
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/JSON/JSONIOHandler.cpp
+++ b/src/IO/JSON/JSONIOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel
+/* Copyright 2017-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Franz Poeschel
+/* Copyright 2017-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/IterationEncoding.cpp
+++ b/src/IterationEncoding.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller, Axel Huebl
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/auxiliary/Date.cpp
+++ b/src/auxiliary/Date.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Fabian Koller
+/* Copyright 2018-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/src/benchmark/mpi/OneDimensionalBlockSlicer.cpp
+++ b/src/benchmark/mpi/OneDimensionalBlockSlicer.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Franz Poeschel
+/* Copyright 2018-2021 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Access.cpp
+++ b/src/binding/python/Access.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/BaseRecord.cpp
+++ b/src/binding/python/BaseRecord.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/ChunkInfo.cpp
+++ b/src/binding/python/ChunkInfo.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Helper.cpp
+++ b/src/binding/python/Helper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl
+/* Copyright 2019-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/IterationEncoding.cpp
+++ b/src/binding/python/IterationEncoding.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/PatchRecord.cpp
+++ b/src/binding/python/PatchRecord.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/PatchRecordComponent.cpp
+++ b/src/binding/python/PatchRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/UnitDimension.cpp
+++ b/src/binding/python/UnitDimension.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020 Axel Huebl
+/* Copyright 2018-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/openpmd_api/ls/__main__.py
+++ b/src/binding/python/openpmd_api/ls/__main__.py
@@ -4,7 +4,7 @@ This file is part of the openPMD-api.
 This module provides functions that are wrapped into sys.exit(...()) calls by
 the setuptools (setup.py) "entry_points" -> "console_scripts" generator.
 
-Copyright 2020 openPMD contributors
+Copyright 2020-2021 openPMD contributors
 Authors: Axel Huebl
 License: LGPLv3+
 """

--- a/src/cli/ls.cpp
+++ b/src/cli/ls.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl
+/* Copyright 2019-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/helper/list_series.cpp
+++ b/src/helper/list_series.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl
+/* Copyright 2019-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl
+/* Copyright 2020-2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1,7 +1,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2018-2020 openPMD contributors
+Copyright 2018-2021 openPMD contributors
 Authors: Axel Huebl, Carsten Fortmann-Grote
 License: LGPLv3+
 """

--- a/test/python/unittest/Test.py
+++ b/test/python/unittest/Test.py
@@ -1,7 +1,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2018-2020 openPMD contributors
+Copyright 2018-2021 openPMD contributors
 Authors: Axel Huebl, Carsten Fortmann-Grote
 License: LGPLv3+
 """

--- a/test/python/unittest/TestUtilities/TestUtilities.py
+++ b/test/python/unittest/TestUtilities/TestUtilities.py
@@ -1,7 +1,7 @@
 """
 This file is part of the openPMD-api.
 
-Copyright 2018-2020 openPMD contributors
+Copyright 2018-2021 openPMD contributors
 Authors: Axel Huebl, Carsten Fortmann-Grote
 License: LGPLv3+
 """


### PR DESCRIPTION
Updating years in header files is cumbersome, so we update all files to include 2021 at once.

Updated via

``` bash
grep -iR "Copyright 20" . | awk -F: '{print $1}' | \
  xargs -n1 -P1 -I{} sed -i 's/\(Copyright 20..\) /\1-2021 /g' {}
grep -iR "Copyright 20" . | awk -F: '{print $1}' | \
  xargs -n1 -P1 -I{} sed -i 's/\(Copyright 20..-20\).. /\121 /g' {}
```

Happy new year! :) :star2: