### PR TITLE
Mesh & ParticleSpecies::seriesFlush

### DIFF
--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -177,6 +177,9 @@ public:
     template< typename T >
     Mesh& setTimeOffset(T timeOffset);
 
+    /** flush the corresponding Series */
+    void seriesFlush();
+
 private:
     Mesh();
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -40,6 +40,9 @@ class ParticleSpecies : public Container< Record >
 public:
     ParticlePatches particlePatches;
 
+    /** flush the corresponding Series */
+    void seriesFlush();
+
 private:
     ParticleSpecies() = default;
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -64,6 +64,8 @@ class WriteIterations;
 class Series : public Attributable
 {
     friend class Iteration;
+    friend class Mesh;
+    friend class ParticleSpecies;
     friend class SeriesIterator;
 
 public:

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -20,6 +20,9 @@
  */
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/Mesh.hpp"
+#include "openPMD/Series.hpp"
+#include "openPMD/auxiliary/DerefDynamicCast.hpp"
+#include "openPMD/backend/Writable.hpp"
 
 #include <iostream>
 
@@ -192,6 +195,23 @@ Mesh::setTimeOffset( double );
 template
 Mesh&
 Mesh::setTimeOffset( float );
+
+void
+Mesh::seriesFlush()
+{
+    Writable * findSeries = &*m_writable;
+    while( findSeries->parent )
+    {
+        findSeries = findSeries->parent;
+    }
+    Series & series =
+        auxiliary::deref_dynamic_cast< Series >( findSeries->attributable );
+    series.flush_impl(
+        series.iterations.begin(),
+        series.iterations.end()
+        //, IOHandler->m_flushLevel
+    );
+}
 
 void
 Mesh::flush_impl(std::string const& name)

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -19,6 +19,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include "openPMD/ParticleSpecies.hpp"
+#include "openPMD/Series.hpp"
+#include "openPMD/auxiliary/DerefDynamicCast.hpp"
+#include "openPMD/backend/Writable.hpp"
 
 #include <algorithm>
 #include <iostream>
@@ -114,6 +117,23 @@ namespace
             && particlePatches.find("numParticlesOffset") != particlePatches.end()
             && particlePatches.size() >= 3;
     }
+}
+
+void
+ParticleSpecies::seriesFlush()
+{
+    Writable * findSeries = &*m_writable;
+    while( findSeries->parent )
+    {
+        findSeries = findSeries->parent;
+    }
+    Series & series =
+        auxiliary::deref_dynamic_cast< Series >( findSeries->attributable );
+    series.flush_impl(
+        series.iterations.begin(),
+        series.iterations.end()
+        //, IOHandler->m_flushLevel
+    );
 }
 
 void

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -41,6 +41,7 @@ void init_Mesh(py::module &m) {
                 return "<openPMD.Mesh record with '" + std::to_string(mesh.size()) + "' record components>";
             }
         )
+        .def("series_flush", &Mesh::seriesFlush)
 
         .def_property("unit_dimension",
             &Mesh::unitDimension,

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -36,6 +36,7 @@ void init_ParticleSpecies(py::module &m) {
                 return "<openPMD.ParticleSpecies>";
             }
         )
+        .def("series_flush", &ParticleSpecies::seriesFlush)
 
         .def_readwrite("particle_patches", &ParticleSpecies::particlePatches)
     ;

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1561,7 +1561,7 @@ void deletion_test(const std::string & backend)
     e["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     e["positionOffset"][RecordComponent::SCALAR].makeConstant(22.0);
     e.erase("deletion");
-    o.flush();
+    e.seriesFlush();
 
     e["deletion_scalar"][RecordComponent::SCALAR].resetDataset(dset);
     o.flush();
@@ -2082,11 +2082,12 @@ TEST_CASE( "git_hdf5_sample_content_test", "[serial][hdf5]" )
                                       {{-1.3271805876513554e-09, -5.9243276950837753e-10, -2.2445734160214670e-10},
                                        {-7.4578609954301101e-10, -1.1995737736469891e-10, 2.5611823772919706e-10},
                                        {-9.4806251738077663e-10, -1.5472800818372434e-10, -3.6461900165818406e-10}}};
-            MeshRecordComponent& rho = o.iterations[100].meshes["rho"][MeshRecordComponent::SCALAR];
+            Mesh rhoMesh = o.iterations[100].meshes["rho"];
+            MeshRecordComponent rho = rhoMesh[MeshRecordComponent::SCALAR];
             Offset offset{20, 20, 190};
             Extent extent{3, 3, 3};
             auto data = rho.loadChunk<double>(offset, extent);
-            o.flush();
+            rhoMesh.seriesFlush();
             double* raw_ptr = data.get();
 
             for( int i = 0; i < 3; ++i )
@@ -2624,7 +2625,7 @@ TEST_CASE( "hzdr_hdf5_sample_content_test", "[serial][hdf5]" )
 
         std::vector< uint64_t > data( e_patches.size() );
         e_extent_z.load(shareRaw(data.data()));
-        o.flush();
+        species_e.seriesFlush();
         REQUIRE(data.at(0) == static_cast< uint64_t >(80));
         REQUIRE(data.at(1) == static_cast< uint64_t >(80));
         REQUIRE(data.at(2) == static_cast< uint64_t >(80));

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -849,7 +849,7 @@ class APITest(unittest.TestCase):
 
             y_data = pos_y.load_chunk([200000, ], [10, ])
             w_data = w.load_chunk([200000, ], [10, ])
-            series.flush()
+            electrons.series_flush()
             self.assertSequenceEqual(y_data.shape, [10, ])
             self.assertSequenceEqual(w_data.shape, [10, ])
 
@@ -887,7 +887,7 @@ class APITest(unittest.TestCase):
 
         if found_numpy:
             chunk_data = E_x.load_chunk(offset, extent)
-            series.flush()
+            E.series_flush()
             self.assertSequenceEqual(chunk_data.shape, extent)
 
             self.assertEqual(chunk_data.dtype, np.float64)


### PR DESCRIPTION
Implement a method in `Mesh` & `ParticleSpecies` to flush their corresponding `Series`.

This simplifies downstream reader implementations operating on a specific mesh or particle species.