### PR TITLE
Attributable & Writable: seriesFlush

### DIFF
--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -177,9 +177,6 @@ public:
     template< typename T >
     Mesh& setTimeOffset(T timeOffset);
 
-    /** flush the corresponding Series */
-    void seriesFlush();
-
 private:
     Mesh();
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -40,9 +40,6 @@ class ParticleSpecies : public Container< Record >
 public:
     ParticlePatches particlePatches;
 
-    /** flush the corresponding Series */
-    void seriesFlush();
-
 private:
     ParticleSpecies() = default;
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -64,8 +64,7 @@ class WriteIterations;
 class Series : public Attributable
 {
     friend class Iteration;
-    friend class Mesh;
-    friend class ParticleSpecies;
+    friend class Writable;
     friend class SeriesIterator;
 
 public:

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -151,6 +151,15 @@ public:
      */
     Attributable& setComment(std::string const& comment);
 
+    /** Flush the corresponding Series object
+     *
+     * Writable connects all objects of an openPMD series through a linked list
+     * of parents. This method will walk up the parent list until it reaches
+     * an object that has no parent, which is the Series object, and flush()-es
+     * it.
+     */
+    void seriesFlush();
+
 OPENPMD_protected:
     void flushAttributes();
     void readAttributes();

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -83,6 +83,15 @@ public:
     Writable(Attributable* = nullptr);
     ~Writable() = default;
 
+    /** Flush the corresponding Series object
+     *
+     * Writable connects all objects of an openPMD series through a linked list
+     * of parents. This method will walk up the parent list until it reaches
+     * an object that has no parent, which is the Series object, and flush()-es
+     * it.
+     */
+    void seriesFlush();
+
 OPENPMD_private:
     std::shared_ptr< AbstractFilePosition > abstractFilePosition;
     std::shared_ptr< AbstractIOHandler > IOHandler;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -197,23 +197,6 @@ Mesh&
 Mesh::setTimeOffset( float );
 
 void
-Mesh::seriesFlush()
-{
-    Writable * findSeries = &*m_writable;
-    while( findSeries->parent )
-    {
-        findSeries = findSeries->parent;
-    }
-    Series & series =
-        auxiliary::deref_dynamic_cast< Series >( findSeries->attributable );
-    series.flush_impl(
-        series.iterations.begin(),
-        series.iterations.end()
-        //, IOHandler->m_flushLevel
-    );
-}
-
-void
 Mesh::flush_impl(std::string const& name)
 {
     if(IOHandler->m_frontendAccess == Access::READ_ONLY )

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -120,23 +120,6 @@ namespace
 }
 
 void
-ParticleSpecies::seriesFlush()
-{
-    Writable * findSeries = &*m_writable;
-    while( findSeries->parent )
-    {
-        findSeries = findSeries->parent;
-    }
-    Series & series =
-        auxiliary::deref_dynamic_cast< Series >( findSeries->attributable );
-    series.flush_impl(
-        series.iterations.begin(),
-        series.iterations.end()
-        //, IOHandler->m_flushLevel
-    );
-}
-
-void
 ParticleSpecies::flush(std::string const& path)
 {
     if(IOHandler->m_frontendAccess == Access::READ_ONLY )

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -124,6 +124,12 @@ Attributable::setComment(std::string const& c)
 }
 
 void
+Attributable::seriesFlush()
+{
+    m_writable->seriesFlush();
+}
+
+void
 Attributable::flushAttributes()
 {
     if( dirty() )

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -20,17 +20,36 @@
  */
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/Series.hpp"
+#include "openPMD/auxiliary/DerefDynamicCast.hpp"
 
 
 namespace openPMD
 {
-Writable::Writable(Attributable* a)
-        : abstractFilePosition{nullptr},
-          IOHandler{nullptr},
-          attributable{a},
-          parent{nullptr},
-          dirty{true},
-          written{false}
-{ }
+    Writable::Writable(Attributable* a)
+            : abstractFilePosition{nullptr},
+              IOHandler{nullptr},
+              attributable{a},
+              parent{nullptr},
+              dirty{true},
+              written{false}
+    { }
+
+    void
+    Writable::seriesFlush()
+    {
+        Writable * findSeries = this;
+        while( findSeries->parent )
+        {
+            findSeries = findSeries->parent;
+        }
+        Series & series =
+                auxiliary::deref_dynamic_cast< Series >( findSeries->attributable );
+        series.flush_impl(
+                series.iterations.begin(),
+                series.iterations.end()
+                //, IOHandler->m_flushLevel
+        );
+    }
 
 } // openPMD

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -267,6 +267,7 @@ void init_Attributable(py::module &m) {
                 return "<openPMD.Attributable with '" + std::to_string(attr.numAttributes()) + "' attributes>";
             }
         )
+        .def("series_flush", &Attributable::seriesFlush)
 
         .def_property_readonly(
             "attributes",

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -41,7 +41,6 @@ void init_Mesh(py::module &m) {
                 return "<openPMD.Mesh record with '" + std::to_string(mesh.size()) + "' record components>";
             }
         )
-        .def("series_flush", &Mesh::seriesFlush)
 
         .def_property("unit_dimension",
             &Mesh::unitDimension,

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -36,7 +36,6 @@ void init_ParticleSpecies(py::module &m) {
                 return "<openPMD.ParticleSpecies>";
             }
         )
-        .def("series_flush", &ParticleSpecies::seriesFlush)
 
         .def_readwrite("particle_patches", &ParticleSpecies::particlePatches)
     ;


### PR DESCRIPTION
Allow any objec that is an attributable or writable to flush the corresponding `Series` object.

This is a generalization of #924. @franzpoeschel what do you think, should we do this?