### PR TITLE
New attribute layout: Read from either int8_t or uint8_t

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -132,8 +132,9 @@ namespace detail
          *      of PreloadAdiosAttributes is called.
          */
         template< typename T >
-        AttributeWithShape< T >
-        getAttribute( std::string const & name ) const;
+        AttributeWithShape< T > getAttribute( std::string const & name ) const;
+
+        Datatype attributeType( std::string const & name ) const;
     };
 
     template< typename T >

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <map>
 #include <stddef.h>
+#include <type_traits>
 
 #include "openPMD/Datatype.hpp"
 
@@ -148,8 +149,18 @@ namespace detail
                 "[ADIOS2] Requested attribute not found: " + name );
         }
         AttributeLocation const & location = it->second;
-        if( location.dt != determineDatatype< T >() )
+        Datatype determinedDatatype = determineDatatype< T >();
+        if( std::is_same< T, signed char >::value )
         {
+            // workaround: we use Datatype::CHAR to represent ADIOS2 signed char
+            // (ADIOS2 does not have chars with unspecified signed-ness
+            // anyway)
+            determinedDatatype = Datatype::CHAR;
+        }
+        if( location.dt != determinedDatatype )
+        {
+            std::cout << "location.dt=" << location.dt <<
+                "\tdetermineDatatype=" << determineDatatype< T > () << std::endl;
             throw std::runtime_error(
                 "[ADIOS2] Wrong datatype for attribute: " + name );
         }

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -26,6 +26,7 @@
 #include <adios2.h>
 #include <functional>
 #include <map>
+#include <sstream>
 #include <stddef.h>
 #include <type_traits>
 
@@ -159,10 +160,11 @@ namespace detail
         }
         if( location.dt != determinedDatatype )
         {
-            std::cout << "location.dt=" << location.dt <<
-                "\tdetermineDatatype=" << determineDatatype< T > () << std::endl;
-            throw std::runtime_error(
-                "[ADIOS2] Wrong datatype for attribute: " + name );
+            std::stringstream errorMsg;
+            errorMsg << "[ADIOS2] Wrong datatype for attribute: " << name
+                     << "(location.dt=" << location.dt
+                     << ", T=" << determineDatatype< T >() << ")";
+            throw std::runtime_error( errorMsg.str() );
         }
         AttributeWithShape< T > res;
         res.shape = location.shape;

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -230,37 +230,29 @@ namespace detail
                             : toVectorType( basicType );
                         return openPmdType;
                     }
-                    else if( shape.size() == 2 && basicType == Datatype::CHAR )
+                    else if(
+                        shape.size() == 2 &&
+                        ( basicType == Datatype::CHAR ||
+                          basicType == Datatype::UCHAR ) )
                     {
                         return Datatype::VEC_STRING;
                     }
                     else
                     {
-                        throw std::runtime_error(
-                            "[ADIOS2] Unexpected shape for " + attributeName );
+                        std::stringstream errorMsg;
+                        errorMsg << "[ADIOS2] Unexpected shape for "
+                                 << attributeName << ": [";
+                        for( auto const ext : shape )
+                        {
+                            errorMsg << std::to_string( ext ) << ", ";
+                        }
+                        errorMsg << "] of type "
+                                 << datatypeToString( basicType );
+                        throw std::runtime_error( errorMsg.str() );
                     }
                 }
             }
-            if( shape.size() <= 1 )
-            {
-                // size == 0 <=> global single value variable
-                auto size = shape.size() == 0 ? 1 : shape[ 0 ];
-                Datatype openPmdType = size == 1
-                    ? basicType
-                    : size == 7 && basicType == Datatype::DOUBLE
-                        ? Datatype::ARR_DBL_7
-                        : toVectorType( basicType );
-                return openPmdType;
-            }
-            else if( shape.size() == 2 && basicType == Datatype::CHAR )
-            {
-                return Datatype::VEC_STRING;
-            }
-            else
-            {
-                throw std::runtime_error(
-                    "[ADIOS2] Unexpected shape for " + attributeName );
-            }
+            throw std::runtime_error( "Unreachable!" );
         }
     }
 } // namespace detail

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -288,6 +288,17 @@ namespace detail
                 pair.second );
         }
     }
+
+    Datatype
+    PreloadAdiosAttributes::attributeType( std::string const & name ) const
+    {
+        auto it = m_offsets.find( name );
+        if( it == m_offsets.end() )
+        {
+            return Datatype::UNDEFINED;
+        }
+        return it->second.dt;
+    }
 } // namespace detail
 } // namespace openPMD
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -48,6 +48,15 @@ TEST_CASE( "adios2_char_portability", "[serial][adios2]" )
      * This tests portability of char attributes in ADIOS2 in schema 20210209.
      */
 
+    if( auxiliary::getEnvString("OPENPMD_NEW_ATTRIBUTE_LAYOUT", "NOT_SET") == "NOT_SET")
+    {
+        /*
+         * @todo As soon as we have added automatic detection for the new
+         *       layout, this environment variable should be ignore read-side.
+         *       Then we can delete this if condition again.
+         */
+        return;
+    }
     // @todo remove new_attribute_layout key as soon as schema-based versioning
     //       is merged
     std::string const config = R"END(

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3146,7 +3146,11 @@ bp4_steps( std::string const & file, std::string const & options_write, std::str
         for( size_t i = 0; i < 10; ++i )
         {
             auto iteration = iterations[ i ];
-            auto E_x = iteration.meshes[ "E" ][ "x" ];
+            auto E = iteration.meshes[ "E" ];
+            auto E_x = E[ "x" ];
+            E.setAttribute(
+                "vector_of_string",
+                std::vector< std::string >{ "vector", "of", "string" } );
             E_x.resetDataset(
                 openPMD::Dataset( openPMD::Datatype::INT, { 10 } ) );
             std::vector< int > data( 10, i );
@@ -3165,7 +3169,12 @@ bp4_steps( std::string const & file, std::string const & options_write, std::str
     size_t last_iteration_index = 0;
     for( auto iteration : readSeries.readIterations() )
     {
-        auto E_x = iteration.meshes[ "E" ][ "x" ];
+        auto E = iteration.meshes[ "E" ];
+        auto E_x = E[ "x" ];
+        REQUIRE(
+            E.getAttribute( "vector_of_string" )
+                .get< std::vector< std::string > >() ==
+            std::vector< std::string >{ "vector", "of", "string" } );
         REQUIRE( E_x.getDimensionality() == 1 );
         REQUIRE( E_x.getExtent()[ 0 ] == 10 );
         auto chunk = E_x.loadChunk< int >( { 0 }, { 10 } );


### PR DESCRIPTION
[CppReference](https://en.cppreference.com/w/cpp/language/types) on `char`:
> has the same representation and alignment as either signed char or unsigned char, but is always a distinct type

When doing `IO::DefineVariable<char>()` in ADIOS2, the resulting variable will be stored in a platform-dependent way:
```
  int8_t    /data/8/meshes/E/vector_of_string  {3, 7}
  uint8_t   /data/8/meshes/E/vector_of_string  {3, 7}
```
Both of the above options may be seen on different platforms.

This PR fixes reading char-based variables **if they were written on a platform with the same representation for the char type**.

I've done some cross-platform testing and come to the conclusion that char/string-based variables are currently not implemented in a portable way in ADIOS2.
Case: Writing on some local x86-based machine where `char` is an unsigned type, reading on Summit where `char` is a signed type:
* Define a scalar string variable `Variable<string>`. The variable will not even occur in `IO::AvailableVariables()`.
* Define a char variable `Variable<char>`. `IO::InquireVariable<char>()` will fail.

Interestingly, writing on Summit and reading on the local machine works fine.

I'll write up a simple reproducer for a bug report, in the meantime this PR allows interaction within the same platform at least.

Also, I think our `Datatype` enum is also broken in this regard: We list `CHAR` and `UCHAR`, but not `SCHAR`. `char` can be either `signed char` or `unsigned char`, but our defintions imply that `char` is simply the signed variant. ADIOS2 gives us types with explicit signedness (`uint8_t` or `int8_t`) and I cannot represent this sensibly with our datatypes.

- [x] The test breaks when `OPENPMD_NEW_ATTRIBUTE_LAYOUT` is set manually, fix that
- [x] Pull #927 first
