### PR TITLE
Docs: dev-centered development

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,7 +12,6 @@ For existing tasks, the labels `good first issue <https://github.com/openPMD/ope
 In case you want to start working on one of those, just *comment* in it first so no work is duplicated.
 
 New contributions in form of `pull requests <https://help.github.com/articles/about-pull-requests/>`_ always need to go in the ``dev`` (development) branch.
-The ``master`` branch contains the last stable release and receives updates only when a new version is drafted.
 
 Maintainers organize prioritites and progress in the `projects tab <https://github.com/openPMD/openPMD-api/projects>`_.
 

--- a/docs/source/dev/repostructure.rst
+++ b/docs/source/dev/repostructure.rst
@@ -6,7 +6,6 @@ Repository Structure
 Branches
 --------
 
-* ``master``: the latest stable release, always tagged with a version
 * ``dev``: the development branch where all features start from and are merged to
 * ``release-X.Y.Z``: release candidate for version ``X.Y.Z`` with an upcoming release, receives updates for bug fixes and documentation such as change logs but usually no new features
 


### PR DESCRIPTION
We only use a `dev` branch for all development and occasionally open `release-X.Y.Z` branches to backport features to prior releases.