### PR TITLE
bp4_steps test: actually use nullcore engine

### DIFF
--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3133,6 +3133,7 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
     std::string nullcore = R"(
     {
         "adios2": {
+            "type": "nullcore",
             "engine": {
                 "type": "bp4",
                 "usesteps": true


### PR DESCRIPTION
Previously, the nullcore configuration of that test forgot to set the nullcore engine. This fixes that.