### PR TITLE
Decay ReadWrite mode into adios2::Mode::Read if the file exists

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -195,8 +195,7 @@ public:
      * @brief The ADIOS2 access type to chose for Engines opened
      * within this instance.
      */
-    adios2::Mode adios2AccessMode( );
-
+    adios2::Mode adios2AccessMode( std::string const & fullPath );
 
 private:
     adios2::ADIOS m_ADIOS;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -904,7 +904,8 @@ ADIOS2IOHandlerImpl::availableChunks(
         datatype, rbi, parameters, ba.m_IO, engine, varName );
 }
 
-adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode( )
+adios2::Mode
+ADIOS2IOHandlerImpl::adios2AccessMode( std::string const & fullPath )
 {
     switch ( m_handler->m_backendAccess )
     {
@@ -913,10 +914,21 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode( )
     case Access::READ_ONLY:
         return adios2::Mode::Read;
     case Access::READ_WRITE:
-        std::cerr << "ADIOS2 does currently not yet implement ReadWrite "
-                     "(Append) mode. "
-                  << "Replacing with Read mode." << std::endl;
-        return adios2::Mode::Read;
+        if( auxiliary::directory_exists( fullPath ) ||
+            auxiliary::file_exists( fullPath ) )
+        {
+            std::cerr << "ADIOS2 does currently not yet implement ReadWrite "
+                         "(Append) mode. "
+                      << "Replacing with Read mode." << std::endl;
+            return adios2::Mode::Read;
+        }
+        else
+        {
+            std::cerr << "ADIOS2 does currently not yet implement ReadWrite "
+                         "(Append) mode. "
+                      << "Replacing with Write mode." << std::endl;
+            return adios2::Mode::Write;
+        }
     default:
         return adios2::Mode::Undefined;
     }
@@ -1978,7 +1990,7 @@ namespace detail
         , m_IOName( std::to_string( impl.nameCounter++ ) )
         , m_ADIOS( impl.m_ADIOS )
         , m_IO( impl.m_ADIOS.DeclareIO( m_IOName ) )
-        , m_mode( impl.adios2AccessMode() )
+        , m_mode( impl.adios2AccessMode( m_file ) )
         , m_writeDataset( &impl )
         , m_readDataset( &impl )
         , m_attributeReader()

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1528,6 +1528,13 @@ void fileBased_write_test(const std::string & backend)
         REQUIRE(o.iterations.size() == 5);
         o.iterations[6];
         REQUIRE(o.iterations.size() == 6);
+        // write something to trigger opening of the file
+        // write something to trigger opening of the file
+        o.iterations[ 6 ].particles[ "e" ][ "position" ][ "x" ].resetDataset(
+            { Datatype::DOUBLE, { 10 } } );
+        o.iterations[ 6 ]
+            .particles[ "e" ][ "position" ][ "x" ]
+            .makeConstant< double >( 1.0 );
     }
     REQUIRE((auxiliary::file_exists("../samples/subdir/serial_fileBased_write00000004." + backend)
         || auxiliary::directory_exists("../samples/subdir/serial_fileBased_write00000004." + backend)));

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1529,7 +1529,6 @@ void fileBased_write_test(const std::string & backend)
         o.iterations[6];
         REQUIRE(o.iterations.size() == 6);
         // write something to trigger opening of the file
-        // write something to trigger opening of the file
         o.iterations[ 6 ].particles[ "e" ][ "position" ][ "x" ].resetDataset(
             { Datatype::DOUBLE, { 10 } } );
         o.iterations[ 6 ]


### PR DESCRIPTION
Bug detected while working on #855.
EDIT: Alright, found out why this bug was triggered by #855, but not previously. Until now, the ADIOS2 backend delayed the opening of the .bp file until an actual access happened. So [this test](https://github.com/openPMD/openPMD-api/blob/09cb592ca611c9a2361c6ee80e5d320242971ea8/test/SerialIOTest.cpp#L1529) never actually created the file for iteration 6, bypassing this bug. Now, with eager opening, this bug is exposed.

TODO:
- [x] Write test that exposes this
- [x] ~~The test exposed the same issue in HDF5. Fix that in this PR too?~~
    That was a different issue. I wrote a little mesh dataset to that iteration in the test originally. Now, that iteration had a defined `/meshesPath` attribute. While reading the file back in some lines further down, the openPMD API expected to find meshes in the other iterations, too, didn't find any and crashed. Is our workflow with the `meshesPath` really that good right now?