### PR TITLE
Check for existence of the correct files in parallel IO tests

### DIFF
--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -960,11 +960,13 @@ TEST_CASE( "parallel_adios2_json_config", "[parallel][adios2]" )
     write( "../samples/jsonConfiguredBP4Parallel.bp", writeConfigBP4 );
     write( "../samples/jsonConfiguredBP3Parallel.bp", writeConfigBP3 );
 
+    MPI_Barrier( MPI_COMM_WORLD );
+
     // BP3 engine writes files, BP4 writes directories
-    REQUIRE(
-        openPMD::auxiliary::file_exists( "../samples/jsonConfiguredBP3.bp" ) );
+    REQUIRE( openPMD::auxiliary::file_exists(
+        "../samples/jsonConfiguredBP3Parallel.bp" ) );
     REQUIRE( openPMD::auxiliary::directory_exists(
-        "../samples/jsonConfiguredBP4.bp" ) );
+        "../samples/jsonConfiguredBP4Parallel.bp" ) );
 
     std::string readConfigBP3 = R"END(
 {


### PR DESCRIPTION
Copy paste error in parallel tests, this checked for file existence of the files written by serial tests. CI didn't have a problem since those run first.