### PR TITLE
Particle Patches: Do not emplace patch records if they don't exist in the file being read

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1166,10 +1166,15 @@ if(openPMD_BUILD_TESTING)
                     COMMAND sh -c
                         "${MPI_TEST_EXE} ${Python_EXECUTABLE}                      \
                             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
-                            --infile ../samples/git-sample/thetaMode/data%T.h5     \
-                            --outfile ../samples/git-sample/thetaMode/data%T.bp;   \
+                            --infile ../samples/git-sample/data%T.h5               \
+                            --outfile ../samples/git-sample/data%T.bp &&           \
                                                                                    \
-                            ${Python_EXECUTABLE}                                   \
+                        ${MPI_TEST_EXE} ${Python_EXECUTABLE}                       \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
+                            --infile ../samples/git-sample/thetaMode/data%T.h5     \
+                            --outfile ../samples/git-sample/thetaMode/data%T.bp && \
+                                                                                   \
+                        ${Python_EXECUTABLE}                                       \
                             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
                             --infile ../samples/git-sample/thetaMode/data%T.bp     \
                             --outfile ../samples/git-sample/thetaMode/data%T.json  \
@@ -1181,10 +1186,15 @@ if(openPMD_BUILD_TESTING)
                     COMMAND sh -c
                         "${Python_EXECUTABLE}                                      \
                             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
-                            --infile ../samples/git-sample/thetaMode/data%T.h5     \
-                            --outfile ../samples/git-sample/thetaMode/data%T.bp;   \
+                            --infile ../samples/git-sample/data%T.h5               \
+                            --outfile ../samples/git-sample/data%T.bp &&           \
                                                                                    \
-                            ${Python_EXECUTABLE}                                   \
+                        ${Python_EXECUTABLE}                                       \
+                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
+                            --infile ../samples/git-sample/thetaMode/data%T.h5     \
+                            --outfile ../samples/git-sample/thetaMode/data%T.bp && \
+                                                                                   \
+                        ${Python_EXECUTABLE}                                       \
                             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
                             --infile ../samples/git-sample/thetaMode/data%T.bp     \
                             --outfile ../samples/git-sample/thetaMode/data%T.json  \

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -40,10 +40,12 @@ ParticleSpecies::read()
 
     Parameter< Operation::OPEN_PATH > pOpen;
     Parameter< Operation::LIST_ATTS > aList;
+    bool hasParticlePatches = false;
     for( auto const& record_name : *pList.paths )
     {
         if( record_name == "particlePatches" )
         {
+            hasParticlePatches = true;
             pOpen.path = "particlePatches";
             IOHandler()->enqueue(IOTask(&particlePatches, pOpen));
             particlePatches.read();
@@ -70,6 +72,13 @@ ParticleSpecies::read()
             }
             r.read();
         }
+    }
+
+    if( !hasParticlePatches )
+    {
+        auto & container = *particlePatches.m_container;
+        container.erase( "numParticles" );
+        container.erase( "numParticlesOffset" );
     }
 
     /* obtain all scalar records */


### PR DESCRIPTION
The `GenerationPolicy` for `ParticleSpecies` automatically fills the `particlePatches` container with the `numParticles` and `numParticlesOffset` components, meaning that a reading code has no way to know whether those records actually exist. This resulted in the `openpmd-pipe` tool failing to convert a dataset containing a particle species without patches (with extremely cryptic error messages from somewhere deep in the backend). This PR adds (1) a failing test and (2) a fix.