### PR TITLE
Fix: FBPIC Example Filename

### DIFF
--- a/share/openPMD/download_samples.ps1
+++ b/share/openPMD/download_samples.ps1
@@ -21,5 +21,5 @@ Remove-Item *.zip
 # Ref.: https://github.com/openPMD/openPMD-viewer/issues/296
 Invoke-WebRequest https://github.com/openPMD/openPMD-viewer/files/5655027/diags.zip -OutFile empty_alternate_fbpic.zip
 Expand-Archive empty_alternate_fbpic.zip
-Move-Item -Path empty_alternate_fbpic\diags\hdf5\data00000050.h5 samples\issue-sample\empty_alternate_fbpic.h5
+Move-Item -Path empty_alternate_fbpic\diags\hdf5\data00000050.h5 samples\issue-sample\empty_alternate_fbpic_00000050.h5
 Remove-Item -Recurse -Force empty_alternate_fbpic*

--- a/share/openPMD/download_samples.sh
+++ b/share/openPMD/download_samples.sh
@@ -24,5 +24,5 @@ rm -rf no_fields.zip no_particles.zip
 # Ref.: https://github.com/openPMD/openPMD-viewer/issues/296
 curl -sOL https://github.com/openPMD/openPMD-viewer/files/5655027/diags.zip
 unzip diags.zip
-mv diags/hdf5/data00000050.h5 samples/issue-sample/empty_alternate_fbpic.h5
+mv diags/hdf5/data00000050.h5 samples/issue-sample/empty_alternate_fbpic_00000050.h5
 rm -rf diags.zip diags

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1887,7 +1887,7 @@ TEST_CASE( "empty_alternate_fbpic", "[serial][hdf5]" )
     try
     {
         {
-            Series s = Series("../samples/issue-sample/empty_alternate_fbpic.h5", Access::READ_ONLY);
+            Series s = Series("../samples/issue-sample/empty_alternate_fbpic_%T.h5", Access::READ_ONLY);
             REQUIRE(s.iterations.contains(50));
             REQUIRE(s.iterations[50].particles.contains("electrons"));
             REQUIRE(s.iterations[50].particles["electrons"].contains("momentum"));
@@ -1900,7 +1900,7 @@ TEST_CASE( "empty_alternate_fbpic", "[serial][hdf5]" )
             REQUIRE(isSame(empty_rc.getDatatype(), determineDatatype< double >()));
         }
         {
-            Series list{ "../samples/issue-sample/empty_alternate_fbpic.h5", Access::READ_ONLY };
+            Series list{ "../samples/issue-sample/empty_alternate_fbpic_%T.h5", Access::READ_ONLY };
             helper::listSeries( list );
         }
     } catch (no_such_file_error& e)


### PR DESCRIPTION
Fix the file-name for the fileBased FBPIC test case.

Fix #948