### PR TITLE
Demonstrator PR to check whether our ICC tests are broken on dev

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -297,6 +297,7 @@ jobs:
         cmake -S .. -B . \
           -DCMAKE_C_COMPILER=$(which icx)    \
           -DCMAKE_CXX_COMPILER=$(which icpx) \
+          -DCMAKE_VERBOSE_MAKEFILES=ON       \
           -DopenPMD_USE_PYTHON=OFF           \
           -DopenPMD_USE_MPI=OFF              \
           -DCMAKE_C_COMPILER_ID="Clang"                  \


### PR DESCRIPTION
icc tests are giving me weird errors on multiple independent PRs
"unitSI scaling during chunk loading not yet implemented"
See:
https://github.com/openPMD/openPMD-api/pull/901/checks?check_run_id=2224675773

It looks like the `std::numeric_limits<double>::quiet_NaN()` that we use as a default value for scaling and check via `std::isnan()` is not returning `true` anymore with the latest ICC.

Issue worked around on #938 by [this commit](https://github.com/openPMD/openPMD-api/pull/938/commits/2671df43754b734233583b39dd635c380e1df236) (using our `auxiliary::Option` instead).