### PR TITLE
RecordComponent: Remove Unimplemented Scaling

### DIFF
--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/auxiliary/Option.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/Dataset.hpp"
 
@@ -174,9 +175,10 @@ public:
      */
     template< typename T >
     std::shared_ptr< T > loadChunk(
-        Offset = {0u},
-        Extent = {-1u},
-        double targetUnitSI = std::numeric_limits< double >::quiet_NaN() );
+        Offset = { 0u },
+        Extent = { -1u },
+        auxiliary::Option< double > targetUnitSI =
+            auxiliary::Option< double >() );
 
     /** Load a chunk of data into pre-allocated memory
      *
@@ -192,7 +194,8 @@ public:
         std::shared_ptr< T >,
         Offset,
         Extent,
-        double targetUnitSI = std::numeric_limits< double >::quiet_NaN() );
+        auxiliary::Option< double > targetUnitSI =
+            auxiliary::Option< double >() );
 
     template< typename T >
     void storeChunk(std::shared_ptr< T >, Offset, Extent);
@@ -273,8 +276,8 @@ RecordComponent::makeEmpty( uint8_t dimensions )
 }
 
 template< typename T >
-inline std::shared_ptr< T >
-RecordComponent::loadChunk(Offset o, Extent e, double targetUnitSI)
+inline std::shared_ptr< T > RecordComponent::loadChunk(
+    Offset o, Extent e, auxiliary::Option< double > targetUnitSI )
 {
     uint8_t dim = getDimensionality();
 
@@ -305,10 +308,13 @@ RecordComponent::loadChunk(Offset o, Extent e, double targetUnitSI)
 }
 
 template< typename T >
-inline void
-RecordComponent::loadChunk(std::shared_ptr< T > data, Offset o, Extent e, double targetUnitSI)
+inline void RecordComponent::loadChunk(
+    std::shared_ptr< T > data,
+    Offset o,
+    Extent e,
+    auxiliary::Option< double > targetUnitSI )
 {
-    if( !std::isnan(targetUnitSI) )
+    if( targetUnitSI.has_value() )
         throw std::runtime_error("unitSI scaling during chunk loading not yet implemented");
     Datatype dtype = determineDatatype(data);
     if( dtype != getDatatype() )

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "openPMD/backend/BaseRecordComponent.hpp"
-#include "openPMD/auxiliary/Option.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/Dataset.hpp"
 
@@ -176,9 +175,7 @@ public:
     template< typename T >
     std::shared_ptr< T > loadChunk(
         Offset = { 0u },
-        Extent = { -1u },
-        auxiliary::Option< double > targetUnitSI =
-            auxiliary::Option< double >() );
+        Extent = { -1u } );
 
     /** Load a chunk of data into pre-allocated memory
      *
@@ -193,9 +190,7 @@ public:
     void loadChunk(
         std::shared_ptr< T >,
         Offset,
-        Extent,
-        auxiliary::Option< double > targetUnitSI =
-            auxiliary::Option< double >() );
+        Extent );
 
     template< typename T >
     void storeChunk(std::shared_ptr< T >, Offset, Extent);
@@ -277,7 +272,7 @@ RecordComponent::makeEmpty( uint8_t dimensions )
 
 template< typename T >
 inline std::shared_ptr< T > RecordComponent::loadChunk(
-    Offset o, Extent e, auxiliary::Option< double > targetUnitSI )
+    Offset o, Extent e )
 {
     uint8_t dim = getDimensionality();
 
@@ -303,7 +298,7 @@ inline std::shared_ptr< T > RecordComponent::loadChunk(
         numPoints *= dimensionSize;
 
     auto newData = std::shared_ptr<T>(new T[numPoints], []( T *p ){ delete [] p; });
-    loadChunk(newData, offset, extent, targetUnitSI);
+    loadChunk(newData, offset, extent);
     return newData;
 }
 
@@ -311,11 +306,8 @@ template< typename T >
 inline void RecordComponent::loadChunk(
     std::shared_ptr< T > data,
     Offset o,
-    Extent e,
-    auxiliary::Option< double > targetUnitSI )
+    Extent e )
 {
-    if( targetUnitSI.has_value() )
-        throw std::runtime_error("unitSI scaling during chunk loading not yet implemented");
     Datatype dtype = determineDatatype(data);
     if( dtype != getDatatype() )
         if( !isSameInteger< T >( dtype ) &&

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -54,6 +54,7 @@ namespace openPMD {}
 
 #include "openPMD/auxiliary/Date.hpp"
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
+#include "openPMD/auxiliary/Option.hpp"
 #include "openPMD/auxiliary/OutOfRangeMsg.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/auxiliary/Variant.hpp"


### PR DESCRIPTION
With the latest ICPX release, it looks like the quiet NaN's we used as a default argument do not yield `true` anymore in `std::nan`. This is confusing... but we will change the default value anyway. #953 https://godbolt.org/z/fbca5ffnP


- [x] `auxiliary::Option`: Make this a public class, so we can use it in user-facing interfaces.
- [x] use an option as default value in `RecordComponent` -> remove unused parameter altogether