### PR TITLE
Default constructors for Series and SeriesIterator

### DIFF
--- a/include/openPMD/ReadIterations.hpp
+++ b/include/openPMD/ReadIterations.hpp
@@ -56,10 +56,10 @@ class SeriesIterator
     maybe_series_t m_series;
     iteration_index_t m_currentIteration = 0;
 
-    //! construct the end() iterator
-    SeriesIterator();
-
 public:
+    //! construct the end() iterator
+    explicit SeriesIterator();
+
     SeriesIterator( Series );
 
     SeriesIterator & operator++();

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -312,17 +312,32 @@ OPENPMD_private:
     using iterations_t = decltype(internal::SeriesData::iterations);
     using iterations_iterator = iterations_t::iterator;
 
-    internal::SeriesData * m_series;
+    internal::SeriesData * m_series = nullptr;
 
     inline internal::SeriesData & get()
     {
-        return *m_series;
+        if( m_series )
+        {
+            return *m_series;
+        }
+        else
+        {
+            throw std::runtime_error(
+                "[Series] Cannot use default-constructed Series." );
+        }
     }
 
     inline internal::SeriesData const & get() const
     {
-        return *m_series;
-    }
+        if( m_series )
+        {
+            return *m_series;
+        }
+        else
+        {
+            throw std::runtime_error(
+                "[Series] Cannot use default-constructed Series." );
+        }    }
 
     std::unique_ptr< ParsedInput > parseInput(std::string);
     void init(std::shared_ptr< AbstractIOHandler >, std::unique_ptr< ParsedInput >);

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -421,6 +421,8 @@ private:
     std::shared_ptr< internal::SeriesInternal > m_series;
 
 public:
+    explicit Series();
+
 #if openPMD_HAVE_MPI
     Series(
         std::string const & filepath,
@@ -446,6 +448,14 @@ public:
     virtual ~Series() = default;
 
     Container< Iteration, uint64_t > iterations;
+
+    /**
+     * @brief Is this a usable Series object?
+     *
+     * @return true If a Series has been opened for reading and/or writing.
+     * @return false If the object has been default-constructed.
+     */
+    operator bool() const;
 
     /**
      * @brief Entry point to the reading end of the streaming API.

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -110,7 +110,7 @@ class AttributableImpl
     friend class Writable;
 
 protected:
-    internal::AttributableData * m_attri;
+    internal::AttributableData * m_attri = nullptr;
 
     // Should not be called publicly, only by implementing classes
     AttributableImpl( internal::AttributableData * );
@@ -269,12 +269,30 @@ OPENPMD_protected:
     inline
     internal::AttributableData & get()
     {
-        return *m_attri;
+        if( m_attri )
+        {
+            return *m_attri;
+        }
+        else
+        {
+            throw std::runtime_error(
+                "[AttributableImpl] "
+                "Cannot use default-constructed Attributable." );
+        }
     }
     inline
     internal::AttributableData const & get() const
     {
-        return *m_attri;
+        if( m_attri )
+        {
+            return *m_attri;
+        }
+        else
+        {
+            throw std::runtime_error(
+                "[AttributableImpl] "
+                "Cannot use default-constructed Attributable." );
+        }
     }
 
     bool dirty() const { return writable().dirty; }

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -81,8 +81,9 @@ class Container : public LegacyAttributable
 
     friend class Iteration;
     friend class ParticleSpecies;
-    friend class SeriesImpl;
     friend class internal::SeriesData;
+    friend class SeriesImpl;
+    friend class Series;
 
 public:
     using key_type = typename InternalContainer::key_type;

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -177,7 +177,7 @@ bool SeriesIterator::operator!=( SeriesIterator const & other ) const
 
 SeriesIterator SeriesIterator::end()
 {
-    return {};
+    return SeriesIterator{};
 }
 
 ReadIterations::ReadIterations( Series series )

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1319,6 +1319,10 @@ SeriesInternal::~SeriesInternal()
 }
 } // namespace internal
 
+Series::Series() : SeriesImpl{ nullptr, nullptr }, iterations{}
+{
+}
+
 #if openPMD_HAVE_MPI
 Series::Series(
     std::string const & filepath,
@@ -1348,6 +1352,11 @@ Series::Series(
     AttributableImpl::m_attri =
         static_cast< internal::AttributableData * >( m_series.get() );
     SeriesImpl::m_series = m_series.get();
+}
+
+Series::operator bool() const
+{
+    return m_series.operator bool();
 }
 
 ReadIterations Series::readIterations()


### PR DESCRIPTION
I've noticed that those can be useful in user code. E.g. in GAPD, openPMD is only one of the many reading routines, making it impossible to use our `for(auto iteration: series.readIterations())…` API, instead resorting to manually using the iterators. That is easier if the iterators are default-constructible.