### PR TITLE
DaskDataFrame: Fix Chunks

### DIFF
--- a/src/binding/python/openpmd_api/DaskDataFrame.py
+++ b/src/binding/python/openpmd_api/DaskDataFrame.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 def read_chunk_to_df(species, chunk):
-    stride = np.s_[chunk.offset[0]:chunk.extent[0]]
+    stride = np.s_[chunk.offset[0]:chunk.offset[0]+chunk.extent[0]]
     return species.to_df(stride)
 
 


### PR DESCRIPTION
For more than one chunk, the extent needs to add the offset to slice the right size.

Follow-up to #935 