### PR TITLE
HDF5: Fix Segfault with libSplash Files

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1466,7 +1466,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                 char* m1 = H5Tget_member_name(attr_type, 1);
                 char* m2 = H5Tget_member_name(attr_type, 2);
                 if( m0 == nullptr || m1 == nullptr || m2 == nullptr )
-                    isLegacyLibSplashAttr = false;
+                    isLegacyLibSplashAttr = false;  // NOLINT(bugprone-branch-clone)
                 else if(strcmp("x", m0) != 0 || strcmp("y", m1) != 0 || strcmp("z", m2) != 0)
                     isLegacyLibSplashAttr = false;
                 H5free_memory(m2);

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1424,8 +1424,9 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
             {
                 char* m0 = H5Tget_member_name(attr_type, 0);
                 char* m1 = H5Tget_member_name(attr_type, 1);
-                if( (strncmp("TRUE" , m0, 4) == 0) && (strncmp("FALSE", m1, 5) == 0) )
-                    attrIsBool = true;
+                if( m0 != nullptr && m1 != nullptr )
+                    if( (strncmp("TRUE" , m0, 4) == 0) && (strncmp("FALSE", m1, 5) == 0) )
+                        attrIsBool = true;
                 H5free_memory(m1);
                 H5free_memory(m0);
             }
@@ -1446,8 +1447,9 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
             {
                 char* m0 = H5Tget_member_name(attr_type, 0);
                 char* m1 = H5Tget_member_name(attr_type, 1);
-                if( (strncmp("r" , m0, 4) == 0) && (strncmp("i", m1, 5) == 0) )
-                    isComplexType = true;
+                if( m0 != nullptr && m1 != nullptr )
+                    if( (strncmp("r" , m0, 1) == 0) && (strncmp("i", m1, 1) == 0) )
+                        isComplexType = true;
                 H5free_memory(m1);
                 H5free_memory(m0);
             }
@@ -1463,7 +1465,9 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                 char* m0 = H5Tget_member_name(attr_type, 0);
                 char* m1 = H5Tget_member_name(attr_type, 1);
                 char* m2 = H5Tget_member_name(attr_type, 2);
-                if(strcmp("x", m0) != 0 || strcmp("y", m1) != 0 || strcmp("z", m2) != 0)
+                if( m0 == nullptr || m1 == nullptr || m2 == nullptr )
+                    isLegacyLibSplashAttr = false;
+                else if(strcmp("x", m0) != 0 || strcmp("y", m1) != 0 || strcmp("z", m2) != 0)
                     isLegacyLibSplashAttr = false;
                 H5free_memory(m2);
                 H5free_memory(m1);
@@ -1498,7 +1502,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                     a = Attribute(cld);
                 }
                 else
-                    throw unsupported_data_error("[HDF5] Unknow complex type representation");
+                    throw unsupported_data_error("[HDF5] Unknown complex type representation");
             }
             else
                 throw unsupported_data_error("[HDF5] Compound attribute type not supported");

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1465,9 +1465,9 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
                 char* m2 = H5Tget_member_name(attr_type, 2);
                 if(strcmp("x", m0) != 0 || strcmp("y", m1) != 0 || strcmp("z", m2) != 0)
                     isLegacyLibSplashAttr = false;
-                free(m2);
-                free(m1);
-                free(m0);
+                H5free_memory(m2);
+                H5free_memory(m1);
+                H5free_memory(m0);
             }
             if( isLegacyLibSplashAttr )
             {


### PR DESCRIPTION
Fix #939: a segfault (triggered reproducibly with pip builds) with legacy libSplash HDF5 files.
Introduced in #641 (`0.10.3-alpha` and newer).

From the docs:
```
Name: H5Tget_member_name
  ...
  The HDF5 Library allocates a buffer to receive the name of the
  field. The caller must subsequently free the buffer with
  H5free_memory.
```

I did not need this in my test to fix the segfault, but revisiting the logic I also noticed that passing `nullptr`s to `str(n)cmp` is undefined behavior and fixed that as well.

Refs.:
- https://support.hdfgroup.org/HDF5/doc/RM/RM_H5T.html#Datatype-GetMemberName
- https://support.hdfgroup.org/HDF5/doc/RM/RM_H5.html#Library-FreeMemory (`IN: Buffer to be freed. Can be NULL.`)
- https://github.com/HDFGroup/hdf5/blob/hdf5-1_12_0/src/H5.c#L971-L984
- https://github.com/HDFGroup/hdf5/blob/hdf5-1_12_0/src/H5MM.c#L509-L527
- https://github.com/ComputationalRadiationPhysics/libSplash/pull/285