### PR TITLE
Retrieve paths of objects in the openPMD hierarchy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,7 @@ set(CORE_SOURCE
         src/auxiliary/JSON.cpp
         src/backend/Attributable.cpp
         src/backend/BaseRecordComponent.cpp
+        src/backend/Container.cpp
         src/backend/MeshRecordComponent.cpp
         src/backend/PatchRecord.cpp
         src/backend/PatchRecordComponent.cpp

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -41,7 +41,7 @@ public:
     ParticlePatches particlePatches;
 
 private:
-    ParticleSpecies() = default;
+    ParticleSpecies();
 
     void read();
     void flush(std::string const &) override;

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -204,6 +204,9 @@ OPENPMD_protected:
     internal::SeriesInternal & retrieveSeries();
 
     void seriesFlush( FlushLevel );
+
+    std::vector< std::string > myPath() const;
+
     void flushAttributes();
     void readAttributes();
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -205,6 +205,13 @@ OPENPMD_protected:
 
     void seriesFlush( FlushLevel );
 
+    /**
+     * @brief The path to this object within its containing Series.
+     *
+     * @return A vector of openPMD group names indicating where this object
+     *     may be found within its Series.
+     *     Notice that RecordComponent::SCALAR is included in this list.
+     */
     std::vector< std::string > myPath() const;
 
     void flushAttributes();

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -62,19 +62,20 @@ class SeriesData;
 namespace detail
 {
 template< typename T >
-std::string keyAsString( T && key, std::string const & parentKey )
+std::vector< std::string >
+keyAsString( T && key, std::vector< std::string > const & parentKey )
 {
     ( void )parentKey;
-    return std::to_string( std::forward< T >( key ) );
+    return { std::to_string( std::forward< T >( key ) ) };
 }
 
 template<>
-std::string keyAsString< std::string const & >(
-    std::string const & key, std::string const & parentKey );
+std::vector< std::string > keyAsString< std::string const & >(
+    std::string const & key, std::vector< std::string > const & parentKey );
 
 template<>
-std::string
-keyAsString< std::string >( std::string && key, std::string const & parentKey );
+std::vector< std::string > keyAsString< std::string >(
+    std::string && key, std::vector< std::string > const & parentKey );
 }
 
 /** @brief Map-like container that enforces openPMD requirements and handles IO.

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -61,6 +61,15 @@ class SeriesData;
 
 namespace detail
 {
+/*
+ * This converts the key (first parameter) to its string name within the
+ * openPMD hierarchy.
+ * If the key is found to be equal to RecordComponent::SCALAR, the parentKey
+ * will be returned, adding RecordComponent::SCALAR to its back.
+ * Reason: Scalar record components do not link their containing record as
+ * parent, but rather the parent's parent, so the own key within the "apparent"
+ * parent must be given as two steps.
+ */
 template< typename T >
 std::vector< std::string >
 keyAsString( T && key, std::vector< std::string > const & parentKey )
@@ -69,6 +78,7 @@ keyAsString( T && key, std::vector< std::string > const & parentKey )
     return { std::to_string( std::forward< T >( key ) ) };
 }
 
+// moved to a *.cpp file so we don't need to include RecordComponent.hpp here
 template<>
 std::vector< std::string > keyAsString< std::string const & >(
     std::string const & key, std::vector< std::string > const & parentKey );

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 // expose private and protected members for invasive testing
 #ifndef OPENPMD_private
@@ -121,8 +122,7 @@ OPENPMD_private:
     internal::AttributableData* attributable;
     Writable* parent;
     bool dirty;
-    // @todo move this to AttributableData
-    std::string ownKeyWithinParent;
+    std::vector< std::string > ownKeyWithinParent;
     /**
      * @brief Whether a Writable has been written to the backend.
      *

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -122,6 +122,12 @@ OPENPMD_private:
     internal::AttributableData* attributable;
     Writable* parent;
     bool dirty;
+    /**
+     * If parent is not null, then this is a vector of keys such that:
+     * &(*parent)[key_1]...[key_n] == this
+     * (Notice that scalar record components do not link their direct parent,
+     * but instead their parent's parent, hence a vector of keys)
+     */
     std::vector< std::string > ownKeyWithinParent;
     /**
      * @brief Whether a Writable has been written to the backend.

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -121,20 +121,22 @@ OPENPMD_private:
     internal::AttributableData* attributable;
     Writable* parent;
     bool dirty;
+    // @todo move this to AttributableData
+    std::string ownKeyWithinParent;
     /**
      * @brief Whether a Writable has been written to the backend.
-     * 
+     *
      * The class Writable is used to link objects in our (frontend) object model
      * of the openPMD group hierarchy to the backends.
      * The openPMD hierarchy needs to be built by each backend independently
      * from the frontend. This involves the following tasks:
      * * Opening/creating files/groups/datasets
      * * Setting up the path structure in Writable::abstractFilePosition
-     * 
+     *
      * If those tasks have been performed, the flag written is set as true.
      * The interpretation of that is that the backend has been made aware of the
      * Writable and its meaning within the current dataset.
-     * 
+     *
      */
     bool written;
 };

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -40,6 +40,8 @@ Iteration::Iteration()
     setTime(static_cast< double >(0));
     setDt(static_cast< double >(1));
     setTimeUnitSI(1);
+    meshes.writable().ownKeyWithinParent = "meshes";
+    particles.writable().ownKeyWithinParent = "particles";
 }
 
 template< typename T >

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -40,8 +40,8 @@ Iteration::Iteration()
     setTime(static_cast< double >(0));
     setDt(static_cast< double >(1));
     setTimeUnitSI(1);
-    meshes.writable().ownKeyWithinParent = "meshes";
-    particles.writable().ownKeyWithinParent = "particles";
+    meshes.writable().ownKeyWithinParent = { "meshes" };
+    particles.writable().ownKeyWithinParent = { "particles" };
 }
 
 template< typename T >

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -31,7 +31,7 @@ namespace openPMD
 {
 ParticleSpecies::ParticleSpecies()
 {
-    particlePatches.writable().ownKeyWithinParent = "particlePatches";
+    particlePatches.writable().ownKeyWithinParent = { "particlePatches" };
 }
 
 void

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -29,6 +29,10 @@
 
 namespace openPMD
 {
+ParticleSpecies::ParticleSpecies()
+{
+    particlePatches.writable().ownKeyWithinParent = "particlePatches";
+}
 
 void
 ParticleSpecies::read()

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -33,6 +33,9 @@
 
 namespace openPMD
 {
+// we must instantiate this somewhere even if it is constexpr
+constexpr char const * const RecordComponent::SCALAR;
+
 RecordComponent::RecordComponent()
         : m_chunks{std::make_shared< std::queue< IOTask > >()},
           m_constantValue{std::make_shared< Attribute >(-1)}

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -420,7 +420,7 @@ void SeriesImpl::init(
     auto & series = get();
     writable().IOHandler = ioHandler;
     series.iterations.linkHierarchy(writable());
-    series.iterations.writable().ownKeyWithinParent = "iterations";
+    series.iterations.writable().ownKeyWithinParent = { "iterations" };
 
     series.m_name = input->name;
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -420,6 +420,7 @@ void SeriesImpl::init(
     auto & series = get();
     writable().IOHandler = ioHandler;
     series.iterations.linkHierarchy(writable());
+    series.iterations.writable().ownKeyWithinParent = "iterations";
 
     series.m_name = input->name;
 

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -23,6 +23,7 @@
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 
+#include <algorithm>
 #include <complex>
 #include <iostream>
 #include <set>
@@ -131,6 +132,22 @@ internal::SeriesInternal & AttributableImpl::retrieveSeries()
 {
     return const_cast< internal::SeriesInternal & >(
         static_cast< AttributableImpl const * >( this )->retrieveSeries() );
+}
+
+std::vector< std::string > AttributableImpl::myPath() const
+{
+    std::vector< std::string > res{};
+    Writable const * findSeries = &writable();
+    while( findSeries->parent )
+    {
+        // we don't need to push_back the ownKeyWithinParent of the Series class
+        // so it's alright that this loop doesn't ask the key of the last found
+        // Writable
+        res.push_back( findSeries->ownKeyWithinParent );
+        findSeries = findSeries->parent;
+    }
+    std::reverse( res.begin(), res.end() );
+    return res;
 }
 
 void

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -143,7 +143,14 @@ std::vector< std::string > AttributableImpl::myPath() const
         // we don't need to push_back the ownKeyWithinParent of the Series class
         // so it's alright that this loop doesn't ask the key of the last found
         // Writable
-        res.push_back( findSeries->ownKeyWithinParent );
+
+        // push these in reverse because we're building the list from the back
+        for( auto it = findSeries->ownKeyWithinParent.rbegin();
+             it != findSeries->ownKeyWithinParent.rend();
+             ++it )
+        {
+            res.push_back( *it );
+        }
         findSeries = findSeries->parent;
     }
     std::reverse( res.begin(), res.end() );

--- a/src/backend/Container.cpp
+++ b/src/backend/Container.cpp
@@ -1,0 +1,57 @@
+/* Copyright 2017-2021 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openPMD/backend/Container.hpp"
+#include "openPMD/RecordComponent.hpp"
+
+namespace openPMD
+{
+namespace detail
+{
+template<>
+std::string keyAsString< std::string const & >(
+    std::string const & key, std::string const & parentKey )
+{
+    if( key == RecordComponent::SCALAR )
+    {
+        return parentKey;
+    }
+    else
+    {
+        return key;
+    }
+}
+
+template<>
+std::string
+keyAsString< std::string >( std::string && key, std::string const & parentKey )
+{
+    if( key == RecordComponent::SCALAR )
+    {
+        return parentKey;
+    }
+    else
+    {
+        return std::move( key );
+    }
+}
+}
+}

--- a/src/backend/Container.cpp
+++ b/src/backend/Container.cpp
@@ -27,30 +27,34 @@ namespace openPMD
 namespace detail
 {
 template<>
-std::string keyAsString< std::string const & >(
-    std::string const & key, std::string const & parentKey )
+std::vector< std::string > keyAsString< std::string const & >(
+    std::string const & key, std::vector< std::string > const & parentKey )
 {
     if( key == RecordComponent::SCALAR )
     {
-        return parentKey;
+        auto ret = parentKey;
+        ret.emplace_back( RecordComponent::SCALAR );
+        return ret;
     }
     else
     {
-        return key;
+        return { key };
     }
 }
 
 template<>
-std::string
-keyAsString< std::string >( std::string && key, std::string const & parentKey )
+std::vector< std::string > keyAsString< std::string >(
+    std::string && key, std::vector< std::string > const & parentKey )
 {
     if( key == RecordComponent::SCALAR )
     {
-        return parentKey;
+        auto ret = parentKey;
+        ret.emplace_back( RecordComponent::SCALAR );
+        return ret;
     }
     else
     {
-        return std::move( key );
+        return { std::move( key ) };
     }
 }
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -147,6 +147,125 @@ TEST_CASE( "attribute_dtype_test", "[core]" )
     }
 }
 
+TEST_CASE( "myPath", "[core]" )
+{
+#if openPMD_USE_INVASIVE_TESTS
+    using vec_t = std::vector< std::string >;
+    Series series( "../samples/myPath.json", Access::CREATE );
+    REQUIRE( series.myPath() == vec_t{} );
+    auto iteration = series.iterations[ 1234 ];
+    REQUIRE( iteration.myPath() == vec_t{ "iterations", "1234" } );
+
+    auto writeSomething = []( auto & recordComponent )
+    {
+        recordComponent.resetDataset( { Datatype::INT, { 100 } } );
+        recordComponent.template makeConstant< int >( 5678 );
+    };
+
+    REQUIRE(
+        iteration.meshes.myPath() == vec_t{ "iterations", "1234", "meshes" } );
+
+    auto scalarMesh = iteration.meshes[ "e_chargeDensity" ];
+    REQUIRE(
+        scalarMesh.myPath() ==
+        vec_t{ "iterations", "1234", "meshes", "e_chargeDensity" } );
+    auto scalarMeshComponent = scalarMesh[ RecordComponent::SCALAR ];
+    // @todo emplace SCALAR string here?
+    REQUIRE(
+        scalarMeshComponent.myPath() ==
+        vec_t{ "iterations", "1234", "meshes", "e_chargeDensity" } );
+    writeSomething( scalarMeshComponent );
+
+    auto vectorMesh = iteration.meshes[ "E" ];
+    REQUIRE(
+        vectorMesh.myPath() == vec_t{ "iterations", "1234", "meshes", "E" } );
+    auto vectorMeshComponent = vectorMesh[ "x" ];
+    REQUIRE(
+        vectorMeshComponent.myPath() ==
+        vec_t{ "iterations", "1234", "meshes", "E", "x" } );
+
+    REQUIRE(
+        iteration.particles.myPath() ==
+        vec_t{ "iterations", "1234", "particles" } );
+
+    auto speciesE = iteration.particles[ "e" ];
+    REQUIRE(
+        speciesE.myPath() == vec_t{ "iterations", "1234", "particles", "e" } );
+
+    auto speciesPosition = speciesE[ "position" ];
+    REQUIRE(
+        speciesPosition.myPath() ==
+        vec_t{ "iterations", "1234", "particles", "e", "position" } );
+
+    auto speciesPositionX = speciesPosition[ "x" ];
+    REQUIRE(
+        speciesPositionX.myPath() ==
+        vec_t{ "iterations", "1234", "particles", "e", "position", "x" } );
+    writeSomething( speciesPositionX );
+
+    auto speciesWeighting = speciesE[ "weighting" ];
+    REQUIRE(
+        speciesWeighting.myPath() ==
+        vec_t{ "iterations", "1234", "particles", "e", "weighting" } );
+
+    auto speciesWeightingX = speciesWeighting[ RecordComponent::SCALAR ];
+    REQUIRE(
+        speciesWeightingX.myPath() ==
+        vec_t{ "iterations", "1234", "particles", "e", "weighting" } );
+    writeSomething( speciesWeightingX );
+
+    REQUIRE(
+        speciesE.particlePatches.myPath() ==
+        vec_t{ "iterations", "1234", "particles", "e", "particlePatches" } );
+
+    auto patchExtent = speciesE.particlePatches[ "extent" ];
+    REQUIRE(
+        patchExtent.myPath() ==
+        vec_t{
+            "iterations",
+            "1234",
+            "particles",
+            "e",
+            "particlePatches",
+            "extent" } );
+
+    auto patchExtentX = patchExtent[ "x" ];
+    REQUIRE(
+        patchExtentX.myPath() ==
+        vec_t{
+            "iterations",
+            "1234",
+            "particles",
+            "e",
+            "particlePatches",
+            "extent",
+            "x" } );
+
+    auto patchNumParticles = speciesE.particlePatches[ "numParticles" ];
+    REQUIRE(
+        patchNumParticles.myPath() ==
+        vec_t{
+            "iterations",
+            "1234",
+            "particles",
+            "e",
+            "particlePatches",
+            "numParticles" } );
+
+    auto patchNumParticlesComponent =
+        patchNumParticles[ RecordComponent::SCALAR ];
+    REQUIRE(
+        patchNumParticlesComponent.myPath() ==
+        vec_t{
+            "iterations",
+            "1234",
+            "particles",
+            "e",
+            "particlePatches",
+            "numParticles" } );
+#endif
+}
+
 TEST_CASE( "output_default_test", "[core]" )
 {
     using IE = IterationEncoding;

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -170,10 +170,14 @@ TEST_CASE( "myPath", "[core]" )
         scalarMesh.myPath() ==
         vec_t{ "iterations", "1234", "meshes", "e_chargeDensity" } );
     auto scalarMeshComponent = scalarMesh[ RecordComponent::SCALAR ];
-    // @todo emplace SCALAR string here?
     REQUIRE(
         scalarMeshComponent.myPath() ==
-        vec_t{ "iterations", "1234", "meshes", "e_chargeDensity" } );
+        vec_t{
+            "iterations",
+            "1234",
+            "meshes",
+            "e_chargeDensity",
+            RecordComponent::SCALAR } );
     writeSomething( scalarMeshComponent );
 
     auto vectorMesh = iteration.meshes[ "E" ];
@@ -211,7 +215,7 @@ TEST_CASE( "myPath", "[core]" )
     auto speciesWeightingX = speciesWeighting[ RecordComponent::SCALAR ];
     REQUIRE(
         speciesWeightingX.myPath() ==
-        vec_t{ "iterations", "1234", "particles", "e", "weighting" } );
+        vec_t{ "iterations", "1234", "particles", "e", "weighting", RecordComponent::SCALAR } );
     writeSomething( speciesWeightingX );
 
     REQUIRE(
@@ -262,7 +266,8 @@ TEST_CASE( "myPath", "[core]" )
             "particles",
             "e",
             "particlePatches",
-            "numParticles" } );
+            "numParticles",
+            RecordComponent::SCALAR } );
 #endif
 }
 


### PR DESCRIPTION
Needed for "serialization" in DASK contexts.

TODO:
- [x] testing