### PR TITLE
CI: Brew Update

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -178,10 +178,12 @@ jobs:
     - name: Install
       run: |
         rm -rf /usr/local/bin/2to3
+        set +e
         brew update
         brew install adios2 || true
         brew install hdf5-mpi || true
         brew install python || true
+        set -e
     - name: Build
       env: {CXXFLAGS: -Werror -Wno-deprecated-declarations, MACOSX_DEPLOYMENT_TARGET: 10.9}
       # C++11 & 14 support in macOS 10.9+


### PR DESCRIPTION
Brew return codes are not logical.

```
You have 12 outdated formulae installed.
You can upgrade them with brew upgrade
or list them with brew outdated.
Error: Process completed with exit code 1.
```