### PR TITLE
Set a default QueueLimit of 2 in the ADIOS2/SST engine

### DIFF
--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -65,6 +65,9 @@ Notice that the ADIOS2 backend is alternatively configurable via :ref:`JSON para
 Due to performance considerations, the ADIOS2 backend configures ADIOS2 not to compute any dataset statistics (Min/Max) by default.
 Statistics may be activated by setting the :ref:`JSON parameter <backendconfig>` ``adios2.engine.parameters.StatsLevel = "1"``.
 
+The ADIOS2 backend overrides the default unlimited queueing behavior of the SST engine with a more cautious limit of 2 steps that may be held in the queue at one time.
+The default behavior may be restored by setting the :ref:`JSON parameter <backendconfig>` ``adios2.engine.parameters.QueueLimit = "0"``.
+
 Best Practice at Large Scale
 ----------------------------
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2399,6 +2399,27 @@ namespace detail
              */
             m_IO.SetParameter( "StatsLevel", "0" );
         }
+        if( m_engineType == "sst" && notYetConfigured( "QueueLimit" ) )
+        {
+            /*
+             * By default, the SST engine of ADIOS2 does not set a limit on its
+             * internal queue length.
+             * If the reading end is slower than the writing end, this will
+             * lead to a congestion in the queue and hence an increasing
+             * memory usage while the writing code goes forward.
+             * We could set a default queue limit of 1, thus forcing the
+             * two codes to proceed entirely in lock-step.
+             * We prefer a default queue limit of 2, which is still lower than
+             * the default infinity, but allows writer and reader to process
+             * data asynchronously as long as neither code fails to keep up the
+             * rhythm. The writer can produce the next iteration while the
+             * reader still deals with the old one.
+             * Thus, a limit of 2 is a good balance between 1 and infinity,
+             * keeping pipeline parallelism a default without running the risk
+             * of using unbound memory.
+             */
+            m_IO.SetParameter( "QueueLimit", "2" );
+        }
 
         // We need to open the engine now already to inquire configuration
         // options stored in there


### PR DESCRIPTION
For reference, see [here](https://github.com/ornladios/ADIOS2/issues/2601#issuecomment-834175861).

For an explanation, I'll copy the in-line comment:
```cpp
            /*
             * By default, the SST engine of ADIOS2 does not set a limit on its
             * internal queue length.
             * If the reading end is slower than the writing end, this will
             * lead to a congestion in the queue and hence an increasing
             * memory usage while the writing code goes forward.
             * We could set a default queue limit of 1, thus forcing the
             * two codes to proceed entirely in lock-step.
             * We prefer a default queue limit of 2, which is still lower than
             * the default infinity, but allows writer and reader to process
             * data asynchronously as long as neither code fails to keep up the
             * rhythm. The writer can produce the next iteration while the
             * reader still deals with the old one.
             * Thus, a limit of 2 is a good balance between 1 and infinity,
             * keeping pipeline parallelism a default without running the risk
             * of using unbound memory.
             */
```

TODO:
- [x] Merge #981 first