### PR TITLE
Variant.hpp: size_t include

### DIFF
--- a/include/openPMD/auxiliary/Variant.hpp
+++ b/include/openPMD/auxiliary/Variant.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -22,6 +22,7 @@
 
 #include "VariantSrc.hpp"
 
+#include <cstddef>
 #include <type_traits>
 
 


### PR DESCRIPTION
Fix the following error on macOS:
```
In file included from openPMD-api/include/openPMD/Iteration.hpp:24,
                 from openPMD-api/src/Iteration.cpp:21:
openPMD-api/include/openPMD/auxiliary/Variant.hpp:81:15: error: 'size_t' does not name a type
   81 |     constexpr size_t index() const noexcept
      |               ^~~~~~
openPMD-api/include/openPMD/auxiliary/Variant.hpp:1:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
  +++ |+#include <cstddef>
```

Thanks to @dpgrote for the report!