### PR TITLE
RTD: Limit Sphinx to <4.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx_rtd_theme>=0.3.1
 recommonmark
-sphinx
+sphinx<4.0
 # docutils 0.17 breaks HTML tags & RTD theme
 # https://github.com/sphinx-doc/sphinx/issues/9001
 docutils<=0.16


### PR DESCRIPTION
Update from sphinx-3.5.4 to -4.0.1 broke our RTD builds:

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/openpmd-api/envs/latest/lib/python3.7/site-packages/breathe/renderer/sphinxrenderer.py", line 96, in DomainDirectiveFactory
    'function': (python.PyModulelevel, 'function'),
AttributeError: module 'sphinx.domains.python' has no attribute 'PyModulelevel'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/openpmd-api/envs/latest/lib/python3.7/site-packages/breathe/renderer/sphinxrenderer.py", line 96, in DomainDirectiveFactory
    'function': (python.PyModulelevel, 'function'),
AttributeError: module 'sphinx.domains.python' has no attribute 'PyModulelevel'
```