### PR TITLE
CMake: Expose Python LTO Control

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Other
 
 - ADIOS2: require version 2.7.0+ #927
 - pybind11: require version 2.6.2+ #977
+- CMake: Expose Python LTO Control #980
 
 
 0.13.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,7 +606,25 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/UnitDimension.cpp
     )
     target_link_libraries(openPMD.py PRIVATE openPMD)
-    target_link_libraries(openPMD.py PRIVATE pybind11::module pybind11::lto pybind11::windows_extras)
+    target_link_libraries(openPMD.py PRIVATE pybind11::module pybind11::windows_extras)
+
+    # LTO/IPO: CMake target properties work well for 3.18+ and are buggy before
+    set(_USE_PY_LTO ON)  # default shall be ON
+    if(DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)  # overwrite default if defined
+        if(NOT CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+            set(_USE_PY_LTO OFF)
+        endif()
+    endif()
+    message(STATUS "Python LTO/IPO: ${_USE_PY_LTO}")
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+        set_target_properties(openPMD.py PROPERTIES
+            INTERPROCEDURAL_OPTIMIZATION ${_USE_PY_LTO})
+    else()
+        if(_USE_PY_LTO)
+            target_link_libraries(openPMD.py PRIVATE pybind11::lto)
+        endif()
+    endif()
+    unset(_USE_PY_LTO)
 
     pybind11_extension(openPMD.py)
     pybind11_strip(openPMD.py)

--- a/README.md
+++ b/README.md
@@ -205,6 +205,13 @@ python3 -m pip install -U cmake
 openPMD_USE_MPI=ON python3 -m pip install openpmd-api --no-binary openpmd-api
 ```
 
+For some exotic architectures and compilers, you might need to disable a compiler feature called [link-time/interprocedural optimization](https://en.wikipedia.org/wiki/Interprocedural_optimization) if you encounter linking problems:
+```bash
+export CMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+# optional:                                                --user
+python3 -m pip install openpmd-api --no-binary openpmd-api
+```
+
 ### From Source
 
 [![Source Use Case](https://img.shields.io/badge/use_case-development-brightgreen)](https://cmake.org)

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -107,6 +107,14 @@ If MPI-support shall be enabled, we always have to recompile:
    # optional:                                                                   --user
    openPMD_USE_MPI=ON python3 -m pip install openpmd-api --no-binary openpmd-api
 
+For some exotic architectures and compilers, you might need to disable a compiler feature called `link-time/interprocedural optimization <https://en.wikipedia.org/wiki/Interprocedural_optimization>`_ if you encounter linking problems:
+
+.. code-block:: bash
+
+   export CMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+   # optional:                                                --user
+   python3 -m pip install openpmd-api --no-binary openpmd-api
+
 .. _install-cmake:
 
 .. only:: html

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,9 @@ class CMakeBuild(build_ext):
             # Windows: has no RPath concept, all `.dll`s must be in %PATH%
             #          or same dir as calling executable
         ]
+        if CMAKE_INTERPROCEDURAL_OPTIMIZATION is not None:
+            cmake_args.append('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=' +
+                              CMAKE_INTERPROCEDURAL_OPTIMIZATION)
         if sys.platform == "darwin":
             cmake_args.append('-DCMAKE_INSTALL_RPATH=@loader_path')
         else:
@@ -133,6 +136,8 @@ BUILD_TESTING = os.environ.get('openPMD_BUILD_TESTING',
                                BUILD_TESTING)
 BUILD_EXAMPLES = os.environ.get('openPMD_BUILD_EXAMPLES',
                                 BUILD_EXAMPLES)
+CMAKE_INTERPROCEDURAL_OPTIMIZATION = os.environ.get(
+    'CMAKE_INTERPROCEDURAL_OPTIMIZATION', None)
 
 # https://cmake.org/cmake/help/v3.0/command/if.html
 if openPMD_USE_MPI.upper() in ['1', 'ON', 'TRUE', 'YES']:


### PR DESCRIPTION
Before, LTO/IPO was default-enabled for the Python bindings. This can sometimes, e.g. on PPC64le with GCC 6.4.0 on Summit, cause problems in complex enough scenarios and fail to link.

We now expose control via the standardized CMake variable `CMAKE_INTERPROCEDURAL_OPTIMIZATION`. This variable populates the `INTERPROCEDURAL_OPTIMIZATION` property of targets but only works really reliably with CMake 3.18+. We keep the default logic to use LTO, use the `pybind11::lto` target for older CMake but let the user deactivate the Python LTO by setting the `CMAKE_INTERPROCEDURAL_OPTIMIZATION` variable to false.

Related to: https://github.com/pybind/pybind11/pull/3006