### PR TITLE
SST tests: start reader a second after the writer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1103,7 +1103,7 @@ if(openPMD_BUILD_TESTING)
         endif()
         if(openPMD_HAVE_ADIOS2)
             add_test(NAME Asynchronous.10_streaming
-                     COMMAND sh -c "$<TARGET_FILE:10_streaming_write> & $<TARGET_FILE:10_streaming_read>"
+                     COMMAND sh -c "$<TARGET_FILE:10_streaming_write> & sleep 1; $<TARGET_FILE:10_streaming_read>"
                      WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
         endif()
     endif()

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -9,6 +9,7 @@
 #if openPMD_HAVE_MPI
 #   include <mpi.h>
 
+#   include <chrono>
 #   include <fstream>
 #   include <iostream>
 #   include <algorithm>
@@ -17,6 +18,7 @@
 #   include <list>
 #   include <memory>
 #   include <numeric>
+#   include <thread>
 #   include <tuple>
 
 using namespace openPMD;
@@ -901,6 +903,14 @@ adios2_streaming( bool variableBasedLayout )
         // read
         // it should be possible to select the sst engine via file ending or
         // via JSON without difference
+
+        /*
+         * Sleep for a second so the writer comes first.
+         * If a previous run of the parallel IO tests left a stale .sst file,
+         * this avoids that the reader sees that file.
+         */
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for( 1s );
         std::string options = R"(
         {
           "adios2": {


### PR DESCRIPTION
If a previous test run left a stale .sst file, this avoids that the reader sees that file.
Theoretically, the timing of reader relative to the writer should not matter, but that's a thing for the ADIOS2 team to test.