### PR TITLE
Make WriteIterations::key_type public

### DIFF
--- a/include/openPMD/WriteIterations.hpp
+++ b/include/openPMD/WriteIterations.hpp
@@ -65,7 +65,6 @@ private:
         ~SharedResources();
     };
 
-    using value_type = typename iterations_t::key_type;
     WriteIterations( iterations_t );
     explicit WriteIterations() = default;
     //! Index of the last opened iteration

--- a/include/openPMD/WriteIterations.hpp
+++ b/include/openPMD/WriteIterations.hpp
@@ -50,6 +50,12 @@ class WriteIterations : private Container< Iteration, uint64_t >
 
 private:
     using iterations_t = Container< Iteration, uint64_t >;
+    
+public:
+    using key_type = typename iterations_t::key_type;
+    using mapped_type = typename iterations_t::mapped_type;
+
+private:
     struct SharedResources
     {
         iterations_t iterations;
@@ -59,7 +65,6 @@ private:
         ~SharedResources();
     };
 
-    using key_type = typename iterations_t::key_type;
     using value_type = typename iterations_t::key_type;
     WriteIterations( iterations_t );
     explicit WriteIterations() = default;

--- a/include/openPMD/WriteIterations.hpp
+++ b/include/openPMD/WriteIterations.hpp
@@ -54,6 +54,7 @@ private:
 public:
     using key_type = typename iterations_t::key_type;
     using mapped_type = typename iterations_t::mapped_type;
+    using value_type = typename iterations_t::value_type;
 
 private:
     struct SharedResources

--- a/include/openPMD/WriteIterations.hpp
+++ b/include/openPMD/WriteIterations.hpp
@@ -55,6 +55,7 @@ public:
     using key_type = typename iterations_t::key_type;
     using mapped_type = typename iterations_t::mapped_type;
     using value_type = typename iterations_t::value_type;
+    using reference = typename iterations_t::reference;
 
 private:
     struct SharedResources


### PR DESCRIPTION
`key_type` and `mapped_type` are used in a public function and should be public types.

Also – is `value_type` defined correctly? I would have expected it to be a pair, not a synonym for the key type.