### PR TITLE
Sphinx: rsvg converter for LaTeX

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,14 @@
-requirements_file: docs/requirements.txt
+version: 2
+
+python:
+  install:
+    - requirements: docs/requirements.txt
 
 formats:
     - htmlzip
     - pdf
     - epub
+
+build:
+  apt_packages:
+    - librsvg2-bin

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@ sphinx<4.0
 docutils<=0.16
 breathe>=4.5,<4.15
 sphinxcontrib.programoutput
+sphinxcontrib-svg2pdfconverter
 pygments
 # generate plots
 matplotlib

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ show_authors = True
 extensions = ['sphinx.ext.mathjax',
               'breathe',
               'sphinxcontrib.programoutput',
-              'sphinx.ext.imgconverter',
+              'sphinxcontrib.rsvgconverter',
               'matplotlib.sphinxext.plot_directive']
 
 if not on_rtd:

--- a/docs/ubuntu-package.list
+++ b/docs/ubuntu-package.list
@@ -1,7 +1,7 @@
 doxygen
 graphviz
 imagemagick
-latexmk
+librsvg2-bin
 texlive-latex-recommended
 texlive-fonts-recommended
 texlive-latex-extra


### PR DESCRIPTION
The imagemagick on RTD (Ubuntu 18.04) is too old and creates artifacts. We now use rsvg to generate a PDF for latex and keep the SVG for HTML & EPUB.

Follow-up to #997