### PR TITLE
Add Env OPENPMD_ADIOS2_STATS_LEVEL

### DIFF
--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -52,7 +52,7 @@ environment variable                  default    description
 ``OPENPMD_ADIOS2_NUM_SUBSTREAMS``     ``0``      Number of files to be created, 0 indicates maximum number possible.
 ``OPENPMD_ADIOS2_ENGINE``             ``File``   `ADIOS2 engine <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_
 ``OPENPMD2_ADIOS2_SCHEMA``            ``0``      ADIOS2 schema version (see below)
-``OPENPMD_ADIOS2_STAT``               ``0``      decide whether stat should be processed in ADIOS2. (1=Yes, 0=No)
+``OPENPMD_ADIOS2_STATS_LEVEL``        ``0``      whether to generate statistics for variables in ADIOS2. (1=Yes, 0=No)
 ``OPENPMD_BP_BACKEND``                ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ===================================== ========== ================================================================================
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -52,7 +52,7 @@ environment variable                  default    description
 ``OPENPMD_ADIOS2_NUM_SUBSTREAMS``     ``0``      Number of files to be created, 0 indicates maximum number possible.
 ``OPENPMD_ADIOS2_ENGINE``             ``File``   `ADIOS2 engine <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_
 ``OPENPMD2_ADIOS2_SCHEMA``            ``0``      ADIOS2 schema version (see below)
-``OPENPMD_ADIOS2_STATS_LEVEL``        ``0``      whether to generate statistics for variables in ADIOS2. (1=Yes, 0=No)
+``OPENPMD_ADIOS2_STATS_LEVEL``        ``0``      whether to generate statistics for variables in ADIOS2. (``1``: yes, ``0``: no).
 ``OPENPMD_BP_BACKEND``                ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ===================================== ========== ================================================================================
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -52,6 +52,7 @@ environment variable                  default    description
 ``OPENPMD_ADIOS2_NUM_SUBSTREAMS``     ``0``      Number of files to be created, 0 indicates maximum number possible.
 ``OPENPMD_ADIOS2_ENGINE``             ``File``   `ADIOS2 engine <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_
 ``OPENPMD2_ADIOS2_SCHEMA``            ``0``      ADIOS2 schema version (see below)
+``OPENPMD_ADIOS2_STAT``               ``0``      decide whether stat should be processed in ADIOS2. (1=Yes, 0=No)
 ``OPENPMD_BP_BACKEND``                ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
 ===================================== ========== ================================================================================
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2393,9 +2393,9 @@ namespace detail
             /*
              * Switch those off by default since they are expensive to compute
              * and to enable it, set the environment variable 
-             * OPENPMD_ADIOS2_STATS_LEVEL be postive (e.g. 1).
+             * OPENPMD_ADIOS2_STATS_LEVEL be postive (on is documented as "1").
              * Can still also be switched on via JSON though.
-             * Default is "1".
+             * The ADIOS2 default is "1" (on).
              */
              auto stats_level = auxiliary::getEnvNum( "OPENPMD_ADIOS2_STATS_LEVEL", 0 );
              m_IO.SetParameter( "StatsLevel", std::to_string( stats_level ) );

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2392,10 +2392,9 @@ namespace detail
         {
             /*
              * Switch those off by default since they are expensive to compute
-             * and to enable it, set the environment variable 
-             * OPENPMD_ADIOS2_STATS_LEVEL be postive (on is documented as "1").
-             * Can still also be switched on via JSON though.
-             * The ADIOS2 default is "1" (on).
+             * and to enable it, set the JSON option "StatsLevel" or the environment
+             * variable "OPENPMD_ADIOS2_STATS_LEVEL" be positive.
+             * The ADIOS2 default was "1" (on).
              */
              auto stats_level = auxiliary::getEnvNum( "OPENPMD_ADIOS2_STATS_LEVEL", 0 );
              m_IO.SetParameter( "StatsLevel", std::to_string( stats_level ) );

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2392,16 +2392,13 @@ namespace detail
         {
             /*
              * Switch those off by default since they are expensive to compute
-             * and we don't read them anyway.
-             * No environement variable for this one, can still be switched
-             * on via JSON though.
+             * and to enable it, set the environment variable 
+             * OPENPMD_ADIOS2_STATS_LEVEL be postive (e.g. 1).
+             * Can still also be switched on via JSON though.
              * Default is "1".
              */
-             m_IO.SetParameter( "StatsLevel", "0" );
-             auto StatLevel = auxiliary::getEnvNum( "OPENPMD_ADIOS2_STAT", 0 );
-
-             if (StatLevel > 0)
-                 m_IO.SetParameter( "StatsLevel", "1" );
+             auto stats_level = auxiliary::getEnvNum( "OPENPMD_ADIOS2_STATS_LEVEL", 0 );
+             m_IO.SetParameter( "StatsLevel", std::to_string( stats_level ) );
         }
         if( m_engineType == "sst" && notYetConfigured( "QueueLimit" ) )
         {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2397,7 +2397,11 @@ namespace detail
              * on via JSON though.
              * Default is "1".
              */
-            m_IO.SetParameter( "StatsLevel", "0" );
+             m_IO.SetParameter( "StatsLevel", "0" );
+             auto StatLevel = auxiliary::getEnvNum( "OPENPMD_ADIOS2_STAT", 0 );
+
+             if (StatLevel > 0)
+                 m_IO.SetParameter( "StatsLevel", "1" );
         }
         if( m_engineType == "sst" && notYetConfigured( "QueueLimit" ) )
         {


### PR DESCRIPTION
The Query functions in ADIOS needs the extra stat info from the metadata.  Therefore added this option to enable it. 