### PR TITLE
ADIOS2 Append Mode

### DIFF
--- a/docs/source/usage/workflow.rst
+++ b/docs/source/usage/workflow.rst
@@ -12,15 +12,16 @@ The openPMD-api distinguishes between a number of different access modes:
 * **Read/Write mode**: Creates a new Series if not existing, otherwise opens an existing Series for reading and writing.
   New datasets and iterations will be inserted as needed.
   Not fully supported by all backends:
+
   * ADIOS1: Automatically coerced to *Create* mode if the file does not exist yet and to *Read-only* mode if it exists.
   * ADIOS2: Automatically coerced to *Create* mode if the file does not exist yet and to *Read-only* mode if it exists.
-    Since this happens on a per-file level, this mode allows to read from existing iterations and write to new iterations at the same time in file-based iteration encoding.
+  Since this happens on a per-file level, this mode allows to read from existing iterations and write to new iterations at the same time in file-based iteration encoding.
 * **Append mode**: Restricted mode for appending new iterations to an existing Series that is supported by all backends at least in file-based iteration encoding, and by all but ADIOS1 in other encodings.
   The API is equivalent to that of the *Create* mode, meaning that no reading is supported whatsoever.
   If the Series does not exist yet, this behaves equivalently to the *Create* mode.
   Existing iterations will not be deleted, newly-written iterations will be inserted.
 
-  **Warning:** If writing an iteration that already exists, the behavior is implementation-defined and depends on the chosen backend and iteration encoding:
+  **Warning:** When writing an iteration that already exists, the behavior is implementation-defined and depends on the chosen backend and iteration encoding:
 
   * The new iteration might fully replace the old one.
   * The new iteration might be merged into the old one.

--- a/docs/source/usage/workflow.rst
+++ b/docs/source/usage/workflow.rst
@@ -1,5 +1,38 @@
 .. _workflow:
 
+Access modes
+============
+
+The openPMD-api distinguishes between a number of different access modes:
+
+* **Create mode**: Used for creating a new Series from scratch.
+  Any file possibly existing in the specified location will be overwritten.
+* **Read-only mode**: Used for reading from an existing Series.
+  No modifications will be made.
+* **Read/Write mode**: Creates a new Series if not existing, otherwise opens an existing Series for reading and writing.
+  New datasets and iterations will be inserted as needed.
+  Not fully supported by all backends:
+  * ADIOS1: Automatically coerced to *Create* mode if the file does not exist yet and to *Read-only* mode if it exists.
+  * ADIOS2: Automatically coerced to *Create* mode if the file does not exist yet and to *Read-only* mode if it exists.
+    Since this happens on a per-file level, this mode allows to read from existing iterations and write to new iterations at the same time in file-based iteration encoding.
+* **Append mode**: Restricted mode for appending new iterations to an existing Series that is supported by all backends at least in file-based iteration encoding, and by all but ADIOS1 in other encodings.
+  The API is equivalent to that of the *Create* mode, meaning that no reading is supported whatsoever.
+  If the Series does not exist yet, this behaves equivalently to the *Create* mode.
+  Existing iterations will not be deleted, newly-written iterations will be inserted.
+
+  **Warning:** If writing an iteration that already exists, the behavior is implementation-defined and depends on the chosen backend and iteration encoding:
+
+  * The new iteration might fully replace the old one.
+  * The new iteration might be merged into the old one.
+  * (To be removed in a future update) The old and new iteration might coexist in the resulting dataset.
+
+  We suggest to fully define iterations when using Append mode (i.e. as if using Create mode) to avoid implementation-specific behavior.
+  Appending to an openPMD Series is only supported on a per-iteration level.
+
+  **Warning:** There is no reading involved in using Append mode.
+  It is a user's responsibility to ensure that the appended dataset and the appended-to dataset are compatible with each other.
+  The results of using incompatible backend configurations are undefined.
+
 Workflow
 ========
 

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -75,7 +75,6 @@ namespace error
      *
      * Example: A nullpointer is observed somewhere.
      */
-
     class Internal : public Error
     {
     public:

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -69,5 +69,17 @@ namespace error
 
         BackendConfigSchema(std::vector<std::string>, std::string what);
     };
+
+    /**
+     * @brief Internal errors that should not happen. Please report.
+     *
+     * Example: A nullpointer is observed somewhere.
+     */
+
+    class Internal : public Error
+    {
+    public:
+        Internal(std::string const &what);
+    };
 } // namespace error
 } // namespace openPMD

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -121,6 +121,23 @@ namespace internal
  */
 class AbstractIOHandler
 {
+    friend class Series;
+
+private:
+    void setIterationEncoding(IterationEncoding encoding)
+    {
+        /*
+         * In file-based iteration encoding, the APPEND mode is handled entirely
+         * by the frontend, the backend should just treat it as CREATE mode
+         */
+        if (encoding == IterationEncoding::fileBased &&
+            m_backendAccess == Access::APPEND)
+        {
+            // do we really want to have those as const members..?
+            *const_cast<Access *>(&m_backendAccess) = Access::CREATE;
+        }
+    }
+
 public:
 #if openPMD_HAVE_MPI
     AbstractIOHandler(std::string path, Access at, MPI_Comm)
@@ -153,6 +170,7 @@ public:
     virtual std::string backendName() const = 0;
 
     std::string const directory;
+    // why do these need to be separate?
     Access const m_backendAccess;
     Access const m_frontendAccess;
     std::queue<IOTask> m_work;

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -266,14 +266,17 @@ public:
      * file.
      *
      * The operation should fail if m_handler->m_frontendAccess is
-     * Access::READ_ONLY. The new file should be located in
-     * m_handler->directory. The new file should have the filename
-     * parameters.name. The filename should include the correct corresponding
-     * filename extension. Any existing file should be overwritten if
-     * m_handler->m_frontendAccess is Access::CREATE. The Writables file
-     * position should correspond to the root group "/" of the hierarchy. The
-     * Writable should be marked written when the operation completes
-     * successfully.
+     * Access::READ_ONLY. If m_handler->m_frontendAccess is Access::APPEND, a
+     * possibly existing file should not be overwritten. Instead, written
+     * updates should then either occur in-place or in form of new IO steps.
+     * Support for reading is not necessary in Append mode.
+     * The new file should be located in m_handler->directory.
+     * The new file should have the filename parameters.name.
+     * The filename should include the correct corresponding filename extension.
+     * Any existing file should be overwritten if m_handler->m_frontendAccess is
+     * Access::CREATE. The Writables file position should correspond to the root
+     * group "/" of the hierarchy. The Writable should be marked written when
+     * the operation completes successfully.
      */
     virtual void
     createFile(Writable *, Parameter<Operation::CREATE_FILE> const &) = 0;

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -28,7 +28,8 @@ enum class Access
 {
     READ_ONLY, //!< open series as read-only, fails if series is not found
     READ_WRITE, //!< open existing series as writable
-    CREATE //!< create new series and truncate existing (files)
+    CREATE, //!< create new series and truncate existing (files)
+    APPEND //!< write new iterations to an existing series without reading
 }; // Access
 
 // deprecated name (used prior to 0.12.0)

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -45,5 +45,9 @@ namespace error
               concatVector(errorLocation_in) + "': " + std::move(what))
         , errorLocation(std::move(errorLocation_in))
     {}
+
+    Internal::Internal(std::string const &what)
+        : Error("Internal error: " + what + "\nThis is a bug. Please report.")
+    {}
 } // namespace error
 } // namespace openPMD

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -47,7 +47,10 @@ namespace error
     {}
 
     Internal::Internal(std::string const &what)
-        : Error("Internal error: " + what + "\nThis is a bug. Please report.")
+        : Error(
+              "Internal error: " + what +
+              "\nThis is a bug. Please report at ' "
+              "https://github.com/openPMD/openPMD-api/issues'.")
     {}
 } // namespace error
 } // namespace openPMD

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp"
+#include "openPMD/Error.hpp"
 
 #if openPMD_HAVE_ADIOS1
 
@@ -405,6 +406,15 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::createFile(
         std::string name = m_handler->directory + parameters.name;
         if (!auxiliary::ends_with(name, ".bp"))
             name += ".bp";
+
+        if (m_handler->m_backendAccess == Access::APPEND &&
+            auxiliary::file_exists(name))
+        {
+            throw error::OperationUnsupportedInBackend(
+                "ADIOS1",
+                "Appending to existing file on disk (use Access::CREATE to "
+                "overwrite)");
+        }
 
         writable->written = true;
         writable->abstractFilePosition =

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -258,7 +258,8 @@ void HDF5IOHandlerImpl::createFile(
             break;
         case Access::READ_ONLY:
             // condition has been checked above
-            throw std::runtime_error("Control flow error");
+            throw std::runtime_error(
+                "[HDF5] Control flow error in createFile backend access mode.");
         }
 
         hid_t id{};
@@ -470,8 +471,8 @@ void HDF5IOHandlerImpl::createDataset(
                 status = H5Ldelete(node_id, name.c_str(), H5P_DEFAULT);
                 VERIFY(
                     status == 0,
-                    "[HDF5] Internal error: Failed to delete old dataset from "
-                    "group for overwriting.");
+                    "[HDF5] Internal error: Failed to delete old dataset '" +
+                        name + "' from group for overwriting.");
                 break;
             }
         }

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -436,6 +436,46 @@ void HDF5IOHandlerImpl::createDataset(
             "[HDF5] Internal error: Failed to open HDF5 group during dataset "
             "creation");
 
+        if (m_handler->m_backendAccess == Access::APPEND)
+        {
+            // The dataset might already exist in the file from a previous run
+            // We delete it, otherwise we could not create it again with
+            // possibly different parameters.
+            // This is inefficient, as only the link to the dataset will be
+            // removed, but not the actual dataset
+            // But such is life if overwriting an iteration in Append mode
+            H5G_info_t group_info;
+            herr_t status = H5Gget_info(node_id, &group_info);
+            VERIFY(
+                status == 0,
+                "[HDF5] Internal error: Failed to get HDF5 group info for " +
+                    concrete_h5_file_position(writable) +
+                    " during dataset creation");
+            for (hsize_t i = 0; i < group_info.nlinks; ++i)
+            {
+                if (H5G_DATASET != H5Gget_objtype_by_idx(node_id, i))
+                {
+                    continue;
+                }
+                ssize_t name_length =
+                    H5Gget_objname_by_idx(node_id, i, nullptr, 0);
+                std::vector<char> charbuffer(name_length + 1);
+                H5Gget_objname_by_idx(
+                    node_id, i, charbuffer.data(), name_length + 1);
+                if (std::strncmp(
+                        name.c_str(), charbuffer.data(), name_length + 1) != 0)
+                {
+                    continue;
+                }
+                status = H5Ldelete(node_id, name.c_str(), H5P_DEFAULT);
+                VERIFY(
+                    status == 0,
+                    "[HDF5] Internal error: Failed to delete old dataset from "
+                    "group for overwriting.");
+                break;
+            }
+        }
+
         Datatype d = parameters.dtype;
         if (d == Datatype::UNDEFINED)
         {

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -298,15 +298,18 @@ void Iteration::flushVariableBased(
 
 void Iteration::flush(internal::FlushParams const &flushParams)
 {
-    if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
+    switch (IOHandler()->m_frontendAccess)
     {
+    case Access::READ_ONLY: {
         for (auto &m : meshes)
             m.second.flush(m.first, flushParams);
         for (auto &species : particles)
             species.second.flush(species.first, flushParams);
+        break;
     }
-    else
-    {
+    case Access::READ_WRITE:
+    case Access::CREATE:
+    case Access::APPEND: {
         /* Find the root point [Series] of this file,
          * meshesPath and particlesPath are stored there */
         Series s = retrieveSeries();
@@ -344,6 +347,8 @@ void Iteration::flush(internal::FlushParams const &flushParams)
         }
 
         flushAttributes(flushParams);
+        break;
+    }
     }
 }
 
@@ -591,15 +596,26 @@ AdvanceStatus Iteration::beginStep(bool reread)
         (this->IOHandler()->m_frontendAccess == Access::READ_ONLY ||
          this->IOHandler()->m_frontendAccess == Access::READ_WRITE))
     {
-        bool previous = series.iterations.written();
-        series.iterations.written() = false;
-        auto oldType = this->IOHandler()->m_frontendAccess;
-        auto newType =
-            const_cast<Access *>(&this->IOHandler()->m_frontendAccess);
-        *newType = Access::READ_WRITE;
-        series.readGorVBased(false);
-        *newType = oldType;
-        series.iterations.written() = previous;
+        switch (IOHandler()->m_frontendAccess)
+        {
+        case Access::READ_ONLY:
+        case Access::READ_WRITE: {
+            bool previous = series.iterations.written();
+            series.iterations.written() = false;
+            auto oldType = this->IOHandler()->m_frontendAccess;
+            auto newType =
+                const_cast<Access *>(&this->IOHandler()->m_frontendAccess);
+            *newType = Access::READ_WRITE;
+            series.readGorVBased(false);
+            *newType = oldType;
+            series.iterations.written() = previous;
+            break;
+        }
+        case Access::CREATE:
+        case Access::APPEND:
+            // no re-reading necessary
+            break;
+        }
     }
 
     return status;
@@ -696,42 +712,48 @@ void Iteration::linkHierarchy(Writable &w)
 
 void Iteration::runDeferredParseAccess()
 {
-    if (IOHandler()->m_frontendAccess == Access::CREATE)
+    switch (IOHandler()->m_frontendAccess)
     {
-        return;
-    }
-
-    auto &it = get();
-    if (!it.m_deferredParseAccess.has_value())
-    {
-        return;
-    }
-    auto const &deferred = it.m_deferredParseAccess.value();
-
-    auto oldAccess = IOHandler()->m_frontendAccess;
-    auto newAccess = const_cast<Access *>(&IOHandler()->m_frontendAccess);
-    *newAccess = Access::READ_WRITE;
-    try
-    {
-        if (deferred.fileBased)
+    case Access::READ_ONLY:
+    case Access::READ_WRITE: {
+        auto &it = get();
+        if (!it.m_deferredParseAccess.has_value())
         {
-            readFileBased(deferred.filename, deferred.path, deferred.beginStep);
+            return;
         }
-        else
+        auto const &deferred = it.m_deferredParseAccess.value();
+
+        auto oldAccess = IOHandler()->m_frontendAccess;
+        auto newAccess = const_cast<Access *>(&IOHandler()->m_frontendAccess);
+        *newAccess = Access::READ_WRITE;
+        try
         {
-            readGorVBased(deferred.path, deferred.beginStep);
+            if (deferred.fileBased)
+            {
+                readFileBased(
+                    deferred.filename, deferred.path, deferred.beginStep);
+            }
+            else
+            {
+                readGorVBased(deferred.path, deferred.beginStep);
+            }
         }
-    }
-    catch (...)
-    {
+        catch (...)
+        {
+            // reset this thing
+            it.m_deferredParseAccess = std::optional<DeferredParseAccess>();
+            *newAccess = oldAccess;
+        }
         // reset this thing
         it.m_deferredParseAccess = std::optional<DeferredParseAccess>();
         *newAccess = oldAccess;
-        throw;
+        break;
     }
-    // reset this thing
-    it.m_deferredParseAccess = std::optional<DeferredParseAccess>();
-    *newAccess = oldAccess;
+    case Access::CREATE:
+    case Access::APPEND:
+        // no parsing in those modes
+        return;
+    }
 }
 
 template float Iteration::time<float>() const;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -743,6 +743,7 @@ void Iteration::runDeferredParseAccess()
             // reset this thing
             it.m_deferredParseAccess = std::optional<DeferredParseAccess>();
             *newAccess = oldAccess;
+            throw;
         }
         // reset this thing
         it.m_deferredParseAccess = std::optional<DeferredParseAccess>();

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -216,13 +216,16 @@ template Mesh &Mesh::setTimeOffset(float);
 void Mesh::flush_impl(
     std::string const &name, internal::FlushParams const &flushParams)
 {
-    if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
+    switch (IOHandler()->m_frontendAccess)
     {
+    case Access::READ_ONLY: {
         for (auto &comp : *this)
             comp.second.flush(comp.first, flushParams);
+        break;
     }
-    else
-    {
+    case Access::READ_WRITE:
+    case Access::CREATE:
+    case Access::APPEND: {
         if (!written())
         {
             if (scalar())
@@ -260,6 +263,8 @@ void Mesh::flush_impl(
         }
 
         flushAttributes(flushParams);
+        break;
+    }
     }
 }
 

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -141,15 +141,18 @@ namespace
 void ParticleSpecies::flush(
     std::string const &path, internal::FlushParams const &flushParams)
 {
-    if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
+    switch (IOHandler()->m_frontendAccess)
     {
+    case Access::READ_ONLY: {
         for (auto &record : *this)
             record.second.flush(record.first, flushParams);
         for (auto &patch : particlePatches)
             patch.second.flush(patch.first, flushParams);
+        break;
     }
-    else
-    {
+    case Access::READ_WRITE:
+    case Access::CREATE:
+    case Access::APPEND: {
         auto it = find("position");
         if (it != end())
             it->second.setUnitDimension({{UnitDimension::L, 1}});
@@ -168,6 +171,8 @@ void ParticleSpecies::flush(
             for (auto &patch : particlePatches)
                 patch.second.flush(patch.first, flushParams);
         }
+        break;
+    }
     }
 }
 

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -46,13 +46,16 @@ Record &Record::setUnitDimension(std::map<UnitDimension, double> const &udim)
 void Record::flush_impl(
     std::string const &name, internal::FlushParams const &flushParams)
 {
-    if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
+    switch (IOHandler()->m_frontendAccess)
     {
+    case Access::READ_ONLY: {
         for (auto &comp : *this)
             comp.second.flush(comp.first, flushParams);
+        break;
     }
-    else
-    {
+    case Access::READ_WRITE:
+    case Access::CREATE:
+    case Access::APPEND: {
         if (!written())
         {
             if (scalar())
@@ -90,6 +93,8 @@ void Record::flush_impl(
         }
 
         flushAttributes(flushParams);
+        break;
+    }
     }
 }
 

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -200,16 +200,18 @@ void RecordComponent::flush(
         rc.m_name = name;
         return;
     }
-    if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
+    switch (IOHandler()->m_frontendAccess)
     {
+    case Access::READ_ONLY:
         while (!rc.m_chunks.empty())
         {
             IOHandler()->enqueue(rc.m_chunks.front());
             rc.m_chunks.pop();
         }
-    }
-    else
-    {
+        break;
+    case Access::READ_WRITE:
+    case Access::CREATE:
+    case Access::APPEND: {
         /*
          * This catches when a user forgets to use resetDataset.
          */
@@ -275,6 +277,8 @@ void RecordComponent::flush(
         }
 
         flushAttributes(flushParams);
+        break;
+    }
     }
 }
 

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -84,16 +84,19 @@ void PatchRecordComponent::flush(
     std::string const &name, internal::FlushParams const &flushParams)
 {
     auto &rc = get();
-    if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
+    switch (IOHandler()->m_frontendAccess)
     {
+    case Access::READ_ONLY: {
         while (!rc.m_chunks.empty())
         {
             IOHandler()->enqueue(rc.m_chunks.front());
             rc.m_chunks.pop();
         }
+        break;
     }
-    else
-    {
+    case Access::READ_WRITE:
+    case Access::CREATE:
+    case Access::APPEND: {
         if (!written())
         {
             Parameter<Operation::CREATE_DATASET> dCreate;
@@ -111,6 +114,8 @@ void PatchRecordComponent::flush(
         }
 
         flushAttributes(flushParams);
+        break;
+    }
     }
 }
 

--- a/src/binding/python/Error.cpp
+++ b/src/binding/python/Error.cpp
@@ -14,6 +14,7 @@ void init_Error(py::module &m)
         m, "ErrorWrongAPIUsage", baseError);
     py::register_exception<error::BackendConfigSchema>(
         m, "ErrorBackendConfigSchema", baseError);
+    py::register_exception<error::Internal>(m, "ErrorInternal", baseError);
 
 #ifndef NDEBUG
     m.def("test_throw", [](std::string description) {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5839,10 +5839,6 @@ TEST_CASE("append_mode", "[serial]")
 {
     for (auto const &t : testedFileExtensions())
     {
-        if (t == "h5")
-        {
-            continue;
-        }
         if (t == "bp")
         {
             std::string jsonConfigOld = R"END(

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1917,9 +1917,26 @@ inline void fileBased_write_test(const std::string &backend)
         REQUIRE(o.iterations[5].time<double>() == 5.0);
     }
 
-    // extend existing series with new step and auto-detection of iteration
-    // padding
+    if (backend == "bp")
     {
+        // Append + filebased iteration encoding works for all backends
+        Series o = Series(
+            "../samples/subdir/serial_fileBased_write%T." + backend,
+            Access::APPEND);
+        // Append mode does not support reading anything that already exists
+        REQUIRE(o.iterations.size() == 0);
+        // write something to trigger opening of the file
+        o.iterations[6].particles["e"]["position"]["x"].resetDataset(
+            {Datatype::DOUBLE, {10}});
+        o.iterations[6].particles["e"]["position"]["x"].makeConstant<double>(
+            1.0);
+    }
+    else
+    {
+        // @todo enable a workflow for ADIOS2 where only either reading from or
+        // writing to an iteration works
+        // extend existing series with new step and auto-detection of iteration
+        // padding
         Series o = Series(
             "../samples/subdir/serial_fileBased_write%T." + backend,
             Access::READ_WRITE);
@@ -2009,6 +2026,7 @@ inline void fileBased_write_test(const std::string &backend)
     }
 
     // write with auto-detection and in-consistent padding from step 10
+    if (backend != "bp")
     {
         REQUIRE_THROWS_WITH(
             Series(
@@ -5713,5 +5731,168 @@ TEST_CASE("varying_zero_pattern", "[serial]")
     for (auto const &t : testedFileExtensions())
     {
         varying_pattern(t);
+    }
+}
+
+void append_mode(std::string const &extension)
+{
+    std::string jsonConfig = R"END(
+{
+    "adios2":
+    {
+        "schema": 20210209,
+        "engine":
+        {
+            "usesteps" : true
+        }
+    }
+})END";
+    auto writeSomeIterations = [](WriteIterations &&writeIterations,
+                                  std::vector<uint64_t> indices) {
+        for (auto index : indices)
+        {
+            auto it = writeIterations[index];
+            auto dataset = it.meshes["E"]["x"];
+            dataset.resetDataset({Datatype::INT, {1}});
+            dataset.makeConstant<int>(0);
+            // test that it works without closing too
+            it.close();
+        }
+    };
+    {
+        Series write(
+            "../samples/append." + extension, Access::CREATE, jsonConfig);
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{0, 1});
+    }
+    {
+        Series write(
+            "../samples/append." + extension, Access::APPEND, jsonConfig);
+        if (write.backend() == "ADIOS1")
+        {
+            REQUIRE_THROWS_AS(
+                write.flush(), error::OperationUnsupportedInBackend);
+            // destructor will be noisy now
+            return;
+        }
+
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{2, 3});
+        write.flush();
+    }
+    {
+        Series write(
+            "../samples/append." + extension, Access::APPEND, jsonConfig);
+        if (write.backend() == "ADIOS1")
+        {
+            REQUIRE_THROWS_AS(
+                write.flush(), error::OperationUnsupportedInBackend);
+            // destructor will be noisy now
+            return;
+        }
+
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{4, 3});
+        write.flush();
+    }
+    {
+        Series read("../samples/append." + extension, Access::READ_ONLY);
+        REQUIRE(read.iterations.size() == 5);
+        /*
+         * Roadmap: for now, reading this should work by ignoring the last
+         * duplicate iteration.
+         * After merging https://github.com/openPMD/openPMD-api/pull/949, we
+         * should see both instances when reading.
+         * Final goal: Read only the last instance.
+         */
+        helper::listSeries(read);
+    }
+}
+
+TEST_CASE("append_mode", "[serial]")
+{
+    for (auto const &t : testedFileExtensions())
+    {
+        append_mode(t);
+    }
+}
+
+void append_mode_filebased(std::string const &extension)
+{
+    std::string jsonConfig = R"END(
+{
+    "adios2":
+    {
+        "schema": 20210209,
+        "engine":
+        {
+            "usesteps" : true
+        }
+    }
+})END";
+    auto writeSomeIterations = [](WriteIterations &&writeIterations,
+                                  std::vector<uint64_t> indices) {
+        for (auto index : indices)
+        {
+            auto it = writeIterations[index];
+            auto dataset = it.meshes["E"]["x"];
+            dataset.resetDataset({Datatype::INT, {1}});
+            dataset.makeConstant<int>(0);
+            // test that it works without closing too
+            it.close();
+        }
+    };
+    if (auxiliary::directory_exists("../samples/append"))
+    {
+        auxiliary::remove_directory("../samples/append");
+    }
+    {
+        Series write(
+            "../samples/append/append_%T." + extension,
+            Access::CREATE,
+            jsonConfig);
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{0, 1});
+    }
+    {
+        Series write(
+            "../samples/append/append_%T." + extension,
+            Access::APPEND,
+            jsonConfig);
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{4, 5});
+        write.flush();
+    }
+    {
+        Series write(
+            "../samples/append/append_%T." + extension,
+            Access::APPEND,
+            jsonConfig);
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{2, 3});
+        write.flush();
+    }
+    {
+        Series write(
+            "../samples/append/append_%T." + extension,
+            Access::APPEND,
+            jsonConfig);
+        // overwrite a previous iteration
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{4, 123});
+        write.flush();
+    }
+    {
+        Series read(
+            "../samples/append/append_%T." + extension, Access::READ_ONLY);
+        REQUIRE(read.iterations.size() == 7);
+    }
+}
+
+TEST_CASE("append_mode_filebased", "[serial]")
+{
+    for (auto const &t : testedFileExtensions())
+    {
+        append_mode_filebased(t);
     }
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5758,8 +5758,11 @@ void append_mode(
         }
         if (write.backend() == "ADIOS1")
         {
-            REQUIRE_THROWS_AS(
-                write.flush(), error::OperationUnsupportedInBackend);
+            REQUIRE_THROWS_WITH(
+                write.flush(),
+                Catch::Equals(
+                    "Operation unsupported in ADIOS1: Appending to existing "
+                    "file on disk (use Access::CREATE to overwrite)"));
             // destructor will be noisy now
             return;
         }
@@ -5776,8 +5779,11 @@ void append_mode(
         }
         if (write.backend() == "ADIOS1")
         {
-            REQUIRE_THROWS_AS(
-                write.flush(), error::OperationUnsupportedInBackend);
+            REQUIRE_THROWS_WITH(
+                write.flush(),
+                Catch::Equals(
+                    "Operation unsupported in ADIOS1: Appending to existing "
+                    "file on disk (use Access::CREATE to overwrite)"));
             // destructor will be noisy now
             return;
         }
@@ -5793,7 +5799,7 @@ void append_mode(
             // in variable-based encodings, iterations are not parsed ahead of
             // time but as they go
             unsigned counter = 0;
-            for (auto iteration : read.readIterations())
+            for (auto const &iteration : read.readIterations())
             {
                 REQUIRE(iteration.iterationIndex == counter);
                 ++counter;

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1917,24 +1917,7 @@ inline void fileBased_write_test(const std::string &backend)
         REQUIRE(o.iterations[5].time<double>() == 5.0);
     }
 
-    if (backend == "bp")
     {
-        // Append + filebased iteration encoding works for all backends
-        Series o = Series(
-            "../samples/subdir/serial_fileBased_write%T." + backend,
-            Access::APPEND);
-        // Append mode does not support reading anything that already exists
-        REQUIRE(o.iterations.size() == 0);
-        // write something to trigger opening of the file
-        o.iterations[6].particles["e"]["position"]["x"].resetDataset(
-            {Datatype::DOUBLE, {10}});
-        o.iterations[6].particles["e"]["position"]["x"].makeConstant<double>(
-            1.0);
-    }
-    else
-    {
-        // @todo enable a workflow for ADIOS2 where only either reading from or
-        // writing to an iteration works
         // extend existing series with new step and auto-detection of iteration
         // padding
         Series o = Series(
@@ -2026,16 +2009,13 @@ inline void fileBased_write_test(const std::string &backend)
     }
 
     // write with auto-detection and in-consistent padding from step 10
-    if (backend != "bp")
-    {
-        REQUIRE_THROWS_WITH(
-            Series(
-                "../samples/subdir/serial_fileBased_write%T." + backend,
-                Access::READ_WRITE),
-            Catch::Equals(
-                "Cannot write to a series with inconsistent iteration padding. "
-                "Please specify '%0<N>T' or open as read-only."));
-    }
+    REQUIRE_THROWS_WITH(
+        Series(
+            "../samples/subdir/serial_fileBased_write%T." + backend,
+            Access::READ_WRITE),
+        Catch::Equals(
+            "Cannot write to a series with inconsistent iteration padding. "
+            "Please specify '%0<N>T' or open as read-only."));
 
     // read back with fixed padding
     {


### PR DESCRIPTION
Our `READ_WRITE` mode is not quite adequate for use in ADIOS2, since ADIOS2 only allows either reading or writing, but our `READ_WRITE` mode's workflow needs that both are working (#996). However, Append mode exposes an interface equivalent to that of the Write mode, but steps already on disk are not deleted, new ones are just appended. Hence, add a new `Access::APPEND` that unlike `READ_WRITE` does not allow any reading, but does not overwrite anything either.

- [x] Simple proof-of-concept implementation
- [x] Test all possible edge cases:
    * Since there is no reading involved, it's on the user to use the exact same configuration of openPMD in append mode as had been used for the appended-to file.
    * This is now testing new and old ADIOS schema, group- file- and variablebased encoding
    * Overwriting old iterations is still a work-in-progress, non-linear read patterns and truncation of files upon opening are to come in a later PR
- [x] Keep possible a workflow where in file-based iteration encoding, already existing iterations can be read and new ones can be written
  The `READ_WRITE` mode currently does this. I would suggest to use new Append mode to support this more properly. Will need some tweaks in the frontend though where APPEND mode is currently treated as equivalent to WRITE mode.
  Idea: In filebased iteration encoding, coerce the backendAccess to CREATE. Any written iteration will then be overwritten in doubt.
- [x] Bring this to the other backends. This should become the new default `READ_WRITE` mode light, unless you really need to read data.
- [ ] Discussion point: Since reading does not work *at all* in this mode, I don't see any way to guarantee that an update to a dataset is written with the same overall settings (schema, usage of steps, ..). Users will need to make sure to create consistent datasets...
- [ ] Discussion point: Checkpoint-restarting. Probably one of the main uses of this. Dump every 100 time steps, checkpoint every 1000, crash at 1500, restart from 1000. Consequence: Steps {1000,1100,…,1500} are written twice. See #949 for an exploration on how to deal with this, but it's not really ideal.
    Update: See https://github.com/ornladios/ADIOS2/issues/2775
    Will still not be trivial to implement, since a preceding read access might be necessary to figure out how many steps should be dropped. Would also require to specify from which iteration to restart writing.
- [x] Documentation page on access modi
- [x] File-based appending in ADIOS2: Throw error if trying to append to already written iteration?
    Update: Given the proposed workflow with https://github.com/ornladios/ADIOS2/issues/2775, it would be most consistent to just overwrite iterations. Maybe use `Access::CREATE` again for the backendAccess.
- [x] ADIOS1 UPDATE: OperationUnsupportedInBackend
- [x] Merge #1080 first
- [x] Document altered meaning of `createFile` task

Also, this introduces a new `Error.hpp`, so I don't need to again throw `std::runtime_errors` around.

