### PR TITLE
Variable-based encoding: Don't accidentally write an (n+1)th step

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1248,7 +1248,9 @@ SeriesImpl::advance(
 
     if( oldCloseStatus == Iteration::CloseStatus::ClosedInFrontend )
     {
-        *iteration.m_closed = oldCloseStatus;
+        // Series::flush() would normally turn a `ClosedInFrontend` into
+        // a `ClosedInBackend`. Do that manually.
+        *iteration.m_closed = Iteration::CloseStatus::ClosedInBackend;
     }
     else if(
         oldCloseStatus == Iteration::CloseStatus::ClosedInBackend &&


### PR DESCRIPTION
Bug found by @guj. Some attributes may see an unwanted (n+1)th step written when using variable-based encoding. This should fix that. First commit adds a failing test, second one adds the fix.

Example for an erroneous output:
```
  string    /basePath                                 scalar
  uint8_t   /data/closed                              10*scalar
  double    /data/dt                                  10*scalar
  float     /data/particles/e/position/timeOffset     11*scalar
  double    /data/particles/e/position/unitDimension  11*{7}
  double    /data/particles/e/position/x/__data__     10*{10}
  double    /data/particles/e/position/x/unitSI       10*scalar
  double    /data/particles/e/position/y/__data__     10*{10}
  double    /data/particles/e/position/y/unitSI       10*scalar
  double    /data/particles/e/position/z/__data__     10*{10}
  double    /data/particles/e/position/z/unitSI       10*scalar
  uint64_t  /data/snapshot                            10*scalar
  double    /data/time                                10*scalar
  double    /data/timeUnitSI                          10*scalar
  string    /date                                     scalar
  string    /iterationEncoding                        scalar
  string    /iterationFormat                          scalar
  string    /openPMD                                  scalar
  uint32_t  /openPMDextension                         scalar
  string    /particlesPath                            scalar
  string    /software                                 scalar
  string    /softwareVersion                          scalar
```
Note the 11th step for some attributes.