### PR TITLE
Support for custom geometries

### DIFF
--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -58,7 +58,7 @@ public:
         thetaMode,
         cylindrical,
         spherical,
-        custom
+        other
     };  //Geometry
 
     /** @brief Enumerated datatype for the memory layout of N-dimensional data.

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -88,7 +88,7 @@ public:
      * @param   geometry    geometry of the mesh of the mesh record, as string
      * @return  Reference to modified mesh.
      */
-    Mesh& setGeometry(std::string const& geometry);
+    Mesh& setGeometry(std::string geometry);
 
     /**
      * @throw   no_such_attribute_error If Mesh::geometry is not Mesh::Geometry::thetaMode.

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -57,7 +57,8 @@ public:
         cartesian,
         thetaMode,
         cylindrical,
-        spherical
+        spherical,
+        custom
     };  //Geometry
 
     /** @brief Enumerated datatype for the memory layout of N-dimensional data.
@@ -78,6 +79,12 @@ public:
      * @return  Reference to modified mesh.
      */
     Mesh& setGeometry(Geometry g);
+    /** Set the geometry of the mesh of the mesh record.
+     *
+     * @param   g    geometry of the mesh of the mesh record, as string
+     * @return  Reference to modified mesh.
+     */
+    Mesh& setGeometry(std::string const& geometry);
 
     /**
      * @throw   no_such_attribute_error If Mesh::geometry is not Mesh::Geometry::thetaMode.

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -84,6 +84,7 @@ public:
      */
     Mesh& setGeometry(Geometry g);
     /** Set the geometry of the mesh of the mesh record.
+     *
      * If the geometry is unknown to the openPMD-api, the string is prefixed
      * with "other:" automatically unless the prefix is already present.
      *

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -70,9 +70,13 @@ public:
     };  //DataOrder
 
     /**
-     * @return String representing the geometry of the mesh of the mesh record.
+     * @return Enum representing the geometry of the mesh of the mesh record.
      */
     Geometry geometry() const;
+    /**
+     * @return String representing the geometry of the mesh of the mesh record.
+     */
+    std::string geometryString() const;
     /** Set the geometry of the mesh of the mesh record.
      *
      * @param   g    geometry of the mesh of the mesh record.

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -84,6 +84,8 @@ public:
      */
     Mesh& setGeometry(Geometry g);
     /** Set the geometry of the mesh of the mesh record.
+     * If the geometry is unknown to the openPMD-api, the string is prefixed
+     * with "other:" automatically unless the prefix is already present.
      *
      * @param   geometry    geometry of the mesh of the mesh record, as string
      * @return  Reference to modified mesh.

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -85,7 +85,7 @@ public:
     Mesh& setGeometry(Geometry g);
     /** Set the geometry of the mesh of the mesh record.
      *
-     * @param   g    geometry of the mesh of the mesh record, as string
+     * @param   geometry    geometry of the mesh of the mesh record, as string
      * @return  Reference to modified mesh.
      */
     Mesh& setGeometry(std::string const& geometry);

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -139,7 +139,7 @@ public:
      * @{
      */
     template< typename T >
-    bool setAttribute(std::string const& key, T const& value);
+    bool setAttribute(std::string const& key, T value);
     bool setAttribute(std::string const& key, char const value[]);
     /** @}
      */
@@ -357,7 +357,7 @@ public:
 //TODO explicitly instantiate Attributable::setAttribute for all T in Datatype
 template< typename T >
 inline bool
-AttributableImpl::setAttribute( std::string const & key, T const & value )
+AttributableImpl::setAttribute( std::string const & key, T value )
 {
     auto & attri = get();
     if(IOHandler() && Access::READ_ONLY == IOHandler()->m_frontendAccess )
@@ -381,7 +381,7 @@ AttributableImpl::setAttribute( std::string const & key, T const & value )
     {
         // emplace a new map element for an unknown key
         attri.m_attributes.emplace_hint(
-            it, std::make_pair(key, Attribute(value)));
+            it, std::make_pair(key, Attribute(std::move(value))));
         return false;
     }
 }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -45,12 +45,17 @@ Mesh::Mesh()
 Mesh::Geometry
 Mesh::geometry() const
 {
-    std::string ret = getAttribute("geometry").get< std::string >();
+    std::string ret = geometryString();
     if( "cartesian" == ret ) { return Geometry::cartesian; }
     else if( "thetaMode" == ret ) { return Geometry::thetaMode; }
     else if( "cylindrical" == ret ) { return Geometry::cylindrical; }
     else if( "spherical" == ret ) { return Geometry::spherical; }
     else { return Geometry::custom; }
+}
+
+std::string Mesh::geometryString() const
+{
+    return getAttribute( "geometry" ).get< std::string >();
 }
 
 Mesh&

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -83,9 +83,9 @@ Mesh::setGeometry(Mesh::Geometry g)
     return *this;
 }
 
-Mesh & Mesh::setGeometry( std::string const & geometry )
+Mesh & Mesh::setGeometry( std::string geometry )
 {
-    setAttribute( "geometry", geometry );
+    setAttribute( "geometry", std::move( geometry ) );
     return *this;
 }
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -24,8 +24,8 @@
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Writable.hpp"
 
+#include <algorithm>
 #include <iostream>
-
 
 namespace openPMD
 {
@@ -85,6 +85,18 @@ Mesh::setGeometry(Mesh::Geometry g)
 
 Mesh & Mesh::setGeometry( std::string geometry )
 {
+    std::string knownGeometries[] = {
+        "cartesian", "thetaMode", "cylindrical", "spherical", "other" };
+    if( // 1. condition: geometry is not one of the known geometries
+        std::find(
+            std::begin( knownGeometries ),
+            std::end( knownGeometries ),
+            geometry ) == std::end( knownGeometries )
+        // 2. condition: prefix is not already there
+        && !auxiliary::starts_with( geometry, std::string( "other:" ) ) )
+    {
+        geometry = "other:" + geometry;
+    }
     setAttribute( "geometry", std::move( geometry ) );
     return *this;
 }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -50,7 +50,7 @@ Mesh::geometry() const
     else if( "thetaMode" == ret ) { return Geometry::thetaMode; }
     else if( "cylindrical" == ret ) { return Geometry::cylindrical; }
     else if( "spherical" == ret ) { return Geometry::spherical; }
-    else { return Geometry::custom; }
+    else { return Geometry::other; }
 }
 
 std::string Mesh::geometryString() const
@@ -75,9 +75,9 @@ Mesh::setGeometry(Mesh::Geometry g)
         case Geometry::spherical:
             setAttribute("geometry", std::string("spherical"));
             break;
-        case Geometry::custom:
+        case Geometry::other:
             // use the std::string overload to be more specific
-            setAttribute("geometry", std::string("custom"));
+            setAttribute("geometry", std::string("other"));
             break;
     }
     return *this;
@@ -407,8 +407,8 @@ openPMD::operator<<(std::ostream& os, openPMD::Mesh::Geometry const& go)
         case openPMD::Mesh::Geometry::spherical:
             os<<"spherical";
             break;
-        case openPMD::Mesh::Geometry::custom:
-            os<<"custom";
+        case openPMD::Mesh::Geometry::other:
+            os<<"other";
             break;
     }
     return os;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -50,7 +50,7 @@ Mesh::geometry() const
     else if( "thetaMode" == ret ) { return Geometry::thetaMode; }
     else if( "cylindrical" == ret ) { return Geometry::cylindrical; }
     else if( "spherical" == ret ) { return Geometry::spherical; }
-    else { throw std::runtime_error("Unknown geometry " + ret); }
+    else { return Geometry::custom; }
 }
 
 Mesh&
@@ -70,7 +70,17 @@ Mesh::setGeometry(Mesh::Geometry g)
         case Geometry::spherical:
             setAttribute("geometry", std::string("spherical"));
             break;
+        case Geometry::custom:
+            // use the std::string overload to be more specific
+            setAttribute("geometry", std::string("custom"));
+            break;
     }
+    return *this;
+}
+
+Mesh & Mesh::setGeometry( std::string const & geometry )
+{
+    setAttribute( "geometry", geometry );
     return *this;
 }
 
@@ -267,7 +277,7 @@ Mesh::read()
         else if( "spherical" == tmpGeometry )
             setGeometry(Geometry::spherical);
         else
-            throw std::runtime_error("Unknown geometry " + tmpGeometry);
+            setGeometry(tmpGeometry);
     }
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'geometry'");
@@ -391,6 +401,9 @@ openPMD::operator<<(std::ostream& os, openPMD::Mesh::Geometry const& go)
             break;
         case openPMD::Mesh::Geometry::spherical:
             os<<"spherical";
+            break;
+        case openPMD::Mesh::Geometry::custom:
+            os<<"custom";
             break;
     }
     return os;

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -49,7 +49,7 @@ void init_Mesh(py::module &m) {
 
         .def_property("geometry", &Mesh::geometry, py::overload_cast<Mesh::Geometry>(&Mesh::setGeometry))
         .def_property(
-            "geometry_string", &Mesh::geometryString, py::overload_cast<std::string const &>(&Mesh::setGeometry))
+            "geometry_string", &Mesh::geometryString, py::overload_cast<std::string>(&Mesh::setGeometry))
         .def_property("geometry_parameters", &Mesh::geometryParameters, &Mesh::setGeometryParameters)
         .def_property("data_order",
               [](Mesh const & mesh){ return static_cast< char >(mesh.dataOrder()); },

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -47,7 +47,7 @@ void init_Mesh(py::module &m) {
             &Mesh::setUnitDimension,
             python::doc_unit_dimension)
 
-        .def_property("geometry", &Mesh::geometry, &Mesh::setGeometry)
+        .def_property("geometry", &Mesh::geometry, py::overload_cast<Mesh::Geometry>(&Mesh::setGeometry))
         .def_property("geometry_parameters", &Mesh::geometryParameters, &Mesh::setGeometryParameters)
         .def_property("data_order",
               [](Mesh const & mesh){ return static_cast< char >(mesh.dataOrder()); },
@@ -66,7 +66,7 @@ void init_Mesh(py::module &m) {
 
         // TODO remove in future versions (deprecated)
         .def("set_unit_dimension", &Mesh::setUnitDimension)
-        .def("set_geometry", &Mesh::setGeometry)
+        .def("set_geometry", py::overload_cast<Mesh::Geometry>(&Mesh::setGeometry))
         .def("set_geometry_parameters", &Mesh::setGeometryParameters)
         .def("set_axis_labels", &Mesh::setAxisLabels)
         .def("set_grid_spacing", &Mesh::setGridSpacing<float>)
@@ -81,5 +81,6 @@ void init_Mesh(py::module &m) {
         .value("thetaMode", Mesh::Geometry::thetaMode)
         .value("cylindrical", Mesh::Geometry::cylindrical)
         .value("spherical", Mesh::Geometry::spherical)
+        .value("custom", Mesh::Geometry::custom)
     ;
 }

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -69,6 +69,7 @@ void init_Mesh(py::module &m) {
         // TODO remove in future versions (deprecated)
         .def("set_unit_dimension", &Mesh::setUnitDimension)
         .def("set_geometry", py::overload_cast<Mesh::Geometry>(&Mesh::setGeometry))
+        .def("set_geometry", py::overload_cast<std::string>(&Mesh::setGeometry))
         .def("set_geometry_parameters", &Mesh::setGeometryParameters)
         .def("set_axis_labels", &Mesh::setAxisLabels)
         .def("set_grid_spacing", &Mesh::setGridSpacing<float>)

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -48,6 +48,8 @@ void init_Mesh(py::module &m) {
             python::doc_unit_dimension)
 
         .def_property("geometry", &Mesh::geometry, py::overload_cast<Mesh::Geometry>(&Mesh::setGeometry))
+        .def_property(
+            "geometry_string", &Mesh::geometryString, py::overload_cast<std::string const &>(&Mesh::setGeometry))
         .def_property("geometry_parameters", &Mesh::geometryParameters, &Mesh::setGeometryParameters)
         .def_property("data_order",
               [](Mesh const & mesh){ return static_cast< char >(mesh.dataOrder()); },

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -83,6 +83,6 @@ void init_Mesh(py::module &m) {
         .value("thetaMode", Mesh::Geometry::thetaMode)
         .value("cylindrical", Mesh::Geometry::cylindrical)
         .value("spherical", Mesh::Geometry::spherical)
-        .value("custom", Mesh::Geometry::custom)
+        .value("other", Mesh::Geometry::other)
     ;
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -861,7 +861,7 @@ TEST_CASE( "custom_geometries", "[core]" )
 
         auto e_chargeDensity =
             write.iterations[ 0 ].meshes[ "e_chargeDensity" ];
-        e_chargeDensity.setGeometry( Mesh::Geometry::custom );
+        e_chargeDensity.setGeometry( Mesh::Geometry::other );
         auto e_chargeDensity_x = e_chargeDensity[ MeshRecordComponent::SCALAR ];
         e_chargeDensity_x.resetDataset( { Datatype::INT, { 10 } } );
         e_chargeDensity_x.storeChunk( sampleData, { 0 }, { 10 } );
@@ -873,21 +873,21 @@ TEST_CASE( "custom_geometries", "[core]" )
         REQUIRE(
             E.getAttribute( "geometry" ).get< std::string >() ==
             "customGeometry" );
-        REQUIRE( E.geometry() == Mesh::Geometry::custom );
+        REQUIRE( E.geometry() == Mesh::Geometry::other );
         REQUIRE( E.geometryString() == "customGeometry" );
 
         auto B = read.iterations[ 0 ].meshes[ "B" ];
         REQUIRE(
             B.getAttribute( "geometry" ).get< std::string >() ==
             "customGeometry" );
-        REQUIRE( B.geometry() == Mesh::Geometry::custom );
+        REQUIRE( B.geometry() == Mesh::Geometry::other );
         REQUIRE( B.geometryString() == "customGeometry" );
 
         auto e_chargeDensity = read.iterations[ 0 ].meshes[ "e_chargeDensity" ];
         REQUIRE(
             e_chargeDensity.getAttribute( "geometry" ).get< std::string >() ==
-            "custom" );
-        REQUIRE( e_chargeDensity.geometry() == Mesh::Geometry::custom );
-        REQUIRE( e_chargeDensity.geometryString() == "custom" );
+            "other" );
+        REQUIRE( e_chargeDensity.geometry() == Mesh::Geometry::other );
+        REQUIRE( e_chargeDensity.geometryString() == "other" );
     }
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -852,12 +852,42 @@ TEST_CASE( "custom_geometries", "[core]" )
         E_x.resetDataset( { Datatype::INT, { 10 } } );
         std::vector< int > sampleData( 10, 0 );
         E_x.storeChunk( sampleData, { 0 }, { 10 } );
+
+        auto B = write.iterations[ 0 ].meshes[ "B" ];
+        B.setGeometry( "customGeometry" );
+        auto B_x = B[ "x" ];
+        B_x.resetDataset( { Datatype::INT, { 10 } } );
+        B_x.storeChunk( sampleData, { 0 }, { 10 } );
+
+        auto e_chargeDensity =
+            write.iterations[ 0 ].meshes[ "e_chargeDensity" ];
+        e_chargeDensity.setGeometry( Mesh::Geometry::custom );
+        auto e_chargeDensity_x = e_chargeDensity[ MeshRecordComponent::SCALAR ];
+        e_chargeDensity_x.resetDataset( { Datatype::INT, { 10 } } );
+        e_chargeDensity_x.storeChunk( sampleData, { 0 }, { 10 } );
     }
+
     {
         Series read( "../samples/custom_geometry.json", Access::READ_ONLY );
         auto E = read.iterations[ 0 ].meshes[ "E" ];
         REQUIRE(
             E.getAttribute( "geometry" ).get< std::string >() ==
             "customGeometry" );
+        REQUIRE( E.geometry() == Mesh::Geometry::custom );
+        REQUIRE( E.geometryString() == "customGeometry" );
+
+        auto B = read.iterations[ 0 ].meshes[ "B" ];
+        REQUIRE(
+            B.getAttribute( "geometry" ).get< std::string >() ==
+            "customGeometry" );
+        REQUIRE( B.geometry() == Mesh::Geometry::custom );
+        REQUIRE( B.geometryString() == "customGeometry" );
+
+        auto e_chargeDensity = read.iterations[ 0 ].meshes[ "e_chargeDensity" ];
+        REQUIRE(
+            e_chargeDensity.getAttribute( "geometry" ).get< std::string >() ==
+            "custom" );
+        REQUIRE( e_chargeDensity.geometry() == Mesh::Geometry::custom );
+        REQUIRE( e_chargeDensity.geometryString() == "custom" );
     }
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -841,3 +841,23 @@ TEST_CASE( "no_file_ending", "[core]" )
     REQUIRE_THROWS_WITH(Series("./new_openpmd_output_%05T", Access::CREATE),
                         Catch::Equals("Unknown file format! Did you specify a file ending?"));
 }
+
+TEST_CASE( "custom_geometries", "[core]" )
+{
+    {
+        Series write( "../samples/custom_geometry.json", Access::CREATE );
+        auto E = write.iterations[ 0 ].meshes[ "E" ];
+        E.setAttribute( "geometry", "customGeometry" );
+        auto E_x = E[ "x" ];
+        E_x.resetDataset( { Datatype::INT, { 10 } } );
+        std::vector< int > sampleData( 10, 0 );
+        E_x.storeChunk( sampleData, { 0 }, { 10 } );
+    }
+    {
+        Series read( "../samples/custom_geometry.json", Access::READ_ONLY );
+        auto E = read.iterations[ 0 ].meshes[ "E" ];
+        REQUIRE(
+            E.getAttribute( "geometry" ).get< std::string >() ==
+            "customGeometry" );
+    }
+}

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -848,7 +848,7 @@ TEST_CASE( "custom_geometries", "[core]" )
     {
         Series write( "../samples/custom_geometry.json", Access::CREATE );
         auto E = write.iterations[ 0 ].meshes[ "E" ];
-        E.setAttribute( "geometry", "customGeometry" );
+        E.setAttribute( "geometry", "other:customGeometry" );
         auto E_x = E[ "x" ];
         E_x.resetDataset( { Datatype::INT, { 10 } } );
         E_x.storeChunk( sampleData, { 0 }, { 10 } );
@@ -861,7 +861,7 @@ TEST_CASE( "custom_geometries", "[core]" )
 
         auto e_energyDensity =
             write.iterations[ 0 ].meshes[ "e_energyDensity" ];
-        e_energyDensity.setGeometry( "customGeometry" );
+        e_energyDensity.setGeometry( "other:customGeometry" );
         auto e_energyDensity_x = e_energyDensity[ RecordComponent::SCALAR ];
         e_energyDensity_x.resetDataset( { Datatype::INT, { 10 } } );
         e_energyDensity_x.storeChunk( sampleData, { 0 }, { 10 } );
@@ -879,9 +879,9 @@ TEST_CASE( "custom_geometries", "[core]" )
         auto E = read.iterations[ 0 ].meshes[ "E" ];
         REQUIRE(
             E.getAttribute( "geometry" ).get< std::string >() ==
-            "customGeometry" );
+            "other:customGeometry" );
         REQUIRE( E.geometry() == Mesh::Geometry::other );
-        REQUIRE( E.geometryString() == "customGeometry" );
+        REQUIRE( E.geometryString() == "other:customGeometry" );
 
         auto B = read.iterations[ 0 ].meshes[ "B" ];
         REQUIRE(

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -859,6 +859,13 @@ TEST_CASE( "custom_geometries", "[core]" )
         B_x.resetDataset( { Datatype::INT, { 10 } } );
         B_x.storeChunk( sampleData, { 0 }, { 10 } );
 
+        auto e_energyDensity =
+            write.iterations[ 0 ].meshes[ "e_energyDensity" ];
+        e_energyDensity.setGeometry( "customGeometry" );
+        auto e_energyDensity_x = e_energyDensity[ RecordComponent::SCALAR ];
+        e_energyDensity_x.resetDataset( { Datatype::INT, { 10 } } );
+        e_energyDensity_x.storeChunk( sampleData, { 0 }, { 10 } );
+
         auto e_chargeDensity =
             write.iterations[ 0 ].meshes[ "e_chargeDensity" ];
         e_chargeDensity.setGeometry( Mesh::Geometry::other );
@@ -879,9 +886,16 @@ TEST_CASE( "custom_geometries", "[core]" )
         auto B = read.iterations[ 0 ].meshes[ "B" ];
         REQUIRE(
             B.getAttribute( "geometry" ).get< std::string >() ==
-            "customGeometry" );
+            "other:customGeometry" );
         REQUIRE( B.geometry() == Mesh::Geometry::other );
-        REQUIRE( B.geometryString() == "customGeometry" );
+        REQUIRE( B.geometryString() == "other:customGeometry" );
+
+        auto e_energyDensity = read.iterations[ 0 ].meshes[ "e_energyDensity" ];
+        REQUIRE(
+            e_energyDensity.getAttribute( "geometry" ).get< std::string >() ==
+            "other:customGeometry" );
+        REQUIRE( e_energyDensity.geometry() == Mesh::Geometry::other );
+        REQUIRE( e_energyDensity.geometryString() == "other:customGeometry" );
 
         auto e_chargeDensity = read.iterations[ 0 ].meshes[ "e_chargeDensity" ];
         REQUIRE(

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -844,13 +844,13 @@ TEST_CASE( "no_file_ending", "[core]" )
 
 TEST_CASE( "custom_geometries", "[core]" )
 {
+    std::vector< int > sampleData( 10, 0 );
     {
         Series write( "../samples/custom_geometry.json", Access::CREATE );
         auto E = write.iterations[ 0 ].meshes[ "E" ];
         E.setAttribute( "geometry", "customGeometry" );
         auto E_x = E[ "x" ];
         E_x.resetDataset( { Datatype::INT, { 10 } } );
-        std::vector< int > sampleData( 10, 0 );
         E_x.storeChunk( sampleData, { 0 }, { 10 } );
 
         auto B = write.iterations[ 0 ].meshes[ "B" ];

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1868,6 +1868,64 @@ class APITest(unittest.TestCase):
             self.assertEqual(chunk_x[i], i)
             self.assertEqual(chunk_y[i], i)
 
+    def testCustomGeometries(self):
+        DS = io.Dataset
+        DT = io.Datatype
+        sample_data = np.ones([10], dtype=np.long)
+
+        write = io.Series("../samples/custom_geometries_python.json",
+                          io.Access.create)
+        E = write.iterations[0].meshes["E"]
+        E.set_attribute("geometry", "other:customGeometry")
+        E_x = E["x"]
+        E_x.reset_dataset(DS(DT.LONG, [10]))
+        E_x[:] = sample_data
+
+        B = write.iterations[0].meshes["B"]
+        B.set_geometry("customGeometry")
+        B_x = B["x"]
+        B_x.reset_dataset(DS(DT.LONG, [10]))
+        B_x[:] = sample_data
+
+        e_energyDensity = write.iterations[0].meshes["e_energyDensity"]
+        e_energyDensity.set_geometry("other:customGeometry")
+        e_energyDensity_x = e_energyDensity[io.Mesh_Record_Component.SCALAR]
+        e_energyDensity_x.reset_dataset(DS(DT.LONG, [10]))
+        e_energyDensity_x[:] = sample_data
+
+        e_chargeDensity = write.iterations[0].meshes["e_chargeDensity"]
+        e_chargeDensity.set_geometry(io.Geometry.other)
+        e_chargeDensity_x = e_chargeDensity[io.Mesh_Record_Component.SCALAR]
+        e_chargeDensity_x.reset_dataset(DS(DT.LONG, [10]))
+        e_chargeDensity_x[:] = sample_data
+
+        del write
+
+        read = io.Series("../samples/custom_geometries_python.json",
+                         io.Access.read_only)
+
+        E = read.iterations[0].meshes["E"]
+        self.assertEqual(E.get_attribute("geometry"), "other:customGeometry")
+        self.assertEqual(E.geometry, io.Geometry.other)
+        self.assertEqual(E.geometry_string, "other:customGeometry")
+
+        B = read.iterations[0].meshes["B"]
+        self.assertEqual(B.get_attribute("geometry"), "other:customGeometry")
+        self.assertEqual(B.geometry, io.Geometry.other)
+        self.assertEqual(B.geometry_string, "other:customGeometry")
+
+        e_energyDensity = read.iterations[0].meshes["e_energyDensity"]
+        self.assertEqual(e_energyDensity.get_attribute("geometry"),
+                         "other:customGeometry")
+        self.assertEqual(e_energyDensity.geometry, io.Geometry.other)
+        self.assertEqual(e_energyDensity.geometry_string,
+                         "other:customGeometry")
+
+        e_chargeDensity = read.iterations[0].meshes["e_chargeDensity"]
+        self.assertEqual(e_chargeDensity.get_attribute("geometry"), "other")
+        self.assertEqual(e_chargeDensity.geometry, io.Geometry.other)
+        self.assertEqual(e_chargeDensity.geometry_string, "other")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We have some use cases that need to define custom geometries as they don't really fit with any of the predefined ones. Example: https://github.com/ComputationalRadiationPhysics/picongpu/pull/3560 (this needs support for binning and logarithmic scales).

Currently, setting a custom geometry is fine, but trying to read one fails. This PR adds a failing test and will add support for easier writing to and reading from datasets with custom geometries.