### PR TITLE
HDF5 1.12.0 fallback APIs: No Wrapper

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1773,11 +1773,12 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
                       H5P_DEFAULT);
     VERIFY(node_id >= 0, "[HDF5] Internal error: Failed to open HDF5 group during attribute listing");
 
-    H5O_info_t object_info;
     herr_t status;
 #if H5_VERSION_GE(1,12,0)
-    status = H5Oget_info(node_id, &object_info, H5O_INFO_NUM_ATTRS);
+    H5O_info2_t object_info;
+    status = H5Oget_info3(node_id, &object_info, H5O_INFO_NUM_ATTRS);
 #else
+    H5O_info_t object_info;
     status = H5Oget_info(node_id, &object_info);
 #endif
     VERIFY(status == 0, "[HDF5] Internal error: Failed to get HDF5 object info for " + concrete_h5_file_position(writable) + " during attribute listing");


### PR DESCRIPTION
HDF5 can be built with "old" API support, e.g. building the v1.10 or v1.8 APIs at compile-time.

In that case, the HDF5 1.12.0 macro for `H5Oget_info` will resolve to `H5Oget_info1` which only took two arguments.

In order to avoid breaking in such builds, we will now map explicitly to the 1.12.0 API `H5Oget_info3` function and avoid the compat. macros.

## Spack tests with the patch

- [x] `spack install openpmd-api ^hdf5@1.12.0 api=v110`  (0.13.4)
- [x] `spack install openpmd-api@0.12.0 ^hdf5@1.12.0 api=v18`

## Ref.
- https://github.com/HDFGroup/hdf5/issues/754
- https://github.com/spack/spack/pull/24323
- #696