### PR TITLE
Custom Copy: Add Source Dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,10 +671,17 @@ if(openPMD_HAVE_PYTHON)
         PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
         COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
     )
-    add_custom_command(TARGET openPMD.py POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${openPMD_SOURCE_DIR}/src/binding/python/openpmd_api
-        ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api
+    function(copy_aux_py)
+        set(AUX_PY_SRC_DIR ${openPMD_SOURCE_DIR}/src/binding/python/openpmd_api/)
+        set(AUX_PY_DSR_DIR ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/openpmd_api/)
+        foreach(src_name IN LISTS ARGN)
+            configure_file(${AUX_PY_SRC_DIR}/${src_name} ${AUX_PY_DSR_DIR}/${src_name} COPYONLY)
+        endforeach()
+    endfunction()
+    copy_aux_py(
+        __init__.py DaskArray.py DaskDataFrame.py DataFrame.py
+        ls/__init__.py   ls/__main__.py
+        pipe/__init__.py pipe/__main__.py
     )
 endif()
 
@@ -1156,15 +1163,11 @@ if(openPMD_BUILD_TESTING)
     # Python-based command line tools
     if(openPMD_BUILD_CLI_TOOLS AND openPMD_HAVE_PYTHON)
         # all tools must provide a "--help"
-        # The custom target ensures that the file is copied to the build dir
-        # anew if the source file changes (and not only if openPMD.py is rebuilt)
-        add_custom_target(openPMD.py.cliTools)
-        add_dependencies(openPMD.py openPMD.py.cliTools)
         foreach(toolname ${openPMD_PYTHON_CLI_TOOL_NAMES})
-            add_custom_command(TARGET openPMD.py.cliTools POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy
-                        ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
-                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname}
+            configure_file(
+                ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
+                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openpmd-${toolname}
+                COPYONLY
             )
             add_test(NAME CLI.help.${toolname}.py
                 COMMAND ${Python_EXECUTABLE}
@@ -1234,10 +1237,10 @@ if(openPMD_BUILD_TESTING)
     if(openPMD_HAVE_PYTHON AND openPMD_HAVE_HDF5)
         if(EXAMPLE_DATA_FOUND)
             foreach(examplename ${openPMD_PYTHON_EXAMPLE_NAMES})
-                add_custom_command(TARGET openPMD.py POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E copy
-                            ${openPMD_SOURCE_DIR}/examples/${examplename}.py
-                            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
+                configure_file(
+                    ${openPMD_SOURCE_DIR}/examples/${examplename}.py
+                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${examplename}.py
+                    COPYONLY
                 )
                 if(openPMD_BUILD_TESTING)
                     if(${examplename} MATCHES "^.*_parallel$")


### PR DESCRIPTION
- copy if source changes
- simplify dependencies

This will re-run CMake if a source-change was detected, but since the CMake results are cached this will still be fast.
This is better for dev workflows than what we had before, where examples and Python auxiliary files did not update unless we rebuilt an (unrelated) target.

Follow-up to #904 
Try to fix #1000