### PR TITLE
Don't flush Series a second time after throwing an error

### DIFF
--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -349,7 +349,8 @@ OPENPMD_private:
     std::future< void > flush_impl(
         iterations_iterator begin,
         iterations_iterator end,
-        FlushLevel );
+        FlushLevel,
+        bool flushIOHandler );
     void flushFileBased( iterations_iterator begin, iterations_iterator end );
     /*
      * Group-based and variable-based iteration layouts share a lot of logic

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -347,10 +347,21 @@ OPENPMD_private:
     std::unique_ptr< ParsedInput > parseInput(std::string);
     void init(std::shared_ptr< AbstractIOHandler >, std::unique_ptr< ParsedInput >);
     void initDefaults( IterationEncoding );
+    /**
+     * @brief Internal call for flushing a Series.
+     *
+     * Any flushing of the Series will pass through this call.
+     * 
+     * @param begin Start of the range of iterations to flush.
+     * @param end End of the range of iterations to flush.
+     * @param level Flush level, as documented in AbstractIOHandler.hpp.
+     * @param flushIOHandler Tasks will always be enqueued to the backend.
+     *     If this flag is true, tasks will be flushed to the backend.
+     */
     std::future< void > flush_impl(
         iterations_iterator begin,
         iterations_iterator end,
-        FlushLevel,
+        FlushLevel level,
         bool flushIOHandler );
     void flushFileBased( iterations_iterator begin, iterations_iterator end );
     /*

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -96,6 +96,7 @@ public:
      */
     StepStatus m_stepStatus = StepStatus::NoStep;
     bool m_parseLazily = false;
+    bool m_lastFlushSuccessful = true;
 }; // SeriesData
 
 class SeriesInternal;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -131,7 +131,11 @@ Iteration::close( bool _flush )
             auto end = begin;
             ++end;
 
-            s->flush_impl( begin, end, FlushLevel::UserFlush );
+            s->flush_impl(
+                begin,
+                end,
+                FlushLevel::UserFlush,
+                /* flushIOHandler = */ true );
         }
     }
     else
@@ -160,7 +164,8 @@ Iteration::open()
     ++end;
     // set dirty, so Series::flush will open the file
     this->dirty() = true;
-    s->flush_impl( begin, end, FlushLevel::UserFlush );
+    s->flush_impl(
+        begin, end, FlushLevel::UserFlush, /* flushIOHandler = */ true );
     this->dirty() = false;
 
     return *this;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1424,6 +1424,14 @@ SeriesInternal::~SeriesInternal()
     // we must not throw in a destructor
     try
     {
+        /*
+         * Scenario: A user calls `Series::flush()` but does not check for thrown
+         * exceptions. The exception will propagate further up, usually thereby
+         * popping the stack frame that holds the `Series` object.
+         * `Series::~Series()` will run. This check avoids that the `Series` is
+         * needlessly flushed a second time. Otherwise, error messages can get
+         * very confusing.
+         */
         if( get().m_lastFlushSuccessful )
         {
             flush();

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -502,6 +502,8 @@ SeriesImpl::flush_impl(
     bool flushIOHandler )
 {
     IOHandler()->m_flushLevel = level;
+    auto & series = get();
+    series.m_lastFlushSuccessful = true;
     try
     {
         switch( iterationEncoding() )
@@ -530,6 +532,7 @@ SeriesImpl::flush_impl(
     catch( ... )
     {
         IOHandler()->m_flushLevel = FlushLevel::InternalFlush;
+        series.m_lastFlushSuccessful = false;
         throw;
     }
 }
@@ -1421,7 +1424,10 @@ SeriesInternal::~SeriesInternal()
     // we must not throw in a destructor
     try
     {
-        flush();
+        if( get().m_lastFlushSuccessful )
+        {
+            flush();
+        }
     }
     catch( std::exception const & ex )
     {

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1225,10 +1225,12 @@ SeriesImpl::advance(
     auto end = begin;
     ++end;
     /*
-     * @todo By calling flushFileBased/GroupBased, we do not propagate tasks to
-     *       the backend yet. We will append ADVANCE and CLOSE_FILE tasks
-     *       manually. In order to avoid having them automatically appended by
-     *       the flush*Based methods, set CloseStatus to Open for now.
+     * We call flush_impl() with flushIOHandler = false, meaning that tasks are
+     * not yet propagated to the backend.
+     * We will append ADVANCE and CLOSE_FILE tasks manually and then flush the
+     * IOHandler manually.
+     * In order to avoid having those tasks automatically appended by
+     * flush_impl(), set CloseStatus to Open for now.
      */
     Iteration::CloseStatus oldCloseStatus = *iteration.m_closed;
     if( oldCloseStatus == Iteration::CloseStatus::ClosedInFrontend )

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -47,7 +47,8 @@ namespace openPMD
         series.flush_impl(
                 series.iterations.begin(),
                 series.iterations.end(),
-                level
+                level,
+                /* flushIOHandler = */ true
         );
     }
 


### PR DESCRIPTION
Fix #1006. Remember in a flag whether the last flush was successful. If it was not, don't flush again upon `Series::~Series`.

Example: `close_iteration_test` was very noisy until now since it deliberately left the `Series` in an invalid state:
```
Filters: close_iteration_test
[~Series] An error occurred: [Series] Detected illegal access to iteration that has been closed previously.
openPMD series: close_iterations_%T
openPMD standard: 1.1.0
openPMD extensions: 0

number of iterations: 2

number of meshes: 1

number of particle species: 0
[~Series] An error occurred: [Series] Detected illegal access to iteration that has been closed previously.
[~Series] An error occurred: [Series] Detected illegal access to iteration that has been closed previously.
openPMD series: close_iterations_%T
openPMD standard: 1.1.0
openPMD extensions: 0

number of iterations: 2

number of meshes: 1

number of particle species: 0
[~Series] An error occurred: [Series] Detected illegal access to iteration that has been closed previously.
[~Series] An error occurred: [Series] Detected illegal access to iteration that has been closed previously.
openPMD series: close_iterations_%T
openPMD standard: 1.1.0
openPMD extensions: 0

number of iterations: 2

number of meshes: 1

number of particle species: 0
[~Series] An error occurred: [Series] Detected illegal access to iteration that has been closed previously.
```

After this PR:
```
Filters: close_iteration_test
openPMD series: close_iterations_%T
openPMD standard: 1.1.0
openPMD extensions: 0

number of iterations: 2

number of meshes: 1

number of particle species: 0
openPMD series: close_iterations_%T
openPMD standard: 1.1.0
openPMD extensions: 0

number of iterations: 2

number of meshes: 1

number of particle species: 0
openPMD series: close_iterations_%T
openPMD standard: 1.1.0
openPMD extensions: 0

number of iterations: 2

number of meshes: 1

number of particle species: 0
```