### PR TITLE
HDF5: Resizable Datasets

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -46,6 +46,11 @@ Using the Streaming API (i.e. ``SeriesImpl::readIteration()``) will do this auto
 Parsing eagerly might be very expensive for a Series with many iterations, but will avoid bugs by forgotten calls to ``Iteration::open()``.
 In complex environments, calling ``Iteration::open()`` on an already open environment does no harm (and does not incur additional runtime cost for additional ``open()`` calls).
 
+The key ``resizable`` can be passed to ``Dataset`` options.
+It if set to ``{"resizable": true}``, this declares that it shall be allowed to increased the ``Extent`` of a ``Dataset`` via ``resetDataset()`` at a later time, i.e., after it has been first declared (and potentially written).
+For HDF5, resizable Datasets come with a performance penalty.
+For JSON and ADIOS2, all datasets are resizable, independent of this option.
+
 Configuration Structure per Backend
 -----------------------------------
 

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2021 Fabian Koller, Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3836,7 +3836,8 @@ extendDataset( std::string const & ext )
         }
         // only one iteration written anyway
         write.setIterationEncoding( IterationEncoding::variableBased );
-        Dataset ds1{ Datatype::INT, { 5, 5 } };
+
+        Dataset ds1{ Datatype::INT, { 5, 5 }, "{ \"resizable\": true }" };
         Dataset ds2{ Datatype::INT, { 10, 5 } };
 
         // array record component -> array record component
@@ -3953,7 +3954,12 @@ TEST_CASE( "extend_dataset", "[serial]" )
     extendDataset( "bp" );
 #endif
 #if openPMD_HAVE_HDF5
-    // extendDataset( "h5" );
+    // extensible datasets require chunking
+    // skip this test for if chunking is disabled
+    if( auxiliary::getEnvString( "OPENPMD_HDF5_CHUNKS", "auto" ) != "none" )
+    {
+        extendDataset("h5");
+    }
 #endif
 }
 


### PR DESCRIPTION
Implement resizeable datasets in HDF5.

Follow-up to #829 and #916.

Close #658
Close #510