### PR TITLE
Follow-up to #1017: Fix little bug introduced there

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2717,7 +2717,7 @@ namespace detail
                  */
                 if( streamStatus == StreamStatus::OutsideOfStep )
                 {
-                    if( m_engine.get().BeginStep() != adios2::StepStatus::OK )
+                    if( getEngine().BeginStep() != adios2::StepStatus::OK )
                     {
                         throw std::runtime_error(
                             "[ADIOS2] Trying to close a step that cannot be "


### PR DESCRIPTION
The old control flow was better in guaranteeing that an engine will certainly be opened if it is not open yet.

Follow-up to #1017