### PR TITLE
Bug fix: Use Series::writeIterations() without explicit flushing

### DIFF
--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -117,6 +117,7 @@ class SeriesImpl : public AttributableImpl
     friend class SeriesIterator;
     friend class internal::SeriesInternal;
     friend class Series;
+    friend class WriteIterations;
 
 protected:
     // Should not be called publicly, only by implementing classes

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -108,6 +108,7 @@ class AttributableImpl
     friend class Series;
     friend class SeriesImpl;
     friend class Writable;
+    friend class WriteIterations;
 
 protected:
     internal::AttributableData * m_attri = nullptr;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1426,10 +1426,13 @@ SeriesInternal::~SeriesInternal()
     // we must not throw in a destructor
     try
     {
+        auto & series = get();
+        // WriteIterations gets the first shot at flushing
+        series.m_writeIterations = auxiliary::Option< WriteIterations >();
         /*
-         * Scenario: A user calls `Series::flush()` but does not check for thrown
-         * exceptions. The exception will propagate further up, usually thereby
-         * popping the stack frame that holds the `Series` object.
+         * Scenario: A user calls `Series::flush()` but does not check for
+         * thrown exceptions. The exception will propagate further up, usually
+         * thereby popping the stack frame that holds the `Series` object.
          * `Series::~Series()` will run. This check avoids that the `Series` is
          * needlessly flushed a second time. Otherwise, error messages can get
          * very confusing.

--- a/src/WriteIterations.cpp
+++ b/src/WriteIterations.cpp
@@ -32,7 +32,8 @@ WriteIterations::SharedResources::SharedResources( iterations_t _iterations )
 
 WriteIterations::SharedResources::~SharedResources()
 {
-    if( currentlyOpen.has_value() )
+    if( currentlyOpen.has_value() &&
+        iterations.retrieveSeries().get().m_lastFlushSuccessful )
     {
         auto lastIterationIndex = currentlyOpen.get();
         auto & lastIteration = iterations.at( lastIterationIndex );

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4344,7 +4344,7 @@ TEST_CASE( "no_explicit_flush", "[serial]" )
 {
     for( auto const & t : testedFileExtensions() )
     {
-        no_explicit_flush( "../samples/chaotic_stream_filebased_%T." + t );
-        no_explicit_flush( "../samples/chaotic_stream." + t );
+        no_explicit_flush( "../samples/no_explicit_flush_filebased_%T." + t );
+        no_explicit_flush( "../samples/no_explicit_flush." + t );
     }
 }


### PR DESCRIPTION
First commit adds a failing test
Second commit will add a fix

Probably related: https://github.com/openPMD/openPMD-api/issues/994