### PR TITLE
availableChunks open logic (HDF5: Early Chunk Read)

### DIFF
--- a/docs/source/details/mpi.rst
+++ b/docs/source/details/mpi.rst
@@ -13,20 +13,21 @@ A **collective** operation needs to be executed by *all* MPI ranks of the MPI co
 Contrarily, **independent** operations can also be called by a subset of these MPI ranks.
 For more information, please see the `MPI standard documents <https://www.mpi-forum.org/docs/>`_, for example MPI-3.1 in `"Section 2.4 - Semantic Terms" <https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report.pdf>`_.
 
-======================== ================== ===========================
-Functionality            Behavior           Description
-======================== ================== ===========================
-``Series``               **collective**     open and close
-``::flush()``            **collective**     read and write
-``Iteration`` [1]_       independent        declare and open
-``::open()`` [3]_        **collective**     explicit open
-``Mesh`` [1]_            independent        declare, open, write
-``ParticleSpecies`` [1]_ independent        declare, open, write
-``::setAttribute`` [2]_  *backend-specific* declare, write
-``::getAttribute``       independent        open, reading
-``::storeChunk`` [1]_    independent        write
-``::loadChunk``          independent        read
-======================== ================== ===========================
+========================== ================== ===========================
+Functionality              Behavior           Description
+========================== ================== ===========================
+``Series``                 **collective**     open and close
+``::flush()``              **collective**     read and write
+``Iteration`` [1]_         independent        declare and open
+``::open()`` [3]_          **collective**     explicit open
+``Mesh`` [1]_              independent        declare, open, write
+``ParticleSpecies`` [1]_   independent        declare, open, write
+``::setAttribute`` [2]_    *backend-specific* declare, write
+``::getAttribute``         independent        open, reading
+``::storeChunk`` [1]_      independent        write
+``::loadChunk``            independent        read
+``::availableChunks`` [3]_ collective         read, immediate result
+========================== ================== ===========================
 
 .. [1] Individual backends, e.g. :ref:`HDF5 <backends-hdf5>`, will only support independent operations if the default, non-collective behavior is kept.
        (Otherwise these operations are collective.)
@@ -35,6 +36,7 @@ Functionality            Behavior           Description
        If you want to support all backends equally, treat as a collective operation.
 
 .. [3] We usually open iterations delayed on first access. This first access is usually the ``flush()`` call after a ``storeChunk``/``loadChunk`` operation. If the first access is non-collective, an explicit, collective ``Iteration::open()`` can be used to have the files already open.
+Alternatively, iterations might be accessed for the first time by immediate operations such as ``::availableChunks()``.
 
 .. tip::
 

--- a/docs/source/usage/streaming.rst
+++ b/docs/source/usage/streaming.rst
@@ -25,6 +25,7 @@ The reading end of the streaming API is activated through use of ``Series::readI
 The returned object of type ``ReadIterations`` can be used in a C++11 range-based for loop to iterate over objects of type ``IndexedIteration``.
 This class extends the ``Iteration`` class with a field ``IndexedIteration::iterationIndex``, denoting this iteration's index.
 
+Iterations are implicitly opened by the Streaming API and ``Iteration::open()`` needs not be called explicitly.
 Users are encouraged to explicitly ``.close()`` the iteration after reading from it.
 Closing the iteration will flush all pending operations on that iteration.
 If an iteration is not closed until the beginning of the next iteration, it will be closed automatically.
@@ -42,6 +43,7 @@ The reading end of the streaming API is activated through use of ``Series.read_i
 The returned object of type ``ReadIterations`` can be used in a Python range-based for loop to iterate over objects of type ``IndexedIteration``.
 This class extends the ``Iteration`` class with a field ``IndexedIteration.iteration_index``, denoting this iteration's index.
 
+Iterations are implicitly opened by the Streaming API and ``Iteration.open()`` needs not be called explicitly.
 Users are encouraged to explicitly ``.close()`` the iteration after reading from it.
 Closing the iteration will flush all pending operations on that iteration.
 If an iteration is not closed until the beginning of the next iteration, it will be closed automatically.

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -118,6 +118,9 @@ public:
      * operation is flush-ed. In parallel contexts where it is know that such a
      * first access needs to be run non-collectively, one can explicitly open
      * an iteration through this collective call.
+     * Also necessary when using defer_iteration_parsing.
+     * The Streaming API (i.e. Series::readIterations()) will call this method
+     * implicitly and users need not call it.
      *
      * @return Reference to iteration.
      */

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -385,6 +385,13 @@ OPENPMD_private:
     void readGorVBased( bool init = true );
     void readBase();
     std::string iterationFilename( uint64_t i );
+
+    enum class IterationOpened : bool
+    {
+        HasBeenOpened,
+        RemainsClosed
+    };
+    IterationOpened openIterationIfDirty( uint64_t index, Iteration iteration );
     void openIteration( uint64_t index, Iteration iteration );
 
     /**

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -391,7 +391,19 @@ OPENPMD_private:
         HasBeenOpened,
         RemainsClosed
     };
+    /*
+     * For use by flushFileBased, flushGorVBased
+     * Open an iteration, but only if necessary.
+     * Only open if the iteration is dirty and if it is not in deferred
+     * parse state.
+     */
     IterationOpened openIterationIfDirty( uint64_t index, Iteration iteration );
+    /*
+     * Open an iteration. Ensures that the iteration's m_closed status
+     * is set properly and that any files pertaining to the iteration
+     * is opened.
+     * Does not create files when called in CREATE mode.
+     */
     void openIteration( uint64_t index, Iteration iteration );
 
     /**

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -47,9 +47,10 @@ namespace traits
 } // traits
 class AbstractFilePosition;
 class AttributableImpl;
+class Iteration;
 namespace internal
 {
-class SeriesInternal;
+    class SeriesInternal;
 }
 
 class no_such_attribute_error : public std::runtime_error
@@ -234,6 +235,9 @@ OPENPMD_protected:
 
     internal::SeriesInternal const & retrieveSeries() const;
     internal::SeriesInternal & retrieveSeries();
+
+    Iteration const & containingIteration() const;
+    Iteration & containingIteration();
 
     void seriesFlush( FlushLevel );
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -236,8 +236,16 @@ OPENPMD_protected:
     internal::SeriesInternal const & retrieveSeries() const;
     internal::SeriesInternal & retrieveSeries();
 
+    /** Returns the corresponding Iteration
+     *
+     * Return the openPMD::iteration that this Attributable is contained in.
+     * This walks up the linked parents until it finds the Iteration object.
+     * Throws an error otherwise, e.g., for Series objects.
+     * @{
+     */
     Iteration const & containingIteration() const;
     Iteration & containingIteration();
+    /** @} */
 
     void seriesFlush( FlushLevel );
 

--- a/share/openPMD/download_samples.sh
+++ b/share/openPMD/download_samples.sh
@@ -3,9 +3,9 @@
 
 mkdir -p samples/git-sample/thetaMode
 mkdir -p samples/git-sample/3d-bp4
-curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz
-curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-thetaMode.tar.gz
-curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d-bp4.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-thetaMode.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d-bp4.tar.gz
 tar -xzf example-3d.tar.gz
 tar -xzf example-thetaMode.tar.gz
 tar -xzf example-3d-bp4.tar.gz

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -156,13 +156,8 @@ Iteration::open()
     internal::SeriesInternal * s = &retrieveSeries();
     // figure out my iteration number
     auto begin = s->indexOf( *this );
-    auto end = begin;
-    ++end;
-    // set dirty, so Series::flush will open the file
-    this->dirty() = true;
-    s->flush_impl( begin, end, FlushLevel::UserFlush );
-    this->dirty() = false;
-
+    s->openIteration( begin->first, *this );
+    IOHandler()->flush();
     return *this;
 }
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -599,18 +599,6 @@ SeriesImpl::flushFileBased( iterations_iterator begin, iterations_iterator end )
 
             flushAttributes();
 
-            switch( *it->second.m_closed )
-            {
-                using CL = Iteration::CloseStatus;
-            case CL::Open:
-            case CL::ClosedTemporarily:
-                *it->second.m_closed = CL::Open;
-                break;
-            default:
-                // keep it
-                break;
-            }
-
             if( *it->second.m_closed ==
                 Iteration::CloseStatus::ClosedInFrontend )
             {

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -547,42 +547,20 @@ SeriesImpl::flushFileBased( iterations_iterator begin, iterations_iterator end )
     if( IOHandler()->m_frontendAccess == Access::READ_ONLY )
         for( auto it = begin; it != end; ++it )
         {
-            if( *it->second.m_closed
-                == Iteration::CloseStatus::ParseAccessDeferred )
+            switch( openIterationIfDirty( it->first, it->second ) )
             {
+                using IO = IterationOpened;
+            case IO::RemainsClosed:
                 continue;
-            }
-            bool const dirtyRecursive = it->second.dirtyRecursive();
-            if( *it->second.m_closed
-                == Iteration::CloseStatus::ClosedInBackend )
-            {
-                // file corresponding with the iteration has previously been
-                // closed and fully flushed
-                // verify that there have been no further accesses
-                if( dirtyRecursive )
-                {
-                    throw std::runtime_error(
-                        "[Series] Detected illegal access to iteration that "
-                        "has been closed previously." );
-                }
-                continue;
-            }
-            /*
-             * Opening a file is expensive, so let's do it only if necessary.
-             * Necessary if:
-             * 1. The iteration itself has been changed somewhere.
-             * 2. Or the Series has been changed globally in a manner that
-             *    requires adapting all iterations.
-             */
-            if( dirtyRecursive || this->dirty() )
-            {
-                // openIteration() will update the close status
-                openIteration( it->first, it->second );
-                it->second.flush();
+            case IO::HasBeenOpened:
+                // continue below
+                break;
             }
 
-            if( *it->second.m_closed
-                == Iteration::CloseStatus::ClosedInFrontend )
+            it->second.flush();
+
+            if( *it->second.m_closed ==
+                Iteration::CloseStatus::ClosedInFrontend )
             {
                 Parameter< Operation::CLOSE_FILE > fClose;
                 IOHandler()->enqueue(
@@ -596,68 +574,41 @@ SeriesImpl::flushFileBased( iterations_iterator begin, iterations_iterator end )
         bool allDirty = dirty();
         for( auto it = begin; it != end; ++it )
         {
-            if( *it->second.m_closed
-                == Iteration::CloseStatus::ParseAccessDeferred )
+            switch( openIterationIfDirty( it->first, it->second ) )
             {
+                using IO = IterationOpened;
+            case IO::RemainsClosed:
                 continue;
-            }
-            bool const dirtyRecursive = it->second.dirtyRecursive();
-            if( *it->second.m_closed
-                == Iteration::CloseStatus::ClosedInBackend )
-            {
-                // file corresponding with the iteration has previously been
-                // closed and fully flushed
-                // verify that there have been no further accesses
-                if (!it->second.written())
-                {
-                    throw std::runtime_error(
-                        "[Series] Closed iteration has not been written. This "
-                        "is an internal error." );
-                }
-                if( dirtyRecursive )
-                {
-                    throw std::runtime_error(
-                        "[Series] Detected illegal access to iteration that "
-                        "has been closed previously." );
-                }
-                continue;
+            case IO::HasBeenOpened:
+                // continue below
+                break;
             }
 
-            /*
-             * Opening a file is expensive, so let's do it only if necessary.
-             * Necessary if:
-             * 1. The iteration itself has been changed somewhere.
-             * 2. Or the Series has been changed globally in a manner that
-             *    requires adapting all iterations.
+            /* as there is only one series,
+             * emulate the file belonging to each iteration as not yet written
              */
-            if( dirtyRecursive || this->dirty() )
+            written() = false;
+            series.iterations.written() = false;
+
+            dirty() |= it->second.dirty();
+            std::string filename = iterationFilename( it->first );
+            it->second.flushFileBased( filename, it->first );
+
+            series.iterations.flush(
+                auxiliary::replace_first( basePath(), "%T/", "" ) );
+
+            flushAttributes();
+
+            switch( *it->second.m_closed )
             {
-                /* as there is only one series,
-                * emulate the file belonging to each iteration as not yet written
-                */
-                written() = false;
-                series.iterations.written() = false;
-
-                dirty() |= it->second.dirty();
-                std::string filename = iterationFilename( it->first );
-                it->second.flushFileBased(filename, it->first);
-
-                series.iterations.flush(
-                    auxiliary::replace_first(basePath(), "%T/", ""));
-
-                flushAttributes();
-
-                switch( *it->second.m_closed )
-                {
-                    using CL = Iteration::CloseStatus;
-                    case CL::Open:
-                    case CL::ClosedTemporarily:
-                        *it->second.m_closed = CL::Open;
-                        break;
-                    default:
-                        // keep it
-                        break;
-                }
+                using CL = Iteration::CloseStatus;
+            case CL::Open:
+            case CL::ClosedTemporarily:
+                *it->second.m_closed = CL::Open;
+                break;
+            default:
+                // keep it
+                break;
             }
 
             if( *it->second.m_closed ==
@@ -686,28 +637,19 @@ SeriesImpl::flushGorVBased( iterations_iterator begin, iterations_iterator end )
     if( IOHandler()->m_frontendAccess == Access::READ_ONLY )
         for( auto it = begin; it != end; ++it )
         {
-            if( *it->second.m_closed
-                == Iteration::CloseStatus::ParseAccessDeferred )
+            switch( openIterationIfDirty( it->first, it->second ) )
             {
+                using IO = IterationOpened;
+            case IO::RemainsClosed:
                 continue;
+            case IO::HasBeenOpened:
+                // continue below
+                break;
             }
-            if( *it->second.m_closed ==
-                Iteration::CloseStatus::ClosedInBackend )
-            {
-                // file corresponding with the iteration has previously been
-                // closed and fully flushed
-                // verify that there have been no further accesses
-                if( it->second.dirtyRecursive() )
-                {
-                    throw std::runtime_error(
-                        "[Series] Illegal access to iteration " +
-                        std::to_string( it->first ) +
-                        " that has been closed previously." );
-                }
-                continue;
-            }
+
             it->second.flush();
-            if( *it->second.m_closed == Iteration::CloseStatus::ClosedInFrontend )
+            if( *it->second.m_closed ==
+                Iteration::CloseStatus::ClosedInFrontend )
             {
                 // the iteration has no dedicated file in group-based mode
                 *it->second.m_closed = Iteration::CloseStatus::ClosedInBackend;
@@ -728,31 +670,14 @@ SeriesImpl::flushGorVBased( iterations_iterator begin, iterations_iterator end )
 
         for( auto it = begin; it != end; ++it )
         {
-            if( *it->second.m_closed
-                == Iteration::CloseStatus::ParseAccessDeferred )
+            switch( openIterationIfDirty( it->first, it->second ) )
             {
+                using IO = IterationOpened;
+            case IO::RemainsClosed:
                 continue;
-            }
-            if( *it->second.m_closed ==
-                Iteration::CloseStatus::ClosedInBackend )
-            {
-                // file corresponding with the iteration has previously been
-                // closed and fully flushed
-                // verify that there have been no further accesses
-                if (!it->second.written())
-                {
-                    throw std::runtime_error(
-                        "[Series] Closed iteration has not been written. This "
-                        "is an internal error." );
-                }
-                if( it->second.dirtyRecursive() )
-                {
-                    throw std::runtime_error(
-                        "[Series] Illegal access to iteration " +
-                        std::to_string( it->first ) +
-                        " that has been closed previously." );
-                }
-                continue;
+            case IO::HasBeenOpened:
+                // continue below
+                break;
             }
             if( !it->second.written() )
             {
@@ -1329,41 +1254,127 @@ SeriesImpl::advance(
     return *param.status;
 }
 
-void
-SeriesImpl::openIteration( uint64_t index, Iteration iteration )
+auto SeriesImpl::openIterationIfDirty( uint64_t index, Iteration iteration )
+    -> IterationOpened
 {
-    auto & series = get();
-    // open the iteration's file again
-    Parameter< Operation::OPEN_FILE > fOpen;
-    fOpen.encoding = iterationEncoding();
-    fOpen.name = iterationFilename( index );
-    IOHandler()->enqueue( IOTask( this, fOpen ) );
-
-    /* open base path */
-    Parameter< Operation::OPEN_PATH > pOpen;
-    pOpen.path = auxiliary::replace_first( basePath(), "%T/", "" );
-    IOHandler()->enqueue( IOTask( &series.iterations, pOpen ) );
-    /* open iteration path */
-    pOpen.path = iterationEncoding() == IterationEncoding::variableBased
-        ? ""
-        : std::to_string( index );
-    IOHandler()->enqueue( IOTask( &iteration, pOpen ) );
-    switch( *iteration.m_closed )
+    if( *iteration.m_closed == Iteration::CloseStatus::ParseAccessDeferred )
     {
-        using CL = Iteration::CloseStatus;
-        case CL::ClosedInBackend:
+        return IterationOpened::RemainsClosed;
+    }
+    bool const dirtyRecursive = iteration.dirtyRecursive();
+    if( *iteration.m_closed == Iteration::CloseStatus::ClosedInBackend )
+    {
+        // file corresponding with the iteration has previously been
+        // closed and fully flushed
+        // verify that there have been no further accesses
+        if( !iteration.written() )
+        {
+            throw std::runtime_error(
+                "[Series] Closed iteration has not been written. This "
+                "is an internal error." );
+        }
+        if( dirtyRecursive )
+        {
             throw std::runtime_error(
                 "[Series] Detected illegal access to iteration that "
                 "has been closed previously." );
-        case CL::ParseAccessDeferred:
-        case CL::Open:
-        case CL::ClosedTemporarily:
-            *iteration.m_closed = CL::Open;
-            break;
-        case CL::ClosedInFrontend:
-            // just keep it like it is
+        }
+        return IterationOpened::RemainsClosed;
+    }
+
+    switch( iterationEncoding() )
+    {
+        using IE = IterationEncoding;
+    case IE::fileBased:
+        /*
+         * Opening a file is expensive, so let's do it only if necessary.
+         * Necessary if:
+         * 1. The iteration itself has been changed somewhere.
+         * 2. Or the Series has been changed globally in a manner that
+         *    requires adapting all iterations.
+         */
+        if( dirtyRecursive || this->dirty() )
+        {
+            // openIteration() will update the close status
+            openIteration( index, iteration );
+            return IterationOpened::HasBeenOpened;
+        }
+        break;
+    case IE::groupBased:
+    case IE::variableBased:
+        // open unconditionally
+        // openIteration() will update the close status
+        openIteration( index, iteration );
+        return IterationOpened::HasBeenOpened;
+    }
+    return IterationOpened::RemainsClosed;
+}
+
+void SeriesImpl::openIteration( uint64_t index, Iteration iteration )
+{
+    switch( *iteration.m_closed )
+    {
+        using CL = Iteration::CloseStatus;
+    case CL::ClosedInBackend:
+        throw std::runtime_error(
+            "[Series] Detected illegal access to iteration that "
+            "has been closed previously." );
+    case CL::ParseAccessDeferred:
+    case CL::Open:
+    case CL::ClosedTemporarily:
+        *iteration.m_closed = CL::Open;
+        break;
+    case CL::ClosedInFrontend:
+        // just keep it like it is
+        break;
+    }
+
+    switch( IOHandler()->m_frontendAccess )
+    {
+    case Access::READ_ONLY:
+        switch( iterationEncoding() )
+        {
+            using IE = IterationEncoding;
+        case IE::fileBased: {
+            auto & series = get();
+            // open the iteration's file again
+            Parameter< Operation::OPEN_FILE > fOpen;
+            fOpen.encoding = iterationEncoding();
+            fOpen.name = iterationFilename( index );
+            IOHandler()->enqueue( IOTask( this, fOpen ) );
+
+            /* open base path */
+            Parameter< Operation::OPEN_PATH > pOpen;
+            pOpen.path = auxiliary::replace_first( basePath(), "%T/", "" );
+            IOHandler()->enqueue( IOTask( &series.iterations, pOpen ) );
+            /* open iteration path */
+            pOpen.path = iterationEncoding() == IterationEncoding::variableBased
+                ? ""
+                : std::to_string( index );
+            IOHandler()->enqueue( IOTask( &iteration, pOpen ) );
             break;
         }
+        case IE::groupBased:
+        case IE::variableBased:
+            // nothing to do, no opening necessary in those modes
+            break;
+        }
+        break;
+    case Access::CREATE:
+    case Access::READ_WRITE:
+        switch( iterationEncoding() )
+        {
+            using IE = IterationEncoding;
+        case IE::fileBased:
+            // nothing to do, file will be opened by writing routines
+            break;
+        case IE::groupBased:
+        case IE::variableBased:
+            // nothing to do, no opening necessary in those modes
+            break;
+        }
+        break;
+    }
 }
 
 namespace

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -178,7 +178,8 @@ Iteration const & AttributableImpl::containingIteration() const
 Iteration & AttributableImpl::containingIteration()
 {
     return const_cast< Iteration & >(
-        static_cast< Iteration const * >( this )->containingIteration() );
+        static_cast< AttributableImpl const * >( this )
+            ->containingIteration() );
 }
 
 std::string Attributable::MyPath::filePath() const

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -156,6 +156,8 @@ Iteration const & AttributableImpl::containingIteration() const
     }
     auto end = searchQueue.rbegin();
     internal::AttributableData const * attr = ( *( end + 2 ) )->attributable;
+    if( attr == nullptr )
+        throw std::runtime_error( "containingIteration(): attributable must not be a nullptr." );
     /*
      * We now know the unique instance of Attributable that corresponds with
      * the iteration.

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -64,17 +64,10 @@ BaseRecordComponent::availableChunks()
         Offset offset( m_dataset->extent.size(), 0 );
         return ChunkTable{ { std::move( offset ), m_dataset->extent } };
     }
-
-    // set dirty, so Series::flush will open the file if needed
-    this->dirty() = true;
-    this->seriesFlush();
-    this->dirty() = false;
-
     Parameter< Operation::AVAILABLE_CHUNKS > param;
     IOTask task( this, param );
     IOHandler()->enqueue( task );
     IOHandler()->flush();
-
     return std::move( *param.chunks );
 }
 } // namespace openPMD

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -19,7 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include "openPMD/backend/BaseRecordComponent.hpp"
-
+#include "openPMD/Iteration.hpp"
 
 namespace openPMD
 {
@@ -64,6 +64,7 @@ BaseRecordComponent::availableChunks()
         Offset offset( m_dataset->extent.size(), 0 );
         return ChunkTable{ { std::move( offset ), m_dataset->extent } };
     }
+    containingIteration().open();
     Parameter< Operation::AVAILABLE_CHUNKS > param;
     IOTask task( this, param );
     IOHandler()->enqueue( task );

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -64,10 +64,17 @@ BaseRecordComponent::availableChunks()
         Offset offset( m_dataset->extent.size(), 0 );
         return ChunkTable{ { std::move( offset ), m_dataset->extent } };
     }
+
+    // set dirty, so Series::flush will open the file if needed
+    this->dirty() = true;
+    this->seriesFlush();
+    this->dirty() = false;
+
     Parameter< Operation::AVAILABLE_CHUNKS > param;
     IOTask task( this, param );
     IOHandler()->enqueue( task );
     IOHandler()->flush();
+
     return std::move( *param.chunks );
 }
 } // namespace openPMD

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4279,10 +4279,12 @@ TEST_CASE( "extend_dataset", "[serial]" )
 
 void deferred_parsing( std::string const & extension )
 {
+    if( auxiliary::directory_exists( "../samples/lazy_parsing" ) )
+        auxiliary::remove_directory( "../samples/lazy_parsing" );
     std::string const basename = "../samples/lazy_parsing/lazy_parsing_";
     // create a single iteration
     {
-        Series series( basename + "%T." + extension, Access::CREATE );
+        Series series( basename + "%06T." + extension, Access::CREATE );
         std::vector< float > buffer( 20 );
         std::iota( buffer.begin(), buffer.end(), 0.f );
         auto dataset = series.iterations[ 1000 ].meshes[ "E" ][ "x" ];
@@ -4295,20 +4297,69 @@ void deferred_parsing( std::string const & extension )
     {
         for( size_t i = 0; i < 1000; i += 100 )
         {
+            std::string infix = std::to_string( i );
+            std::string padding;
+            for( size_t j = 0; j < 6 - infix.size(); ++j )
+            {
+                padding += "0";
+            }
+            infix = padding + infix;
             std::ofstream file;
-            file.open( basename + std::to_string( i ) + "." + extension );
+            file.open( basename + infix + "." + extension );
             file.close();
         }
     }
     {
         Series series(
-            basename + "%T." + extension,
+            basename + "%06T." + extension,
             Access::READ_ONLY,
             "{\"defer_iteration_parsing\": true}" );
         auto dataset = series.iterations[ 1000 ]
             .open()
             .meshes[ "E" ][ "x" ]
             .loadChunk< float >( { 0 }, { 20 } );
+        series.flush();
+        for( size_t i = 0; i < 20; ++i )
+        {
+            REQUIRE(
+                std::abs( dataset.get()[ i ] - float( i ) ) <=
+                std::numeric_limits< float >::epsilon() );
+        }
+    }
+    {
+        Series series(
+            basename + "%06T." + extension,
+            Access::READ_WRITE,
+            "{\"defer_iteration_parsing\": true}" );
+        auto dataset = series.iterations[ 1000 ]
+                           .open()
+                           .meshes[ "E" ][ "x" ]
+                           .loadChunk< float >( { 0 }, { 20 } );
+        series.flush();
+        for( size_t i = 0; i < 20; ++i )
+        {
+            REQUIRE(
+                std::abs( dataset.get()[ i ] - float( i ) ) <=
+                std::numeric_limits< float >::epsilon() );
+        }
+
+        // create a new iteration
+        std::vector< float > buffer( 20 );
+        std::iota( buffer.begin(), buffer.end(), 0.f );
+        auto writeDataset = series.iterations[ 1001 ].meshes[ "E" ][ "x" ];
+        writeDataset.resetDataset( { Datatype::FLOAT, { 20 } } );
+        writeDataset.storeChunk( buffer, { 0 }, { 20 } );
+        series.flush();
+    }
+    {
+        Series series(
+            basename + "%06T." + extension,
+            Access::READ_ONLY,
+            "{\"defer_iteration_parsing\": true}" );
+        auto dataset = series.iterations[ 1001 ]
+                           .open()
+                           .meshes[ "E" ][ "x" ]
+                           .loadChunk< float >( { 0 }, { 20 } );
         series.flush();
         for( size_t i = 0; i < 20; ++i )
         {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2402,6 +2402,35 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
     }
 }
 
+TEST_CASE( "git_hdf5_early_chunk_query", "[serial][hdf5]" )
+{
+    try
+    {
+        Series s = Series(
+            "../samples/git-sample/data%T.h5",
+            Access::READ_ONLY
+        );
+
+        auto electrons = s.iterations[400].particles["electrons"];
+
+        for( auto & r : electrons )
+        {
+            std::cout << r.first << ": ";
+            for( auto & r_c : r.second )
+            {
+                std::cout << r_c.first << "\n";
+                if( !r_c.second.constant() )
+                    auto chunks = r_c.second.availableChunks();
+            }
+        }
+
+    } catch (no_such_file_error& e)
+    {
+        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+        return;
+    }
+}
+
 TEST_CASE( "git_hdf5_sample_read_thetaMode", "[serial][hdf5][thetaMode]" )
 {
     try


### PR DESCRIPTION
This adds a test for early reading of chunks (via `availableChunks`) with HDF5 that appears quite often with post-processing routines based on chunks.

I have not yet found the reason for this fail, but it seems to be HDF5 specific (details documented in #961). Either the writable is a bit off or the file not yet open.

- [x] add test
- [x] fix #961
- [x] merge https://github.com/ax3l/openPMD-api/pull/1
- [x] update [MPI - Collective Behavior](https://openpmd-api.readthedocs.io/en/latest/details/mpi.html):
  - [x] document the "first call to loadChunk/storeChunk/availableChunks is collective" unless we first called `::open()`;
        expand that `Iteration::open()` is used only for (MPI || deferred iteration parsing), elaborate on open() relation to flushing logic
  - [x] add `availableChunks` to table (behavior independent unless it's the first call to a freshly opened series)