### PR TITLE
ADIOS2: More obvious error message if datatype cannot be found

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -75,9 +75,10 @@ namespace detail
     /**
      * @brief Convert ADIOS2 datatype to openPMD type.
      * @param dt
+     * @param verbose If false, don't print warnings.
      * @return
      */
-    Datatype fromADIOS2Type( std::string const & dt );
+    Datatype fromADIOS2Type( std::string const & dt, bool verbose = true );
 
     enum class VariableOrAttribute : unsigned char
     {

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -75,8 +75,7 @@ namespace detail
         return "";
     }
 
-    Datatype
-    fromADIOS2Type( std::string const & dt )
+    Datatype fromADIOS2Type( std::string const & dt, bool verbose )
     {
         static std::map< std::string, Datatype > map{
             { "string", Datatype::STRING },
@@ -113,8 +112,13 @@ namespace detail
         }
         else
         {
-            std::cerr << "[ADIOS2] Warning: Encountered unknown ADIOS2 datatype,"
-                         " defaulting to UNDEFINED." << std::endl;
+            if( verbose )
+            {
+                std::cerr
+                    << "[ADIOS2] Warning: Encountered unknown ADIOS2 datatype,"
+                       " defaulting to UNDEFINED."
+                    << std::endl;
+            }
             return Datatype::UNDEFINED;
         }
     }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1209,10 +1209,13 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
     {
         auto requiredType = adios2::GetType< T >( );
         auto actualType = IO.VariableType( varName );
-        VERIFY_ALWAYS( requiredType == actualType,
-                       "[ADIOS2] Trying to access a dataset with wrong type (trying to "
-                       "access dataset with type " +
-                           requiredType + ", but has type " + actualType + ")" )
+        std::stringstream errorMessage;
+        errorMessage
+            << "[ADIOS2] Trying to access a dataset with wrong type (trying to "
+               "access dataset with type "
+            << determineDatatype< T >() << ", but has type "
+            << detail::fromADIOS2Type( actualType ) << ")";
+        VERIFY_ALWAYS( requiredType == actualType, errorMessage.str() );
     }
     adios2::Variable< T > var = IO.InquireVariable< T >( varName );
     VERIFY_ALWAYS( var.operator bool( ),

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1214,7 +1214,7 @@ ADIOS2IOHandlerImpl::verifyDataset( Offset const & offset,
             << "[ADIOS2] Trying to access a dataset with wrong type (trying to "
                "access dataset with type "
             << determineDatatype< T >() << ", but has type "
-            << detail::fromADIOS2Type( actualType ) << ")";
+            << detail::fromADIOS2Type( actualType, false ) << ")";
         VERIFY_ALWAYS( requiredType == actualType, errorMessage.str() );
     }
     adios2::Variable< T > var = IO.InquireVariable< T >( varName );


### PR DESCRIPTION
Fix #1028

ADIOS2 reports datatypes as strings, and when a datatype cannot be found (e.g. when a variable is not found), it returns an empty string. The error message was a bit cryptic as a result.

New error message:
```
  [ADIOS2] Trying to access a dataset with wrong type (trying to access dataset
  with type INT, but has type UNDEFINED)
```