### PR TITLE
Dowload Samples: Optional Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1050,7 +1050,7 @@ if(openPMD_BUILD_TESTING)
                            "to add example files to samples/git-sample/ directory!")
         else()
             message(STATUS "Note: run\n"
-                           "    . ${openPMD_SOURCE_DIR}/share/openPMD/download_samples.sh\n"
+                           "    ${openPMD_SOURCE_DIR}/share/openPMD/download_samples.sh\n"
                            "to add example files to samples/git-sample/ directory!")
         endif()
     endif()

--- a/share/openPMD/download_samples.ps1
+++ b/share/openPMD/download_samples.ps1
@@ -1,5 +1,15 @@
+# build directory as optional first argument, otherwise $PWD
+# we assume PWD is inside the CMake build directory
+Param(
+  [parameter(Position=0)]$bdir = $(Get-Location | Foreach-Object { $_.Path })
+)
+
+$orgdir = $(Get-Location | Foreach-Object { $_.Path })
+cd $bdir
+
 New-item -ItemType directory -Name samples\git-sample\thetaMode\
 New-item -ItemType directory -Name samples\git-sample\3d-bp4\
+
 Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d.tar.gz -OutFile example-3d.tar.gz
 Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-thetaMode.tar.gz -OutFile example-thetaMode.tar.gz
 Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d-bp4.tar.gz -OutFile example-3d-bp4.tar.gz
@@ -29,3 +39,5 @@ Invoke-WebRequest https://github.com/openPMD/openPMD-viewer/files/5655027/diags.
 Expand-Archive empty_alternate_fbpic.zip
 Move-Item -Path empty_alternate_fbpic\diags\hdf5\data00000050.h5 samples\issue-sample\empty_alternate_fbpic_00000050.h5
 Remove-Item -Recurse -Force empty_alternate_fbpic*
+
+cd $orgdir

--- a/share/openPMD/download_samples.sh
+++ b/share/openPMD/download_samples.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 #
 
+# build directory as optional first argument, otherwise $PWD
+# we assume PWD is inside the CMake build directory
+bdir=${1:-$(pwd)}
+
+orgdir=$(pwd)
+mkdir -p ${bdir}
+cd ${bdir}
+
 mkdir -p samples/git-sample/thetaMode
 mkdir -p samples/git-sample/3d-bp4
+
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d.tar.gz
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-thetaMode.tar.gz
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d-bp4.tar.gz
@@ -30,3 +39,5 @@ curl -sOL https://github.com/openPMD/openPMD-viewer/files/5655027/diags.zip
 unzip diags.zip
 mv diags/hdf5/data00000050.h5 samples/issue-sample/empty_alternate_fbpic_00000050.h5
 rm -rf diags.zip diags
+
+cd ${orgdir}


### PR DESCRIPTION
Add an optional directory argument to the download sample scripts.

Remove the unix script-source "dot", was never needed.