### PR TITLE
Datatype: Fix std::array template

### DIFF
--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -629,7 +629,7 @@ namespace detail {
         Datatype m_dt = BasicDatatypeHelper<T>{}.m_dt;
     };
 
-    template<typename T, long n>
+    template<typename T, std::size_t n>
     struct BasicDatatypeHelper<std::array<T, n>> {
         Datatype m_dt = BasicDatatypeHelper<T>{}.m_dt;
     };


### PR DESCRIPTION
Avoid platform-specific `long` type and use real signature.

Fix #1038