### PR TITLE
Docs: makeConstant & Parallel HDF5

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -54,6 +54,8 @@ For JSON and ADIOS2, all datasets are resizable, independent of this option.
 Configuration Structure per Backend
 -----------------------------------
 
+.. _backendconfig-adios2:
+
 ADIOS2
 ^^^^^^
 
@@ -78,6 +80,8 @@ Explanation of the single keys:
 
 Any setting specified under ``adios2.dataset`` is applicable globally as well as on a per-dataset level.
 Any setting under ``adios2.engine`` is applicable globally only.
+
+.. _backendconfig-hdf5:
 
 HDF5
 ^^^^

--- a/docs/source/details/mpi.rst
+++ b/docs/source/details/mpi.rst
@@ -13,28 +13,35 @@ A **collective** operation needs to be executed by *all* MPI ranks of the MPI co
 Contrarily, **independent** operations can also be called by a subset of these MPI ranks.
 For more information, please see the `MPI standard documents <https://www.mpi-forum.org/docs/>`_, for example MPI-3.1 in `"Section 2.4 - Semantic Terms" <https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report.pdf>`_.
 
-======================== ================== ===========================
-Functionality            Behavior           Description
-======================== ================== ===========================
-``Series``               **collective**     open and close
-``::flush()``            **collective**     read and write
-``Iteration`` [1]_       independent        declare and open
-``::open()`` [3]_        **collective**     explicit open
-``Mesh`` [1]_            independent        declare, open, write
-``ParticleSpecies`` [1]_ independent        declare, open, write
-``::setAttribute`` [2]_  *backend-specific* declare, write
-``::getAttribute``       independent        open, reading
-``::storeChunk`` [1]_    independent        write
-``::loadChunk``          independent        read
-======================== ================== ===========================
+============================ ================== ===========================
+Functionality                Behavior           Description
+============================ ================== ===========================
+``Series``                   **collective**     open and close
+``::flush()``                **collective**     read and write
+``Iteration`` [1]_           independent        declare and open
+``::open()`` [4]_            **collective**     explicit open
+``Mesh`` [1]_                independent        declare, open, write
+``ParticleSpecies`` [1]_     independent        declare, open, write
+``::setAttribute`` [3]_      *backend-specific* declare, write
+``::getAttribute``           independent        open, reading
+``RecordComponent`` [1]_     independent        declare, open, write
+``::resetDataset`` [1]_ [2]_ *backend-specific* declare, write
+``::makeConstant`` [3]_      *backend-specific* declare, write
+``::storeChunk`` [1]_        independent        write
+``::loadChunk``              independent        read
+============================ ================== ===========================
 
-.. [1] Individual backends, e.g. :ref:`HDF5 <backends-hdf5>`, will only support independent operations if the default, non-collective behavior is kept.
-       (Otherwise these operations are collective.)
+.. [1] Individual backends, i.e. :ref:`parallel HDF5 <backends-hdf5>`, will only support independent operations if the default, non-collective (aka independent) behavior is kept.
+       Otherwise these operations are collective.
 
-.. [2] :ref:`HDF5 <backends-hdf5>` only supports collective attribute definitions/writes; :ref:`ADIOS1 <backends-adios1>` and :ref:`ADIOS2 <backends-adios2>` attributes can be written independently.
+.. [2] Dataset declarations in :ref:`parallel HDF5 <backends-hdf5>` are only non-collective if :ref:`chunking <backendconfig-hdf5>` is set to ``none`` (``auto`` by default).
+       Otherwise these operations are collective.
+
+.. [3] :ref:`HDF5 <backends-hdf5>` only supports collective attribute definitions/writes; :ref:`ADIOS1 <backends-adios1>` and :ref:`ADIOS2 <backends-adios2>` attributes can be written independently.
        If you want to support all backends equally, treat as a collective operation.
+       Note that openPMD represents constant record components with attributes, thus inheriting this for ``::makeConstant``.
 
-.. [3] We usually open iterations delayed on first access. This first access is usually the ``flush()`` call after a ``storeChunk``/``loadChunk`` operation. If the first access is non-collective, an explicit, collective ``Iteration::open()`` can be used to have the files already open.
+.. [4] We usually open iterations delayed on first access. This first access is usually the ``flush()`` call after a ``storeChunk``/``loadChunk`` operation. If the first access is non-collective, an explicit, collective ``Iteration::open()`` can be used to have the files already open.
 
 .. tip::
 


### PR DESCRIPTION
In parallel HDF5, attribute writes are all collective.
Also document another PHDF5 constrain with chunking from #916, which is now default-on.

Document for a question in https://github.com/openPMD/openPMD-api/issues/1021#issuecomment-876782931

Close #1021