### PR TITLE
Mesh: Enable-If Float APIs

### DIFF
--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -27,6 +27,7 @@
 #include <array>
 #include <ostream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 
@@ -142,7 +143,8 @@ public:
      * @param   gridSpacing     vector containing N (T) elements, where N is the number of dimensions in the simulation.
      * @return  Reference to modified mesh.
      */
-    template< typename T >
+    template< typename T,
+              typename = std::enable_if_t<std::is_floating_point< T >::value> >
     Mesh& setGridSpacing(std::vector< T > const & gridSpacing);
 
     /**
@@ -188,7 +190,8 @@ public:
      * @param   timeOffset  Offset between the time at which this record is defined and the Iteration::time attribute of the Series::basePath level.
      * @return  Reference to modified mesh.
      */
-    template< typename T >
+    template< typename T,
+              typename = std::enable_if_t<std::is_floating_point< T >::value> >
     Mesh& setTimeOffset(T timeOffset);
 
 private:

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -142,7 +142,7 @@ Mesh::setAxisLabels(std::vector< std::string > const & als)
     return *this;
 }
 
-template< typename T >
+template< typename T, typename >
 Mesh&
 Mesh::setGridSpacing(std::vector< T > const & gs)
 {
@@ -201,7 +201,7 @@ Mesh::setUnitDimension(std::map< UnitDimension, double > const& udim)
     return *this;
 }
 
-template< typename T >
+template< typename T, typename >
 Mesh&
 Mesh::setTimeOffset(T to)
 {


### PR DESCRIPTION
Disable Overloads for non-float values in `Mesh::` template member functions. This is needed for members that are only defined in `.cpp` files.

This reports usage errors as proper compile-time issues, not as link-time issues.

Fix #990