### PR TITLE
JSON update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,6 +581,11 @@ if(openPMD_HAVE_ADIOS1)
         target_compile_definitions(openPMD.ADIOS1.Parallel PRIVATE openPMD_HAVE_MPI=0)
     endif()
 
+    target_include_directories(openPMD.ADIOS1.Serial SYSTEM PRIVATE
+        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+    target_include_directories(openPMD.ADIOS1.Parallel SYSTEM PRIVATE
+        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+
     set_target_properties(openPMD.ADIOS1.Serial PROPERTIES
         POSITION_INDEPENDENT_CODE ON
         CXX_VISIBILITY_PRESET hidden

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,6 +777,7 @@ set(openPMD_TEST_NAMES
     Auxiliary
     SerialIO
     ParallelIO
+    JSON
 )
 # command line tools
 set(openPMD_CLI_TOOL_NAMES
@@ -863,8 +864,10 @@ if(openPMD_BUILD_TESTING)
             target_link_libraries(${testname}Tests PRIVATE CatchMain)
         endif()
 
-        target_include_directories(${testname}Tests SYSTEM PRIVATE
-            $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+        if(${testname} STREQUAL JSON)
+            target_include_directories(${testname}Tests SYSTEM PRIVATE
+                $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+        endif()
     endforeach()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -857,6 +857,9 @@ if(openPMD_BUILD_TESTING)
         else()
             target_link_libraries(${testname}Tests PRIVATE CatchMain)
         endif()
+
+        target_include_directories(${testname}Tests SYSTEM PRIVATE
+            $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
     endforeach()
 endif()
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,10 @@ Upgrade Guide
 Python 3.10 is now supported.
 openPMD-api now depends on `toml11 <https://github.com/ToruNiina/toml11>`__ 3.7.0+.
 
+The following backend-specific members of the ``Dataset`` class have been removed: ``Dataset::setChunkSize()``, ``Dataset::setCompression()``, ``Dataset::setCustomTransform()``, ``Dataset::chunkSize``, ``Dataset::compression``, ``Dataset::transform``.
+They are replaced by backend-specific options in the JSON-based backend configuration.
+This can be passed in ``Dataset::options``.
+
 
 0.14.0
 ------

--- a/docs/source/details/adios1.json
+++ b/docs/source/details/adios1.json
@@ -1,0 +1,7 @@
+{
+  "adios2": {
+    "dataset": {
+      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
+    }
+  }
+}

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -14,7 +14,18 @@ The fundamental structure of this JSON configuration string is given as follows:
 
 This structure allows keeping one configuration string for several backends at once, with the concrete backend configuration being chosen upon choosing the backend itself.
 
-The configuration is read in a case-sensitive manner.
+Options that can be configured via JSON are often also accessible via other means, e.g. environment variables.
+The following list specifies the priority of these means, beginning with the lowest priority:
+
+1. Default values
+2. Automatically detected options, e.g. the backend being detected by inspection of the file extension
+3. Environment variables
+4. JSON configuration. For JSON, a dataset-specific configuration overwrites a global, Series-wide configuration.
+5. Explicit API calls such as ``setIterationEncoding()``
+
+The configuration is read in a case-insensitive manner, keys as well as values.
+An exception to this are string values which are forwarded to other libraries such as ADIOS1 and ADIOS2.
+Those are read "as-is" and interpreted by the backend library.
 Generally, keys of the configuration are *lower case*.
 Parameters that are directly passed through to an external library and not interpreted within openPMD API (e.g. ``adios2.engine.parameters``) are unaffected by this and follow the respective library's conventions.
 
@@ -35,6 +46,11 @@ For a consistent user interface, backends shall follow the following rules:
 
 Backend-independent JSON configuration
 --------------------------------------
+
+The openPMD backend can be chosen via the JSON key ``backend`` which recognizes the alternatives ``["hdf5", "adios1", "adios2", "json"]``.
+
+The iteration encoding can be chosen via the JSON key ``iteration_encoding`` which recognizes the alternatives ``["file_based", "group_based", "variable_based"]``.
+Note that for file-based iteration encoding, specification of the expansion pattern in the file name (e.g. ``data_%T.json``) remains mandatory.
 
 The key ``defer_iteration_parsing`` can be used to optimize the process of opening an openPMD Series (deferred/lazy parsing).
 By default, a Series is parsed eagerly, i.e. opening a Series implies reading all available iterations.
@@ -99,6 +115,17 @@ Explanation of the single keys:
   The default is ``"auto"`` for a heuristic.
   ``"none"`` can be used to disable chunking.
   Chunking generally improves performance and only needs to be disabled in corner-cases, e.g. when heavily relying on independent, parallel I/O that non-collectively declares data records.
+
+ADIOS1
+^^^^^^
+
+ADIOS1 allows configuring custom dataset transforms via JSON:
+
+.. literalinclude:: adios1.json
+   :language: json
+
+This configuration can be passed globally (i.e. for the ``Series`` object) to apply for all datasets.
+Alternatively, it can also be passed for single ``Dataset`` objects to only apply for single datasets.
 
 
 Other backends

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -92,8 +92,27 @@ main()
         // this describes the datatype and shape of data as it should be written to disk
         io::Datatype dtype = io::determineDatatype(partial_mesh);
         auto d = io::Dataset(dtype, io::Extent{2, 5});
-        d.setCompression("zlib", 9);
-        d.setCustomTransform("blosc:compressor=zlib,shuffle=bit,lvl=1;nometa");
+        std::string datasetConfig = R"END(
+{
+  "adios1": {
+    "dataset": {
+      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
+    }
+  },
+  "adios2": {
+    "dataset": {
+      "operators": [
+        {
+          "type": "zlib",
+          "parameters": {
+            "clevel": 9
+          }
+        }
+      ]
+    }
+  }
+})END";
+        d.options = datasetConfig;
         mesh["x"].resetDataset(d);
 
         io::ParticleSpecies electrons = cur_it.particles["electrons"];

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -102,8 +102,27 @@ if __name__ == "__main__":
     # component this describes the datatype and shape of data as it should be
     # written to disk
     d = Dataset(partial_mesh.dtype, extent=[2, 5])
-    d.set_compression("zlib", 9)
-    d.set_custom_transform("blosc:compressor=zlib,shuffle=bit,lvl=1;nometa")
+    dataset_config = """
+{
+  "adios1": {
+    "dataset": {
+      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
+    }
+  },
+  "adios2": {
+    "dataset": {
+      "operators": [
+        {
+          "type": "zlib",
+          "parameters": {
+            "clevel": 9
+          }
+        }
+      ]
+    }
+  }
+}"""
+    d.options = dataset_config
     mesh["x"].reset_dataset(d)
 
     electrons = cur_it.particles["electrons"]

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -8,6 +8,7 @@ License: LGPLv3+
 """
 from openpmd_api import Series, Access, Dataset, Mesh_Record_Component, \
     Unit_Dimension
+import json
 import numpy as np
 
 
@@ -102,27 +103,24 @@ if __name__ == "__main__":
     # component this describes the datatype and shape of data as it should be
     # written to disk
     d = Dataset(partial_mesh.dtype, extent=[2, 5])
-    dataset_config = """
-{
-  "adios1": {
-    "dataset": {
-      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
-    }
-  },
-  "adios2": {
-    "dataset": {
-      "operators": [
-        {
-          "type": "zlib",
-          "parameters": {
-            "clevel": 9
-          }
+    dataset_config = {
+        "adios1": {
+            "dataset": {
+                "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
+            }
+        },
+        "adios2": {
+            "dataset": {
+                "operators": [{
+                    "type": "zlib",
+                    "parameters": {
+                        "clevel": 9
+                    }
+                }]
+            }
         }
-      ]
     }
-  }
-}"""
-    d.options = dataset_config
+    d.options = json.dumps(dataset_config)
     mesh["x"].reset_dataset(d)
 
     electrons = cur_it.particles["electrons"]

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -148,10 +148,10 @@ int main(
     // * The number of iterations. Effectively, the benchmark will be repeated for this many
     //   times.
 #if openPMD_HAVE_ADIOS1 || openPMD_HAVE_ADIOS2
-    benchmark.addConfiguration("", 0, "bp", dt, 10);
+    benchmark.addConfiguration("bp", dt, 10);
 #endif
 #if openPMD_HAVE_HDF5
-    benchmark.addConfiguration("", 0, "h5", dt, 10);
+    benchmark.addConfiguration("h5", dt, 10);
 #endif
 
     // Execute all previously configured benchmarks. Will return a MPIBenchmarkReport object

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -148,10 +148,14 @@ int main(
     // * The number of iterations. Effectively, the benchmark will be repeated for this many
     //   times.
 #if openPMD_HAVE_ADIOS1 || openPMD_HAVE_ADIOS2
-    benchmark.addConfiguration("bp", dt, 10);
+    benchmark.addConfiguration(
+        R"({"adios2": {"dataset":{"operators":[{"type": "blosc"}]}}})",
+        "bp",
+        dt,
+        10 );
 #endif
 #if openPMD_HAVE_HDF5
-    benchmark.addConfiguration("h5", dt, 10);
+    benchmark.addConfiguration( "{}", "h5", dt, 10 );
 #endif
 
     // Execute all previously configured benchmarks. Will return a MPIBenchmarkReport object

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -49,16 +49,10 @@ public:
     Dataset( Extent );
 
     Dataset& extend(Extent newExtent);
-    Dataset& setChunkSize(Extent const&);
-    Dataset& setCompression(std::string const&, uint8_t const);
-    Dataset& setCustomTransform(std::string const&);
 
     Extent extent;
     Datatype dtype;
     uint8_t rank;
-    Extent chunkSize;
-    std::string compression;
-    std::string transform;
     std::string options = "{}"; //!< backend-dependent JSON configuration
 };
 } // namespace openPMD

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -3,6 +3,7 @@
 #include <exception>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace openPMD
 {
@@ -61,6 +62,14 @@ namespace error
     {
     public:
         WrongAPIUsage( std::string what );
+    };
+
+    class BackendConfigSchema : public Error
+    {
+    public:
+        std::vector< std::string > errorLocation;
+
+        BackendConfigSchema( std::vector< std::string >, std::string what );
     };
 }
 }

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -22,6 +22,7 @@
 
 #include "openPMD/config.hpp"
 #include "openPMD/auxiliary/Export.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #include <future>
@@ -42,7 +43,7 @@ namespace openPMD
         friend class ADIOS1IOHandlerImpl;
 
     public:
-        ADIOS1IOHandler(std::string path, Access);
+        ADIOS1IOHandler(std::string path, Access, json::TracingJSON );
         ~ADIOS1IOHandler() override;
 
         std::string backendName() const override { return "ADIOS1"; }
@@ -61,7 +62,7 @@ namespace openPMD
         friend class ADIOS1IOHandlerImpl;
 
     public:
-        ADIOS1IOHandler(std::string path, Access);
+        ADIOS1IOHandler(std::string path, Access, json::TracingJSON );
         ~ADIOS1IOHandler() override;
 
         std::string backendName() const override { return "DUMMY_ADIOS1"; }

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -46,7 +46,7 @@ namespace openPMD
     private:
         using Base_t = CommonADIOS1IOHandlerImpl< ADIOS1IOHandlerImpl >;
     public:
-        ADIOS1IOHandlerImpl(AbstractIOHandler*);
+        ADIOS1IOHandlerImpl(AbstractIOHandler*, json::TracingJSON);
         virtual ~ADIOS1IOHandlerImpl();
 
         virtual void init();

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -130,14 +130,14 @@ public:
     ADIOS2IOHandlerImpl(
         AbstractIOHandler *,
         MPI_Comm,
-        nlohmann::json config,
+        json::TracingJSON config,
         std::string engineType );
 
 #endif // openPMD_HAVE_MPI
 
     explicit ADIOS2IOHandlerImpl(
         AbstractIOHandler *,
-        nlohmann::json config,
+        json::TracingJSON config,
         std::string engineType );
 
 
@@ -281,7 +281,7 @@ private:
     static json::TracingJSON nullvalue;
 
     void
-    init( nlohmann::json config );
+    init( json::TracingJSON config );
 
     template< typename Key >
     json::TracingJSON
@@ -1398,7 +1398,7 @@ public:
         std::string path,
         Access,
         MPI_Comm,
-        nlohmann::json options,
+        json::TracingJSON options,
         std::string engineType );
 
 #endif
@@ -1406,7 +1406,7 @@ public:
     ADIOS2IOHandler(
         std::string path,
         Access,
-        nlohmann::json options,
+        json::TracingJSON options,
         std::string engineType );
 
     std::string backendName() const override { return "ADIOS2"; }

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -28,7 +28,7 @@
 #include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
 #include "openPMD/IO/IOTask.hpp"
 #include "openPMD/IO/InvalidatableFile.hpp"
-#include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/auxiliary/Option.hpp"
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/config.hpp"
@@ -277,15 +277,15 @@ private:
 
     std::vector< ParameterizedOperator > defaultOperators;
 
-    auxiliary::TracingJSON m_config;
-    static auxiliary::TracingJSON nullvalue;
+    json::TracingJSON m_config;
+    static json::TracingJSON nullvalue;
 
     void
     init( nlohmann::json config );
 
     template< typename Key >
-    auxiliary::TracingJSON
-    config( Key && key, auxiliary::TracingJSON & cfg )
+    json::TracingJSON
+    config( Key && key, json::TracingJSON & cfg )
     {
         if( cfg.json().is_object() && cfg.json().contains( key ) )
         {
@@ -298,7 +298,7 @@ private:
     }
 
     template< typename Key >
-    auxiliary::TracingJSON
+    json::TracingJSON
     config( Key && key )
     {
         return config< Key >( std::forward< Key >( key ), m_config );
@@ -312,7 +312,7 @@ private:
      * operators have been configured
      */
     auxiliary::Option< std::vector< ParameterizedOperator > >
-    getOperators( auxiliary::TracingJSON config );
+    getOperators( json::TracingJSON config );
 
     // use m_config
     auxiliary::Option< std::vector< ParameterizedOperator > >

--- a/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
@@ -27,6 +27,7 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
@@ -89,11 +90,15 @@ namespace openPMD
         std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
         std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
         std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
+        // config options
+        std::string m_defaultTransform;
         /**
          * Call this function to get adios file id for a Writable. Will create one if does not exist
          * @return  returns an adios file id.
          */
         int64_t GetFileHandle(Writable*);
+
+        void initJson( json::TracingJSON );
     }; // ParallelADIOS1IOHandlerImpl
 } // openPMD
 

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -22,6 +22,7 @@
 
 #include "openPMD/config.hpp"
 #include "openPMD/auxiliary/Export.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #include <future>
@@ -42,9 +43,9 @@ namespace openPMD
 
     public:
 #   if openPMD_HAVE_MPI
-        ParallelADIOS1IOHandler(std::string path, Access, MPI_Comm);
+        ParallelADIOS1IOHandler(std::string path, Access, json::TracingJSON , MPI_Comm);
 #   else
-        ParallelADIOS1IOHandler(std::string path, Access);
+        ParallelADIOS1IOHandler(std::string path, Access, json::TracingJSON);
 #   endif
         ~ParallelADIOS1IOHandler() override;
 

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -22,6 +22,7 @@
 
 #include "openPMD/config.hpp"
 #include "openPMD/auxiliary/Export.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
@@ -46,7 +47,7 @@ namespace openPMD
     private:
         using Base_t = CommonADIOS1IOHandlerImpl< ParallelADIOS1IOHandlerImpl >;
     public:
-        ParallelADIOS1IOHandlerImpl(AbstractIOHandler*, MPI_Comm);
+        ParallelADIOS1IOHandlerImpl(AbstractIOHandler*, json::TracingJSON, MPI_Comm);
         virtual ~ParallelADIOS1IOHandlerImpl();
 
         virtual void init();

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -20,9 +20,8 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
-
-#include <nlohmann/json.hpp>
 
 #include <future>
 #include <memory>
@@ -36,7 +35,7 @@ class HDF5IOHandlerImpl;
 class HDF5IOHandler : public AbstractIOHandler
 {
 public:
-    HDF5IOHandler(std::string path, Access, nlohmann::json config);
+    HDF5IOHandler(std::string path, Access, json::TracingJSON config);
     ~HDF5IOHandler() override;
 
     std::string backendName() const override { return "HDF5"; }

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -39,7 +39,7 @@ namespace openPMD
     class HDF5IOHandlerImpl : public AbstractIOHandlerImpl
     {
     public:
-        HDF5IOHandlerImpl(AbstractIOHandler*, nlohmann::json config);
+        HDF5IOHandlerImpl(AbstractIOHandler*, json::TracingJSON config);
         ~HDF5IOHandlerImpl() override;
 
         void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) override;

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -24,7 +24,7 @@
 #if openPMD_HAVE_HDF5
 #   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 
-#   include "openPMD/auxiliary/JSON.hpp"
+#   include "openPMD/auxiliary/JSON_internal.hpp"
 #   include "openPMD/auxiliary/Option.hpp"
 
 #   include <hdf5.h>
@@ -81,7 +81,7 @@ namespace openPMD
         hid_t m_H5T_CLONG_DOUBLE;
 
     private:
-        auxiliary::TracingJSON m_config;
+        json::TracingJSON m_config;
         std::string m_chunks = "auto";
         struct File
         {

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -40,7 +40,7 @@ namespace openPMD
         ParallelHDF5IOHandler(
             std::string path, Access, MPI_Comm, json::TracingJSON config);
     #else
-        ParallelHDF5IOHandler(std::string path, Access, nlohmann::json config);
+        ParallelHDF5IOHandler(std::string path, Access, json::TracingJSON config);
     #endif
         ~ParallelHDF5IOHandler() override;
 

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -21,9 +21,8 @@
 #pragma once
 
 #include "openPMD/config.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
-
-#include <nlohmann/json.hpp>
 
 #include <future>
 #include <memory>
@@ -39,7 +38,7 @@ namespace openPMD
     public:
     #if openPMD_HAVE_MPI
         ParallelHDF5IOHandler(
-            std::string path, Access, MPI_Comm, nlohmann::json config);
+            std::string path, Access, MPI_Comm, json::TracingJSON config);
     #else
         ParallelHDF5IOHandler(std::string path, Access, nlohmann::json config);
     #endif

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
@@ -27,7 +27,7 @@
 #   include <mpi.h>
 #   if openPMD_HAVE_HDF5
 #       include "openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp"
-#       include <nlohmann/json.hpp>
+#       include "openPMD/auxiliary/JSON_internal.hpp"
 #   endif
 #endif
 
@@ -39,7 +39,7 @@ namespace openPMD
     {
     public:
         ParallelHDF5IOHandlerImpl(
-            AbstractIOHandler*, MPI_Comm, nlohmann::json config);
+            AbstractIOHandler*, MPI_Comm, json::TracingJSON config);
         ~ParallelHDF5IOHandlerImpl() override;
 
         MPI_Comm m_mpiComm;

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -281,6 +281,16 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_DATASET > : public Abstrac
     Extent extent = {};
     Datatype dtype = Datatype::UNDEFINED;
     std::string options = "{}";
+
+    // template parameter so we don't have to include the JSON lib here
+    // this function is useful for the createDataset() methods in,
+    // IOHandlerImpl's, so putting that here is the simplest way to make it
+    // available for them
+    template< typename TracingJSON >
+    static void warnUnusedParameters(
+        TracingJSON &,
+        std::string const & currentBackendName,
+        std::string const & warningMessage );
 };
 
 template<>

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -268,8 +268,7 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_DATASET > : public Abstrac
     Parameter() = default;
     Parameter(Parameter const & p) : AbstractParameter(),
         name(p.name), extent(p.extent), dtype(p.dtype),
-        chunkSize(p.chunkSize), compression(p.compression),
-        transform(p.transform), options(p.options) {}
+        options(p.options) {}
 
     std::unique_ptr< AbstractParameter >
     clone() const override
@@ -281,9 +280,6 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_DATASET > : public Abstrac
     std::string name = "";
     Extent extent = {};
     Datatype dtype = Datatype::UNDEFINED;
-    Extent chunkSize = {};
-    std::string compression = "";
-    std::string transform = "";
     std::string options = "{}";
 };
 

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -282,10 +282,12 @@ struct OPENPMDAPI_EXPORT Parameter< Operation::CREATE_DATASET > : public Abstrac
     Datatype dtype = Datatype::UNDEFINED;
     std::string options = "{}";
 
-    // template parameter so we don't have to include the JSON lib here
-    // this function is useful for the createDataset() methods in,
-    // IOHandlerImpl's, so putting that here is the simplest way to make it
-    // available for them
+    /** Warn about unused JSON paramters
+     *
+     * Template parameter so we don't have to include the JSON lib here.
+     * This function is useful for the createDataset() methods in,
+     * IOHandlerImpl's, so putting that here is the simplest way to make it
+     * available for them. */
     template< typename TracingJSON >
     static void warnUnusedParameters(
         TracingJSON &,

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -298,9 +298,6 @@ RecordComponent::storeChunk( Offset o, Extent e, F && createBuffer )
         dCreate.name = rc.m_name;
         dCreate.extent = getExtent();
         dCreate.dtype = getDatatype();
-        dCreate.chunkSize = rc.m_dataset.chunkSize;
-        dCreate.compression = rc.m_dataset.compression;
-        dCreate.transform = rc.m_dataset.transform;
         dCreate.options = rc.m_dataset.options;
         IOHandler()->enqueue(IOTask(this, dCreate));
     }

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -408,6 +408,9 @@ OPENPMD_private:
         }    }
 
     std::unique_ptr< ParsedInput > parseInput(std::string);
+    // template parameter so we don't have to include the JSON lib here
+    template< typename TracingJSON >
+    void parseJsonOptions( TracingJSON & options, ParsedInput & );
     bool hasExpansionPattern( std::string filenameWithExtension );
     bool reparseExpansionPattern( std::string filenameWithExtension );
     void init(std::shared_ptr< AbstractIOHandler >, std::unique_ptr< ParsedInput >);

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -408,7 +408,15 @@ OPENPMD_private:
         }    }
 
     std::unique_ptr< ParsedInput > parseInput(std::string);
-    // template parameter so we don't have to include the JSON lib here
+    /**
+     * @brief Parse non-backend-specific configuration in JSON config.
+     *
+     * Currently this parses the keys defer_iteration_parsing, backend and
+     * iteration_encoding.
+     *
+     * @tparam TracingJSON template parameter so we don't have
+     *         to include the JSON lib here
+     */
     template< typename TracingJSON >
     void parseJsonOptions( TracingJSON & options, ParsedInput & );
     bool hasExpansionPattern( std::string filenameWithExtension );

--- a/include/openPMD/auxiliary/JSON.hpp
+++ b/include/openPMD/auxiliary/JSON.hpp
@@ -1,0 +1,63 @@
+/* Copyright 2021 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace openPMD
+{
+namespace json
+{
+    /**
+     * @brief Merge two JSON datasets into one.
+     *
+     * Merging rules:
+     * 1. If both `defaultValue` and `overwrite` are JSON objects, then the
+     *    resulting JSON object will contain the union of both objects' keys.
+     *    If a key is specified in both objects, the values corresponding to the
+     *    key are merged recursively.
+     *    Keys that point to a null value after this procedure will be pruned.
+     * 2. In any other case, the JSON dataset `defaultValue` is replaced in its
+     *    entirety with the JSON dataset `overwrite`.
+     *
+     * Note that item 2 means that datasets of different type will replace each
+     * other without error.
+     * It also means that array types will replace each other without any notion
+     * of appending or merging.
+     *
+     * Possible use case:
+     * An application uses openPMD-api and wants to do the following:
+     * 1. Set some default backend options as JSON parameters.
+     * 2. Let its users specify custom backend options additionally.
+     *
+     * By using the json::merge() function, this application can then allow
+     * users to overwrite default options, while keeping any other ones.
+     *
+     * @param defaultValue
+     * @param overwrite
+     * @return std::string
+     */
+    std::string merge(
+        std::string const & defaultValue,
+        std::string const & overwrite );
+}
+}

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -195,5 +195,8 @@ namespace json
     extern std::vector< std::string > backendKeys;
 
     void warnGlobalUnusedOptions( TracingJSON const & config );
+
+    nlohmann::json &
+    merge( nlohmann::json & defaultVal, nlohmann::json const & overwrite );
 } // namespace json
 } // namespace openPMD

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -185,17 +185,50 @@ namespace json
 
 #endif
 
+    /**
+     * Recursively transform all keys in a JSON dataset to lower case.
+     * String values are unaffected.
+     * JSON objects at the following openPMD-defined locations are not affected:
+     * * adios2.engine.parameters
+     * * adios2.dataset.operators.<number>.parameters
+     * This helps us forward configurations from these locations to ADIOS2
+     * "as-is".
+     */
     nlohmann::json & lowerCase( nlohmann::json & );
 
+    /**
+     * Read a JSON literal as a string.
+     * If the literal is a number, convert that number to its string
+     * representation.
+     * If it is a bool, convert it to either "0" or "1".
+     * If it is not a literal, return an empty option.
+     */
     auxiliary::Option< std::string > asStringDynamic( nlohmann::json const & );
 
+    /**
+     * Like asStringDynamic(), but convert the string to lowercase afterwards.
+     */
     auxiliary::Option< std::string >
     asLowerCaseStringDynamic( nlohmann::json const & );
 
+    /**
+     * Vector containing the lower-case keys to the single backends'
+     * configurations.
+     */
     extern std::vector< std::string > backendKeys;
 
+    /**
+     * Function that can be called after reading all global options from the
+     * JSON configuration (i.e. all the options that are not handled by the
+     * single backends).
+     * If any unread value persists, a warning is printed to stderr.
+     */
     void warnGlobalUnusedOptions( TracingJSON const & config );
 
+    /**
+     * Like merge() as defined in JSON.hpp, but this overload works directly
+     * on nlohmann::json values.
+     */
     nlohmann::json &
     merge( nlohmann::json & defaultVal, nlohmann::json const & overwrite );
 } // namespace json

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -189,8 +189,8 @@ namespace json
      * Recursively transform all keys in a JSON dataset to lower case.
      * String values are unaffected.
      * JSON objects at the following openPMD-defined locations are not affected:
-     * * adios2.engine.parameters
-     * * adios2.dataset.operators.<number>.parameters
+     * * `adios2.engine.parameters`
+     * * `adios2.dataset.operators.<number>.parameters`
      * This helps us forward configurations from these locations to ADIOS2
      * "as-is".
      */

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -21,12 +21,12 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
+#include <cctype> // std::tolower
 #include <iterator>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <cassert>
-
 
 namespace openPMD
 {
@@ -261,5 +261,13 @@ removeSlashes( std::string s )
     return s;
 }
 
+template< typename S >
+S && lowerCase( S && s )
+{
+    std::transform( s.begin(), s.end(), s.begin(), []( unsigned char c ) {
+        return std::tolower( c );
+    } );
+    return std::forward< S >( s );
+}
 } // auxiliary
 } // openPMD

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -131,7 +131,6 @@ class Attributable
     friend struct traits::GenerationPolicy;
     friend class Iteration;
     friend class Series;
-    friend class Series;
     friend class Writable;
     friend class WriteIterations;
 

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -56,9 +56,7 @@ class BaseRecord : public Container< T_elem >
     friend class ParticleSpecies;
     friend class PatchRecord;
     friend class Record;
-
     friend class Mesh;
-    friend class ParticleSpecies;
 
     std::shared_ptr< internal::BaseRecordData< T_elem > > m_baseRecordData{
         new internal::BaseRecordData< T_elem >() };

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -135,7 +135,6 @@ class Container : public Attributable
     friend class ParticlePatches;
     friend class internal::SeriesData;
     friend class Series;
-    friend class Series;
     template< typename > friend class internal::EraseStaleEntries;
 
 protected:

--- a/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
@@ -53,6 +53,7 @@ namespace openPMD
         std::map<
             std::tuple<
                 int, // rank
+                std::string, // jsonConfig
                 std::string, // extension
                 int, // thread size
                 Datatype,
@@ -79,6 +80,7 @@ namespace openPMD
          * Add results for a certain compression strategy and level.
          *
          * @param rootThread The MPI rank which will collect the data.
+         * @param jsonConfig Compression strategy.
          * @param extension The openPMD filename extension.
          * @param threadSize The MPI size.
          * @param dt The openPMD datatype.
@@ -87,6 +89,7 @@ namespace openPMD
          */
         void addReport(
             int rootThread,
+            std::string jsonConfig,
             std::string extension,
             int threadSize,
             Datatype dt,
@@ -100,6 +103,7 @@ namespace openPMD
         /** Retrieve the time measured for a certain compression strategy.
          *
          * @param rank Which MPI rank's duration results to retrieve.
+         * @param jsonConfig Compression strategy.
          * @param extension The openPMD filename extension.
          * @param threadSize The MPI size.
          * @param dt The openPMD datatype.
@@ -111,6 +115,7 @@ namespace openPMD
             Duration
         > getReport(
             int rank,
+            std::string jsonConfig,
             std::string extension,
             int threadSize,
             Datatype dt,
@@ -234,6 +239,7 @@ namespace openPMD
     template< typename Duration >
     void MPIBenchmarkReport< Duration >::addReport(
         int rootThread,
+        std::string jsonConfig,
         std::string extension,
         int threadSize,
         Datatype dt,
@@ -304,6 +310,7 @@ namespace openPMD
                     .emplace(
                         std::make_tuple(
                             i,
+                            jsonConfig,
                             extension,
                             threadSize,
                             dt,
@@ -334,6 +341,7 @@ namespace openPMD
         Duration
     > MPIBenchmarkReport< Duration >::getReport(
         int rank,
+        std::string jsonConfig,
         std::string extension,
         int threadSize,
         Datatype dt,
@@ -346,6 +354,7 @@ namespace openPMD
                 .find(
                     std::make_tuple(
                         rank,
+                        jsonConfig,
                         extension,
                         threadSize,
                         dt,

--- a/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
@@ -53,8 +53,6 @@ namespace openPMD
         std::map<
             std::tuple<
                 int, // rank
-                std::string, // compression
-                uint8_t, // compression level
                 std::string, // extension
                 int, // thread size
                 Datatype,
@@ -81,8 +79,6 @@ namespace openPMD
          * Add results for a certain compression strategy and level.
          *
          * @param rootThread The MPI rank which will collect the data.
-         * @param compression Compression strategy.
-         * @param level Compression level
          * @param extension The openPMD filename extension.
          * @param threadSize The MPI size.
          * @param dt The openPMD datatype.
@@ -91,8 +87,6 @@ namespace openPMD
          */
         void addReport(
             int rootThread,
-            std::string compression,
-            uint8_t level,
             std::string extension,
             int threadSize,
             Datatype dt,
@@ -106,8 +100,6 @@ namespace openPMD
         /** Retrieve the time measured for a certain compression strategy.
          *
          * @param rank Which MPI rank's duration results to retrieve.
-         * @param compression Compression strategy.
-         * @param level Compression level
          * @param extension The openPMD filename extension.
          * @param threadSize The MPI size.
          * @param dt The openPMD datatype.
@@ -119,8 +111,6 @@ namespace openPMD
             Duration
         > getReport(
             int rank,
-            std::string compression,
-            uint8_t level,
             std::string extension,
             int threadSize,
             Datatype dt,
@@ -244,8 +234,6 @@ namespace openPMD
     template< typename Duration >
     void MPIBenchmarkReport< Duration >::addReport(
         int rootThread,
-        std::string compression,
-        uint8_t level,
         std::string extension,
         int threadSize,
         Datatype dt,
@@ -316,8 +304,6 @@ namespace openPMD
                     .emplace(
                         std::make_tuple(
                             i,
-                            compression,
-                            level,
                             extension,
                             threadSize,
                             dt,
@@ -348,8 +334,6 @@ namespace openPMD
         Duration
     > MPIBenchmarkReport< Duration >::getReport(
         int rank,
-        std::string compression,
-        uint8_t level,
         std::string extension,
         int threadSize,
         Datatype dt,
@@ -362,8 +346,6 @@ namespace openPMD
                 .find(
                     std::make_tuple(
                         rank,
-                        compression,
-                        level,
                         extension,
                         threadSize,
                         dt,

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -55,6 +55,7 @@ namespace openPMD {}
 
 #include "openPMD/auxiliary/Date.hpp"
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
+#include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/auxiliary/Option.hpp"
 #include "openPMD/auxiliary/OutOfRangeMsg.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -30,7 +30,6 @@ Dataset::Dataset(Datatype d, Extent e, std::string options_in)
         : extent{e},
           dtype{d},
           rank{static_cast<uint8_t>(e.size())},
-          chunkSize{e},
           options{std::move(options_in)}
 { }
 
@@ -48,43 +47,6 @@ Dataset::extend( Extent newExtents )
             throw std::runtime_error("New Extent must be equal or greater than previous Extent");
 
     extent = newExtents;
-    return *this;
-}
-
-Dataset&
-Dataset::setChunkSize(Extent const& cs)
-{
-    if( extent.size() != rank )
-        throw std::runtime_error("Dimensionality of extended Dataset must match the original dimensionality");
-    for( size_t i = 0; i < cs.size(); ++i )
-        if( cs[i] > extent[i] )
-            throw std::runtime_error("Dataset chunk size must be equal or smaller than Extent");
-
-    chunkSize = cs;
-    return *this;
-}
-
-Dataset&
-Dataset::setCompression(std::string const& format, uint8_t const level)
-{
-    if(format == "zlib" || format == "gzip" || format == "deflate")
-    {
-        if(level > 9)
-            throw std::runtime_error("Compression level out of range for " + format);
-    }
-    else
-        std::cerr << "Unknown compression format " << format
-                  << ". This might mean that compression will not be enabled."
-                  << std::endl;
-
-    compression = format + ':' + std::to_string(static_cast< int >(level));
-    return *this;
-}
-
-Dataset&
-Dataset::setCustomTransform(std::string const& parameter)
-{
-    transform = parameter;
     return *this;
 }
 } // openPMD

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -1,5 +1,7 @@
 #include "openPMD/Error.hpp"
 
+#include <sstream>
+
 namespace openPMD
 {
 const char * Error::what() const noexcept
@@ -18,6 +20,32 @@ namespace error
 
     WrongAPIUsage::WrongAPIUsage( std::string what )
         : Error( "Wrong API usage: " + what )
+    {
+    }
+
+    static std::string concatVector(
+        std::vector< std::string > const & vec,
+        std::string const & intersperse = "." )
+    {
+        if( vec.empty() )
+        {
+            return "";
+        }
+        std::stringstream res;
+        res << vec[ 0 ];
+        for( size_t i = 1; i < vec.size(); ++i )
+        {
+            res << intersperse << vec[ i ];
+        }
+        return res.str();
+    }
+
+    BackendConfigSchema::BackendConfigSchema(
+        std::vector< std::string > errorLocation_in, std::string what )
+        : Error(
+              "Wrong JSON schema at index '" +
+              concatVector( errorLocation_in ) + "': " + std::move( what ) )
+        , errorLocation( std::move( errorLocation_in ) )
     {
     }
 }

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -59,9 +59,8 @@ namespace openPMD {
             return Format::ADIOS2_SSC;
         if (auxiliary::ends_with(filename, ".json"))
             return Format::JSON;
-        if (std::string::npos != filename.find('.') /* extension is provided */ )
-            throw std::runtime_error("Unknown file format. Did you append a valid filename extension?");
 
+        // Format might still be specified via JSON
         return Format::DUMMY;
     }
 

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -43,9 +43,11 @@ namespace openPMD
 #       define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
 #   endif
 
-ADIOS1IOHandlerImpl::ADIOS1IOHandlerImpl(AbstractIOHandler* handler)
+ADIOS1IOHandlerImpl::ADIOS1IOHandlerImpl(AbstractIOHandler* handler, json::TracingJSON json)
         : Base_t(handler)
-{ }
+{
+    initJson( std::move( json ) );
+}
 
 ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
 {
@@ -220,9 +222,9 @@ ADIOS1IOHandlerImpl::init()
 #endif
 
 #if openPMD_HAVE_ADIOS1
-ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at)
+ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at, json::TracingJSON json)
         : AbstractIOHandler(std::move(path), at),
-          m_impl{new ADIOS1IOHandlerImpl(this)}
+          m_impl{new ADIOS1IOHandlerImpl(this, std::move(json))}
 {
     m_impl->init();
 }
@@ -317,7 +319,7 @@ ADIOS1IOHandlerImpl::initialize_group(std::string const &name)
 }
 
 #else
-ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at)
+ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at, json::TracingJSON)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without ADIOS1 support");

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -376,17 +376,6 @@ void ADIOS2IOHandlerImpl::createDataset(
             operators = defaultOperators;
         }
 
-        if( !parameters.compression.empty() )
-        {
-            auxiliary::Option< adios2::Operator > adiosOperator =
-                getCompressionOperator( parameters.compression );
-            if( adiosOperator )
-            {
-                operators.push_back( ParameterizedOperator{
-                    adiosOperator.get(), adios2::Params() } );
-            }
-        }
-
         // cast from openPMD::Extent to adios2::Dims
         adios2::Dims const shape( parameters.extent.begin(), parameters.extent.end() );
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -159,7 +159,7 @@ ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
 }
 
 auxiliary::Option< std::vector< ADIOS2IOHandlerImpl::ParameterizedOperator > >
-ADIOS2IOHandlerImpl::getOperators( auxiliary::TracingJSON cfg )
+ADIOS2IOHandlerImpl::getOperators( json::TracingJSON cfg )
 {
     using ret_t = auxiliary::Option< std::vector< ParameterizedOperator > >;
     std::vector< ParameterizedOperator > res;
@@ -353,9 +353,10 @@ void ADIOS2IOHandlerImpl::createDataset(
 
         std::vector< ParameterizedOperator > operators;
         nlohmann::json options = nlohmann::json::parse( parameters.options );
+        json::lowerCase( options );
         if( options.contains( "adios2" ) )
         {
-            auxiliary::TracingJSON datasetConfig( options[ "adios2" ] );
+            json::TracingJSON datasetConfig( options[ "adios2" ] );
             auto datasetOperators = getOperators( datasetConfig );
 
             operators = datasetOperators ? std::move( datasetOperators.get() )
@@ -1080,7 +1081,7 @@ ADIOS2IOHandlerImpl::adios2AccessMode( std::string const & fullPath )
     }
 }
 
-auxiliary::TracingJSON ADIOS2IOHandlerImpl::nullvalue = nlohmann::json();
+json::TracingJSON ADIOS2IOHandlerImpl::nullvalue = nlohmann::json();
 
 std::string
 ADIOS2IOHandlerImpl::filePositionToString(

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -67,7 +67,7 @@ namespace openPMD
 ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(
     AbstractIOHandler * handler,
     MPI_Comm communicator,
-    nlohmann::json cfg,
+    json::TracingJSON cfg,
     std::string engineType )
     : AbstractIOHandlerImplCommon( handler )
     , m_ADIOS{ communicator, ADIOS2_DEBUG_MODE }
@@ -80,7 +80,7 @@ ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(
 
 ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(
     AbstractIOHandler * handler,
-    nlohmann::json cfg,
+    json::TracingJSON cfg,
     std::string engineType )
     : AbstractIOHandlerImplCommon( handler )
     , m_ADIOS{ ADIOS2_DEBUG_MODE }
@@ -120,11 +120,11 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
 }
 
 void
-ADIOS2IOHandlerImpl::init( nlohmann::json cfg )
+ADIOS2IOHandlerImpl::init( json::TracingJSON cfg )
 {
-    if( cfg.contains( "adios2" ) )
+    if( cfg.json().contains( "adios2" ) )
     {
-        m_config = std::move( cfg[ "adios2" ] );
+        m_config = cfg[ "adios2" ];
 
         if( m_config.json().contains( "schema" ) )
         {
@@ -2915,7 +2915,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     openPMD::Access at,
     MPI_Comm comm,
-    nlohmann::json options,
+    json::TracingJSON options,
     std::string engineType )
     : AbstractIOHandler( std::move( path ), at, comm )
     , m_impl{ this, comm, std::move( options ), std::move( engineType ) }
@@ -2927,7 +2927,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     Access at,
-    nlohmann::json options,
+    json::TracingJSON options,
     std::string engineType )
     : AbstractIOHandler( std::move( path ), at )
     , m_impl{ this, std::move( options ), std::move( engineType ) }
@@ -2947,7 +2947,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     Access at,
     MPI_Comm comm,
-    nlohmann::json,
+    json::TracingJSON,
     std::string )
     : AbstractIOHandler( std::move( path ), at, comm )
 {
@@ -2958,7 +2958,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(
 ADIOS2IOHandler::ADIOS2IOHandler(
     std::string path,
     Access at,
-    nlohmann::json,
+    json::TracingJSON,
     std::string )
     : AbstractIOHandler( std::move( path ), at )
 {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2344,7 +2344,8 @@ namespace detail
                             {"adios2", "engine", "parameters", it.key() },
                             "Must be convertible to string type." );
                     }
-                    alreadyConfigured.emplace( it.key() );
+                    alreadyConfigured.emplace(
+                        auxiliary::lowerCase( std::string( it.key() ) ) );
                 }
             }
             auto _useAdiosSteps =
@@ -2371,8 +2372,9 @@ namespace detail
                       << shadow << std::endl;
         }
         auto notYetConfigured =
-            [&alreadyConfigured]( std::string const & param ) {
-                auto it = alreadyConfigured.find( param );
+            [ &alreadyConfigured ]( std::string const & param ) {
+                auto it = alreadyConfigured.find(
+                    auxiliary::lowerCase( std::string( param ) ) );
                 return it == alreadyConfigured.end();
             };
 

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -41,6 +41,7 @@ namespace openPMD
 #   endif
 
 ParallelADIOS1IOHandlerImpl::ParallelADIOS1IOHandlerImpl(AbstractIOHandler* handler,
+                                                         json::TracingJSON json,
                                                          MPI_Comm comm)
         : Base_t{handler},
           m_mpiInfo{MPI_INFO_NULL}
@@ -48,6 +49,7 @@ ParallelADIOS1IOHandlerImpl::ParallelADIOS1IOHandlerImpl(AbstractIOHandler* hand
     int status = MPI_SUCCESS;
     status = MPI_Comm_dup(comm, &m_mpiComm);
     VERIFY(status == MPI_SUCCESS, "[ADIOS1] Internal error: Failed to duplicate MPI communicator");
+    initJson( std::move( json ) );
 }
 
 ParallelADIOS1IOHandlerImpl::~ParallelADIOS1IOHandlerImpl()
@@ -240,9 +242,10 @@ ParallelADIOS1IOHandlerImpl::init()
 
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
                                                  Access at,
+                                                 json::TracingJSON json,
                                                  MPI_Comm comm)
         : AbstractIOHandler(std::move(path), at, comm),
-          m_impl{new ParallelADIOS1IOHandlerImpl(this, comm)}
+          m_impl{new ParallelADIOS1IOHandlerImpl(this, std::move(json), comm)}
 {
     m_impl->init();
 }
@@ -347,6 +350,7 @@ ParallelADIOS1IOHandlerImpl::initialize_group(std::string const &name)
 #   if openPMD_HAVE_MPI
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
                                                  Access at,
+                                                 json::TracingJSON,
                                                  MPI_Comm comm)
         : AbstractIOHandler(std::move(path), at, comm)
 {
@@ -354,7 +358,8 @@ ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
 }
 #   else
 ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(std::string path,
-                                                 Access at)
+                                                 Access at,
+                                                 json::TracingJSON)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without parallel ADIOS1 support");

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -27,7 +27,7 @@
 #include "openPMD/IO/HDF5/HDF5IOHandler.hpp"
 #include "openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp"
 #include "openPMD/IO/JSON/JSONIOHandler.hpp"
-#include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 
 namespace openPMD
 {

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -49,7 +49,8 @@ namespace openPMD
                     path, access, comm, std::move( options ) );
             case Format::ADIOS1:
 #   if openPMD_HAVE_ADIOS1
-                return std::make_shared< ParallelADIOS1IOHandler >( path, access, comm );
+                return std::make_shared< ParallelADIOS1IOHandler >(
+                    path, access, std::move( options ), comm );
 #   else
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #   endif
@@ -85,7 +86,8 @@ namespace openPMD
                     path, access, std::move( options ) );
             case Format::ADIOS1:
 #if openPMD_HAVE_ADIOS1
-                return std::make_shared< ADIOS1IOHandler >( path, access );
+                return std::make_shared< ADIOS1IOHandler >(
+                    path, access, std::move( options ) );
 #else
                 throw std::runtime_error("openPMD-api built without ADIOS1 support");
 #endif

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -34,12 +34,12 @@ namespace openPMD
 #if openPMD_HAVE_MPI
     template<>
     std::shared_ptr< AbstractIOHandler >
-    createIOHandler< nlohmann::json >(
+    createIOHandler< json::TracingJSON >(
         std::string path,
         Access access,
         Format format,
         MPI_Comm comm,
-        nlohmann::json options )
+        json::TracingJSON options )
     {
         (void) options;
         switch( format )
@@ -71,11 +71,11 @@ namespace openPMD
 
     template<>
     std::shared_ptr< AbstractIOHandler >
-    createIOHandler< nlohmann::json >(
+    createIOHandler< json::TracingJSON >(
         std::string path,
         Access access,
         Format format,
-        nlohmann::json options )
+        json::TracingJSON options )
     {
         (void) options;
         switch( format )
@@ -112,6 +112,9 @@ namespace openPMD
     createIOHandler( std::string path, Access access, Format format )
     {
         return createIOHandler(
-            std::move( path ), access, format, nlohmann::json::object() );
+            std::move( path ),
+            access,
+            format,
+            json::TracingJSON( nlohmann::json::object() ));
     }
 } // namespace openPMD

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -295,6 +295,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
             name = auxiliary::replace_last(name, "/", "");
 
         auto config = nlohmann::json::parse( parameters.options );
+        json::lowerCase( config );
 
         // general
         bool is_resizable_dataset = false;
@@ -307,7 +308,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         if( config.contains( "hdf5" ) &&
             config[ "hdf5" ].contains( "dataset" ) )
         {
-            auxiliary::TracingJSON datasetConfig{
+            json::TracingJSON datasetConfig{
                 config[ "hdf5" ][ "dataset" ] };
 
             /*

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -386,7 +386,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
             VERIFY(status == 0, "[HDF5] Internal error: Failed to set chunk size during dataset creation");
         }
 
-        std::string const& compression = parameters.compression;
+        std::string const& compression = ""; // @todo read from JSON
         if( !compression.empty() )
           std::cerr << "[HDF5] Compression not yet implemented in HDF5 backend."
                     << std::endl;
@@ -409,11 +409,6 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
                           << std::endl;
         }
          */
-
-        std::string const& transform = parameters.transform;
-        if( !transform.empty() )
-            std::cerr << "[HDF5] Custom transform not yet implemented in HDF5 backend."
-                      << std::endl;
 
         GetH5DataType getH5DataType({
             { typeid(bool).name(), m_H5T_BOOL_ENUM },

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -53,7 +53,7 @@ namespace openPMD
 #   endif
 
 HDF5IOHandlerImpl::HDF5IOHandlerImpl(
-    AbstractIOHandler* handler, nlohmann::json config)
+    AbstractIOHandler* handler, json::TracingJSON config)
         : AbstractIOHandlerImpl(handler),
           m_datasetTransferProperty{H5P_DEFAULT},
           m_fileAccessProperty{H5P_DEFAULT},
@@ -87,9 +87,9 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
 
     m_chunks = auxiliary::getEnvString( "OPENPMD_HDF5_CHUNKS", "auto" );
     // JSON option can overwrite env option:
-    if( config.contains( "hdf5" ) )
+    if( config.json().contains( "hdf5" ) )
     {
-        m_config = std::move( config[ "hdf5" ] );
+        m_config = config[ "hdf5" ];
 
         // check for global dataset configs
         if( m_config.json().contains( "dataset" ) )
@@ -2019,7 +2019,7 @@ HDF5IOHandlerImpl::getFile( Writable * writable )
 #endif
 
 #if openPMD_HAVE_HDF5
-HDF5IOHandler::HDF5IOHandler(std::string path, Access at, nlohmann::json config)
+HDF5IOHandler::HDF5IOHandler(std::string path, Access at, json::TracingJSON config)
         : AbstractIOHandler(std::move(path), at),
           m_impl{new HDF5IOHandlerImpl(this, std::move(config))}
 { }
@@ -2032,7 +2032,7 @@ HDF5IOHandler::flush()
     return m_impl->flush();
 }
 #else
-HDF5IOHandler::HDF5IOHandler(std::string path, Access at, nlohmann::json /* config */)
+HDF5IOHandler::HDF5IOHandler(std::string path, Access at, json::TracingJSON /* config */)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without HDF5 support");

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -40,7 +40,7 @@ namespace openPMD
 #   endif
 
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(
-    std::string path, Access at, MPI_Comm comm, nlohmann::json config )
+    std::string path, Access at, MPI_Comm comm, json::TracingJSON config )
         : AbstractIOHandler(std::move(path), at, comm),
           m_impl{new ParallelHDF5IOHandlerImpl(this, comm, std::move(config))}
 { }
@@ -54,7 +54,7 @@ ParallelHDF5IOHandler::flush()
 }
 
 ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
-    AbstractIOHandler* handler, MPI_Comm comm, nlohmann::json config )
+    AbstractIOHandler* handler, MPI_Comm comm, json::TracingJSON config )
         : HDF5IOHandlerImpl{handler, std::move(config)},
           m_mpiComm{comm},
           m_mpiInfo{MPI_INFO_NULL} /* MPI 3.0+: MPI_INFO_ENV */

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -150,7 +150,7 @@ ParallelHDF5IOHandlerImpl::~ParallelHDF5IOHandlerImpl()
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
                                              Access at,
                                              MPI_Comm comm,
-                                             nlohmann::json /* config */)
+                                             json::TracingJSON /* config */)
         : AbstractIOHandler(std::move(path), at, comm)
 {
     throw std::runtime_error("openPMD-api built without HDF5 support");
@@ -158,7 +158,7 @@ ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
 #   else
 ParallelHDF5IOHandler::ParallelHDF5IOHandler(std::string path,
                                              Access at,
-                                             nlohmann::json /* config */)
+                                             json::TracingJSON /* config */)
         : AbstractIOHandler(std::move(path), at)
 {
     throw std::runtime_error("openPMD-api built without parallel support and without HDF5 support");

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -256,9 +256,6 @@ RecordComponent::flush(std::string const& name)
                 dCreate.name = name;
                 dCreate.extent = getExtent();
                 dCreate.dtype = getDatatype();
-                dCreate.chunkSize = rc.m_dataset.chunkSize;
-                dCreate.compression = rc.m_dataset.compression;
-                dCreate.transform = rc.m_dataset.transform;
                 dCreate.options = rc.m_dataset.options;
                 IOHandler()->enqueue(IOTask(this, dCreate));
             }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -38,6 +38,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <utility>
 
 
 namespace openPMD
@@ -1458,6 +1459,10 @@ void Series::openIteration( uint64_t index, Iteration iteration )
 
 namespace
 {
+    /**
+     * Look up if the specified key is contained in the JSON dataset.
+     * If yes, read it into the specified location.
+     */
     template< typename From, typename Dest = From >
     void getJsonOption(
         json::TracingJSON & config, std::string const & key, Dest & dest )
@@ -1468,6 +1473,11 @@ namespace
         }
     }
 
+    /**
+     * Like getJsonOption(), but for string types.
+     * Numbers and booleans are converted to their string representation.
+     * The string is converted to lower case.
+     */
     template< typename Dest = std::string >
     void getJsonOptionLowerCase(
         json::TracingJSON & config, std::string const & key, Dest & dest )

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -20,7 +20,7 @@
  */
 #include "openPMD/auxiliary/Date.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
-#include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerHelper.hpp"
@@ -1531,7 +1531,8 @@ Series::Series(
 {
     Attributable::setData( m_series );
     iterations = m_series->iterations;
-    nlohmann::json optionsJson = auxiliary::parseOptions( options, comm );
+    nlohmann::json optionsJson = json::parseOptions(
+        options, comm, /* considerFiles = */ true );
     parseJsonOptions( get(), optionsJson );
     auto input = parseInput( filepath );
     auto handler = createIOHandler(
@@ -1547,7 +1548,8 @@ Series::Series(
 {
     Attributable::setData( m_series );
     iterations = m_series->iterations;
-    nlohmann::json optionsJson = auxiliary::parseOptions( options );
+    nlohmann::json optionsJson =
+        json::parseOptions( options, /* considerFiles = */ true );
     parseJsonOptions( get(), optionsJson );
     auto input = parseInput( filepath );
     auto handler = createIOHandler(

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1510,6 +1510,15 @@ void Series::parseJsonOptions(
             auto it = backendDescriptors.find( backend );
             if( it != backendDescriptors.end() )
             {
+                if( input.format != Format::DUMMY &&
+                    suffix( input.format ) != suffix( it->second ) )
+                {
+                    std::cerr << "[Warning] Supplied filename extension '"
+                              << suffix( input.format )
+                              << "' contradicts the backend specified via the "
+                                 "'backend' key. Will go on with backend "
+                              << it->first << "." << std::endl;
+                }
                 input.format = it->second;
             }
             else

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -266,6 +266,9 @@ namespace json
                     { "adios2",
                       "dataset",
                       "operators",
+                      /*
+                       * We use "\vnum" to indicate "any array index".
+                       */
                       "\vnum",
                       "parameters" } };
                 for( auto const & ignored : ignoredPaths )

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -102,9 +102,6 @@ PatchRecordComponent::flush(std::string const& name)
             dCreate.name = name;
             dCreate.extent = getExtent();
             dCreate.dtype = getDatatype();
-            dCreate.chunkSize = getExtent();
-            dCreate.compression = rc.m_dataset.compression;
-            dCreate.transform = rc.m_dataset.transform;
             dCreate.options = rc.m_dataset.options;
             IOHandler()->enqueue(IOTask(this, dCreate));
         }

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -61,12 +61,6 @@ void init_Dataset(py::module &m) {
 
         .def_readonly("extent", &Dataset::extent)
         .def("extend", &Dataset::extend)
-        .def_readonly("chunk_size", &Dataset::chunkSize)
-        .def("set_chunk_size", &Dataset::setChunkSize)
-        .def_readonly("compression", &Dataset::compression)
-        .def("set_compression", &Dataset::setCompression)
-        .def_readonly("transform", &Dataset::transform)
-        .def("set_custom_transform", &Dataset::setCustomTransform)
         .def_readonly("rank", &Dataset::rank)
         .def_property_readonly("dtype", [](const Dataset &d) {
             return dtype_to_numpy( d.dtype );

--- a/src/binding/python/Error.cpp
+++ b/src/binding/python/Error.cpp
@@ -12,6 +12,8 @@ void init_Error( py::module & m )
         m, "ErrorOperationUnsupportedInBackend", baseError );
     py::register_exception< error::WrongAPIUsage >(
         m, "ErrorWrongAPIUsage", baseError );
+    py::register_exception< error::BackendConfigSchema >(
+        m, "ErrorBackendConfigSchema", baseError );
 
 #ifndef NDEBUG
     m.def( "test_throw", []( std::string description ) {

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -95,6 +95,7 @@ TEST_CASE( "json_parsing", "[auxiliary]" )
         json::parseOptions( same1, false ).dump() !=
         json::parseOptions( different, false ).dump() );
 
+    // Keys forwarded to ADIOS2 should remain untouched
     std::string upper = R"END(
 {
   "ADIOS2": {
@@ -128,8 +129,8 @@ TEST_CASE( "json_parsing", "[auxiliary]" )
       "type": "BP3",
       "unused": "PARAMETER",
       "parameters": {
-        "buffergrowthfactor": "2.0",
-        "profile": "ON"
+        "BUFFERGROWTHFACTOR": "2.0",
+        "PROFILE": "ON"
       }
     },
     "unused": "AS WELL",
@@ -138,8 +139,8 @@ TEST_CASE( "json_parsing", "[auxiliary]" )
         {
           "type": "BLOSC",
           "parameters": {
-              "clevel": "1",
-              "doshuffle": "BLOSC_BITSHUFFLE"
+              "CLEVEL": "1",
+              "DOSHUFFLE": "BLOSC_BITSHUFFLE"
           }
         }
       ]

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -3,20 +3,18 @@
 #   define OPENPMD_private public
 #   define OPENPMD_protected public
 #endif
-#include "openPMD/Dataset.hpp"
-#include "openPMD/IO/AbstractIOHandler.hpp"
-#include "openPMD/IO/AbstractIOHandlerHelper.hpp"
+#include "openPMD/config.hpp"
+#include "openPMD/backend/Writable.hpp"
+#include "openPMD/backend/Attributable.hpp"
+#include "openPMD/backend/Container.hpp"
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
-#include "openPMD/auxiliary/JSON.hpp"
-#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/auxiliary/Option.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
-#include "openPMD/backend/Attributable.hpp"
-#include "openPMD/backend/Container.hpp"
-#include "openPMD/backend/Writable.hpp"
-#include "openPMD/config.hpp"
+#include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/IO/AbstractIOHandlerHelper.hpp"
+#include "openPMD/Dataset.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -44,171 +42,6 @@ struct TestHelper : public Attributable
 } // test
 } // openPMD
 
-TEST_CASE( "json_parsing", "[auxiliary]" )
-{
-    std::string wrongValue = R"END(
-{
-  "ADIOS2": {
-    "duplicate key": 1243,
-    "DUPLICATE KEY": 234
-  }
-})END";
-    REQUIRE_THROWS_WITH(
-        json::parseOptions( wrongValue, false ),
-        error::BackendConfigSchema(
-            { "adios2", "duplicate key" }, "JSON config: duplicate keys." )
-            .what() );
-    std::string same1 = R"(
-{
-  "ADIOS2": {
-    "type": "nullcore",
-    "engine": {
-      "type": "bp4",
-      "usesteps": true
-    }
-  }
-})";
-    std::string same2 = R"(
-{
-  "adios2": {
-    "type": "nullcore",
-    "ENGINE": {
-      "type": "bp4",
-      "usesteps": true
-    }
-  }
-})";
-    std::string different = R"(
-{
-  "adios2": {
-    "type": "NULLCORE",
-    "ENGINE": {
-      "type": "bp4",
-      "usesteps": true
-    }
-  }
-})";
-    REQUIRE(
-        json::parseOptions( same1, false ).dump() ==
-        json::parseOptions( same2, false ).dump() );
-    // Only keys should be transformed to lower case, values must stay the same
-    REQUIRE(
-        json::parseOptions( same1, false ).dump() !=
-        json::parseOptions( different, false ).dump() );
-
-    // Keys forwarded to ADIOS2 should remain untouched
-    std::string upper = R"END(
-{
-  "ADIOS2": {
-    "ENGINE": {
-      "TYPE": "BP3",
-      "UNUSED": "PARAMETER",
-      "PARAMETERS": {
-        "BUFFERGROWTHFACTOR": "2.0",
-        "PROFILE": "ON"
-      }
-    },
-    "UNUSED": "AS WELL",
-    "DATASET": {
-      "OPERATORS": [
-        {
-          "TYPE": "BLOSC",
-          "PARAMETERS": {
-              "CLEVEL": "1",
-              "DOSHUFFLE": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  }
-}
-)END";
-    std::string lower = R"END(
-{
-  "adios2": {
-    "engine": {
-      "type": "BP3",
-      "unused": "PARAMETER",
-      "parameters": {
-        "BUFFERGROWTHFACTOR": "2.0",
-        "PROFILE": "ON"
-      }
-    },
-    "unused": "AS WELL",
-    "dataset": {
-      "operators": [
-        {
-          "type": "BLOSC",
-          "parameters": {
-              "CLEVEL": "1",
-              "DOSHUFFLE": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  }
-}
-)END";
-    nlohmann::json jsonUpper = nlohmann::json::parse( upper );
-    nlohmann::json jsonLower = nlohmann::json::parse( lower );
-    REQUIRE( jsonUpper.dump() != jsonLower.dump() );
-    json::lowerCase( jsonUpper );
-    REQUIRE( jsonUpper.dump() == jsonLower.dump() );
-}
-
-TEST_CASE( "json_merging", "auxiliary" )
-{
-    std::string defaultVal = R"END(
-{
-  "mergeRecursively": {
-    "changed": 43,
-    "unchanged": true,
-    "delete_me": "adsf"
-  },
-  "dontmergearrays": [
-    1,
-    2,
-    3,
-    4,
-    5
-  ],
-  "delete_me": [345,2345,36]
-}
-)END";
-
-    std::string overwrite = R"END(
-{
-  "mergeRecursively": {
-    "changed": "new value",
-    "newValue": "44",
-    "delete_me": null
-  },
-  "dontmergearrays": [
-    5,
-    6,
-    7
-  ],
-  "delete_me": null
-}
-)END";
-
-    std::string expect = R"END(
-{
-  "mergeRecursively": {
-    "changed": "new value",
-    "unchanged": true,
-    "newValue": "44"
-  },
-  "dontmergearrays": [
-    5,
-    6,
-    7
-  ]
-})END";
-    REQUIRE(
-        json::merge( defaultVal, overwrite ) ==
-        json::parseOptions( expect, false ).dump() );
-}
 
 TEST_CASE( "optional", "[auxiliary]" ) {
     using namespace auxiliary;

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -959,7 +959,7 @@ TEST_CASE( "backend_via_json", "[core]" )
     }
     {
         /*
-         * … but specifying both the pattern and the option in JSON should work.
+         * ... but specifying both the pattern and the option in JSON should work.
          */
         Series series(
             "../samples/optionsViaJson%06T",
@@ -971,7 +971,7 @@ TEST_CASE( "backend_via_json", "[core]" )
         R"({"backend": "json", "iteration_encoding": "group_based"})";
     {
         /*
-         * … and if a pattern is detected, but the JSON config says to use
+         * ... and if a pattern is detected, but the JSON config says to use
          * an iteration encoding that is not file-based, the pattern should
          * be ignored.
          */

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -9,7 +9,6 @@
 #include "openPMD/auxiliary/JSON.hpp"
 
 #include <catch2/catch.hpp>
-#include <nlohmann/json.hpp>
 
 #include <algorithm>
 #include <array>

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -876,7 +876,7 @@ TEST_CASE( "no_file_ending", "[core]" )
         Series(
             "../samples/no_extension_specified",
             Access::CREATE,
-            "{\"backend\": \"json\"}" );
+            R"({"backend": "json"})" );
     }
     REQUIRE(
         auxiliary::file_exists( "../samples/no_extension_specified.json" ) );
@@ -885,7 +885,7 @@ TEST_CASE( "no_file_ending", "[core]" )
 TEST_CASE( "backend_via_json", "[core]" )
 {
     std::string encodingVariableBased =
-        "{\"backend\": \"json\", \"iteration_encoding\": \"variable_based\"}";
+        R"({"backend": "json", "iteration_encoding": "variable_based"})";
     {
         Series series(
             "../samples/optionsViaJson",
@@ -910,7 +910,7 @@ TEST_CASE( "backend_via_json", "[core]" )
         Series series(
             "../samples/optionsViaJsonOverwritesAutomaticDetection.sst",
             Access::CREATE,
-            "{\"adios2\": {\"engine\": {\"type\": \"bp4\"}}}" );
+            R"({"adios2": {"engine": {"type": "bp4"}}})" );
     }
     REQUIRE( auxiliary::directory_exists(
         "../samples/optionsViaJsonOverwritesAutomaticDetection.bp" ) );
@@ -922,7 +922,7 @@ TEST_CASE( "backend_via_json", "[core]" )
         Series series(
             "../samples/optionsPreferJsonOverEnvVar.bp",
             Access::CREATE,
-            "{\"backend\": \"ADIOS2\"}" );
+            R"({"backend": "ADIOS2"})" );
         REQUIRE( series.backend() == "ADIOS2" );
     }
     // unset again
@@ -932,7 +932,7 @@ TEST_CASE( "backend_via_json", "[core]" )
 #endif
 #endif
     std::string encodingFileBased =
-        "{\"backend\": \"json\", \"iteration_encoding\": \"file_based\"}";
+        R"({"backend": "json", "iteration_encoding": "file_based"})";
     {
         /*
          * Should we add JSON options to set the filebased expansion pattern?
@@ -948,7 +948,7 @@ TEST_CASE( "backend_via_json", "[core]" )
             error::WrongAPIUsage );
     }
     std::string encodingGroupBased =
-        "{\"backend\": \"json\", \"iteration_encoding\": \"group_based\"}";
+        R"({"backend": "json", "iteration_encoding": "group_based"})";
     {
         Series series(
             "../samples/optionsViaJsonPseudoFilebased%T.json",

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -1,0 +1,198 @@
+#include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
+
+#include <catch2/catch.hpp>
+
+using namespace openPMD;
+
+TEST_CASE( "json_parsing", "[auxiliary]" )
+{
+    std::string wrongValue = R"END(
+{
+  "ADIOS2": {
+    "duplicate key": 1243,
+    "DUPLICATE KEY": 234
+  }
+})END";
+    REQUIRE_THROWS_WITH(
+        json::parseOptions( wrongValue, false ),
+        error::BackendConfigSchema(
+            { "adios2", "duplicate key" }, "JSON config: duplicate keys." )
+            .what() );
+    std::string same1 = R"(
+{
+  "ADIOS2": {
+    "type": "nullcore",
+    "engine": {
+      "type": "bp4",
+      "usesteps": true
+    }
+  }
+})";
+    std::string same2 = R"(
+{
+  "adios2": {
+    "type": "nullcore",
+    "ENGINE": {
+      "type": "bp4",
+      "usesteps": true
+    }
+  }
+})";
+    std::string different = R"(
+{
+  "adios2": {
+    "type": "NULLCORE",
+    "ENGINE": {
+      "type": "bp4",
+      "usesteps": true
+    }
+  }
+})";
+    REQUIRE(
+        json::parseOptions( same1, false ).dump() ==
+        json::parseOptions( same2, false ).dump() );
+    // Only keys should be transformed to lower case, values must stay the same
+    REQUIRE(
+        json::parseOptions( same1, false ).dump() !=
+        json::parseOptions( different, false ).dump() );
+
+    // Keys forwarded to ADIOS2 should remain untouched
+    std::string upper = R"END(
+{
+  "ADIOS2": {
+    "ENGINE": {
+      "TYPE": "BP3",
+      "UNUSED": "PARAMETER",
+      "PARAMETERS": {
+        "BUFFERGROWTHFACTOR": "2.0",
+        "PROFILE": "ON"
+      }
+    },
+    "UNUSED": "AS WELL",
+    "DATASET": {
+      "OPERATORS": [
+        {
+          "TYPE": "BLOSC",
+          "PARAMETERS": {
+              "CLEVEL": "1",
+              "DOSHUFFLE": "BLOSC_BITSHUFFLE"
+          }
+        }
+      ]
+    }
+  }
+}
+)END";
+    std::string lower = R"END(
+{
+  "adios2": {
+    "engine": {
+      "type": "BP3",
+      "unused": "PARAMETER",
+      "parameters": {
+        "BUFFERGROWTHFACTOR": "2.0",
+        "PROFILE": "ON"
+      }
+    },
+    "unused": "AS WELL",
+    "dataset": {
+      "operators": [
+        {
+          "type": "BLOSC",
+          "parameters": {
+              "CLEVEL": "1",
+              "DOSHUFFLE": "BLOSC_BITSHUFFLE"
+          }
+        }
+      ]
+    }
+  }
+}
+)END";
+    nlohmann::json jsonUpper = nlohmann::json::parse( upper );
+    nlohmann::json jsonLower = nlohmann::json::parse( lower );
+    REQUIRE( jsonUpper.dump() != jsonLower.dump() );
+    json::lowerCase( jsonUpper );
+    REQUIRE( jsonUpper.dump() == jsonLower.dump() );
+}
+
+TEST_CASE( "json_merging", "auxiliary" )
+{
+    std::string defaultVal = R"END(
+{
+  "mergeRecursively": {
+    "changed": 43,
+    "unchanged": true,
+    "delete_me": "adsf"
+  },
+  "dontmergearrays": [
+    1,
+    2,
+    3,
+    4,
+    5
+  ],
+  "delete_me": [345,2345,36]
+}
+)END";
+
+    std::string overwrite = R"END(
+{
+  "mergeRecursively": {
+    "changed": "new value",
+    "newValue": "44",
+    "delete_me": null
+  },
+  "dontmergearrays": [
+    5,
+    6,
+    7
+  ],
+  "delete_me": null
+}
+)END";
+
+    std::string expect = R"END(
+{
+  "mergeRecursively": {
+    "changed": "new value",
+    "unchanged": true,
+    "newValue": "44"
+  },
+  "dontmergearrays": [
+    5,
+    6,
+    7
+  ]
+})END";
+    REQUIRE(
+        json::merge( defaultVal, overwrite ) ==
+        json::parseOptions( expect, false ).dump() );
+}
+
+TEST_CASE( "optional", "[auxiliary]" ) {
+    using namespace auxiliary;
+
+    Option<int> opt;
+
+    REQUIRE_THROWS_AS(opt.get(), variantSrc::bad_variant_access);
+    REQUIRE_THROWS_AS(opt.get() = 42, variantSrc::bad_variant_access);
+    REQUIRE(!opt);
+    REQUIRE(!opt.has_value());
+
+    opt = 43;
+    REQUIRE(opt);
+    REQUIRE(opt.has_value());
+    REQUIRE(opt.get() == 43);
+
+    Option<int> opt2{ opt };
+    REQUIRE(opt2);
+    REQUIRE(opt2.has_value());
+    REQUIRE(opt2.get() == 43);
+
+    Option<int> opt3 = makeOption( 3 );
+    REQUIRE(opt3);
+    REQUIRE(opt3.has_value());
+    REQUIRE(opt3.get() == 3);
+}

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -804,11 +804,15 @@ hipace_like_write( std::string file_ending )
     bool const isHDF5 = file_ending == "h5";
     std::string options = "{}";
     if( isHDF5 )
+        /*
+         * some keys and values capitalized randomly to check whether
+         * capitalization-insensitivity is working.
+         */
         options = R"(
         {
-          "hdf5": {
+          "HDF5": {
             "dataset": {
-              "chunks": "none"
+              "chunks": "NONE"
             }
           }
         })";

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3316,6 +3316,10 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
     }
     std::string writeConfigBP3 = R"END(
 {
+  "unused": "global parameter",
+  "hdf5": {
+    "unused": "hdf5 parameter please dont warn"
+  },
   "adios2": {
     "engine": {
       "type": "bp3",
@@ -3678,8 +3682,13 @@ variableBasedSingleIteration( std::string const & file )
 {
     constexpr Extent::value_type extent = 1000;
     {
-        Series writeSeries( file, Access::CREATE );
-        writeSeries.setIterationEncoding( IterationEncoding::variableBased );
+        Series writeSeries(
+            file,
+            Access::CREATE,
+            "{\"iteration_encoding\": \"variable_based\"}" );
+        REQUIRE(
+            writeSeries.iterationEncoding() ==
+            IterationEncoding::variableBased );
         auto iterations = writeSeries.writeIterations();
         auto iteration = writeSeries.iterations[ 0 ];
         auto E_x = iteration.meshes[ "E" ][ "x" ];

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3547,7 +3547,7 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
 {
     std::string useSteps = R"(
     {
-        "adios2": {
+        "ADIOS2": {
             "engine": {
                 "type": "bp4",
                 "usesteps": true
@@ -3559,7 +3559,7 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
     {
         "adios2": {
             "type": "nullcore",
-            "engine": {
+            "ENGINE": {
                 "type": "bp4",
                 "usesteps": true
             }
@@ -3571,7 +3571,7 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
         "adios2": {
             "engine": {
                 "type": "bp4",
-                "usesteps": false
+                "UseSteps": false
             }
         }
     }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3321,7 +3321,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
       "type": "bp3",
       "unused": "parameter",
       "parameters": {
-        "BufferGrowthFactor": "2.0",
+        "BufferGrowthFactor": 2,
         "Profile": "On"
       }
     },
@@ -3347,7 +3347,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
       "type": "bp4",
       "unused": "parameter",
       "parameters": {
-        "BufferGrowthFactor": "2.0",
+        "BufferGrowthFactor": 2.0,
         "Profile": "On"
       }
     },
@@ -3357,7 +3357,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
         {
           "type": "blosc",
           "parameters": {
-              "clevel": "1",
+              "clevel": 1,
               "doshuffle": "BLOSC_BITSHUFFLE"
           }
         }
@@ -3394,6 +3394,8 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
 )END";
     std::string datasetConfig = R"END(
 {
+  "resizable": true,
+  "asdf": "asdf",
   "adios2": {
     "unused": "dataset parameter",
     "dataset": {
@@ -3402,12 +3404,15 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
         {
           "type": "blosc",
           "parameters": {
-              "clevel": "3",
-              "doshuffle": "BLOSC_BITSHUFFLE"
+            "clevel": 3,
+            "doshuffle": "BLOSC_BITSHUFFLE"
           }
         }
       ]
     }
+  },
+  "hdf5": {
+    "this": "should not warn"
   }
 }
 )END";
@@ -4361,7 +4366,10 @@ extendDataset( std::string const & ext )
         // only one iteration written anyway
         write.setIterationEncoding( IterationEncoding::variableBased );
 
-        Dataset ds1{ Datatype::INT, { 5, 5 }, "{ \"resizable\": true }" };
+        Dataset ds1{
+            Datatype::INT,
+            { 5, 5 },
+            "{ \"resizable\": true, \"resizeble\": \"typo\" }" };
         Dataset ds2{ Datatype::INT, { 10, 5 } };
 
         // array record component -> array record component

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3685,7 +3685,7 @@ variableBasedSingleIteration( std::string const & file )
         Series writeSeries(
             file,
             Access::CREATE,
-            "{\"iteration_encoding\": \"variable_based\"}" );
+            R"({"iteration_encoding": "variable_based"})" );
         REQUIRE(
             writeSeries.iterationEncoding() ==
             IterationEncoding::variableBased );
@@ -4378,7 +4378,7 @@ extendDataset( std::string const & ext )
         Dataset ds1{
             Datatype::INT,
             { 5, 5 },
-            "{ \"resizable\": true, \"resizeble\": \"typo\" }" };
+            R"({ "resizable": true, "resizeble": "typo" })" };
         Dataset ds2{ Datatype::INT, { 10, 5 } };
 
         // array record component -> array record component

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3360,7 +3360,7 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
 {
   "unused": "global parameter",
   "hdf5": {
-    "unused": "hdf5 parameter please dont warn"
+    "unused": "hdf5 parameter please do not warn"
   },
   "adios2": {
     "engine": {
@@ -3438,6 +3438,21 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
   }
 }
 )END";
+    /*
+     * Notes on the upcoming dataset JSON configuration:
+     * * The resizable key is needed by some backends (HDF5) so the backend can
+     *   create a dataset that can later be resized.
+     * * The asdf key should lead to a warning about unused parameters.
+     * * Inside the hdf5 configuration, there are unused keys ("this").
+     *   However, since this configuration is used by the ADIOS2 backend, there
+     *   will be no warning for it.
+     *
+     * In the end, this config should lead to a warning similar to:
+     * > Warning: parts of the JSON configuration for ADIOS2 dataset
+     * > '/data/0/meshes/E/y' remain unused:
+     * > {"adios2":{"dataset":{"unused":"too"},"unused":"dataset parameter"},
+     * >  "asdf":"asdf"}
+     */
     std::string datasetConfig = R"END(
 {
   "resizable": true,
@@ -4177,12 +4192,12 @@ void variableBasedSeries( std::string const & file )
     testRead( "{\"defer_iteration_parsing\": false}" );
 }
 
+#if openPMD_HAVE_ADIOS2
 TEST_CASE( "variableBasedSeries", "[serial][adios2]" )
 {
-#if openPMD_HAVE_ADIOS2
     variableBasedSeries( "../samples/variableBasedSeries.bp" );
-#endif
 }
+#endif
 
 void variableBasedParticleData()
 {


### PR DESCRIPTION
Fix #1037, see there for a description.
This will probably not address all of the points noted therein, currently we have:
- [x] capitalization. I favor capitalization-insensitivity, keeping consistent with how ADIOS2 does it.
- [x] More lenient datatypes in ADIOS2: To users, it seems weird that they should specify `adios2.engine.usesteps = true` (as a boolean) but `adios2.engine.parameters.OpenTimeoutSecs = "30"` (as a string).
- [x] Use `TracingJSON` everywhere: partially implemented, warnings not yet shown for global options
- [x] Merge #1101 first
- [x] This PR removes some keys from `Dataset`: `chunks`, `compression` and `transform`. So far, only `transform` was even implemented (I've replaced that implementation with a JSON-based one now), and only in ADIOS1 which is legacy anyway. For keeping compatibility with user code, we should maybe keep the fields for now, but deprecate them and remove all implementation surrounding them. Discussed: remove them fully in the API if we change the API contract (implementation) to break only once.
- [x] Warn for global options: https://github.com/openPMD/openPMD-api/issues/1095
- [x] Warning if file ending collides with JSON option
- [x] ~~Are [these options](https://adios2.readthedocs.io/en/latest/engines/engines.html) in ADIOS2 capitalization insensitive? If not, I'll need to add some handling for that.~~ Eh, let's not rely on this in ADIOS2. I've added exceptions for the lower case transformation now.