### PR TITLE
ADIOS2: Don't implicitly open files

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -384,7 +384,14 @@ private:
      */
     ADIOS2FilePosition::GD groupOrDataset( Writable * );
 
-    detail::BufferedActions & getFileData( InvalidatableFile file );
+    enum class IfFileNotOpen : bool
+    {
+        OpenImplicitly,
+        ThrowError
+    };
+
+    detail::BufferedActions &
+    getFileData( InvalidatableFile file, IfFileNotOpen );
 
     void dropFileData( InvalidatableFile file );
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -292,7 +292,8 @@ void ADIOS2IOHandlerImpl::createFile(
         m_iterationEncoding = parameters.encoding;
         associateWithFile( writable, shared_name );
         this->m_dirty.emplace( shared_name );
-        getFileData( shared_name ).m_mode = adios2::Mode::Write; // WORKAROUND
+        getFileData( shared_name, IfFileNotOpen::OpenImplicitly ).m_mode =
+            adios2::Mode::Write; // WORKAROUND
         // ADIOS2 does not yet implement ReadWrite Mode
 
         writable->written = true;
@@ -384,7 +385,7 @@ void ADIOS2IOHandlerImpl::createDataset(
         // cast from openPMD::Extent to adios2::Dims
         adios2::Dims const shape( parameters.extent.begin(), parameters.extent.end() );
 
-        auto & fileData = getFileData( file );
+        auto & fileData = getFileData( file, IfFileNotOpen::ThrowError );
         switchAdios2VariableType(
             parameters.dtype,
             detail::VariableDefiner(),
@@ -440,7 +441,7 @@ ADIOS2IOHandlerImpl::extendDataset(
     setAndGetFilePosition( writable );
     auto file = refreshFileFromParent( writable );
     std::string name = nameOfVariable( writable );
-    auto & filedata = getFileData( file );
+    auto & filedata = getFileData( file, IfFileNotOpen::ThrowError );
     static detail::DatasetExtender de;
     Datatype dt = detail::fromADIOS2Type( filedata.m_IO.VariableType( name ) );
     switchAdios2VariableType( dt, de, filedata.m_IO, name, parameters.extent );
@@ -474,7 +475,7 @@ ADIOS2IOHandlerImpl::openFile(
     m_iterationEncoding = parameters.encoding;
     // enforce opening the file
     // lazy opening is deathly in parallel situations
-    getFileData( file );
+    getFileData( file, IfFileNotOpen::OpenImplicitly );
 }
 
 void
@@ -535,8 +536,9 @@ void ADIOS2IOHandlerImpl::openDataset(
     pos->gd = ADIOS2FilePosition::GD::DATASET;
     auto file = refreshFileFromParent( writable );
     auto varName = nameOfVariable( writable );
-    *parameters.dtype = detail::fromADIOS2Type(
-        getFileData( file ).m_IO.VariableType( varName ) );
+    *parameters.dtype =
+        detail::fromADIOS2Type( getFileData( file, IfFileNotOpen::ThrowError )
+                                    .m_IO.VariableType( varName ) );
     switchAdios2VariableType(
         *parameters.dtype,
         detail::DatasetOpener( this ),
@@ -582,7 +584,8 @@ void ADIOS2IOHandlerImpl::writeDataset(
                    "[ADIOS2] Cannot write data in read-only mode." );
     setAndGetFilePosition( writable );
     auto file = refreshFileFromParent( writable );
-    detail::BufferedActions & ba = getFileData( file );
+    detail::BufferedActions & ba =
+        getFileData( file, IfFileNotOpen::ThrowError );
     detail::BufferedPut bp;
     bp.name = nameOfVariable( writable );
     bp.param = parameters;
@@ -614,7 +617,7 @@ void ADIOS2IOHandlerImpl::writeAttribute(
             auto fullName = nameOfAttribute( writable, parameters.name );
             auto prefix = filePositionToString( pos );
 
-            auto & filedata = getFileData( file );
+            auto & filedata = getFileData( file, IfFileNotOpen::ThrowError );
             filedata.invalidateAttributesMap();
             m_dirty.emplace( std::move( file ) );
 
@@ -635,7 +638,8 @@ void ADIOS2IOHandlerImpl::readDataset(
 {
     setAndGetFilePosition( writable );
     auto file = refreshFileFromParent( writable );
-    detail::BufferedActions & ba = getFileData( file );
+    detail::BufferedActions & ba =
+        getFileData( file, IfFileNotOpen::ThrowError );
     detail::BufferedGet bg;
     bg.name = nameOfVariable( writable );
     bg.param = parameters;
@@ -706,7 +710,8 @@ ADIOS2IOHandlerImpl::getBufferView(
     }
     setAndGetFilePosition( writable );
     auto file = refreshFileFromParent( writable );
-    detail::BufferedActions &ba = getFileData( file );
+    detail::BufferedActions & ba =
+        getFileData( file, IfFileNotOpen::ThrowError );
     if( parameters.update )
     {
         detail::I_UpdateSpan &updater =
@@ -744,7 +749,8 @@ ADIOS2IOHandlerImpl::readAttribute(
 {
     auto file = refreshFileFromParent( writable );
     auto pos = setAndGetFilePosition( writable );
-    detail::BufferedActions & ba = getFileData( file );
+    detail::BufferedActions & ba =
+        getFileData( file, IfFileNotOpen::ThrowError );
     switch( attributeLayout() )
     {
         using AL = AttributeLayout;
@@ -788,7 +794,7 @@ void ADIOS2IOHandlerImpl::listPaths(
      * since ADIOS does not have a concept of paths, restore them
      * from variables and attributes.
      */
-    auto & fileData = getFileData( file );
+    auto & fileData = getFileData( file, IfFileNotOpen::ThrowError );
     fileData.requireActiveStep();
 
     std::unordered_set< std::string > subdirs;
@@ -907,7 +913,7 @@ void ADIOS2IOHandlerImpl::listDatasets(
      * from variables and attributes.
      */
 
-    auto & fileData = getFileData( file );
+    auto & fileData = getFileData( file, IfFileNotOpen::ThrowError );
     fileData.requireActiveStep();
 
     std::unordered_set< std::string > subdirs;
@@ -953,7 +959,7 @@ void ADIOS2IOHandlerImpl::listAttributes(
     {
         attributePrefix = "";
     }
-    auto & ba = getFileData( file );
+    auto & ba = getFileData( file, IfFileNotOpen::ThrowError );
     ba.requireActiveStep(); // make sure that the attributes are present
 
     std::vector< std::string > attrs;
@@ -989,7 +995,7 @@ ADIOS2IOHandlerImpl::advance(
     Parameter< Operation::ADVANCE > & parameters )
 {
     auto file = m_files[ writable ];
-    auto & ba = getFileData( file );
+    auto & ba = getFileData( file, IfFileNotOpen::ThrowError );
     *parameters.status = ba.advance( parameters.mode );
 }
 
@@ -1007,7 +1013,7 @@ ADIOS2IOHandlerImpl::closePath(
         return;
     }
     auto file = refreshFileFromParent( writable );
-    auto & fileData = getFileData( file );
+    auto & fileData = getFileData( file, IfFileNotOpen::ThrowError );
     if( !fileData.optimizeAttributesStreaming )
     {
         return;
@@ -1033,9 +1039,10 @@ ADIOS2IOHandlerImpl::availableChunks(
 {
     setAndGetFilePosition( writable );
     auto file = refreshFileFromParent( writable );
-    detail::BufferedActions & ba = getFileData( file );
+    detail::BufferedActions & ba =
+        getFileData( file, IfFileNotOpen::ThrowError );
     std::string varName = nameOfVariable( writable );
-    auto engine = ba.getEngine( ); // make sure that data are present
+    auto engine = ba.getEngine(); // make sure that data are present
     auto datatype = detail::fromADIOS2Type( ba.m_IO.VariableType( varName ) );
     static detail::RetrieveBlocksInfo rbi;
     switchAdios2VariableType(
@@ -1170,19 +1177,30 @@ ADIOS2IOHandlerImpl::groupOrDataset( Writable * writable )
 }
 
 detail::BufferedActions &
-ADIOS2IOHandlerImpl::getFileData( InvalidatableFile file )
+ADIOS2IOHandlerImpl::getFileData( InvalidatableFile file, IfFileNotOpen flag )
 {
-    VERIFY_ALWAYS( file.valid( ),
-                   "[ADIOS2] Cannot retrieve file data for a file that has "
-                   "been overwritten or deleted." )
+    VERIFY_ALWAYS(
+        file.valid(),
+        "[ADIOS2] Cannot retrieve file data for a file that has "
+        "been overwritten or deleted." )
     auto it = m_fileData.find( file );
-    if ( it == m_fileData.end( ) )
+    if( it == m_fileData.end() )
     {
-        return *m_fileData
-                    .emplace( std::move( file ),
-                              std::make_unique< detail::BufferedActions >(
-                                  *this, file) )
-                    .first->second;
+        switch( flag )
+        {
+        case IfFileNotOpen::OpenImplicitly: {
+
+            auto res = m_fileData.emplace(
+                std::move( file ),
+                std::make_unique< detail::BufferedActions >( *this, file ) );
+            return *res.first->second;
+        }
+        case IfFileNotOpen::ThrowError:
+            throw std::runtime_error(
+                "[ADIOS2] Requested file has not been opened yet: " +
+                ( file.fileState ? file.fileState->name
+                                 : "Unknown file name" ) );
+        }
     }
     else
     {
@@ -1395,7 +1413,8 @@ namespace detail
         auto fullName = impl->nameOfAttribute( writable, parameters.name );
         auto prefix = impl->filePositionToString( pos );
 
-        auto & filedata = impl->getFileData( file );
+        auto & filedata = impl->getFileData(
+            file, ADIOS2IOHandlerImpl::IfFileNotOpen::ThrowError );
         filedata.invalidateAttributesMap();
         adios2::IO IO = filedata.m_IO;
         impl->m_dirty.emplace( std::move( file ) );
@@ -1476,11 +1495,12 @@ namespace detail
     operator( )( InvalidatableFile file, const std::string & varName,
                  Parameter< Operation::OPEN_DATASET > & parameters )
     {
-        auto & fileData = m_impl->getFileData( file );
+        auto & fileData = m_impl->getFileData(
+            file, ADIOS2IOHandlerImpl::IfFileNotOpen::ThrowError );
         fileData.requireActiveStep();
         auto & IO = fileData.m_IO;
         adios2::Variable< T > var = IO.InquireVariable< T >( varName );
-        if ( !var )
+        if( !var )
         {
             throw std::runtime_error(
                 "[ADIOS2] Failed retrieving ADIOS2 Variable with name '" + varName +

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1887,6 +1887,39 @@ void optional_paths_110_test(const std::string & backend)
     }
 }
 
+void git_early_chunk_query(
+    std::string const filename,
+    std::string const species,
+    int const step
+)
+{
+    try
+    {
+        Series s = Series(
+            filename,
+            Access::READ_ONLY
+        );
+
+        auto electrons = s.iterations[step].particles[species];
+
+        for( auto & r : electrons )
+        {
+            std::cout << r.first << ": ";
+            for( auto & r_c : r.second )
+            {
+                std::cout << r_c.first << "\n";
+                auto chunks = r_c.second.availableChunks();
+                std::cout << "no. of chunks: " << chunks.size() << std::endl;
+            }
+        }
+
+    } catch (no_such_file_error& e)
+    {
+        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+        return;
+    }
+}
+
 #if openPMD_HAVE_HDF5
 TEST_CASE( "empty_alternate_fbpic", "[serial][hdf5]" )
 {
@@ -2407,31 +2440,7 @@ TEST_CASE( "git_hdf5_sample_fileBased_read_test", "[serial][hdf5]" )
 
 TEST_CASE( "git_hdf5_early_chunk_query", "[serial][hdf5]" )
 {
-    try
-    {
-        Series s = Series(
-            "../samples/git-sample/data%T.h5",
-            Access::READ_ONLY
-        );
-
-        auto electrons = s.iterations[400].particles["electrons"];
-
-        for( auto & r : electrons )
-        {
-            std::cout << r.first << ": ";
-            for( auto & r_c : r.second )
-            {
-                std::cout << r_c.first << "\n";
-                if( !r_c.second.constant() )
-                    auto chunks = r_c.second.availableChunks();
-            }
-        }
-
-    } catch (no_such_file_error& e)
-    {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
-    }
+    git_early_chunk_query("../samples/git-sample/data%T.h5", "electrons", 400);
 }
 
 TEST_CASE( "git_hdf5_sample_read_thetaMode", "[serial][hdf5][thetaMode]" )
@@ -3126,6 +3135,11 @@ TEST_CASE( "no_serial_adios1", "[serial][adios]")
 #endif
 
 #if openPMD_HAVE_ADIOS2
+TEST_CASE( "git_adios2_early_chunk_query", "[serial][adios2]" )
+{
+    git_early_chunk_query("../samples/git-sample/3d-bp4/example-3d-bp4_%T.bp", "e", 600);
+}
+
 TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
 {
     if( auxiliary::getEnvString( "OPENPMD_BP_BACKEND", "NOT_SET" ) == "ADIOS1" )


### PR DESCRIPTION
Bug found [here](https://github.com/openPMD/openPMD-api/pull/1035#issuecomment-878199483). The ADIOS2 backend will implicitly open a file if it has not been opened yet. Files should only be opened if the frontend explicitly requested it, otherwise that's an error.

(Why should we be so strict? Implicit opening can make unsuspected calls accidentally collective. Better to have a clear error stating that something went wrong rather than a hanging parallel program.)

- [x] depends on improved frontend open logic in #1035 to be finalized/merged first
- [x] needs test for bp as in #1035