### PR TITLE
Use specific commit for downloaded samples

### DIFF
--- a/share/openPMD/download_samples.ps1
+++ b/share/openPMD/download_samples.ps1
@@ -1,8 +1,8 @@
 New-item -ItemType directory -Name samples\git-sample\thetaMode\
 New-item -ItemType directory -Name samples\git-sample\3d-bp4\
-Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz -OutFile example-3d.tar.gz
-Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-thetaMode.tar.gz -OutFile example-thetaMode.tar.gz
-Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d-bp4.tar.gz -OutFile example-3d-bp4.tar.gz
+Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d.tar.gz -OutFile example-3d.tar.gz
+Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-thetaMode.tar.gz -OutFile example-thetaMode.tar.gz
+Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d-bp4.tar.gz -OutFile example-3d-bp4.tar.gz
 7z.exe x -r example-3d.tar.gz
 7z.exe x -r example-3d.tar
 7z.exe x -r example-thetaMode.tar.gz

--- a/share/openPMD/download_samples.sh
+++ b/share/openPMD/download_samples.sh
@@ -3,9 +3,9 @@
 
 mkdir -p samples/git-sample/thetaMode
 mkdir -p samples/git-sample/3d-bp4
-curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d.tar.gz
-curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-thetaMode.tar.gz
-curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/draft/example-3d-bp4.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-thetaMode.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/72545c4d6bcca2c258bffd2eabe38679b2507c80/example-3d-bp4.tar.gz
 tar -xzf example-3d.tar.gz
 tar -xzf example-thetaMode.tar.gz
 tar -xzf example-3d-bp4.tar.gz


### PR DESCRIPTION
Instead of just downloading the latest commit from the `draft` branch, pick a specific commit. Currently all tests are failing everywhere since they haven't been adapted to https://github.com/openPMD/openPMD-example-datasets/pull/15 yet.