### PR TITLE
Fix: PkgConfig w/ External Variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,7 @@ target_include_directories(openPMD PUBLIC
 # C++11 std::variant (C++17 stdlib preview)
 # TODO not needed with C++17 compiler
 add_library(openPMD::thirdparty::mpark_variant INTERFACE IMPORTED)
+set(openPMD_PC_EXTRA_INCLUDE "")
 if(openPMD_USE_INTERNAL_VARIANT)
     target_include_directories(openPMD::thirdparty::mpark_variant SYSTEM INTERFACE
         $<BUILD_INTERFACE:${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/variant/include>
@@ -465,6 +466,10 @@ else()
     find_package(mpark_variant 1.3.0 REQUIRED) # TODO: we want 1.4.1+
     target_link_libraries(openPMD::thirdparty::mpark_variant
         INTERFACE mpark_variant)
+    get_target_property(EXTERNAL_MPARK_INCLUDE mpark_variant INTERFACE_INCLUDE_DIRECTORIES)
+    if(openPMD_HAVE_PKGCONFIG AND EXTERNAL_MPARK_INCLUDE)
+        set(openPMD_PC_EXTRA_INCLUDE "-I${EXTERNAL_MPARK_INCLUDE}")
+    endif()
     message(STATUS "MPark.Variant: Found version '${mpark_variant_VERSION}'")
 endif()
 target_link_libraries(openPMD PUBLIC openPMD::thirdparty::mpark_variant)

--- a/openPMD.pc.in
+++ b/openPMD.pc.in
@@ -11,4 +11,4 @@ URL: https://openpmd-api.readthedocs.io
 
 Libs: -L${libdir} -lopenPMD @openPMD_PC_PUBLIC_LIBS@
 Libs.private: -L${libdir} @openPMD_PC_PRIVATE_LIBS@
-Cflags: -I${includedir} @openPMD_PC_PUBLIC_DEFINES@
+Cflags: -I${includedir} @openPMD_PC_EXTRA_INCLUDE@ @openPMD_PC_PUBLIC_DEFINES@


### PR DESCRIPTION
In case users use the pkg-config scripts and depend on an external variant install (e.g. Spack), we will not install the MPark-Variant headers into our own install tree.

When picked up in a Spack software environment via our `.pc` scripts, we thus need to hint again the external include dependency to the external MPark-Variant install location.