### PR TITLE
SerialIOTest: OPENPMD_TEST_NFILES_MAX

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -43,7 +43,7 @@ jobs:
         python3 -m pip install -U numpy
         sudo .github/workflows/dependencies/install_spack
     - name: Build
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror -Wno-deprecated-declarations, OPENPMD_HDF5_CHUNKS: none}
+      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror -Wno-deprecated-declarations, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
       run: |
         eval $(spack env activate --sh .github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad1_ad2/)
         spack install

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -173,7 +173,10 @@ TEST_CASE( "adios2_char_portability", "[serial][adios2]" )
 
 void
 write_and_read_many_iterations( std::string const & ext ) {
-    constexpr unsigned int nIterations = 200; // original: 1000
+    // the idea here is to trigger the maximum allowed number of file handles,
+    // e.g., the upper limit in "ulimit -n" (default: often 1024). Once this
+    // is reached, files should be closed automatically for open iterations
+    unsigned int nIterations = auxiliary::getEnvNum( "OPENPMD_TEST_NFILES_MAX", 1030 );
     std::string filename = "../samples/many_iterations/many_iterations_%T." + ext;
 
     std::vector<float> data(10);


### PR DESCRIPTION
Limit the number of open files for individual tests.
Caused hangs with the sanitizer runs.

Follow-up to #1054