### PR TITLE
CoreTest: Lambda outside uneval context

### DIFF
--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -22,7 +22,8 @@ using namespace openPMD;
 TEST_CASE( "versions_test", "[core]" )
 {
     auto const apiVersion = getVersion( );
-    REQUIRE(2u == std::count_if(apiVersion.begin(), apiVersion.end(), []( char const c ){ return c == '.';}));
+    auto const is_dot = []( char const c ){ return c == '.'; };
+    REQUIRE(2u == std::count_if(apiVersion.begin(), apiVersion.end(), is_dot));
 
     auto const standard = getStandard( );
     REQUIRE(standard == "1.1.0");


### PR DESCRIPTION
Fix:
```
openPMD-api/test/CoreTest.cpp", line 25:
  error: a lambda is not allowed in an unevaluated expression
  REQUIRE(2u == std::count_if(apiVersion.begin(), apiVersion.end(),
                              []( char const c ){ return c == '.';}));
```
seen with NVHPC 21.05