### PR TITLE
Add Dataset(Extent) constructor to Python bindings

### DIFF
--- a/examples/3b_write_resizable_particles.cpp
+++ b/examples/3b_write_resizable_particles.cpp
@@ -71,7 +71,7 @@ int main()
     x = { 5.,  6.,  7. };
     y = {-7., -8., -9. };
     offset.at(0) += dataset.extent.at(0);
-    dataset.extent.at(0) += x.size();
+    dataset = Dataset( { dataset.extent.at(0) + x.size() } );
 
     rc_x.resetDataset( dataset );
     rc_y.resetDataset( dataset );

--- a/examples/3b_write_resizable_particles.py
+++ b/examples/3b_write_resizable_particles.py
@@ -43,11 +43,14 @@ if __name__ == "__main__":
     rc_xo.make_constant(0.0)
     rc_yo.make_constant(0.0)
 
+    # after this call, the provided data buffers can be used again or deleted
+    series.flush()
+
     # extend and append more particles
     x = np.array([5., 6., 7.], dtype=np.double)
     y = np.array([-7., -8., -9.], dtype=np.double)
     offset += dataset.extent[0]
-    dataset.extend([dataset.extent[0] + x.shape[0]])
+    dataset = io.Dataset([dataset.extent[0] + x.shape[0]])
 
     rc_x.reset_dataset(dataset)
     rc_y.reset_dataset(dataset)

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -36,6 +36,7 @@ void init_Dataset(py::module &m) {
         .def(py::init<Datatype, Extent>(),
             py::arg("dtype"), py::arg("extent")
         )
+        .def(py::init<Extent>(), py::arg("extent"))
         .def(py::init( [](py::dtype dt, Extent e) {
             auto const d = dtype_from_numpy( dt );
             return new Dataset{d, e};


### PR DESCRIPTION
There's no Python-based test for resizing since resizing did not add any new API, but was instead a backend-only (~middleend rather) thing. If we want to test this, I suggest rebasing it onto https://github.com/openPMD/openPMD-api/pull/1060?
Otherwise, this just adds a small missing constructor to the Python bindings.