### PR TITLE
Document iteration encodings

### DIFF
--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -139,4 +139,4 @@ The class hierarchy of ``Attributable`` follows a similar design, with some diff
   The ``Attributable`` mixin can be added to those classes by deriving from ``LegacyAttributable``.
 * The ``Attributable`` mixin is added to ``Series`` by deriving ``SeriesData`` from ``AttributableData`` and ``SeriesImpl`` from ``AttributableImpl``.
 
-``Series`` as root of every hierarchy, supporting ``groupBased`` and ``fileBased`` transparently ...
+The ``Series`` class is the entry point to the openPMD-api. An instance of this class always represents an entire series (of iterations), regardless of how this series is modeled in storage or transport (e.g. as multiple files, as a stream, as variables containing multiple snapshots of a dataset or as one file containing all iterations at once).

--- a/docs/source/usage/concepts.rst
+++ b/docs/source/usage/concepts.rst
@@ -57,6 +57,8 @@ The method ``Series::setIterationEncoding()`` (C++) or ``Series.set_iteration_en
   No iteration-specific groups are created and the corresponding layer is dropped from the openPMD hierarchy.
   In backends that do not support this feature, a series created with this encoding can only contain one iteration.
 
+Alternative spellings: groupbased, variablebased, filebased, group_based, variable_based, file_based
+
 Attributes
 ----------
 

--- a/docs/source/usage/concepts.rst
+++ b/docs/source/usage/concepts.rst
@@ -49,11 +49,11 @@ The method ``Series::setIterationEncoding()`` (C++) or ``Series.set_iteration_en
   It creates a separate group in the hierarchy of the openPMD standard for each iteration.
   As an example, all data pertaining to iteration 0 may be found in group ``/data/0``, for iteration 100 in ``/data/100``.
 * **file-based iteration encoding:** A unique file on the filesystem is created for each iteration.
-  The preferred way to create a file-based iteration encoding is by specifying an expansion pattern in the constructor of the ``Series`` class.
-  Creating a ``Series`` by the filename ``series%T.json`` will create files ``series0.json``, ``series100.json`` and ``series200.json`` for iterations 0, 100 and 200.
-  A padding may be specified by ``series%06T.json`` to create files ``series000000.json``, ``series000100.json`` and ``series000200.json``.
+  The preferred way to create a file-based iteration encoding is by specifying an expansion pattern in the ``filepath`` argument of the constructor of the ``Series`` class.
+  Creating a ``Series`` by the filepath ``"series_%T.json"`` will create files ``series_0.json``, ``series_100.json`` and ``series_200.json`` for iterations 0, 100 and 200.
+  A padding may be specified by ``"series_%06T.json"`` to create files ``series_000000.json``, ``series_000100.json`` and ``series_000200.json``.
   The inner group layout of each file is identical to that of the group-based encoding.
-* **variable-based iteration encoding:** This encoding uses a feature of some backends (i.e. ADIOS2) to maintain datasets and attributes in several versions (i.e. to be *variable*).
+* **variable-based iteration encoding:** This experimental encoding uses a feature of some backends (i.e., ADIOS2) to maintain datasets and attributes in several versions (i.e., iterations are stored inside *variables*).
   No iteration-specific groups are created and the corresponding layer is dropped from the openPMD hierarchy.
   In backends that do not support this feature, a series created with this encoding can only contain one iteration.
 

--- a/docs/source/usage/concepts.rst
+++ b/docs/source/usage/concepts.rst
@@ -57,7 +57,7 @@ The method ``Series::setIterationEncoding()`` (C++) or ``Series.set_iteration_en
   No iteration-specific groups are created and the corresponding layer is dropped from the openPMD hierarchy.
   In backends that do not support this feature, a series created with this encoding can only contain one iteration.
 
-Alternative spellings: groupbased, variablebased, filebased, group_based, variable_based, file_based
+Spellings for constants in the C++ (``IterationEncoding``) and Python (``Iteration_Encoding``) API: ``groupBased``, ``variableBased``, ``fileBased``, ``group_based``, ``group_based``, ``variable_based``
 
 Attributes
 ----------

--- a/docs/source/usage/concepts.rst
+++ b/docs/source/usage/concepts.rst
@@ -42,6 +42,21 @@ Iterations are numbered by integers, do not need to be consecutive and can for e
 The collection of iterations is called a *Series*.
 openPMD-api implements various file-formats (backends) and encoding strategies for openPMD Series, from simple one-file-per-iteration writes over using the backend-provided support for internal updates of records to data streaming techniques.
 
+**Iteration encoding:** The openPMD-api can encode iterations in different ways.
+The method ``Series::setIterationEncoding()`` (C++) or ``Series.set_iteration_encoding()`` (Python) may be used in writing for selecting one of the following encodings explicitly:
+
+* **group-based iteration encoding:** This encoding is the default.
+  It creates a separate group in the hierarchy of the openPMD standard for each iteration.
+  As an example, all data pertaining to iteration 0 may be found in group ``/data/0``, for iteration 100 in ``/data/100``.
+* **file-based iteration encoding:** A unique file on the filesystem is created for each iteration.
+  The preferred way to create a file-based iteration encoding is by specifying an expansion pattern in the constructor of the ``Series`` class.
+  Creating a ``Series`` by the filename ``series%T.json`` will create files ``series0.json``, ``series100.json`` and ``series200.json`` for iterations 0, 100 and 200.
+  A padding may be specified by ``series%06T.json`` to create files ``series000000.json``, ``series000100.json`` and ``series000200.json``.
+  The inner group layout of each file is identical to that of the group-based encoding.
+* **variable-based iteration encoding:** This encoding uses a feature of some backends (i.e. ADIOS2) to maintain datasets and attributes in several versions (i.e. to be *variable*).
+  No iteration-specific groups are created and the corresponding layer is dropped from the openPMD hierarchy.
+  In backends that do not support this feature, a series created with this encoding can only contain one iteration.
+
 Attributes
 ----------
 

--- a/src/binding/python/IterationEncoding.cpp
+++ b/src/binding/python/IterationEncoding.cpp
@@ -31,6 +31,6 @@ void init_IterationEncoding(py::module &m) {
     py::enum_<IterationEncoding>(m, "Iteration_Encoding")
         .value("file_based", IterationEncoding::fileBased)
         .value("group_based", IterationEncoding::groupBased)
-        .value("step_based", IterationEncoding::variableBased)
+        .value("variable_based", IterationEncoding::variableBased)
     ;
 }


### PR DESCRIPTION
Iteration encodings were generally undocumented so far?
Since our upcoming release includes a new encoding, I'm taking the chance to write some few sentences on each.