### PR TITLE
Rename SeriesImpl → SeriesInterface, AttributableImpl → AttributableInterface

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -42,7 +42,7 @@ Especially when a Series has many iterations, this can be a costly operation and
 
 When parsing non-eagerly, each iteration needs to be explicitly opened with ``Iteration::open()`` before accessing.
 (Notice that ``Iteration::open()`` is generally recommended to be used in parallel contexts to avoid parallel file accessing hazards).
-Using the Streaming API (i.e. ``SeriesImpl::readIteration()``) will do this automatically.
+Using the Streaming API (i.e. ``SeriesInterface::readIteration()``) will do this automatically.
 Parsing eagerly might be very expensive for a Series with many iterations, but will avoid bugs by forgotten calls to ``Iteration::open()``.
 In complex environments, calling ``Iteration::open()`` on an already open environment does no harm (and does not incur additional runtime cost for additional ``open()`` calls).
 

--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -116,15 +116,15 @@ This serves to separate data from implementation, demonstrated by the class hier
 * ``SeriesData`` contains all actual data members of ``Series``, representing the resources shared between instances.
   Its copy/move constructors/assignment operators are deleted, thus pinning it at one memory location.
   It has no implementation.
-* ``SeriesImpl`` defines the interface of ``Series``.
+* ``SeriesInterface`` defines the interface of ``Series``.
   Its only data member is a pointer to its associated instance of ``SeriesData``.
   Its purpose is to serve as a parent class for any class that implements the ``Series`` interface.
-  The implementing class should deal with resource management for the instance of ``SeriesData``, ``SeriesImpl`` itself performs no resource management for the data and will assume that the pointer points at a valid instance.
+  The implementing class should deal with resource management for the instance of ``SeriesData``, ``SeriesInterface`` itself performs no resource management for the data and will assume that the pointer points at a valid instance.
   (This PIMPL-based design allows us to avoid a similar template-heavy design based on CRTP.)
-* ``SeriesInternal`` is the class created by inheriting directly from ``SeriesData`` and ``SeriesImpl``.
+* ``SeriesInternal`` is the class created by inheriting directly from ``SeriesData`` and ``SeriesInterface``.
   It is intended for internal usage, pinned at a memory location just like ``SeriesData``, but carrying an implementation.
   Its constructor and destructor define the setup and tear-down of shared resources for ``Series``.
-* ``Series`` is a wrapper around a shared pointer to ``SeriesInternal`` and also derives from ``SeriesImpl``.
+* ``Series`` is a wrapper around a shared pointer to ``SeriesInternal`` and also derives from ``SeriesInterface``.
   It implements handle semantics, serving as interface to users.
 
 Other classes within our object model of the openPMD hierarchy are planned to follow in this design.
@@ -137,6 +137,6 @@ The class hierarchy of ``Attributable`` follows a similar design, with some diff
   As a common base class exposed to user code, ``AttributableImpl`` is aliased as ``Attributable``.
 * For classes not yet following the PIMPL-based design, ``LegacyAttributable`` wraps around a shared pointer to ``AttributableData`` and derives from ``AttributableImpl``.
   The ``Attributable`` mixin can be added to those classes by deriving from ``LegacyAttributable``.
-* The ``Attributable`` mixin is added to ``Series`` by deriving ``SeriesData`` from ``AttributableData`` and ``SeriesImpl`` from ``AttributableImpl``.
+* The ``Attributable`` mixin is added to ``Series`` by deriving ``SeriesData`` from ``AttributableData`` and ``SeriesInterface`` from ``AttributableImpl``.
 
 ``Series`` as root of every hierarchy, supporting ``groupBased`` and ``fileBased`` transparently ...

--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -132,11 +132,11 @@ Other classes within our object model of the openPMD hierarchy are planned to fo
 The class hierarchy of ``Attributable`` follows a similar design, with some differences due to its nature as a mixin class that is not instantiated directly:
 
 * ``AttributableData`` serves the same purpose as ``SeriesData``.
-* ``AttributableImpl`` serves the same purpose as ``SeriesData``.
-* Equivalents to ``SeriesInternal`` and ``Series`` do not exist since a combination of ``AttributableData`` and ``AttributableImpl`` is added as a mixin to other classes.
-  As a common base class exposed to user code, ``AttributableImpl`` is aliased as ``Attributable``.
-* For classes not yet following the PIMPL-based design, ``LegacyAttributable`` wraps around a shared pointer to ``AttributableData`` and derives from ``AttributableImpl``.
+* ``AttributableInterface`` serves the same purpose as ``SeriesData``.
+* Equivalents to ``SeriesInternal`` and ``Series`` do not exist since a combination of ``AttributableData`` and ``AttributableInterface`` is added as a mixin to other classes.
+  As a common base class exposed to user code, ``AttributableInterface`` is aliased as ``Attributable``.
+* For classes not yet following the PIMPL-based design, ``LegacyAttributable`` wraps around a shared pointer to ``AttributableData`` and derives from ``AttributableInterface``.
   The ``Attributable`` mixin can be added to those classes by deriving from ``LegacyAttributable``.
-* The ``Attributable`` mixin is added to ``Series`` by deriving ``SeriesData`` from ``AttributableData`` and ``SeriesInterface`` from ``AttributableImpl``.
+* The ``Attributable`` mixin is added to ``Series`` by deriving ``SeriesData`` from ``AttributableData`` and ``SeriesInterface`` from ``AttributableInterface``.
 
 ``Series`` as root of every hierarchy, supporting ``groupBased`` and ``fileBased`` transparently ...

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -38,11 +38,11 @@
 
 namespace openPMD
 {
-class AttributableImpl;
+class AttributableInterface;
 class Writable;
 
 Writable*
-getWritable(AttributableImpl*);
+getWritable(AttributableInterface*);
 
 /** Type of IO operation between logical and persistent data.
  */
@@ -605,7 +605,7 @@ public:
     { }
 
     template< Operation op >
-    explicit IOTask(AttributableImpl* a,
+    explicit IOTask(AttributableInterface* a,
            Parameter< op > const & p)
             : writable{getWritable(a)},
               operation{op},

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -44,7 +44,7 @@ class Iteration : public LegacyAttributable
             typename T_container
     >
     friend class Container;
-    friend class SeriesImpl;
+    friend class SeriesInterface;
     friend class WriteIterations;
     friend class SeriesIterator;
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -109,9 +109,9 @@ class SeriesInternal;
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
  */
-class SeriesInterface : public AttributableImpl
+class SeriesInterface : public AttributableInterface
 {
-    friend class AttributableImpl;
+    friend class AttributableInterface;
     friend class Iteration;
     friend class Writable;
     friend class SeriesIterator;
@@ -458,7 +458,7 @@ public:
         std::string const & filepath,
         Access at,
         std::string const & options = "{}" );
-    // @todo make AttributableImpl<>::linkHierarchy non-virtual
+    // @todo make AttributableInterface<>::linkHierarchy non-virtual
     virtual ~SeriesInternal();
 };
 } // namespace internal

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -54,7 +54,7 @@ namespace openPMD
 {
 class ReadIterations;
 class Series;
-class SeriesImpl;
+class SeriesInterface;
 
 namespace internal
 {
@@ -109,7 +109,7 @@ class SeriesInternal;
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
  */
-class SeriesImpl : public AttributableImpl
+class SeriesInterface : public AttributableImpl
 {
     friend class AttributableImpl;
     friend class Iteration;
@@ -121,7 +121,7 @@ class SeriesImpl : public AttributableImpl
 
 protected:
     // Should not be called publicly, only by implementing classes
-    SeriesImpl( internal::SeriesData *, internal::AttributableData * );
+    SeriesInterface( internal::SeriesData *, internal::AttributableData * );
 
 public:
     /**
@@ -133,7 +133,7 @@ public:
      * @param   openPMD   String <CODE>MAJOR.MINOR.REVISION</CODE> of the desired version of the openPMD standard.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setOpenPMD(std::string const& openPMD);
+    SeriesInterface& setOpenPMD(std::string const& openPMD);
 
     /**
      * @return  32-bit mask of applied extensions to the <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file">openPMD standard</A>.
@@ -144,7 +144,7 @@ public:
      * @param   openPMDextension  Unsigned 32-bit integer used as a bit-mask of applied extensions.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setOpenPMDextension(uint32_t openPMDextension);
+    SeriesInterface& setOpenPMDextension(uint32_t openPMDextension);
 
     /**
      * @return  String representing the common prefix for all data sets and sub-groups of a specific iteration.
@@ -155,7 +155,7 @@ public:
      * @param   basePath    String of the common prefix for all data sets and sub-groups of a specific iteration.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setBasePath(std::string const& basePath);
+    SeriesInterface& setBasePath(std::string const& basePath);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -167,7 +167,7 @@ public:
      * @param   meshesPath  String of the path to <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#mesh-based-records">mesh records</A>, relative(!) to <CODE>basePath</CODE>.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setMeshesPath(std::string const& meshesPath);
+    SeriesInterface& setMeshesPath(std::string const& meshesPath);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -179,7 +179,7 @@ public:
      * @param   particlesPath   String of the path to groups for each <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#particle-records">particle species</A>, relative(!) to <CODE>basePath</CODE>.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setParticlesPath(std::string const& particlesPath);
+    SeriesInterface& setParticlesPath(std::string const& particlesPath);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -191,7 +191,7 @@ public:
      * @param   author  String indicating author and contact for the information in the file.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setAuthor(std::string const& author);
+    SeriesInterface& setAuthor(std::string const& author);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -204,7 +204,7 @@ public:
      * @param   newVersion String indicating the version of the software/code/simulation that created the file.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setSoftware(std::string const& newName, std::string const& newVersion = std::string("unspecified"));
+    SeriesInterface& setSoftware(std::string const& newName, std::string const& newVersion = std::string("unspecified"));
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -219,7 +219,7 @@ public:
      * @return  Reference to modified series.
      */
     [[deprecated("Set the version with the second argument of setSoftware()")]]
-    SeriesImpl& setSoftwareVersion(std::string const& softwareVersion);
+    SeriesInterface& setSoftwareVersion(std::string const& softwareVersion);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -231,7 +231,7 @@ public:
      * @param   date    String indicating the date of creation.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setDate(std::string const& date);
+    SeriesInterface& setDate(std::string const& date);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -243,7 +243,7 @@ public:
      * @param   newSoftwareDependencies String indicating dependencies of software that were used to create the file (semicolon-separated list if needed).
      * @return  Reference to modified series.
      */
-    SeriesImpl& setSoftwareDependencies(std::string const& newSoftwareDependencies);
+    SeriesInterface& setSoftwareDependencies(std::string const& newSoftwareDependencies);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -255,7 +255,7 @@ public:
      * @param   newMachine String indicating the machine or relevant hardware that created the file (semicolon-separated list if needed)..
      * @return  Reference to modified series.
      */
-    SeriesImpl& setMachine(std::string const& newMachine);
+    SeriesInterface& setMachine(std::string const& newMachine);
 
     /**
      * @return  Current encoding style for multiple iterations in this series.
@@ -269,7 +269,7 @@ public:
      * @param   iterationEncoding   Desired <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series">encoding style</A> for multiple iterations in this series.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setIterationEncoding(IterationEncoding iterationEncoding);
+    SeriesInterface& setIterationEncoding(IterationEncoding iterationEncoding);
 
     /**
      * @return  String describing a <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series">pattern</A> describing how to access single iterations in the raw file.
@@ -285,7 +285,7 @@ public:
      *                          The format depends on the selected iterationEncoding method.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setIterationFormat(std::string const& iterationFormat);
+    SeriesInterface& setIterationFormat(std::string const& iterationFormat);
 
     /**
      * @return String of a pattern for file names.
@@ -297,7 +297,7 @@ public:
      * @param   name    String of the pattern for file names. Must include iteration regex <CODE>\%T</CODE> for fileBased data.
      * @return  Reference to modified series.
      */
-    SeriesImpl& setName(std::string const& name);
+    SeriesInterface& setName(std::string const& name);
 
     /** The currently used backend
      *
@@ -434,11 +434,11 @@ OPENPMD_private:
         internal::AttributableData & file,
         iterations_iterator it,
         Iteration & iteration );
-}; // SeriesImpl
+}; // SeriesInterface
 
 namespace internal
 {
-class SeriesInternal : public SeriesData, public SeriesImpl
+class SeriesInternal : public SeriesData, public SeriesInterface
 {
     friend struct SeriesShared;
     friend class openPMD::Iteration;
@@ -473,7 +473,7 @@ public:
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
  */
-class Series : public SeriesImpl
+class Series : public SeriesInterface
 {
 private:
     std::shared_ptr< internal::SeriesInternal > m_series;
@@ -544,5 +544,5 @@ public:
 } // namespace openPMD
 
 // Make sure that this one is always included if Series.hpp is included,
-// otherwise SeriesImpl::readIterations() cannot be used
+// otherwise SeriesInterface::readIterations() cannot be used
 #include "openPMD/ReadIterations.hpp"

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -107,7 +107,7 @@ class AttributableImpl
     friend struct traits::GenerationPolicy;
     friend class Iteration;
     friend class Series;
-    friend class SeriesImpl;
+    friend class SeriesInterface;
     friend class Writable;
     friend class WriteIterations;
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -46,7 +46,7 @@ namespace traits
     struct GenerationPolicy;
 } // traits
 class AbstractFilePosition;
-class AttributableImpl;
+class AttributableInterface;
 class Iteration;
 namespace internal
 {
@@ -66,7 +66,7 @@ namespace internal
 {
 class AttributableData
 {
-    friend class openPMD::AttributableImpl;
+    friend class openPMD::AttributableInterface;
 
 public:
     AttributableData();
@@ -90,11 +90,11 @@ private:
  * Mandatory and user-defined Attributes and their data for every object in the
  * openPMD hierarchy are stored and managed through this class.
  */
-class AttributableImpl
+class AttributableInterface
 {
     // @todo remove unnecessary friend (wew that sounds bitter)
     using A_MAP = std::map< std::string, Attribute >;
-    friend Writable* getWritable(AttributableImpl*);
+    friend Writable* getWritable(AttributableInterface*);
     template< typename T_elem >
     friend class BaseRecord;
     template<
@@ -115,16 +115,16 @@ protected:
     internal::AttributableData * m_attri = nullptr;
 
     // Should not be called publicly, only by implementing classes
-    AttributableImpl( internal::AttributableData * );
+    AttributableInterface( internal::AttributableData * );
     template< typename T >
-    AttributableImpl( T * attri )
-        : AttributableImpl{
+    AttributableInterface( T * attri )
+        : AttributableInterface{
               static_cast< internal::AttributableData * >( attri ) }
     {
     }
 
 public:
-    virtual ~AttributableImpl() = default;
+    virtual ~AttributableInterface() = default;
 
     /** Populate Attribute of provided name with provided value.
      *
@@ -189,7 +189,7 @@ public:
      * @param   comment String value to be stored as a comment.
      * @return  Reference to modified Attributable.
      */
-    AttributableImpl& setComment(std::string const& comment);
+    AttributableInterface& setComment(std::string const& comment);
 
     /** Flush the corresponding Series object
      *
@@ -339,7 +339,7 @@ OPENPMD_protected:
         else
         {
             throw std::runtime_error(
-                "[AttributableImpl] "
+                "[AttributableInterface] "
                 "Cannot use default-constructed Attributable." );
         }
     }
@@ -353,7 +353,7 @@ OPENPMD_protected:
         else
         {
             throw std::runtime_error(
-                "[AttributableImpl] "
+                "[AttributableInterface] "
                 "Cannot use default-constructed Attributable." );
         }
     }
@@ -370,29 +370,29 @@ private:
      * @param w The Writable representing the parent.
      */
     virtual void linkHierarchy(Writable& w);
-}; // AttributableImpl
+}; // AttributableInterface
 
 // Alias this as Attributable since this is a public abstract parent class
 // for most of the classes in our object model of the openPMD hierarchy
-using Attributable = AttributableImpl;
+using Attributable = AttributableInterface;
 
-class LegacyAttributable : public AttributableImpl
+class LegacyAttributable : public AttributableInterface
 {
 protected:
     std::shared_ptr< internal::AttributableData > m_attributableData =
         std::make_shared< internal::AttributableData >();
 
 public:
-    LegacyAttributable() : AttributableImpl{ nullptr }
+    LegacyAttributable() : AttributableInterface{ nullptr }
     {
-        AttributableImpl::m_attri = m_attributableData.get();
+        AttributableInterface::m_attri = m_attributableData.get();
     }
 };
 
 //TODO explicitly instantiate Attributable::setAttribute for all T in Datatype
 template< typename T >
 inline bool
-AttributableImpl::setAttribute( std::string const & key, T value )
+AttributableInterface::setAttribute( std::string const & key, T value )
 {
     auto & attri = get();
     if(IOHandler() && Access::READ_ONLY == IOHandler()->m_frontendAccess )
@@ -421,13 +421,13 @@ AttributableImpl::setAttribute( std::string const & key, T value )
     }
 }
 inline bool
-AttributableImpl::setAttribute( std::string const & key, char const value[] )
+AttributableInterface::setAttribute( std::string const & key, char const value[] )
 {
     return this->setAttribute(key, std::string(value));
 }
 
 template< typename T >
-inline T AttributableImpl::readFloatingpoint( std::string const & key ) const
+inline T AttributableInterface::readFloatingpoint( std::string const & key ) const
 {
     static_assert(std::is_floating_point< T >::value, "Type of attribute must be floating point");
 
@@ -436,7 +436,7 @@ inline T AttributableImpl::readFloatingpoint( std::string const & key ) const
 
 template< typename T >
 inline std::vector< T >
-AttributableImpl::readVectorFloatingpoint( std::string const & key ) const
+AttributableInterface::readVectorFloatingpoint( std::string const & key ) const
 {
     static_assert(std::is_floating_point< T >::value, "Type of attribute must be floating point");
 

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -106,7 +106,7 @@ template<
 class Container : public LegacyAttributable
 {
     static_assert(
-        std::is_base_of< AttributableImpl, T >::value,
+        std::is_base_of< AttributableInterface, T >::value,
         "Type of container element must be derived from Writable");
 
     friend class Iteration;

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -112,7 +112,7 @@ class Container : public LegacyAttributable
     friend class Iteration;
     friend class ParticleSpecies;
     friend class internal::SeriesData;
-    friend class SeriesImpl;
+    friend class SeriesInterface;
     friend class Series;
 
 protected:

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -76,7 +76,7 @@ class Writable final
     friend class Iteration;
     friend class Mesh;
     friend class ParticleSpecies;
-    friend class SeriesImpl;
+    friend class SeriesInterface;
     friend class Record;
     friend class ADIOS1IOHandlerImpl;
     friend class ParallelADIOS1IOHandlerImpl;

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -64,7 +64,7 @@ class AttributableData;
 class Writable final
 {
     friend class internal::AttributableData;
-    friend class AttributableImpl;
+    friend class AttributableInterface;
     template< typename T_elem >
     friend class BaseRecord;
     template<

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -25,6 +25,6 @@
 namespace openPMD
 {
 Writable*
-getWritable(AttributableImpl* a)
+getWritable(AttributableInterface* a)
 { return &a->writable(); }
 } // openPMD

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -671,7 +671,7 @@ Iteration::dirtyRecursive() const
 void
 Iteration::linkHierarchy(Writable& w)
 {
-    AttributableImpl::linkHierarchy(w);
+    AttributableInterface::linkHierarchy(w);
     meshes.linkHierarchy(this->writable());
     particles.linkHierarchy(this->writable());
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -92,7 +92,7 @@ struct SeriesInterface::ParsedInput
 
 SeriesInterface::SeriesInterface(
     internal::SeriesData * series, internal::AttributableData * attri )
-    : AttributableImpl{ attri }
+    : AttributableInterface{ attri }
     , m_series{ series }
 {
 }
@@ -1482,7 +1482,7 @@ Series::Series(
           filepath, at, comm, options ) }
     , iterations{ m_series->iterations }
 {
-    AttributableImpl::m_attri =
+    AttributableInterface::m_attri =
         static_cast< internal::AttributableData * >( m_series.get() );
     SeriesInterface::m_series = m_series.get();
 }
@@ -1497,7 +1497,7 @@ Series::Series(
           filepath, at, options ) }
     , iterations{ m_series->iterations }
 {
-    AttributableImpl::m_attri =
+    AttributableInterface::m_attri =
         static_cast< internal::AttributableData * >( m_series.get() );
     SeriesInterface::m_series = m_series.get();
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -79,7 +79,7 @@ namespace
     matcher(std::string const &prefix, int padding, std::string const &postfix, Format f);
 } // namespace [anonymous]
 
-struct SeriesImpl::ParsedInput
+struct SeriesInterface::ParsedInput
 {
     std::string path;
     std::string name;
@@ -90,7 +90,7 @@ struct SeriesImpl::ParsedInput
     int filenamePadding;
 };  //ParsedInput
 
-SeriesImpl::SeriesImpl(
+SeriesInterface::SeriesInterface(
     internal::SeriesData * series, internal::AttributableData * attri )
     : AttributableImpl{ attri }
     , m_series{ series }
@@ -98,39 +98,39 @@ SeriesImpl::SeriesImpl(
 }
 
 std::string
-SeriesImpl::openPMD() const
+SeriesInterface::openPMD() const
 {
     return getAttribute("openPMD").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setOpenPMD(std::string const& o)
+SeriesInterface&
+SeriesInterface::setOpenPMD(std::string const& o)
 {
     setAttribute("openPMD", o);
     return *this;
 }
 
 uint32_t
-SeriesImpl::openPMDextension() const
+SeriesInterface::openPMDextension() const
 {
     return getAttribute("openPMDextension").get< uint32_t >();
 }
 
-SeriesImpl&
-SeriesImpl::setOpenPMDextension(uint32_t oe)
+SeriesInterface&
+SeriesInterface::setOpenPMDextension(uint32_t oe)
 {
     setAttribute("openPMDextension", oe);
     return *this;
 }
 
 std::string
-SeriesImpl::basePath() const
+SeriesInterface::basePath() const
 {
     return getAttribute("basePath").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setBasePath(std::string const& bp)
+SeriesInterface&
+SeriesInterface::setBasePath(std::string const& bp)
 {
     std::string version = openPMD();
     if( version == "1.0.0" || version == "1.0.1" || version == "1.1.0" )
@@ -141,13 +141,13 @@ SeriesImpl::setBasePath(std::string const& bp)
 }
 
 std::string
-SeriesImpl::meshesPath() const
+SeriesInterface::meshesPath() const
 {
     return getAttribute("meshesPath").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setMeshesPath(std::string const& mp)
+SeriesInterface&
+SeriesInterface::setMeshesPath(std::string const& mp)
 {
     auto & series = get();
     if( std::any_of(series.iterations.begin(), series.iterations.end(),
@@ -163,13 +163,13 @@ SeriesImpl::setMeshesPath(std::string const& mp)
 }
 
 std::string
-SeriesImpl::particlesPath() const
+SeriesInterface::particlesPath() const
 {
     return getAttribute("particlesPath").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setParticlesPath(std::string const& pp)
+SeriesInterface&
+SeriesInterface::setParticlesPath(std::string const& pp)
 {
     auto & series = get();
     if( std::any_of(series.iterations.begin(), series.iterations.end(),
@@ -185,26 +185,26 @@ SeriesImpl::setParticlesPath(std::string const& pp)
 }
 
 std::string
-SeriesImpl::author() const
+SeriesInterface::author() const
 {
     return getAttribute("author").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setAuthor(std::string const& a)
+SeriesInterface&
+SeriesInterface::setAuthor(std::string const& a)
 {
     setAttribute("author", a);
     return *this;
 }
 
 std::string
-SeriesImpl::software() const
+SeriesInterface::software() const
 {
     return getAttribute("software").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setSoftware( std::string const& newName, std::string const& newVersion )
+SeriesInterface&
+SeriesInterface::setSoftware( std::string const& newName, std::string const& newVersion )
 {
     setAttribute( "software", newName );
     setAttribute( "softwareVersion", newVersion );
@@ -212,65 +212,65 @@ SeriesImpl::setSoftware( std::string const& newName, std::string const& newVersi
 }
 
 std::string
-SeriesImpl::softwareVersion() const
+SeriesInterface::softwareVersion() const
 {
     return getAttribute("softwareVersion").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setSoftwareVersion(std::string const& sv)
+SeriesInterface&
+SeriesInterface::setSoftwareVersion(std::string const& sv)
 {
     setAttribute("softwareVersion", sv);
     return *this;
 }
 
 std::string
-SeriesImpl::date() const
+SeriesInterface::date() const
 {
     return getAttribute("date").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setDate(std::string const& d)
+SeriesInterface&
+SeriesInterface::setDate(std::string const& d)
 {
     setAttribute("date", d);
     return *this;
 }
 
 std::string
-SeriesImpl::softwareDependencies() const
+SeriesInterface::softwareDependencies() const
 {
     return getAttribute("softwareDependencies").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setSoftwareDependencies(std::string const &newSoftwareDependencies)
+SeriesInterface&
+SeriesInterface::setSoftwareDependencies(std::string const &newSoftwareDependencies)
 {
     setAttribute("softwareDependencies", newSoftwareDependencies);
     return *this;
 }
 
 std::string
-SeriesImpl::machine() const
+SeriesInterface::machine() const
 {
     return getAttribute("machine").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setMachine(std::string const &newMachine)
+SeriesInterface&
+SeriesInterface::setMachine(std::string const &newMachine)
 {
     setAttribute("machine", newMachine);
     return *this;
 }
 
 IterationEncoding
-SeriesImpl::iterationEncoding() const
+SeriesInterface::iterationEncoding() const
 {
     return get().m_iterationEncoding;
 }
 
-SeriesImpl&
-SeriesImpl::setIterationEncoding(IterationEncoding ie)
+SeriesInterface&
+SeriesInterface::setIterationEncoding(IterationEncoding ie)
 {
     auto & series = get();
     if( written() )
@@ -297,13 +297,13 @@ SeriesImpl::setIterationEncoding(IterationEncoding ie)
 }
 
 std::string
-SeriesImpl::iterationFormat() const
+SeriesInterface::iterationFormat() const
 {
     return getAttribute("iterationFormat").get< std::string >();
 }
 
-SeriesImpl&
-SeriesImpl::setIterationFormat(std::string const& i)
+SeriesInterface&
+SeriesInterface::setIterationFormat(std::string const& i)
 {
     if( written() )
         throw std::runtime_error("A files iterationFormat can not (yet) be changed after it has been written.");
@@ -318,13 +318,13 @@ SeriesImpl::setIterationFormat(std::string const& i)
 }
 
 std::string
-SeriesImpl::name() const
+SeriesInterface::name() const
 {
     return get().m_name;
 }
 
-SeriesImpl&
-SeriesImpl::setName(std::string const& n)
+SeriesInterface&
+SeriesInterface::setName(std::string const& n)
 {
     auto & series = get();
     if( written() )
@@ -339,13 +339,13 @@ SeriesImpl::setName(std::string const& n)
 }
 
 std::string
-SeriesImpl::backend() const
+SeriesInterface::backend() const
 {
     return IOHandler()->backendName();
 }
 
 void
-SeriesImpl::flush()
+SeriesInterface::flush()
 {
     auto & series = get();
     flush_impl(
@@ -354,10 +354,10 @@ SeriesImpl::flush()
         FlushLevel::UserFlush );
 }
 
-std::unique_ptr< SeriesImpl::ParsedInput >
-SeriesImpl::parseInput(std::string filepath)
+std::unique_ptr< SeriesInterface::ParsedInput >
+SeriesInterface::parseInput(std::string filepath)
 {
-    std::unique_ptr< SeriesImpl::ParsedInput > input{new SeriesImpl::ParsedInput};
+    std::unique_ptr< SeriesInterface::ParsedInput > input{new SeriesInterface::ParsedInput};
 
 #ifdef _WIN32
     if( auxiliary::contains(filepath, '/') )
@@ -418,9 +418,9 @@ SeriesImpl::parseInput(std::string filepath)
     return input;
 }
 
-void SeriesImpl::init(
+void SeriesInterface::init(
     std::shared_ptr< AbstractIOHandler > ioHandler,
-    std::unique_ptr< SeriesImpl::ParsedInput > input )
+    std::unique_ptr< SeriesInterface::ParsedInput > input )
 {
     auto & series = get();
     writable().IOHandler = ioHandler;
@@ -469,7 +469,7 @@ void SeriesImpl::init(
 }
 
 void
-SeriesImpl::initDefaults( IterationEncoding ie )
+SeriesInterface::initDefaults( IterationEncoding ie )
 {
     if( !containsAttribute("openPMD"))
         setOpenPMD( getStandard() );
@@ -494,7 +494,7 @@ SeriesImpl::initDefaults( IterationEncoding ie )
 }
 
 std::future< void >
-SeriesImpl::flush_impl(
+SeriesInterface::flush_impl(
     iterations_iterator begin,
     iterations_iterator end,
     FlushLevel level,
@@ -537,7 +537,7 @@ SeriesImpl::flush_impl(
 }
 
 void
-SeriesImpl::flushFileBased( iterations_iterator begin, iterations_iterator end )
+SeriesInterface::flushFileBased( iterations_iterator begin, iterations_iterator end )
 {
     auto & series = get();
     if( end == begin )
@@ -619,7 +619,7 @@ SeriesImpl::flushFileBased( iterations_iterator begin, iterations_iterator end )
 }
 
 void
-SeriesImpl::flushGorVBased( iterations_iterator begin, iterations_iterator end )
+SeriesInterface::flushGorVBased( iterations_iterator begin, iterations_iterator end )
 {
     auto & series = get();
     if( IOHandler()->m_frontendAccess == Access::READ_ONLY )
@@ -697,7 +697,7 @@ SeriesImpl::flushGorVBased( iterations_iterator begin, iterations_iterator end )
 }
 
 void
-SeriesImpl::flushMeshesPath()
+SeriesInterface::flushMeshesPath()
 {
     Parameter< Operation::WRITE_ATT > aWrite;
     aWrite.name = "meshesPath";
@@ -708,7 +708,7 @@ SeriesImpl::flushMeshesPath()
 }
 
 void
-SeriesImpl::flushParticlesPath()
+SeriesInterface::flushParticlesPath()
 {
     Parameter< Operation::WRITE_ATT > aWrite;
     aWrite.name = "particlesPath";
@@ -719,7 +719,7 @@ SeriesImpl::flushParticlesPath()
 }
 
 void
-SeriesImpl::readFileBased( )
+SeriesInterface::readFileBased( )
 {
     auto & series = get();
     Parameter< Operation::OPEN_FILE > fOpen;
@@ -754,7 +754,7 @@ SeriesImpl::readFileBased( )
 
     if( series.iterations.empty() )
     {
-        /* Frontend access type might change during SeriesImpl::read() to allow parameter modification.
+        /* Frontend access type might change during SeriesInterface::read() to allow parameter modification.
          * Backend access type stays unchanged for the lifetime of a Series. */
         if(IOHandler()->m_backendAccess == Access::READ_ONLY  )
             throw no_such_file_error("No matching iterations found: " + name());
@@ -794,14 +794,14 @@ SeriesImpl::readFileBased( )
     if( paddings.size() == 1u )
         series.m_filenamePadding = *paddings.begin();
 
-    /* Frontend access type might change during SeriesImpl::read() to allow parameter modification.
+    /* Frontend access type might change during SeriesInterface::read() to allow parameter modification.
      * Backend access type stays unchanged for the lifetime of a Series. */
     if( paddings.size() > 1u && IOHandler()->m_backendAccess == Access::READ_WRITE )
         throw std::runtime_error("Cannot write to a series with inconsistent iteration padding. "
                                  "Please specify '%0<N>T' or open as read-only.");
 }
 
-void SeriesImpl::readOneIterationFileBased( std::string const & filePath )
+void SeriesInterface::readOneIterationFileBased( std::string const & filePath )
 {
     auto & series = get();
 
@@ -881,7 +881,7 @@ void SeriesImpl::readOneIterationFileBased( std::string const & filePath )
 }
 
 void
-SeriesImpl::readGorVBased( bool do_init )
+SeriesInterface::readGorVBased( bool do_init )
 {
     auto & series = get();
     Parameter< Operation::OPEN_FILE > fOpen;
@@ -1020,7 +1020,7 @@ SeriesImpl::readGorVBased( bool do_init )
 }
 
 void
-SeriesImpl::readBase()
+SeriesInterface::readBase()
 {
     auto & series = get();
     using DT = Datatype;
@@ -1096,7 +1096,7 @@ SeriesImpl::readBase()
 }
 
 std::string
-SeriesImpl::iterationFilename( uint64_t i )
+SeriesInterface::iterationFilename( uint64_t i )
 {
     auto & series = get();
     if( series.m_overrideFilebasedFilename.has_value() )
@@ -1110,8 +1110,8 @@ SeriesImpl::iterationFilename( uint64_t i )
            + series.m_filenamePostfix;
 }
 
-SeriesImpl::iterations_iterator
-SeriesImpl::indexOf( Iteration const & iteration )
+SeriesInterface::iterations_iterator
+SeriesInterface::indexOf( Iteration const & iteration )
 {
     auto & series = get();
     for( auto it = series.iterations.begin(); it != series.iterations.end();
@@ -1127,7 +1127,7 @@ SeriesImpl::indexOf( Iteration const & iteration )
 }
 
 AdvanceStatus
-SeriesImpl::advance(
+SeriesInterface::advance(
     AdvanceMode mode,
     internal::AttributableData & file,
     iterations_iterator begin,
@@ -1224,7 +1224,7 @@ SeriesImpl::advance(
         }
     }
 
-    // We cannot call SeriesImpl::flush now, since the IO handler is still filled
+    // We cannot call SeriesInterface::flush now, since the IO handler is still filled
     // from calling flush(Group|File)based, but has not been emptied yet
     // Do that manually
     IOHandler()->m_flushLevel = FlushLevel::UserFlush;
@@ -1242,7 +1242,7 @@ SeriesImpl::advance(
     return *param.status;
 }
 
-auto SeriesImpl::openIterationIfDirty( uint64_t index, Iteration iteration )
+auto SeriesInterface::openIterationIfDirty( uint64_t index, Iteration iteration )
     -> IterationOpened
 {
     /*
@@ -1304,7 +1304,7 @@ auto SeriesImpl::openIterationIfDirty( uint64_t index, Iteration iteration )
     return IterationOpened::RemainsClosed;
 }
 
-void SeriesImpl::openIteration( uint64_t index, Iteration iteration )
+void SeriesInterface::openIteration( uint64_t index, Iteration iteration )
 {
     auto oldStatus = *iteration.m_closed;
     switch( *iteration.m_closed )
@@ -1408,7 +1408,7 @@ SeriesInternal::SeriesInternal(
     Access at,
     MPI_Comm comm,
     std::string const & options )
-    : SeriesImpl{
+    : SeriesInterface{
           static_cast< internal::SeriesData * >( this ),
           static_cast< internal::AttributableData * >( this ) }
 {
@@ -1423,7 +1423,7 @@ SeriesInternal::SeriesInternal(
 
 SeriesInternal::SeriesInternal(
     std::string const & filepath, Access at, std::string const & options )
-    : SeriesImpl{
+    : SeriesInterface{
           static_cast< internal::SeriesData * >( this ),
           static_cast< internal::AttributableData * >( this ) }
 {
@@ -1467,7 +1467,7 @@ SeriesInternal::~SeriesInternal()
 }
 } // namespace internal
 
-Series::Series() : SeriesImpl{ nullptr, nullptr }, iterations{}
+Series::Series() : SeriesInterface{ nullptr, nullptr }, iterations{}
 {
 }
 
@@ -1477,14 +1477,14 @@ Series::Series(
     Access at,
     MPI_Comm comm,
     std::string const & options )
-    : SeriesImpl{ nullptr, nullptr }
+    : SeriesInterface{ nullptr, nullptr }
     , m_series{ std::make_shared< internal::SeriesInternal >(
           filepath, at, comm, options ) }
     , iterations{ m_series->iterations }
 {
     AttributableImpl::m_attri =
         static_cast< internal::AttributableData * >( m_series.get() );
-    SeriesImpl::m_series = m_series.get();
+    SeriesInterface::m_series = m_series.get();
 }
 #endif
 
@@ -1492,14 +1492,14 @@ Series::Series(
     std::string const & filepath,
     Access at,
     std::string const & options)
-    : SeriesImpl{ nullptr, nullptr }
+    : SeriesInterface{ nullptr, nullptr }
     , m_series{ std::make_shared< internal::SeriesInternal >(
           filepath, at, options ) }
     , iterations{ m_series->iterations }
 {
     AttributableImpl::m_attri =
         static_cast< internal::AttributableData * >( m_series.get() );
-    SeriesImpl::m_series = m_series.get();
+    SeriesInterface::m_series = m_series.get();
 }
 
 Series::operator bool() const

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -38,13 +38,13 @@ AttributableData::AttributableData() : m_writable{ this }
 }
 }
 
-AttributableImpl::AttributableImpl( internal::AttributableData * attri )
+AttributableInterface::AttributableInterface( internal::AttributableData * attri )
     : m_attri{ attri }
 {
 }
 
 Attribute
-AttributableImpl::getAttribute(std::string const& key) const
+AttributableInterface::getAttribute(std::string const& key) const
 {
     auto & attri = get();
     auto it = attri.m_attributes.find(key);
@@ -55,7 +55,7 @@ AttributableImpl::getAttribute(std::string const& key) const
 }
 
 bool
-AttributableImpl::deleteAttribute(std::string const& key)
+AttributableInterface::deleteAttribute(std::string const& key)
 {
     auto & attri = get();
     if(Access::READ_ONLY == IOHandler()->m_frontendAccess )
@@ -75,7 +75,7 @@ AttributableImpl::deleteAttribute(std::string const& key)
 }
 
 std::vector< std::string >
-AttributableImpl::attributes() const
+AttributableInterface::attributes() const
 {
     auto & attri = get();
     std::vector< std::string > ret;
@@ -87,38 +87,38 @@ AttributableImpl::attributes() const
 }
 
 size_t
-AttributableImpl::numAttributes() const
+AttributableInterface::numAttributes() const
 {
     return get().m_attributes.size();
 }
 
 bool
-AttributableImpl::containsAttribute(std::string const &key) const
+AttributableInterface::containsAttribute(std::string const &key) const
 {
     auto & attri = get();
     return attri.m_attributes.find(key) != attri.m_attributes.end();
 }
 
 std::string
-AttributableImpl::comment() const
+AttributableInterface::comment() const
 {
     return getAttribute("comment").get< std::string >();
 }
 
-AttributableImpl&
-AttributableImpl::setComment(std::string const& c)
+AttributableInterface&
+AttributableInterface::setComment(std::string const& c)
 {
     setAttribute("comment", c);
     return *this;
 }
 
 void
-AttributableImpl::seriesFlush()
+AttributableInterface::seriesFlush()
 {
     writable().seriesFlush();
 }
 
-internal::SeriesInternal const & AttributableImpl::retrieveSeries() const
+internal::SeriesInternal const & AttributableInterface::retrieveSeries() const
 {
     Writable const * findSeries = &writable();
     while( findSeries->parent )
@@ -129,13 +129,13 @@ internal::SeriesInternal const & AttributableImpl::retrieveSeries() const
         findSeries->attributable );
 }
 
-internal::SeriesInternal & AttributableImpl::retrieveSeries()
+internal::SeriesInternal & AttributableInterface::retrieveSeries()
 {
     return const_cast< internal::SeriesInternal & >(
-        static_cast< AttributableImpl const * >( this )->retrieveSeries() );
+        static_cast< AttributableInterface const * >( this )->retrieveSeries() );
 }
 
-Iteration const & AttributableImpl::containingIteration() const
+Iteration const & AttributableInterface::containingIteration() const
 {
     std::vector< Writable const * > searchQueue;
     searchQueue.reserve( 7 );
@@ -177,10 +177,10 @@ Iteration const & AttributableImpl::containingIteration() const
         "Containing iteration not found in containing Series." );
 }
 
-Iteration & AttributableImpl::containingIteration()
+Iteration & AttributableInterface::containingIteration()
 {
     return const_cast< Iteration & >(
-        static_cast< AttributableImpl const * >( this )
+        static_cast< AttributableInterface const * >( this )
             ->containingIteration() );
 }
 
@@ -189,7 +189,7 @@ std::string Attributable::MyPath::filePath() const
     return directory + seriesName + seriesExtension;
 }
 
-auto AttributableImpl::myPath() const -> MyPath
+auto AttributableInterface::myPath() const -> MyPath
 {
     MyPath res;
     Writable const * findSeries = &writable();
@@ -219,13 +219,13 @@ auto AttributableImpl::myPath() const -> MyPath
 }
 
 void
-AttributableImpl::seriesFlush( FlushLevel level )
+AttributableInterface::seriesFlush( FlushLevel level )
 {
     writable().seriesFlush( level );
 }
 
 void
-AttributableImpl::flushAttributes()
+AttributableInterface::flushAttributes()
 {
     if( IOHandler()->m_flushLevel == FlushLevel::SkeletonOnly )
     {
@@ -247,7 +247,7 @@ AttributableImpl::flushAttributes()
 }
 
 void
-AttributableImpl::readAttributes( ReadMode mode )
+AttributableInterface::readAttributes( ReadMode mode )
 {
     auto & attri = get();
     Parameter< Operation::LIST_ATTS > aList;
@@ -445,7 +445,7 @@ AttributableImpl::readAttributes( ReadMode mode )
 }
 
 void
-AttributableImpl::linkHierarchy(Writable& w)
+AttributableInterface::linkHierarchy(Writable& w)
 {
     auto handler = w.IOHandler;
     writable().IOHandler = handler;

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -43,7 +43,7 @@ namespace openPMD
     void
     Writable::seriesFlush( FlushLevel level )
     {
-        auto & series = AttributableImpl( attributable ).retrieveSeries();
+        auto & series = AttributableInterface( attributable ).retrieveSeries();
         series.flush_impl(
             series.iterations.begin(), series.iterations.end(), level );
     }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -152,7 +152,7 @@ TEST_CASE( "myPath", "[core]" )
 {
 #if openPMD_USE_INVASIVE_TESTS
     using vec_t = std::vector< std::string >;
-    auto pathOf = []( AttributableImpl & attr )
+    auto pathOf = []( AttributableInterface & attr )
     {
         auto res = attr.myPath();
 #if false


### PR DESCRIPTION
Up for discussion.
The old name is not wrong, but misleading. Those classes *do* implement the logic of `Series` and `Attributable`, but from our users' perspective, the more important aspect is that they define the interface of those classes. The current names may look like we accidentally exposed an internal class.

TODO:
- [x] Discuss this
- [x] I've renamed things automatically. Read through the diff carefully to check that things are fine. (Especially the docs)