### PR TITLE
Fix C++17: ADIOS2IOHandler

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1302,9 +1302,9 @@ namespace detail
          */
         using rep = AttributeTypes< bool >::rep;
         if
-#    if __cplusplus > 201402L
+#if __cplusplus >= 201703L
             constexpr
-#    endif
+#endif
             ( std::is_same< T, rep >::value )
         {
             std::string metaAttr =


### PR DESCRIPTION
We can use the concrete feature-test macro or just require a complete C++17 implementation as in other places:
  https://gcc.gnu.org/projects/cxx-status.html#cxx17

Fixes:
```
src/IO/ADIOS/ADIOS2IOHandler.cpp:1306:13: error: expected ‘(’ before ‘constexpr’
             constexpr
             ^
```
with C++17 builds with GCC 5.5.0