### PR TITLE
Document regexes for showing only attributes or datasets in new ADIOS2 schema

### DIFF
--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -105,6 +105,14 @@ The new layout may be activated **for experimental purposes** in two ways:
 
 The ADIOS2 backend will automatically recognize the layout that has been used by a writer when reading a dataset.
 
+.. tip::
+   This schema does not use ADIOS2 attributes any more, making the ``bpls -a`` and ``bpls -A`` switches useless for openPMD datasets.
+   Their functionality can be emulated via regexes:
+
+   * Print datasets and attributes: Default behavior
+   * Print datasets only: ``bpls -e '.*/__data__$'``
+   * Print attributes only: ``bpls -e '^(.(?!/__data__$))*$'``
+
 Memory usage
 ------------
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -106,7 +106,8 @@ The new layout may be activated **for experimental purposes** in two ways:
 The ADIOS2 backend will automatically recognize the layout that has been used by a writer when reading a dataset.
 
 .. tip::
-   This schema does not use ADIOS2 attributes any more, making the ``bpls -a`` and ``bpls -A`` switches useless for openPMD datasets.
+
+   This schema does not use ADIOS2 attributes anymore, thus ``bpls -a`` and ``bpls -A`` attribute switches do not show openPMD attributes.
    Their functionality can be emulated via regexes:
 
    * Print datasets and attributes: Default behavior


### PR DESCRIPTION
This functionality was previously available via the `-A` or `-a` switches of `bpls`. Since we only use variables now, we have to become a bit more explicit and use regexes.
Document this so I don't have to look up how regex lookaheads work every time I want to do this.