### PR TITLE
Test: Interleaved Write & Close

### DIFF
--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -80,7 +80,7 @@ protected:
      * @param writable The writable whose containing file to figure out.
      * @param preferParentFile If true, the file is set to the parent's file if
      *     present. Otherwise, the parent file is only considered if no own file
-     *     is defined.
+     *     is defined. This is usually needed when switching between iterations when opening paths.
      * @return The containing file of the writable. If its parent is associated
      * with another file, update the writable to match its parent and return
      * the refreshed file.

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -299,6 +299,9 @@ void ADIOS2IOHandlerImpl::createFile(
         writable->written = true;
         writable->abstractFilePosition =
             std::make_shared< ADIOS2FilePosition >( );
+        // enforce opening the file
+        // lazy opening is deathly in parallel situations
+        getFileData( shared_name, IfFileNotOpen::OpenImplicitly );
     }
 }
 


### PR DESCRIPTION
Add a test that performs writes to interleaved iterations and then closes iterations as they are done writing.

Issues:
- [x] as soon as `Iteration::close()` is used in this example, the writes segfault
```
#0  0x0000555555700b20 in ?? ()
#1  0x0000555555608a68 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() ()
#2  0x00007ffff7f45bc8 in void openPMD::detail::OldAttributeWriter::operator()<unsigned char>(openPMD::ADIOS2IOHandlerImpl*, openPMD::Writable*, openPMD::Parameter<(openPMD::Operation)18> const&) ()
   from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#3  0x00007ffff7f58cd6 in decltype (({parm#2}.(operator()<char>))((forward<openPMD::ADIOS2IOHandlerImpl*>)({parm#3}), (forward<openPMD::Writable*&>)({parm#3}), (forward<openPMD::Parameter<(openPMD::Operation)18> const&>)({parm#3}))) openPMD::switchType<openPMD::detail::OldAttributeWriter, openPMD::ADIOS2IOHandlerImpl*, openPMD::Writable*&, openPMD::Parameter<(openPMD::Operation)18> const&>(openPMD::Datatype, openPMD::detail::OldAttributeWriter, openPMD::ADIOS2IOHandlerImpl*&&, openPMD::Writable*&, openPMD::Parameter<(openPMD::Operation)18> const&) () from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#4  0x00007ffff7f008eb in openPMD::ADIOS2IOHandlerImpl::writeAttribute(openPMD::Writable*, openPMD::Parameter<(openPMD::Operation)18> const&) () from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#5  0x00007ffff7eb9c98 in openPMD::AbstractIOHandlerImpl::flush() () from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#6  0x00007ffff7ef51ef in openPMD::ADIOS2IOHandlerImpl::flush() () from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#7  0x00007ffff7ef5319 in openPMD::ADIOS2IOHandler::flush() () from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#8  0x00007ffff7ea873e in std::_Sp_counted_ptr_inplace<openPMD::ADIOS2IOHandler, std::allocator<openPMD::ADIOS2IOHandler>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() ()
   from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#9  0x0000555555608a68 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() ()
#10 0x00007ffff7e57afa in openPMD::internal::SeriesData::~SeriesData() () from /home/axel/src/openPMD/openPMD-api/build/lib/libopenPMD.so
#11 0x00005555555ffe08 in openPMD::Series::~Series() ()
...
```
- [x] in WarpX, a similar pattern throws https://github.com/ECP-WarpX/WarpX/pull/2150#issuecomment-890193164
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  [ADIOS2] Requested file has not been opened yet: openpmd_00003.bp
```