### PR TITLE
Wheels: 0.14.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'src'
-        ref: '0.14.0'
+        ref: '0.14.1'
 
     - uses: actions/checkout@v2
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.14.0"
+    - OPENPMD_GIT_REF="0.14.1"
 
     - CIBW_PROJECT_REQUIRES_PYTHON=">=3.6"
     # Install dependencies on Linux and OSX


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.14.1 release.