### PR TITLE
CMake: Disable In-Source Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,17 +88,6 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-#########
-# CMake #
-#########
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-
 ####################
 # Package Managers #
 ####################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,18 @@ if(POLICY CMP0074)
 endif()
 
 
+# No in-Source builds #########################################################
+#
+# In-source builds clutter up the source directory and lead to mistakes with
+# generated includes
+if(openPMD_SOURCE_DIR STREQUAL openPMD_BINARY_DIR)
+  message(FATAL_ERROR "In-source builds are not possible. "
+          "Please remove the CMakeFiles/ directory and CMakeCache.txt file. "
+          "Then run CMake in a temporary build directory. "
+          "Learn more: https://hsf-training.github.io/hsf-training-cmake-webpage/02-building/index.html")
+endif()
+
+
 # Project structure ###########################################################
 #
 # temporary build directories


### PR DESCRIPTION
Builds that are directly executed in the source directory must fail. This can lead to cluttered up source trees as well as actual build errors when mismatching generated headers.

Close #1074