### PR TITLE
File-based iteration encoding: Re-parse padding when necessary

### DIFF
--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -50,5 +50,17 @@ namespace error
         OperationUnsupportedInBackend(
             std::string backend_in, std::string what );
     };
+
+    /**
+     * @brief The API was used in an illegal way.
+     *
+     * Example: File-based iteration encoding is selected without specifying an
+     *     expansion pattern.
+     */
+    class WrongAPIUsage : public Error
+    {
+    public:
+        WrongAPIUsage( std::string what );
+    };
 }
 }

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -84,7 +84,7 @@ public:
     std::string m_name;
     std::string m_filenamePrefix;
     std::string m_filenamePostfix;
-    int m_filenamePadding = 0;
+    int m_filenamePadding = -1;
     IterationEncoding m_iterationEncoding{};
     Format m_format;
     /**
@@ -346,6 +346,8 @@ OPENPMD_private:
         }    }
 
     std::unique_ptr< ParsedInput > parseInput(std::string);
+    bool hasExpansionPattern( std::string filenameWithExtension );
+    bool reparseExpansionPattern( std::string filenameWithExtension );
     void init(std::shared_ptr< AbstractIOHandler >, std::unique_ptr< ParsedInput >);
     void initDefaults( IterationEncoding );
     /**

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -84,7 +84,7 @@ public:
     std::string m_name;
     std::string m_filenamePrefix;
     std::string m_filenamePostfix;
-    int m_filenamePadding;
+    int m_filenamePadding = 0;
     IterationEncoding m_iterationEncoding{};
     Format m_format;
     /**

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -15,5 +15,10 @@ namespace error
         , backend{ std::move( backend_in ) }
     {
     }
+
+    WrongAPIUsage::WrongAPIUsage( std::string what )
+        : Error( "Wrong API usage: " + what )
+    {
+    }
 }
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -18,16 +18,16 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#include "openPMD/Series.hpp"
-#include "openPMD/Error.hpp"
-#include "openPMD/IO/AbstractIOHandler.hpp"
-#include "openPMD/IO/AbstractIOHandlerHelper.hpp"
-#include "openPMD/IO/Format.hpp"
-#include "openPMD/ReadIterations.hpp"
 #include "openPMD/auxiliary/Date.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
+#include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/IO/AbstractIOHandlerHelper.hpp"
+#include "openPMD/IO/Format.hpp"
+#include "openPMD/Error.hpp"
+#include "openPMD/ReadIterations.hpp"
+#include "openPMD/Series.hpp"
 #include "openPMD/version.hpp"
 
 #include <exception>
@@ -345,9 +345,8 @@ SeriesInterface::setName(std::string const& n)
 
     if( series.m_iterationEncoding == IterationEncoding::fileBased )
     {
-        // Setting a new name should not alter file names in filebased iteration
-        // encoding
-        // Just make sure that an expansion pattern is active
+        // If the filename specifies an expansion pattern, set it.
+        // If not, check if one is already active.
         // Our filename parser expects an extension, so just add any and ignore
         // the result for that
         if( hasExpansionPattern( n + ".json" ) )

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -287,7 +287,7 @@ SeriesInterface::setIterationEncoding(IterationEncoding ie)
             // (e.g. %T) and parses it
             if( series.m_filenamePadding < 0 )
             {
-                if( not reparseExpansionPattern( series.m_name ) )
+                if( !reparseExpansionPattern( series.m_name ) )
                 {
                     throw error::WrongAPIUsage(
                         "For fileBased formats the iteration expansion pattern "

--- a/src/binding/python/Error.cpp
+++ b/src/binding/python/Error.cpp
@@ -10,6 +10,8 @@ void init_Error( py::module & m )
     auto & baseError = py::register_exception< Error >( m, "Error" );
     py::register_exception< error::OperationUnsupportedInBackend >(
         m, "ErrorOperationUnsupportedInBackend", baseError );
+    py::register_exception< error::WrongAPIUsage >(
+        m, "ErrorWrongAPIUsage", baseError );
 
 #ifndef NDEBUG
     m.def( "test_throw", []( std::string description ) {

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -688,14 +688,14 @@ TEST_CASE( "structure_test", "[core]" )
 
 TEST_CASE( "wrapper_test", "[core]" )
 {
-    Series o = Series("./new_openpmd_output.json", Access::CREATE);
+    Series o = Series("./new_openpmd_output_%T.json", Access::CREATE);
 
     o.setOpenPMDextension(42);
     o.setIterationEncoding(IterationEncoding::fileBased);
     Series copy = o;
     REQUIRE(copy.openPMDextension() == 42);
     REQUIRE(copy.iterationEncoding() == IterationEncoding::fileBased);
-    REQUIRE(copy.name() == "new_openpmd_output");
+    REQUIRE(copy.name() == "new_openpmd_output_%T");
     copy.setOpenPMD("1.2.0");
     copy.setIterationEncoding(IterationEncoding::groupBased);
     copy.setName("other_name");

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4583,9 +4583,20 @@ TEST_CASE( "late_setting_of_iterationencoding", "[serial]" )
     }
     {
         ::openPMD::Series series = ::openPMD::Series(
-            "../samples/asdf_%T.json", ::openPMD::Access::CREATE );
+            "../samples/asdf_%T.json",
+            ::openPMD::Access::CREATE );
         series.iterations[ 10 ];
-        series.setName( "change_name_%T" );
+        series.setName(
+            "change_name_%T" );
+        series.flush();
+    }
+    {
+        ::openPMD::Series series = ::openPMD::Series(
+            "../samples/change_name_keep_filename_%T.json",
+            ::openPMD::Access::CREATE );
+        series.iterations[ 10 ];
+        series.setName(
+            "expansion_pattern_was_specified_previously_filename_will_stay" );
         series.flush();
     }
     {
@@ -4597,7 +4608,10 @@ TEST_CASE( "late_setting_of_iterationencoding", "[serial]" )
         series.flush();
     }
 
-    REQUIRE( auxiliary::file_exists( "../samples/change_name_10.json" ) );
+    REQUIRE( auxiliary::file_exists(
+        "../samples/change_name_10.json" ) );
+    REQUIRE( auxiliary::file_exists(
+        "../samples/change_name_keep_filename_10.json" ) );
     REQUIRE( auxiliary::file_exists(
         "../samples/change_name_and_encoding_10.json" ) );
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4566,3 +4566,38 @@ TEST_CASE( "no_explicit_flush", "[serial]" )
         no_explicit_flush( "../samples/no_explicit_flush." + t );
     }
 }
+
+TEST_CASE( "late_setting_of_iterationencoding", "[serial]" )
+{
+    {
+        ::openPMD::Series series = ::openPMD::Series(
+            "../samples/error.json", ::openPMD::Access::CREATE );
+        series.iterations[ 10 ];
+        REQUIRE_THROWS_WITH(
+            series.setIterationEncoding(
+                ::openPMD::IterationEncoding::fileBased ),
+            Catch::Equals( "Wrong API usage: For fileBased formats the "
+                           "iteration expansion pattern %T must "
+                           "be included in the file name" ) );
+        series.flush();
+    }
+    {
+        ::openPMD::Series series = ::openPMD::Series(
+            "../samples/asdf_%T.json", ::openPMD::Access::CREATE );
+        series.iterations[ 10 ];
+        series.setName( "change_name_%T" );
+        series.flush();
+    }
+    {
+        ::openPMD::Series series = ::openPMD::Series(
+            "../samples/asdf.json", ::openPMD::Access::CREATE );
+        series.iterations[ 10 ];
+        series.setName( "change_name_and_encoding_%T" );
+        series.setIterationEncoding( IterationEncoding::fileBased );
+        series.flush();
+    }
+
+    REQUIRE( auxiliary::file_exists( "../samples/change_name_10.json" ) );
+    REQUIRE( auxiliary::file_exists(
+        "../samples/change_name_and_encoding_10.json" ) );
+}


### PR DESCRIPTION
Close #1048

- [x] Merge #1080 first
- [x] rebase after merge of #1080

Until now, the methods `SeriesInterface::setName` and `SeriesInterface::setIterationEncoding` do not modify the parsed filename prefix, padding and postfix.
Reparse them when necessary and detect wrong specifications.

Meta: We might want to introduce a label middle-end? This is not a user-facing change (except for fixing a bug), so I don't want to add the label Frontend-C++14. It's a change in the implementation of our frontend, i.e. the middle-end.