### PR TITLE
setAttribute: Reject Empty Strings

### DIFF
--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include <type_traits>
 
 // expose private and protected members for invasive testing
 #ifndef OPENPMD_protected
@@ -394,6 +395,17 @@ template< typename T >
 inline bool
 AttributableInterface::setAttribute( std::string const & key, T value )
 {
+#if __cplusplus >= 201703L
+    // verify strings are not empty (backend restriction, e.g., HDF5)
+    if constexpr( std::is_same< T, std::string >::value )
+    {
+        if( value.empty() )
+            throw std::runtime_error(
+                "[setAttribute] Value for string attribute '" + key +
+                "' must not be empty!" );
+    }
+#endif
+
     auto & attri = get();
     if(IOHandler() && Access::READ_ONLY == IOHandler()->m_frontendAccess )
     {
@@ -420,6 +432,7 @@ AttributableInterface::setAttribute( std::string const & key, T value )
         return false;
     }
 }
+
 inline bool
 AttributableInterface::setAttribute( std::string const & key, char const value[] )
 {

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -84,7 +84,28 @@ public:
 private:
     A_MAP m_attributes;
 };
+
+/** Verify values of attributes in the frontend
+ *
+ * verify string attributes are not empty (backend restriction, e.g., HDF5)
+ */
+template< typename T >
+inline void
+attr_value_check( std::string const /* key */, T /* value */ )
+{
 }
+
+template< >
+inline void
+attr_value_check( std::string const key, std::string const value )
+{
+    if( value.empty() )
+        throw std::runtime_error(
+                "[setAttribute] Value for string attribute '" + key +
+                "' must not be empty!" );
+}
+
+} // namespace internal
 
 /** @brief Layer to manage storage of attributes associated with file objects.
  *
@@ -395,16 +416,7 @@ template< typename T >
 inline bool
 AttributableInterface::setAttribute( std::string const & key, T value )
 {
-#if __cplusplus >= 201703L
-    // verify strings are not empty (backend restriction, e.g., HDF5)
-    if constexpr( std::is_same< T, std::string >::value )
-    {
-        if( value.empty() )
-            throw std::runtime_error(
-                "[setAttribute] Value for string attribute '" + key +
-                "' must not be empty!" );
-    }
-#endif
+    internal::attr_value_check( key, value );
 
     auto & attri = get();
     if(IOHandler() && Access::READ_ONLY == IOHandler()->m_frontendAccess )

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -227,9 +227,7 @@ TEST_CASE( "hdf5_write_test", "[parallel][hdf5]" )
     auto mpi_rank = static_cast<uint64_t>(mpi_r);
     Series o = Series("../samples/parallel_write.h5", Access::CREATE, MPI_COMM_WORLD);
 
-#if __cplusplus >= 201703L
     REQUIRE_THROWS_AS(o.setAuthor(""), std::runtime_error);
-#endif
     o.setAuthor("Parallel HDF5");
     ParticleSpecies& e = o.iterations[1].particles["e"];
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -13,6 +13,7 @@
 #   include <fstream>
 #   include <iostream>
 #   include <algorithm>
+#   include <stdexcept>
 #   include <string>
 #   include <vector>
 #   include <list>
@@ -226,6 +227,9 @@ TEST_CASE( "hdf5_write_test", "[parallel][hdf5]" )
     auto mpi_rank = static_cast<uint64_t>(mpi_r);
     Series o = Series("../samples/parallel_write.h5", Access::CREATE, MPI_COMM_WORLD);
 
+#if __cplusplus >= 201703L
+    REQUIRE_THROWS_AS(o.setAuthor(""), std::runtime_error);
+#endif
     o.setAuthor("Parallel HDF5");
     ParticleSpecies& e = o.iterations[1].particles["e"];
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1782,10 +1782,7 @@ void bool_test(const std::string & backend)
     {
         Series o = Series("../samples/serial_bool." + backend, Access::CREATE);
 
-#if __cplusplus >= 201703L
         REQUIRE_THROWS_AS(o.setAuthor(""), std::runtime_error);
-#endif
-
         o.setAttribute("Bool attribute (true)", true);
         o.setAttribute("Bool attribute (false)", false);
     }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -24,6 +24,7 @@
 #include <list>
 #include <memory>
 #include <numeric>
+#include <stdexcept>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -1780,6 +1781,10 @@ void bool_test(const std::string & backend)
 {
     {
         Series o = Series("../samples/serial_bool." + backend, Access::CREATE);
+
+#if __cplusplus >= 201703L
+        REQUIRE_THROWS_AS(o.setAuthor(""), std::runtime_error);
+#endif
 
         o.setAttribute("Bool attribute (true)", true);
         o.setAttribute("Bool attribute (false)", false);


### PR DESCRIPTION
Some backends, especially HDF5, do not allow us to define zero-sized strings. We thus need to catch this in the frontend and forward the restriction to the user.

Part of the debugging effort for the 0.14.* release in WarpX: https://github.com/ECP-WarpX/WarpX/pull/2150

Follow-up to #979