### PR TITLE
Deprecate Iteration.closed attribute

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -147,6 +147,7 @@ public:
      * @return Whether the iteration has been explicitly closed (yet) by the
      *         writer.
      */
+    [[deprecated( "This attribute is no longer set by the openPMD-api." )]]
     bool
     closedByWriter() const;
 

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -82,11 +82,6 @@ using iterator_t = Container< Iteration, uint64_t >::iterator;
 Iteration &
 Iteration::close( bool _flush )
 {
-    using bool_type = unsigned char;
-    if( this->IOHandler()->m_frontendAccess != Access::READ_ONLY )
-    {
-        setAttribute< bool_type >( "closed", 1u );
-    }
     StepStatus flag = getStepStatus();
     // update close status
     switch( *m_closed )


### PR DESCRIPTION
1. Don't write "closed" attribute in iterations any more
2. Don't read it inside openPMD-api any more
3. Deprecate `Iteration::closedByWriter`

This attribute was introduced during the work on our streaming API when openPMD iterations and ADIOS steps were not yet coupled as concepts. As a result, readers needed a way to know when an iteration was fully defined, for this, we introduced this attribute.
Nowadays, iterations are fully defined as soon as the reader sees them.

TODO:
- [x] Check that replacing `iteration.closedByWriter()` with `iteration.written()` is fine in our reading routines. (Should be fine, I want to carefully go through it in the debugger to be sure anyway).
- [x] Check that old versions of openPMD can successfully read datasets written without that attribute. Otherwise, we'll need to keep setting it for a while at least.
   EDIT: Yes, it's possible, but it turns out that the streaming read API is implemented inefficiently for groupbased series that don't use steps, because all iterations will be parsed anew in every step. This PR fixes that.
- [x] split PR into a backportable bugfix and a deprecation PR