### PR TITLE
Don't read iterations if they have already been parsed

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1022,13 +1022,15 @@ SeriesInterface::readGorVBased( bool do_init )
 
     auto readSingleIteration =
         [&series, &pOpen, this]
-        (uint64_t index, std::string path, bool guardClosed )
+        (uint64_t index, std::string path, bool guardAgainstRereading )
     {
         if( series.iterations.contains( index ) )
         {
             // maybe re-read
             auto & i = series.iterations.at( index );
-            if( guardClosed && i.closedByWriter() )
+            // i.written(): the iteration has already been parsed
+            // reparsing is not needed
+            if( guardAgainstRereading && i.written() )
             {
                 return;
             }


### PR DESCRIPTION
Until now the condition to not reread an iteration in the streaming API was if the `Iteration.closed` attribute was present.
In datasets where such an attribute was never written, this leads to reparsing of the entire series in every iteration (i.e. quadratic parsing cost). Iterations are not changed after they are first seen, so rereading is not necessary.