### PR TITLE
switchType: Do not take action object as argument any more

### DIFF
--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -629,10 +629,10 @@ namespace detail {
 
     struct BasicDatatype {
         template <typename T>
-        Datatype operator()();
+        static Datatype call();
 
         template <int n>
-        Datatype operator()();
+        static Datatype call();
     };
 }
 

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -89,14 +89,13 @@ namespace detail
     struct AttributeInfo
     {
         template< typename T >
-        Extent
-        operator()(
+        static Extent call(
             adios2::IO &,
             std::string const & attributeName,
             VariableOrAttribute );
 
         template < int n, typename... Params >
-        Extent operator( )( Params &&... );
+        static Extent call( Params &&... );
     };
 
     /**
@@ -116,85 +115,71 @@ namespace detail
         VariableOrAttribute = VariableOrAttribute::Attribute );
 } // namespace detail
 
-#if defined( _MSC_VER ) && !defined( __INTEL_COMPILER ) && !defined( __clang__ )
-#define OPENPMD_TEMPLATE_OPERATOR operator
-#else
-#define OPENPMD_TEMPLATE_OPERATOR template operator
-#endif
-
 /**
  * Generalizes switching over an openPMD datatype.
  *
- * Will call the functor passed
- * to it using the C++ internal datatype corresponding to the openPMD datatype
- * as template parameter for the templated <operator()>().
+ * Will call the function template found at Action::call< T >(), instantiating T
+ * with the C++ internal datatype corresponding to the openPMD datatype.
  * Considers only types that are eligible for an ADIOS2 attribute.
  *
- * @tparam ReturnType The functor's return type.
- * @tparam Action The functor's type.
- * @tparam Args The functors argument types.
+ * @tparam ReturnType The function template's return type.
+ * @tparam Action The struct containing the function template.
+ * @tparam Args The function template's argument types.
  * @param dt The openPMD datatype.
- * @param action The functor.
- * @param args The functor's arguments.
- * @return The return value of the functor, when calling its <operator()>() with
- * the passed arguments and the template parameter type corresponding to the
- * openPMD type.
+ * @param args The function template's arguments.
+ * @return Passes on the result of invoking the function template with the given
+ *     arguments and with the template parameter specified by dt.
  */
 template< typename Action, typename... Args >
-auto switchAdios2AttributeType( Datatype dt, Action action, Args &&... args )
-    -> decltype(
-        action.OPENPMD_TEMPLATE_OPERATOR() < char >
-        ( std::forward< Args >( args )... ) )
+auto switchAdios2AttributeType( Datatype dt, Args &&... args )
+    -> decltype( Action::template call< char >(
+        std::forward< Args >( args )... ) )
 {
-    using ReturnType = decltype(
-        action.OPENPMD_TEMPLATE_OPERATOR() < char >
-        ( std::forward< Args >( args )... ) );
+    using ReturnType = decltype( Action::template call< char >(
+        std::forward< Args >( args )... ) );
     switch( dt )
     {
     case Datatype::CHAR:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< char >(
-            std::forward< Args >( args )... );
+        return Action::template call< char >( std::forward< Args >( args )... );
     case Datatype::UCHAR:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned char >(
+        return Action::template call< unsigned char >(
             std::forward< Args >( args )... );
     case Datatype::SHORT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< short >(
+        return Action::template call< short >(
             std::forward< Args >( args )... );
     case Datatype::INT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< int >(
-            std::forward< Args >( args )... );
+        return Action::template call< int >( std::forward< Args >( args )... );
     case Datatype::LONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< long >(
-            std::forward< Args >( args )... );
+        return Action::template call< long >( std::forward< Args >( args )... );
     case Datatype::LONGLONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< long long >(
+        return Action::template call< long long >(
             std::forward< Args >( args )... );
     case Datatype::USHORT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned short >(
+        return Action::template call< unsigned short >(
             std::forward< Args >( args )... );
     case Datatype::UINT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned int >(
+        return Action::template call< unsigned int >(
             std::forward< Args >( args )... );
     case Datatype::ULONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned long >(
+        return Action::template call< unsigned long >(
             std::forward< Args >( args )... );
     case Datatype::ULONGLONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned long long >(
+        return Action::template call< unsigned long long >(
             std::forward< Args >( args )... );
     case Datatype::FLOAT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< float >(
+        return Action::template call< float >(
             std::forward< Args >( args )... );
     case Datatype::DOUBLE:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< double >(
+        return Action::template call< double >(
             std::forward< Args >( args )... );
     case Datatype::LONG_DOUBLE:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< long double >(
+        return Action::template call< long double >(
             std::forward< Args >( args )... );
     case Datatype::CFLOAT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< std::complex< float > >(
+        return Action::template call< std::complex< float > >(
             std::forward< Args >( args )... );
     case Datatype::CDOUBLE:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< std::complex< double > >(
+        return Action::template call< std::complex< double > >(
             std::forward< Args >( args )... );
     // missing std::complex< long double > type in ADIOS2 v2.6.0
     // case Datatype::CLONG_DOUBLE:
@@ -202,7 +187,7 @@ auto switchAdios2AttributeType( Datatype dt, Action action, Args &&... args )
     //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
     //             std::forward< Args >( args )... );
     case Datatype::STRING:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< std::string >(
+        return Action::template call< std::string >(
             std::forward< Args >( args )... );
     case Datatype::DATATYPE:
         return detail::CallUndefinedDatatype<
@@ -210,16 +195,14 @@ auto switchAdios2AttributeType( Datatype dt, Action action, Args &&... args )
             ReturnType,
             Action,
             void,
-            Args &&... >::
-            call( std::move( action ), std::forward< Args >( args )... );
+            Args &&... >::call( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
             LOWEST_DATATYPE,
             ReturnType,
             Action,
             void,
-            Args &&... >::
-            call( std::move( action ), std::forward< Args >( args )... );
+            Args &&... >::call( std::forward< Args >( args )... );
     default:
         throw std::runtime_error(
             "Internal error: Encountered unknown datatype (switchType) ->" +
@@ -230,77 +213,70 @@ auto switchAdios2AttributeType( Datatype dt, Action action, Args &&... args )
 /**
  * Generalizes switching over an openPMD datatype.
  *
- * Will call the functor passed
- * to it using the C++ internal datatype corresponding to the openPMD datatype
- * as template parameter for the templated <operator()>().
+ * Will call the function template found at Action::call< T >(), instantiating T
+ * with the C++ internal datatype corresponding to the openPMD datatype.
  * Considers only types that are eligible for an ADIOS2 variable
  * (excluding STRING. Use switchAdios2AttributeType() for that).
  *
- * @tparam ReturnType The functor's return type.
- * @tparam Action The functor's type.
- * @tparam Args The functors argument types.
+ * @tparam ReturnType The function template's return type.
+ * @tparam Action The struct containing the function template.
+ * @tparam Args The function template's argument types.
  * @param dt The openPMD datatype.
- * @param action The functor.
- * @param args The functor's arguments.
- * @return The return value of the functor, when calling its <operator()>() with
- * the passed arguments and the template parameter type corresponding to the
- * openPMD type.
+ * @param args The function template's arguments.
+ * @return Passes on the result of invoking the function template with the given
+ *     arguments and with the template parameter specified by dt.
  */
 template< typename Action, typename... Args >
-auto switchAdios2VariableType( Datatype dt, Action action, Args &&... args )
+auto switchAdios2VariableType( Datatype dt, Args &&... args )
     -> decltype(
-        action.OPENPMD_TEMPLATE_OPERATOR() < char >
+        Action::template call < char >
         ( std::forward< Args >( args )... ) )
 {
-    using ReturnType = decltype(
-        action.OPENPMD_TEMPLATE_OPERATOR() < char >
-        ( std::forward< Args >( args )... ) );
+    using ReturnType = decltype( Action::template call< char >(
+        std::forward< Args >( args )... ) );
     switch( dt )
     {
     case Datatype::CHAR:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< char >(
-            std::forward< Args >( args )... );
+        return Action::template call< char >( std::forward< Args >( args )... );
     case Datatype::UCHAR:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned char >(
+        return Action::template call< unsigned char >(
             std::forward< Args >( args )... );
     case Datatype::SHORT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< short >(
+        return Action::template call< short >(
             std::forward< Args >( args )... );
     case Datatype::INT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< int >(
-            std::forward< Args >( args )... );
+        return Action::template call< int >( std::forward< Args >( args )... );
     case Datatype::LONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< long >(
-            std::forward< Args >( args )... );
+        return Action::template call< long >( std::forward< Args >( args )... );
     case Datatype::LONGLONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< long long >(
+        return Action::template call< long long >(
             std::forward< Args >( args )... );
     case Datatype::USHORT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned short >(
+        return Action::template call< unsigned short >(
             std::forward< Args >( args )... );
     case Datatype::UINT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned int >(
+        return Action::template call< unsigned int >(
             std::forward< Args >( args )... );
     case Datatype::ULONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned long >(
+        return Action::template call< unsigned long >(
             std::forward< Args >( args )... );
     case Datatype::ULONGLONG:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< unsigned long long >(
+        return Action::template call< unsigned long long >(
             std::forward< Args >( args )... );
     case Datatype::FLOAT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< float >(
+        return Action::template call< float >(
             std::forward< Args >( args )... );
     case Datatype::DOUBLE:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< double >(
+        return Action::template call< double >(
             std::forward< Args >( args )... );
     case Datatype::LONG_DOUBLE:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< long double >(
+        return Action::template call< long double >(
             std::forward< Args >( args )... );
     case Datatype::CFLOAT:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< std::complex< float > >(
+        return Action::template call< std::complex< float > >(
             std::forward< Args >( args )... );
     case Datatype::CDOUBLE:
-        return action.OPENPMD_TEMPLATE_OPERATOR()< std::complex< double > >(
+        return Action::template call< std::complex< double > >(
             std::forward< Args >( args )... );
     // missing std::complex< long double > type in ADIOS2 v2.6.0
     // case Datatype::CLONG_DOUBLE:
@@ -313,8 +289,7 @@ auto switchAdios2VariableType( Datatype dt, Action action, Args &&... args )
             ReturnType,
             Action,
             void,
-            Args &&... >::
-            call( std::move( action ), std::forward< Args >( args )... );
+            Args &&... >::call( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
             LOWEST_DATATYPE,
@@ -322,15 +297,13 @@ auto switchAdios2VariableType( Datatype dt, Action action, Args &&... args )
             Action,
             void,
             Args &&... >::
-            call( std::move( action ), std::forward< Args >( args )... );
+            call( std::forward< Args >( args )... );
     default:
         throw std::runtime_error(
             "Internal error: Encountered unknown datatype (switchType) ->" +
             std::to_string( static_cast< int >( dt ) ) );
     }
 }
-
-#undef OPENPMD_TEMPLATE_OPERATOR
 } // namespace openPMD
 
 #endif // openPMD_HAVE_ADIOS2

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -436,45 +436,40 @@ namespace openPMD
         struct DatasetWriter
         {
             template< typename T >
-            void operator()(
+            static void call(
                 nlohmann::json & json,
-                const Parameter< Operation::WRITE_DATASET > & parameters
-            );
+                const Parameter< Operation::WRITE_DATASET > & parameters );
 
-            std::string errorMsg = "JSON: writeDataset";
+            static constexpr char const * errorMsg = "JSON: writeDataset";
         };
 
         struct DatasetReader
         {
             template< typename T >
-            void operator()(
+            static void call(
                 nlohmann::json & json,
-                Parameter< Operation::READ_DATASET > & parameters
-            );
+                Parameter< Operation::READ_DATASET > & parameters );
 
-            std::string errorMsg = "JSON: readDataset";
+            static constexpr char const * errorMsg = "JSON: readDataset";
         };
 
         struct AttributeWriter
         {
             template< typename T >
-            void operator()(
-                nlohmann::json &,
-                Attribute::resource const &
-            );
+            static void call( nlohmann::json &, Attribute::resource const & );
 
-            std::string errorMsg = "JSON: writeAttribute";
+            static constexpr char const * errorMsg = "JSON: writeAttribute";
         };
 
         struct AttributeReader
         {
             template< typename T >
-            void operator()(
+            static void call(
                 nlohmann::json &,
                 Parameter< Operation::READ_ATT > &
             );
 
-            std::string errorMsg = "JSON: writeAttribute";
+            static constexpr char const * errorMsg = "JSON: writeAttribute";
         };
 
         template< typename T >

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -99,15 +99,13 @@ template< typename T_RecordComponent >
 struct DefaultValue
 {
     template< typename T >
-    void
-    operator()( T_RecordComponent & rc )
+    static void call( T_RecordComponent & rc )
     {
         rc.makeConstant( T() );
     }
 
     template< unsigned n, typename... Args >
-    void
-    operator()( Args &&... )
+    static void call( Args &&... )
     {
         throw std::runtime_error(
             "makeEmpty: Datatype not supported by openPMD." );

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -387,7 +387,7 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
 
     Datatype basicDatatype( Datatype dt )
     {
-        return switchType( dt, detail::BasicDatatype{} );
+        return switchType< detail::BasicDatatype >( dt );
     }
 
     Datatype toVectorType( Datatype dt )
@@ -420,7 +420,7 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
 
     namespace detail {
         template< typename T >
-        Datatype BasicDatatype::operator()()
+        Datatype BasicDatatype::call()
         {
             static auto res = BasicDatatypeHelper<T>{}.m_dt;
             return res;
@@ -428,7 +428,7 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
 
 
         template< int n >
-        Datatype BasicDatatype::operator()()
+        Datatype BasicDatatype::call()
         {
             throw std::runtime_error( "basicDatatype: received unknown datatype." );
         }

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -125,7 +125,7 @@ namespace detail
 
     template< typename T >
     Extent
-    AttributeInfo::operator()(
+    AttributeInfo::call(
         adios2::IO & IO,
         std::string const & attributeName,
         VariableOrAttribute voa )
@@ -166,7 +166,7 @@ namespace detail
 
     template< int n, typename... Params >
     Extent
-    AttributeInfo::operator()( Params &&... )
+    AttributeInfo::call( Params &&... )
     {
         return { 0 };
     }
@@ -200,10 +200,9 @@ namespace detail
         }
         else
         {
-            static AttributeInfo ai;
             Datatype basicType = fromADIOS2Type( type );
-            Extent shape = switchAdios2AttributeType(
-                basicType, ai, IO, attributeName, voa );
+            Extent shape = switchAdios2AttributeType< AttributeInfo >(
+                basicType, IO, attributeName, voa );
 
             switch( voa )
             {

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -895,14 +895,7 @@ namespace openPMD
             j
         );
 
-
-        DatasetWriter dw;
-        switchType(
-            parameters.dtype,
-            dw,
-            j,
-            parameters
-        );
+        switchType< DatasetWriter >( parameters.dtype, j, parameters );
 
         writable->written = true;
         putJsonContents( file );
@@ -931,13 +924,8 @@ namespace openPMD
                 nlohmann::json::object( );
         }
         nlohmann::json value;
-        AttributeWriter aw;
-        switchType(
-            parameter.dtype,
-            aw,
-            value,
-            parameter.resource
-        );
+        switchType< AttributeWriter >(
+            parameter.dtype, value, parameter.resource );
         ( *jsonVal )[filePosition->id]["attributes"][parameter.name] = {
             {
                 "datatype",
@@ -968,13 +956,8 @@ namespace openPMD
 
         try
         {
-            DatasetReader dr;
-            switchType(
-                parameters.dtype,
-                dr,
-                j["data"],
-                parameters
-            );
+            switchType< DatasetReader >(
+                parameters.dtype, j[ "data" ], parameters );
         } catch( json::basic_json::type_error & )
         {
             throw std::runtime_error( "[JSON] The given path does not contain a valid dataset." );
@@ -1007,13 +990,8 @@ namespace openPMD
         {
             *parameters.dtype =
                 Datatype( stringToDatatype( j["datatype"].get< std::string >( ) ) );
-            AttributeReader ar;
-            switchType(
-                *parameters.dtype,
-                ar,
-                j["value"],
-                parameters
-            );
+            switchType< AttributeReader >(
+                *parameters.dtype, j[ "value" ], parameters );
         } catch( json::type_error & )
         {
             throw std::runtime_error( "[JSON] The given location does not contain a properly formatted attribute" );
@@ -1653,7 +1631,7 @@ namespace openPMD
 
 
     template< typename T >
-    void JSONIOHandlerImpl::DatasetWriter::operator()(
+    void JSONIOHandlerImpl::DatasetWriter::call(
         nlohmann::json & json,
         const Parameter< Operation::WRITE_DATASET > & parameters
     )
@@ -1678,7 +1656,7 @@ namespace openPMD
 
 
     template< typename T >
-    void JSONIOHandlerImpl::DatasetReader::operator()(
+    void JSONIOHandlerImpl::DatasetReader::call(
         nlohmann::json & json,
         Parameter< Operation::READ_DATASET > & parameters
     )
@@ -1705,7 +1683,7 @@ namespace openPMD
 
 
     template< typename T >
-    void JSONIOHandlerImpl::AttributeWriter::operator()(
+    void JSONIOHandlerImpl::AttributeWriter::call(
         nlohmann::json & value,
         Attribute::resource const & resource
     )
@@ -1716,7 +1694,7 @@ namespace openPMD
 
 
     template< typename T >
-    void JSONIOHandlerImpl::AttributeReader::operator()(
+    void JSONIOHandlerImpl::AttributeReader::call(
         nlohmann::json & json,
         Parameter< Operation::READ_ATT > & parameters
     )

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -109,13 +109,13 @@ namespace detail
 struct MakeEmpty
 {
     template< typename T >
-    RecordComponent& operator()( RecordComponent & rc, uint8_t dimensions )
+    static RecordComponent& call( RecordComponent & rc, uint8_t dimensions )
     {
         return rc.makeEmpty< T >( dimensions );
     }
 
     template< unsigned int N >
-    RecordComponent& operator()( RecordComponent &, uint8_t )
+    static RecordComponent& call( RecordComponent &, uint8_t )
     {
         throw std::runtime_error(
             "RecordComponent::makeEmpty: Unknown datatype." );
@@ -126,8 +126,7 @@ struct MakeEmpty
 RecordComponent&
 RecordComponent::makeEmpty( Datatype dt, uint8_t dimensions )
 {
-    static detail::MakeEmpty me;
-    return switchType( dt, me, *this, dimensions );
+    return switchType< detail::MakeEmpty >( dt, *this, dimensions );
 }
 
 RecordComponent&
@@ -166,8 +165,8 @@ RecordComponent::makeEmpty( Dataset d )
     dirty() = true;
     if( !written() )
     {
-        static detail::DefaultValue< RecordComponent > dv;
-        switchType( m_dataset->dtype, dv, *this );
+        switchType< detail::DefaultValue< RecordComponent > >(
+            m_dataset->dtype, *this );
     }
     return *this;
 }

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -262,10 +262,10 @@ bool setAttributeFromBufferInfo(
 
 struct SetAttributeFromObject
 {
-    std::string errorMsg = "Attributable.set_attribute()";
+    static constexpr char const * errorMsg = "Attributable.set_attribute()";
 
     template< typename RequestedType >
-    bool operator()(
+    static bool call(
         Attributable & attr,
         std::string const& key,
         py::object& obj )
@@ -284,7 +284,7 @@ struct SetAttributeFromObject
 };
 
 template<>
-bool SetAttributeFromObject::operator()< double >(
+bool SetAttributeFromObject::call< double >(
     Attributable & attr, std::string const & key, py::object & obj )
 {
     if( std::string( py::str( obj.get_type() ) ) == "<class 'list'>" )
@@ -310,14 +310,14 @@ bool SetAttributeFromObject::operator()< double >(
 }
 
 template<>
-bool SetAttributeFromObject::operator()< bool >(
+bool SetAttributeFromObject::call< bool >(
     Attributable & attr, std::string const & key, py::object & obj )
 {
     return attr.setAttribute< bool >( key, obj.cast< bool >() );
 }
 
 template<>
-bool SetAttributeFromObject::operator()< char >(
+bool SetAttributeFromObject::call< char >(
     Attributable & attr, std::string const & key, py::object & obj )
 {
     if( std::string( py::str( obj.get_type() ) ) == "<class 'list'>" )
@@ -352,8 +352,8 @@ bool setAttributeFromObject(
     pybind11::dtype datatype )
 {
     Datatype requestedDatatype = dtype_from_numpy( datatype );
-    static SetAttributeFromObject safo;
-    return switchNonVectorType( requestedDatatype, safo, attr, key, obj );
+    return switchNonVectorType< SetAttributeFromObject >(
+        requestedDatatype, attr, key, obj );
 }
 
 void init_Attributable(py::module &m) {


### PR DESCRIPTION
Most instances did not use this anyway, it is unnecessary since it can be made part of the variadic arguments if needed. In other places, this just requires instantiating unneeded empty objects.

TODO:
- [x] Either remove the template operator macro if MSVC plays nice, or adapt it to this PR
- [x] Fix documentation