### PR TITLE
Read: time/dt also in long double

### DIFF
--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -391,6 +391,8 @@ void Iteration::read_impl( std::string const & groupPath )
         setDt(Attribute(*aRead.resource).get< float >());
     else if( *aRead.dtype == DT::DOUBLE )
         setDt(Attribute(*aRead.resource).get< double >());
+    else if( *aRead.dtype == DT::LONG_DOUBLE )
+        setDt(Attribute(*aRead.resource).get< long double >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'dt'");
 
@@ -401,6 +403,8 @@ void Iteration::read_impl( std::string const & groupPath )
         setTime(Attribute(*aRead.resource).get< float >());
     else if( *aRead.dtype == DT::DOUBLE )
         setTime(Attribute(*aRead.resource).get< double >());
+    else if( *aRead.dtype == DT::LONG_DOUBLE )
+        setTime(Attribute(*aRead.resource).get< long double >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'time'");
 

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -578,7 +578,12 @@ class APITest(unittest.TestCase):
             io.Access.create
         )
 
-        ms = series.iterations[0].meshes
+        it = series.iterations[0]
+
+        it.time = np.single(1.23)
+        it.dt = np.longdouble(1.2)
+
+        ms = it.meshes
         SCALAR = io.Mesh_Record_Component.SCALAR
         DS = io.Dataset
 
@@ -610,7 +615,15 @@ class APITest(unittest.TestCase):
             io.Access.read_only
         )
 
-        ms = series.iterations[0].meshes
+        it = series.iterations[0]
+
+        np.testing.assert_almost_equal(it.time, 1.23)
+        np.testing.assert_almost_equal(it.dt, 1.2)
+        # TODO
+        # self.assertTrue(it.time.dtype == np.dtype('single'))
+        # self.assertTrue(it.dt.dtype == np.dtype('longdouble'))
+
+        ms = it.meshes
         o = [1, 2, 3]
         e = [1, 1, 1]
 


### PR DESCRIPTION
Reading `iteration`'s `time` and `dt` attributes should support all float types.

Related to #1092