### PR TITLE
RecordComponent::resetDataset(): Reject undefined datatypes

### DIFF
--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -202,6 +202,15 @@ RecordComponent::flush(std::string const& name)
         }
     } else
     {
+        /*
+         * This catches when a user forgets to use resetDataset.
+         */
+        if( m_dataset->dtype == Datatype::UNDEFINED )
+        {
+            throw error::WrongAPIUsage(
+                "[RecordComponent] Must set specific datatype (Use "
+                "resetDataset call)." );
+        }
         if( !written() )
         {
             if( constant() )

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -22,6 +22,7 @@
 #include "openPMD/RecordComponent.hpp"
 #include "openPMD/Dataset.hpp"
 #include "openPMD/DatatypeHelpers.hpp"
+#include "openPMD/Error.hpp"
 #include "openPMD/Series.hpp"
 #include "openPMD/IO/Format.hpp"
 
@@ -69,6 +70,12 @@ RecordComponent::resetDataset( Dataset d )
                 "Cannot change the datatype of a dataset." );
         }
         *m_hasBeenExtended = true;
+    }
+
+    if( d.dtype == Datatype::UNDEFINED )
+    {
+        throw error::WrongAPIUsage(
+            "[RecordComponent] Must set specific datatype." );
     }
     // if( d.extent.empty() )
     //    throw std::runtime_error("Dataset extent must be at least 1D.");


### PR DESCRIPTION
Currently, `RecordComponent::resetDataset()` does not check if the passed dataset has an undefined datatype. In case this happened erroneously, this will result in a backend error which is probably not the best UX. Instead, throw a clear error as soon as possible.

Slightly API breaking since it's theoretically possible to call `resetDataset()` twice, so the first call doesn't count. But in reality, that's useless.