### PR TITLE
Remove Datatype::DATATYPE

### DIFF
--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -37,14 +37,11 @@
 namespace openPMD
 {
 
-constexpr int LOWEST_DATATYPE = 0;
-constexpr int HIGHEST_DATATYPE = 1000;
-
 /** Concrete datatype of an object available at runtime.
  */
 enum class Datatype : int
 {
-    CHAR = LOWEST_DATATYPE, UCHAR, // SCHAR,
+    CHAR, UCHAR, // SCHAR,
     SHORT, INT, LONG, LONGLONG,
     USHORT, UINT, ULONG, ULONGLONG,
     FLOAT, DOUBLE, LONG_DOUBLE,

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -71,8 +71,6 @@ enum class Datatype : int
 
     BOOL,
 
-    DATATYPE = HIGHEST_DATATYPE,
-
     UNDEFINED
 }; // Datatype
 
@@ -280,7 +278,6 @@ toBytes( Datatype d )
             return sizeof(long double) * 2;
         case DT::BOOL:
             return sizeof(bool);
-        case DT::DATATYPE:
         case DT::UNDEFINED:
         default:
             throw std::runtime_error("toBytes: Invalid datatype!");

--- a/include/openPMD/DatatypeHelpers.hpp
+++ b/include/openPMD/DatatypeHelpers.hpp
@@ -232,7 +232,7 @@ auto switchType( Datatype dt, Args &&... args )
         return Action::template call< bool >( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
-            LOWEST_DATATYPE,
+            0,
             ReturnType,
             Action,
             void,
@@ -320,7 +320,7 @@ auto switchNonVectorType( Datatype dt, Args &&... args )
         return Action::template call< bool >( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
-            LOWEST_DATATYPE,
+            0,
             ReturnType,
             Action,
             void,

--- a/include/openPMD/DatatypeHelpers.hpp
+++ b/include/openPMD/DatatypeHelpers.hpp
@@ -230,13 +230,6 @@ auto switchType( Datatype dt, Args &&... args )
             std::forward< Args >( args )... );
     case Datatype::BOOL:
         return Action::template call< bool >( std::forward< Args >( args )... );
-    case Datatype::DATATYPE:
-        return detail::CallUndefinedDatatype<
-            HIGHEST_DATATYPE,
-            ReturnType,
-            Action,
-            void,
-            Args &&... >::call( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
             LOWEST_DATATYPE,
@@ -325,13 +318,6 @@ auto switchNonVectorType( Datatype dt, Args &&... args )
             std::forward< Args >( args )... );
     case Datatype::BOOL:
         return Action::template call< bool >( std::forward< Args >( args )... );
-    case Datatype::DATATYPE:
-        return detail::CallUndefinedDatatype<
-            HIGHEST_DATATYPE,
-            ReturnType,
-            Action,
-            void,
-            Args &&... >::call( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
             LOWEST_DATATYPE,

--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -194,8 +194,6 @@ getBP1DataType(Datatype dtype)
             return adios_string;
         case DT::VEC_STRING:
             return adios_string_array;
-        case DT::DATATYPE:
-            throw std::runtime_error("Meta-Datatype leaked into IO");
         case DT::UNDEFINED:
             throw std::runtime_error("Unknown Attribute datatype (ADIOS datatype)");
         default:

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -189,13 +189,6 @@ auto switchAdios2AttributeType( Datatype dt, Args &&... args )
     case Datatype::STRING:
         return Action::template call< std::string >(
             std::forward< Args >( args )... );
-    case Datatype::DATATYPE:
-        return detail::CallUndefinedDatatype<
-            HIGHEST_DATATYPE,
-            ReturnType,
-            Action,
-            void,
-            Args &&... >::call( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
             LOWEST_DATATYPE,
@@ -283,13 +276,6 @@ auto switchAdios2VariableType( Datatype dt, Args &&... args )
     //     return action
     //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
     //             std::forward< Args >( args )... );
-    case Datatype::DATATYPE:
-        return detail::CallUndefinedDatatype<
-            HIGHEST_DATATYPE,
-            ReturnType,
-            Action,
-            void,
-            Args &&... >::call( std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
             LOWEST_DATATYPE,

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -191,7 +191,7 @@ auto switchAdios2AttributeType( Datatype dt, Args &&... args )
             std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
-            LOWEST_DATATYPE,
+            0,
             ReturnType,
             Action,
             void,
@@ -278,7 +278,7 @@ auto switchAdios2VariableType( Datatype dt, Args &&... args )
     //             std::forward< Args >( args )... );
     case Datatype::UNDEFINED:
         return detail::CallUndefinedDatatype<
-            LOWEST_DATATYPE,
+            0,
             ReturnType,
             Action,
             void,

--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -209,7 +209,6 @@ namespace openPMD
             case DT::BOOL:
                 return pybind11::dtype("bool"); // also "?"
                 break;
-            case DT::DATATYPE:
             case DT::UNDEFINED:
             default:
                 throw std::runtime_error("dtype_to_numpy: Invalid Datatype '{...}'!"); // _s.format(dt)

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -153,9 +153,6 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
         case DT::BOOL:
             os << "BOOL";
             break;
-        case DT::DATATYPE:
-            os << "DATATYPE";
-            break;
         case DT::UNDEFINED:
             os << "UNDEFINED";
             break;
@@ -315,10 +312,6 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
                 Datatype::BOOL
             },
             {
-                "DATATYPE",
-                Datatype::DATATYPE
-            },
-            {
                 "UNDEFINED",
                 Datatype::UNDEFINED
             }
@@ -380,7 +373,6 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
            Datatype::VEC_STRING,
            Datatype::ARR_DBL_7,
            Datatype::BOOL,
-           Datatype::DATATYPE,
            Datatype::UNDEFINED
    };
 
@@ -396,8 +388,7 @@ operator<<(std::ostream& os, openPMD::Datatype const & d)
             std::map<Datatype, Datatype> res;
             for (Datatype d: openPMD_Datatypes) {
                 if (d == Datatype::ARR_DBL_7
-                        || d == Datatype::UNDEFINED
-                        || d == Datatype::DATATYPE)
+                        || d == Datatype::UNDEFINED)
                     continue;
                 Datatype basic = basicDatatype(d);
                 if (basic == d)

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -98,7 +98,6 @@ CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& nam
             nelems = 7;
             break;
         case DT::UNDEFINED:
-        case DT::DATATYPE:
             throw std::runtime_error("[ADIOS1] Unknown Attribute datatype (ADIOS1 Attribute flush)");
         default:
             nelems = 1;
@@ -351,7 +350,6 @@ CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& nam
             break;
         }
         case DT::UNDEFINED:
-        case DT::DATATYPE:
             throw std::runtime_error("[ADIOS1] Unknown Attribute datatype (ADIOS1 Attribute flush)");
         default:
             throw std::runtime_error("[ADIOS1] Datatype not implemented in ADIOS IO");
@@ -1005,8 +1003,6 @@ CommonADIOS1IOHandlerImpl::readDataset(Writable* writable,
             break;
         case DT::UNDEFINED:
             throw std::runtime_error("[ADIOS1] Unknown Attribute datatype (ADIOS1 Dataset read)");
-        case DT::DATATYPE:
-            throw std::runtime_error("[ADIOS1] Meta-Datatype leaked into IO");
         default:
             throw std::runtime_error("[ADIOS1] Datatype not implemented in ADIOS1 IO");
     }

--- a/src/IO/HDF5/HDF5Auxiliary.cpp
+++ b/src/IO/HDF5/HDF5Auxiliary.cpp
@@ -118,8 +118,6 @@ openPMD::GetH5DataType::operator()(Attribute const &att)
         }
         case DT::BOOL:
             return H5Tcopy( m_userTypes.at( typeid(bool).name() ) );
-        case DT::DATATYPE:
-            throw std::runtime_error("[HDF5] Meta-Datatype leaked into IO");
         case DT::UNDEFINED:
             throw std::runtime_error("[HDF5] Unknown Attribute datatype (HDF5 datatype)");
         default:

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -962,8 +962,6 @@ HDF5IOHandlerImpl::writeDataset(Writable* writable,
             break;
         case DT::UNDEFINED:
             throw std::runtime_error("[HDF5] Undefined Attribute datatype");
-        case DT::DATATYPE:
-            throw std::runtime_error("[HDF5] Meta-Datatype leaked into IO");
         default:
             throw std::runtime_error("[HDF5] Datatype not implemented in HDF5 IO");
     }
@@ -1234,8 +1232,6 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
             break;
         }
         case DT::UNDEFINED:
-        case DT::DATATYPE:
-            throw std::runtime_error("[HDF5] Unknown Attribute datatype (HDF5 Attribute write)");
         default:
             throw std::runtime_error("[HDF5] Datatype not implemented in HDF5 IO");
     }
@@ -1310,8 +1306,6 @@ HDF5IOHandlerImpl::readDataset(Writable* writable,
             break;
         case DT::UNDEFINED:
             throw std::runtime_error("[HDF5] Unknown Attribute datatype (HDF5 Dataset read)");
-        case DT::DATATYPE:
-            throw std::runtime_error("[HDF5] Meta-Datatype leaked into IO");
         default:
             throw std::runtime_error("[HDF5] Datatype not implemented in HDF5 IO");
     }

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -435,7 +435,6 @@ AttributableInterface::readAttributes( ReadMode mode )
             case DT::BOOL:
                 setAttribute(att, a.get< bool >());
                 break;
-            case DT::DATATYPE:
             case DT::UNDEFINED:
                 throw std::runtime_error("Invalid Attribute datatype during read");
         }

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -60,7 +60,6 @@ void init_Datatype(py::module &m) {
         .value("VEC_STRING", Datatype::VEC_STRING)
         .value("ARR_DBL_7", Datatype::ARR_DBL_7)
         .value("BOOL", Datatype::BOOL)
-        .value("DATATYPE", Datatype::DATATYPE)
         .value("UNDEFINED", Datatype::UNDEFINED)
     ;
 


### PR DESCRIPTION
Is this even used anywhere? 
I think this was initially used in some backend somewhere? If yes, it should not leak into the API datatypes and something like `auxiliary::Option` should be preferred.

Alternatively, deprecate for now and leave this PR open for a later point.