### PR TITLE
Two suggestions to fix CommonADIOS1IOHandlerImpl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,11 +426,13 @@ set(IO_ADIOS1_SEQUENTIAL_SOURCE
         src/Error.cpp
         src/auxiliary/Filesystem.cpp
         src/ChunkInfo.cpp
+        src/IO/ADIOS/CommonADIOS1IOHandler.cpp
         src/IO/ADIOS/ADIOS1IOHandler.cpp)
 set(IO_ADIOS1_SOURCE
         src/Error.cpp
         src/auxiliary/Filesystem.cpp
         src/ChunkInfo.cpp
+        src/IO/ADIOS/CommonADIOS1IOHandler.cpp
         src/IO/ADIOS/ParallelADIOS1IOHandler.cpp)
 
 # library

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -25,8 +25,7 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #if openPMD_HAVE_ADIOS1
-#   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
-#   include <adios_read.h>
+#   include "openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp"
 #endif
 
 #include <future>
@@ -41,8 +40,11 @@
 namespace openPMD
 {
 #if openPMD_HAVE_ADIOS1
-    class OPENPMDAPI_EXPORT ADIOS1IOHandlerImpl : public AbstractIOHandlerImpl
+    class OPENPMDAPI_EXPORT ADIOS1IOHandlerImpl
+        : public CommonADIOS1IOHandlerImpl< ADIOS1IOHandlerImpl >
     {
+    private:
+        using Base_t = CommonADIOS1IOHandlerImpl< ADIOS1IOHandlerImpl >;
     public:
         ADIOS1IOHandlerImpl(AbstractIOHandler*);
         virtual ~ADIOS1IOHandlerImpl();
@@ -51,48 +53,9 @@ namespace openPMD
 
         std::future< void > flush() override;
 
-        void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) override;
-        void createPath(Writable*, Parameter< Operation::CREATE_PATH > const&) override;
-        void createDataset(Writable*, Parameter< Operation::CREATE_DATASET > const&) override;
-        void extendDataset(Writable*, Parameter< Operation::EXTEND_DATASET > const&) override;
-        void openFile(Writable*, Parameter< Operation::OPEN_FILE > const&) override;
-        void closeFile(Writable*, Parameter< Operation::CLOSE_FILE > const&) override;
-        void availableChunks(Writable*, Parameter< Operation::AVAILABLE_CHUNKS > &) override;
-        void openPath(Writable*, Parameter< Operation::OPEN_PATH > const&) override;
-        void openDataset(Writable*, Parameter< Operation::OPEN_DATASET > &) override;
-        void deleteFile(Writable*, Parameter< Operation::DELETE_FILE > const&) override;
-        void deletePath(Writable*, Parameter< Operation::DELETE_PATH > const&) override;
-        void deleteDataset(Writable*, Parameter< Operation::DELETE_DATASET > const&) override;
-        void deleteAttribute(Writable*, Parameter< Operation::DELETE_ATT > const&) override;
-        void writeDataset(Writable*, Parameter< Operation::WRITE_DATASET > const&) override;
-        void writeAttribute(Writable*, Parameter< Operation::WRITE_ATT > const&) override;
-        void readDataset(Writable*, Parameter< Operation::READ_DATASET > &) override;
-        void readAttribute(Writable*, Parameter< Operation::READ_ATT > &) override;
-        void listPaths(Writable*, Parameter< Operation::LIST_PATHS > &) override;
-        void listDatasets(Writable*, Parameter< Operation::LIST_DATASETS > &) override;
-        void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
-
         virtual int64_t open_write(Writable *);
         virtual ADIOS_FILE* open_read(std::string const & name);
-        void close(int64_t);
-        void close(ADIOS_FILE*);
         int64_t initialize_group(std::string const& name);
-        void flush_attribute(int64_t group, std::string const& name, Attribute const&);
-
-    protected:
-        ADIOS_READ_METHOD m_readMethod;
-        std::unordered_map< Writable*, std::shared_ptr< std::string > > m_filePaths;
-        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_groups;
-        std::unordered_map< std::shared_ptr< std::string >, bool > m_existsOnDisk;
-        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_openWriteFileHandles;
-        std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
-        std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
-        std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
-        /**
-         * Call this function to get adios file id for a Writable. Will create one if does not exist
-         * @return  returns an adios file id. 
-         */	  
-        int64_t GetFileHandle(Writable*);
     }; // ADIOS1IOHandlerImpl
 #else
     class OPENPMDAPI_EXPORT ADIOS1IOHandlerImpl

--- a/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
@@ -1,0 +1,100 @@
+/* Copyright 2017-2021 Fabian Koller and Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "openPMD/config.hpp"
+
+#if openPMD_HAVE_ADIOS1
+
+#include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/auxiliary/Filesystem.hpp"
+#include "openPMD/auxiliary/DerefDynamicCast.hpp"
+#include "openPMD/auxiliary/Memory.hpp"
+#include "openPMD/auxiliary/StringManip.hpp"
+#include "openPMD/IO/AbstractIOHandlerImpl.hpp"
+#include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
+#include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
+
+#include <adios.h>
+#include <adios_read.h>
+
+#include <future>
+#include <memory>
+#include <string>
+#include <utility>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace openPMD
+{
+    template< typename ChildClass > // CRT pattern
+    class CommonADIOS1IOHandlerImpl : public AbstractIOHandlerImpl
+    {
+    public:
+
+        void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) override;
+        void createPath(Writable*, Parameter< Operation::CREATE_PATH > const&) override;
+        void createDataset(Writable*, Parameter< Operation::CREATE_DATASET > const&) override;
+        void extendDataset(Writable*, Parameter< Operation::EXTEND_DATASET > const&) override;
+        void openFile(Writable*, Parameter< Operation::OPEN_FILE > const&) override;
+        void closeFile(Writable*, Parameter< Operation::CLOSE_FILE > const&) override;
+        void availableChunks(Writable*, Parameter< Operation::AVAILABLE_CHUNKS > &) override;
+        void openPath(Writable*, Parameter< Operation::OPEN_PATH > const&) override;
+        void openDataset(Writable*, Parameter< Operation::OPEN_DATASET > &) override;
+        void deleteFile(Writable*, Parameter< Operation::DELETE_FILE > const&) override;
+        void deletePath(Writable*, Parameter< Operation::DELETE_PATH > const&) override;
+        void deleteDataset(Writable*, Parameter< Operation::DELETE_DATASET > const&) override;
+        void deleteAttribute(Writable*, Parameter< Operation::DELETE_ATT > const&) override;
+        void writeDataset(Writable*, Parameter< Operation::WRITE_DATASET > const&) override;
+        void writeAttribute(Writable*, Parameter< Operation::WRITE_ATT > const&) override;
+        void readDataset(Writable*, Parameter< Operation::READ_DATASET > &) override;
+        void readAttribute(Writable*, Parameter< Operation::READ_ATT > &) override;
+        void listPaths(Writable*, Parameter< Operation::LIST_PATHS > &) override;
+        void listDatasets(Writable*, Parameter< Operation::LIST_DATASETS > &) override;
+        void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
+
+        void close(int64_t);
+        void close(ADIOS_FILE*);
+        void flush_attribute(int64_t group, std::string const& name, Attribute const&);
+
+    protected:
+        template< typename... Args >
+        CommonADIOS1IOHandlerImpl( Args &&... args)
+            : AbstractIOHandlerImpl{ std::forward< Args >( args )... }
+        {}
+
+        ADIOS_READ_METHOD m_readMethod;
+        std::unordered_map< Writable*, std::shared_ptr< std::string > > m_filePaths;
+        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_groups;
+        std::unordered_map< std::shared_ptr< std::string >, bool > m_existsOnDisk;
+        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_openWriteFileHandles;
+        std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
+        std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
+        std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
+        /**
+         * Call this function to get adios file id for a Writable. Will create one if does not exist
+         * @return  returns an adios file id. 
+         */	  
+        int64_t GetFileHandle(Writable*);
+    }; // ParallelADIOS1IOHandlerImpl
+} // openPMD
+
+#endif

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -25,9 +25,7 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 
 #if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
-#   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
-#   include <adios.h>
-#   include <adios_read.h>
+#   include "openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp"
 #endif
 
 #include <future>
@@ -42,8 +40,11 @@
 namespace openPMD
 {
 #if openPMD_HAVE_ADIOS1 && openPMD_HAVE_MPI
-    class OPENPMDAPI_EXPORT ParallelADIOS1IOHandlerImpl : public AbstractIOHandlerImpl
+    class OPENPMDAPI_EXPORT ParallelADIOS1IOHandlerImpl
+        : public CommonADIOS1IOHandlerImpl< ParallelADIOS1IOHandlerImpl >
     {
+    private:
+        using Base_t = CommonADIOS1IOHandlerImpl< ParallelADIOS1IOHandlerImpl >;
     public:
         ParallelADIOS1IOHandlerImpl(AbstractIOHandler*, MPI_Comm);
         virtual ~ParallelADIOS1IOHandlerImpl();
@@ -52,48 +53,11 @@ namespace openPMD
 
         std::future< void > flush() override;
 
-        void createFile(Writable*, Parameter< Operation::CREATE_FILE > const&) override;
-        void createPath(Writable*, Parameter< Operation::CREATE_PATH > const&) override;
-        void createDataset(Writable*, Parameter< Operation::CREATE_DATASET > const&) override;
-        void extendDataset(Writable*, Parameter< Operation::EXTEND_DATASET > const&) override;
-        void openFile(Writable*, Parameter< Operation::OPEN_FILE > const&) override;
-        void closeFile(Writable*, Parameter< Operation::CLOSE_FILE > const&) override;
-        void availableChunks(Writable*, Parameter< Operation::AVAILABLE_CHUNKS > &) override;
-        void openPath(Writable*, Parameter< Operation::OPEN_PATH > const&) override;
-        void openDataset(Writable*, Parameter< Operation::OPEN_DATASET > &) override;
-        void deleteFile(Writable*, Parameter< Operation::DELETE_FILE > const&) override;
-        void deletePath(Writable*, Parameter< Operation::DELETE_PATH > const&) override;
-        void deleteDataset(Writable*, Parameter< Operation::DELETE_DATASET > const&) override;
-        void deleteAttribute(Writable*, Parameter< Operation::DELETE_ATT > const&) override;
-        void writeDataset(Writable*, Parameter< Operation::WRITE_DATASET > const&) override;
-        void writeAttribute(Writable*, Parameter< Operation::WRITE_ATT > const&) override;
-        void readDataset(Writable*, Parameter< Operation::READ_DATASET > &) override;
-        void readAttribute(Writable*, Parameter< Operation::READ_ATT > &) override;
-        void listPaths(Writable*, Parameter< Operation::LIST_PATHS > &) override;
-        void listDatasets(Writable*, Parameter< Operation::LIST_DATASETS > &) override;
-        void listAttributes(Writable*, Parameter< Operation::LIST_ATTS > &) override;
-
         virtual int64_t open_write(Writable *);
         virtual ADIOS_FILE* open_read(std::string const & name);
-        void close(int64_t);
-        void close(ADIOS_FILE*);
         int64_t initialize_group(std::string const& name);
-        void flush_attribute(int64_t group, std::string const& name, Attribute const&);
 
     protected:
-        ADIOS_READ_METHOD m_readMethod;
-        std::unordered_map< Writable*, std::shared_ptr< std::string > > m_filePaths;
-        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_groups;
-        std::unordered_map< std::shared_ptr< std::string >, bool > m_existsOnDisk;
-        std::unordered_map< std::shared_ptr< std::string >, int64_t > m_openWriteFileHandles;
-        std::unordered_map< std::shared_ptr< std::string >, ADIOS_FILE* > m_openReadFileHandles;
-        std::unordered_map< ADIOS_FILE*, std::vector< ADIOS_SELECTION* > > m_scheduledReads;
-        std::unordered_map< int64_t, std::unordered_map< std::string, Attribute > > m_attributeWrites;
-        /**
-         * Call this function to get adios file id for a Writable. Will create one if does not exist
-         * @return  returns an adios file id. 
-         */	  
-        int64_t GetFileHandle(Writable*);
         MPI_Comm m_mpiComm;
         MPI_Info m_mpiInfo;
     }; // ParallelADIOS1IOHandlerImpl

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -78,6 +78,7 @@ class Writable final
     friend class ParticleSpecies;
     friend class SeriesInterface;
     friend class Record;
+    template< typename > friend class CommonADIOS1IOHandlerImpl;
     friend class ADIOS1IOHandlerImpl;
     friend class ParallelADIOS1IOHandlerImpl;
     friend class ADIOS2IOHandlerImpl;

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -22,19 +22,16 @@
 #include "openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp"
 
 #if openPMD_HAVE_ADIOS1
-#   include "openPMD/auxiliary/Filesystem.hpp"
-#   include "openPMD/auxiliary/DerefDynamicCast.hpp"
-#   include "openPMD/auxiliary/Memory.hpp"
-#   include "openPMD/auxiliary/StringManip.hpp"
 #   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
-#   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
-#   include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
+
 #   include "openPMD/IO/IOTask.hpp"
 #   include <adios.h>
+#   include <cstring>
 #   include <iostream>
+#   include <map>
 #   include <memory>
+#   include <string>
 #endif
-#include <utility>
 
 
 namespace openPMD
@@ -47,7 +44,7 @@ namespace openPMD
 #   endif
 
 ADIOS1IOHandlerImpl::ADIOS1IOHandlerImpl(AbstractIOHandler* handler)
-        : AbstractIOHandlerImpl(handler)
+        : Base_t(handler)
 { }
 
 ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
@@ -318,17 +315,6 @@ ADIOS1IOHandlerImpl::initialize_group(std::string const &name)
     VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to select ADIOS method");
     return group;
 }
-
-} // namespace openPMD
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-#define CommonADIOS1IOHandlerImpl ADIOS1IOHandlerImpl
-#include "CommonADIOS1IOHandler.cpp"
-#undef CommonADIOS1IOHandlerImpl
-#endif
-
-namespace openPMD
-{
 
 #else
 ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at)

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -319,11 +319,16 @@ ADIOS1IOHandlerImpl::initialize_group(std::string const &name)
     return group;
 }
 
+} // namespace openPMD
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 #define CommonADIOS1IOHandlerImpl ADIOS1IOHandlerImpl
 #include "CommonADIOS1IOHandler.cpp"
 #undef CommonADIOS1IOHandlerImpl
 #endif
+
+namespace openPMD
+{
 
 #else
 ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at)

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -18,32 +18,55 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include "openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp"
+
+#if openPMD_HAVE_ADIOS1
+
+#include "openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp"
+#include "openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp"
+
+#include <adios.h>
 #include <algorithm>
 #include <complex>
-#include <tuple>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <memory>
 #include <string>
+#include <string>
+#include <tuple>
 
 namespace openPMD
 {
 
+#if openPMD_USE_VERIFY
+#    define VERIFY(CONDITION, TEXT) { if(!(CONDITION)) throw std::runtime_error((TEXT)); }
+#else
+#    define VERIFY(CONDITION, TEXT) do{ (void)sizeof(CONDITION); } while( 0 )
+#endif
+
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::close(int64_t fd)
+CommonADIOS1IOHandlerImpl< ChildClass >::close(int64_t fd)
 {
     int status;
     status = adios_close(fd);
     VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to close ADIOS file (open_write)");
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::close(ADIOS_FILE* f)
+CommonADIOS1IOHandlerImpl< ChildClass >::close(ADIOS_FILE* f)
 {
     int status;
     status = adios_read_close(f);
     VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to close ADIOS file (open_read)");
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& name, Attribute const& att)
+CommonADIOS1IOHandlerImpl< ChildClass >::flush_attribute(int64_t group, std::string const& name, Attribute const& att)
 {
     auto dtype = att.dtype;
     // https://github.com/ComputationalRadiationPhysics/picongpu/pull/1756
@@ -376,8 +399,9 @@ CommonADIOS1IOHandlerImpl::flush_attribute(int64_t group, std::string const& nam
     }
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::createFile(Writable* writable,
                                 Parameter< Operation::CREATE_FILE > const& parameters)
 {
     if( m_handler->m_backendAccess == Access::READ_ONLY )
@@ -410,8 +434,9 @@ CommonADIOS1IOHandlerImpl::createFile(Writable* writable,
     }
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::createPath(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::createPath(Writable* writable,
                                 Parameter< Operation::CREATE_PATH > const& parameters)
 {
     if( m_handler->m_backendAccess == Access::READ_ONLY )
@@ -443,8 +468,9 @@ CommonADIOS1IOHandlerImpl::createPath(Writable* writable,
     }
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::createDataset(Writable* writable,
                                    Parameter< Operation::CREATE_DATASET > const& parameters)
 {
     if( m_handler->m_backendAccess == Access::READ_ONLY )
@@ -513,15 +539,17 @@ CommonADIOS1IOHandlerImpl::createDataset(Writable* writable,
     }
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::extendDataset(Writable*,
+CommonADIOS1IOHandlerImpl< ChildClass >::extendDataset(Writable*,
                                    Parameter< Operation::EXTEND_DATASET > const&)
 {
     throw std::runtime_error("[ADIOS1] Dataset extension not implemented in ADIOS backend");
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::openFile(Writable* writable,
                               Parameter< Operation::OPEN_FILE > const& parameters)
 {
     if( !auxiliary::directory_exists(m_handler->directory) )
@@ -557,11 +585,12 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
     }
 
     if( m_groups.find(filePath) == m_groups.end() )
-        m_groups[filePath] = initialize_group(name);
+        m_groups[filePath] =
+            static_cast< ChildClass * >( this )->initialize_group(name);
 
     if( m_openReadFileHandles.find(filePath) == m_openReadFileHandles.end() )
     {
-        ADIOS_FILE* f = open_read(name);
+        ADIOS_FILE* f = static_cast< ChildClass * >( this )->open_read(name);
         m_openReadFileHandles[filePath] = f;
     }
 
@@ -572,8 +601,9 @@ CommonADIOS1IOHandlerImpl::openFile(Writable* writable,
     m_existsOnDisk[filePath] = true;
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::closeFile(
+CommonADIOS1IOHandlerImpl< ChildClass >::closeFile(
     Writable * writable,
     Parameter< Operation::CLOSE_FILE > const & )
 {
@@ -631,8 +661,9 @@ CommonADIOS1IOHandlerImpl::closeFile(
     m_filePaths.erase( myFile );
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::availableChunks(
+CommonADIOS1IOHandlerImpl< ChildClass >::availableChunks(
     Writable * writable,
     Parameter< Operation::AVAILABLE_CHUNKS > & params )
 {
@@ -672,8 +703,9 @@ CommonADIOS1IOHandlerImpl::availableChunks(
     adios_free_varinfo( varinfo );
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::openPath(
+CommonADIOS1IOHandlerImpl< ChildClass >::openPath(
     Writable * writable,
     Parameter< Operation::OPEN_PATH > const & parameters )
 {
@@ -695,8 +727,9 @@ CommonADIOS1IOHandlerImpl::openPath(
     m_filePaths[writable] = res->second;
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::openDataset(Writable* writable,
                                  Parameter< Operation::OPEN_DATASET >& parameters)
 {
     ADIOS_FILE *f;
@@ -849,8 +882,9 @@ CommonADIOS1IOHandlerImpl::openDataset(Writable* writable,
     m_filePaths[writable] = res->second;
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::deleteFile(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::deleteFile(Writable* writable,
                                 Parameter< Operation::DELETE_FILE > const& parameters)
 {
     if( m_handler->m_backendAccess == Access::READ_ONLY )
@@ -886,28 +920,32 @@ CommonADIOS1IOHandlerImpl::deleteFile(Writable* writable,
     }
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::deletePath(Writable*,
+CommonADIOS1IOHandlerImpl< ChildClass >::deletePath(Writable*,
                                 Parameter< Operation::DELETE_PATH > const&)
 {
     throw std::runtime_error("[ADIOS1] Path deletion not implemented in ADIOS backend");
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::deleteDataset(Writable*,
+CommonADIOS1IOHandlerImpl< ChildClass >::deleteDataset(Writable*,
                                    Parameter< Operation::DELETE_DATASET > const&)
 {
     throw std::runtime_error("[ADIOS1] Dataset deletion not implemented in ADIOS backend");
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::deleteAttribute(Writable*,
+CommonADIOS1IOHandlerImpl< ChildClass >::deleteAttribute(Writable*,
                                      Parameter< Operation::DELETE_ATT > const&)
 {
     throw std::runtime_error("[ADIOS1] Attribute deletion not implemented in ADIOS backend");
 }
 
-int64_t CommonADIOS1IOHandlerImpl::GetFileHandle(Writable* writable)
+template< typename ChildClass >
+int64_t CommonADIOS1IOHandlerImpl< ChildClass >::GetFileHandle(Writable* writable)
 {
     auto res = m_filePaths.find(writable);
     if( res == m_filePaths.end() )
@@ -917,17 +955,20 @@ int64_t CommonADIOS1IOHandlerImpl::GetFileHandle(Writable* writable)
     if( m_openWriteFileHandles.find(res->second) == m_openWriteFileHandles.end() )
     {
         std::string  name  = *(res->second);
-        m_groups[m_filePaths[writable]] = initialize_group(name);
+        m_groups[m_filePaths[writable]] =
+            static_cast< ChildClass * >( this )->initialize_group(name);
 
-        fd = open_write(writable);
+        fd = static_cast< ChildClass * >( this )->open_write(writable);
         m_openWriteFileHandles[res->second] = fd;
     } else
         fd = m_openWriteFileHandles.at(res->second);
 
     return fd;
 }
+
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::writeDataset(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::writeDataset(Writable* writable,
                                   Parameter< Operation::WRITE_DATASET > const& parameters)
 {
     if( m_handler->m_backendAccess == Access::READ_ONLY )
@@ -958,8 +999,9 @@ CommonADIOS1IOHandlerImpl::writeDataset(Writable* writable,
     VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to write ADIOS variable during Dataset writing");
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::writeAttribute(Writable* writable,
                                     Parameter< Operation::WRITE_ATT > const& parameters)
 {
     if( m_handler->m_backendAccess == Access::READ_ONLY )
@@ -982,8 +1024,9 @@ CommonADIOS1IOHandlerImpl::writeAttribute(Writable* writable,
     attributes.emplace(name, parameters.resource);
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::readDataset(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::readDataset(Writable* writable,
                                  Parameter< Operation::READ_DATASET >& parameters)
 {
     switch( parameters.dtype )
@@ -1041,8 +1084,9 @@ CommonADIOS1IOHandlerImpl::readDataset(Writable* writable,
     m_scheduledReads[f].push_back(sel);
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::readAttribute(Writable* writable,
                                    Parameter< Operation::READ_ATT >& parameters)
 {
     if( !writable->written )
@@ -1513,8 +1557,9 @@ CommonADIOS1IOHandlerImpl::readAttribute(Writable* writable,
     *parameters.resource = a.getResource();
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::listPaths(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::listPaths(Writable* writable,
                                Parameter< Operation::LIST_PATHS >& parameters)
 {
     if( !writable->written )
@@ -1571,8 +1616,9 @@ CommonADIOS1IOHandlerImpl::listPaths(Writable* writable,
     *parameters.paths = std::vector< std::string >(paths.begin(), paths.end());
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::listDatasets(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::listDatasets(Writable* writable,
                                   Parameter< Operation::LIST_DATASETS >& parameters)
 {
     if( !writable->written )
@@ -1603,8 +1649,9 @@ CommonADIOS1IOHandlerImpl::listDatasets(Writable* writable,
     *parameters.datasets = std::vector< std::string >(paths.begin(), paths.end());
 }
 
+template< typename ChildClass >
 void
-CommonADIOS1IOHandlerImpl::listAttributes(Writable* writable,
+CommonADIOS1IOHandlerImpl< ChildClass >::listAttributes(Writable* writable,
                                     Parameter< Operation::LIST_ATTS >& parameters)
 {
     if( !writable->written )
@@ -1656,4 +1703,9 @@ CommonADIOS1IOHandlerImpl::listAttributes(Writable* writable,
     }
 }
 
-} // namespace openPMD
+template class CommonADIOS1IOHandlerImpl< ADIOS1IOHandlerImpl >;
+#if openPMD_HAVE_MPI
+template class CommonADIOS1IOHandlerImpl< ParallelADIOS1IOHandlerImpl >;
+#endif // opepnPMD_HAVE_MPI
+#endif // openPMD_HAVE_ADIOS1
+}

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -23,6 +23,8 @@
 #include <tuple>
 #include <string>
 
+namespace openPMD
+{
 
 void
 CommonADIOS1IOHandlerImpl::close(int64_t fd)
@@ -1653,3 +1655,5 @@ CommonADIOS1IOHandlerImpl::listAttributes(Writable* writable,
         *parameters.attributes = std::vector< std::string >(attributes.begin(), attributes.end());
     }
 }
+
+} // namespace openPMD

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -348,11 +348,16 @@ ParallelADIOS1IOHandlerImpl::initialize_group(std::string const &name)
     return group;
 }
 
+} // namespace openPMD
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 #define CommonADIOS1IOHandlerImpl ParallelADIOS1IOHandlerImpl
 #include "CommonADIOS1IOHandler.cpp"
 #undef CommonADIOS1IOHandlerImpl
 #endif
+
+namespace openPMD
+{
 
 #else
 #   if openPMD_HAVE_MPI

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -22,17 +22,12 @@
 #include "openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp"
 
 #if openPMD_HAVE_MPI && openPMD_HAVE_ADIOS1
-#   include "openPMD/auxiliary/Filesystem.hpp"
-#   include "openPMD/auxiliary/DerefDynamicCast.hpp"
-#   include "openPMD/auxiliary/Memory.hpp"
-#   include "openPMD/auxiliary/StringManip.hpp"
-#   include "openPMD/IO/AbstractIOHandlerImpl.hpp"
-#   include "openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp"
-#   include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
 #   include "openPMD/IO/IOTask.hpp"
 #   include <adios.h>
 #   include <cstring>
+#   include <iostream>
 #   include <map>
+#   include <memory>
 #   include <string>
 #endif
 
@@ -47,7 +42,7 @@ namespace openPMD
 
 ParallelADIOS1IOHandlerImpl::ParallelADIOS1IOHandlerImpl(AbstractIOHandler* handler,
                                                          MPI_Comm comm)
-        : AbstractIOHandlerImpl{handler},
+        : Base_t{handler},
           m_mpiInfo{MPI_INFO_NULL}
 {
     int status = MPI_SUCCESS;
@@ -347,17 +342,6 @@ ParallelADIOS1IOHandlerImpl::initialize_group(std::string const &name)
     VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to select ADIOS method");
     return group;
 }
-
-} // namespace openPMD
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-#define CommonADIOS1IOHandlerImpl ParallelADIOS1IOHandlerImpl
-#include "CommonADIOS1IOHandler.cpp"
-#undef CommonADIOS1IOHandlerImpl
-#endif
-
-namespace openPMD
-{
 
 #else
 #   if openPMD_HAVE_MPI


### PR DESCRIPTION
The current macro hack we have works, but is annoying:

1. It's impossible to include other openPMD headers into CommonADIOS1IOHandlerImpl.cpp, since that file is itself included into the openPMD namespace. The first commit fixes the namespaces.
2. IDEs usually don't understand what is going on and these macro things are not really compatible with the upcoming C++20 modules. The second commit suggests replacing things with a CRT pattern. Also has the advantage of having a separate class declaration for all things that are actually shared between the parallel and serial implementations.