### PR TITLE
Executables: CXX_STANDARD/EXTENSIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -827,6 +827,11 @@ if(openPMD_BUILD_TESTING)
         else()
             target_link_libraries(${testname}Tests PRIVATE CatchMain)
         endif()
+
+        set_target_properties(${testname}Tests PROPERTIES
+            CXX_EXTENSIONS OFF
+            CXX_STANDARD_REQUIRED ON
+        )
     endforeach()
 endif()
 
@@ -834,6 +839,10 @@ if(openPMD_BUILD_CLI_TOOLS)
     foreach(toolname ${openPMD_CLI_TOOL_NAMES})
         add_executable(openpmd-${toolname} src/cli/${toolname}.cpp)
         target_link_libraries(openpmd-${toolname} PRIVATE openPMD)
+        set_target_properties(openpmd-${toolname} PROPERTIES
+            CXX_EXTENSIONS OFF
+            CXX_STANDARD_REQUIRED ON
+        )
     endforeach()
 endif()
 
@@ -843,10 +852,18 @@ if(openPMD_BUILD_EXAMPLES)
             if(openPMD_HAVE_MPI)
                 add_executable(${examplename} examples/${examplename}.cpp)
                 target_link_libraries(${examplename} PRIVATE openPMD)
+                set_target_properties(${examplename} PROPERTIES
+                    CXX_EXTENSIONS OFF
+                    CXX_STANDARD_REQUIRED ON
+                )
             endif()
         else()
             add_executable(${examplename} examples/${examplename}.cpp)
             target_link_libraries(${examplename} PRIVATE openPMD)
+            set_target_properties(${examplename} PROPERTIES
+                CXX_EXTENSIONS OFF
+                CXX_STANDARD_REQUIRED ON
+            )
         endif()
     endforeach()
 endif()


### PR DESCRIPTION
Set `CXX_EXTENSIONS OFF` and `CXX_STANDARD_REQUIRED ON` for created executables.

This mitigates issues with NVCC 11.0 and C++17 builds seen as added `-std=gnu++17` flags that lead to
```
nvcc fatal   : Value 'gnu++17' is not defined for option 'std'
```
when using `nvcc` as CXX compiler directly.