### PR TITLE
NVCC + C++17

### DIFF
--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -434,7 +434,8 @@ AttributableInterface::setAttribute( std::string const & key, T value )
         && !attri.m_attributes.key_comp()(key, it->first) )
     {
         // key already exists in map, just replace the value
-        it->second = Attribute(value);
+        Attribute::resource val(value);
+        it->second = Attribute(std::move(val));
         return true;
     } else
     {

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -434,8 +434,12 @@ AttributableInterface::setAttribute( std::string const & key, T value )
         && !attri.m_attributes.key_comp()(key, it->first) )
     {
         // key already exists in map, just replace the value
-        Attribute::resource val(value);
-        it->second = Attribute(std::move(val));
+
+        // note: due to a C++17 issue with NVCC 11.0.2 we write the
+        //       T value to variant conversion explicitly
+        //       https://github.com/openPMD/openPMD-api/pull/1103
+        //it->second = Attribute(std::move(value));
+        it->second = Attribute(Attribute::resource(std::move(value)));
         return true;
     } else
     {


### PR DESCRIPTION
Work-around a build issue with NVCC in C++17 builds.
```
include/openPMD/backend/Attributable.hpp(437):
error #289: no instance of constructor "openPMD::Attribute::Attribute" matches the argument list
            argument types are: (std::__cxx11::string)
          detected during instantiation of "__nv_bool openPMD::AttributableInterface::setAttribute(const std::__cxx11::string &, T) [with T=std::__cxx11::string]"
```
from
```C++
inline bool
AttributableInterface::setAttribute( std::string const & key, char const value[] )
{
    return this->setAttribute(key, std::string(value));
}
```

Seen with WarpX and:
- CUDA 11.0.2 + GCC 8.3.0 (x86_64, Cori GPU@NERSC)
- CUDA 11.0.2 + GCC 7.5.0 (x86_64, GitHub Actions with Ubuntu 18.04 https://github.com/ECP-WarpX/WarpX/pull/2300)

Not seen with WarpX and:
- CUDA 11.0.3 (NVCC 11.0.221) + GCC 9.3.0 (ppc64le, Summit@OLCF)