### PR TITLE
Doc: More Locations -DPython_EXECUTABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ cd openPMD-api-build
 # for options append:
 #   -DopenPMD_USE_...=...
 # e.g. for python support add:
-#   -DopenPMD_USE_PYTHON=ON
+#   -DopenPMD_USE_PYTHON=ON -DPython_EXECUTABLE=$(which python3)
 cmake ../openPMD-api
 
 cmake --build .

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -146,7 +146,7 @@ Linux & OSX
    # for options append:
    #   -DopenPMD_USE_...=...
    # e.g. for python support add:
-   #   -DopenPMD_USE_PYTHON=ON
+   #   -DopenPMD_USE_PYTHON=ON -DPython_EXECUTABLE=$(which python3)
    cmake ../openPMD-api
 
    cmake --build .


### PR DESCRIPTION
Mention the `-DPython_EXECUTABLE` twice more in build examples.