### PR TITLE
Avoid object slicing when deriving from Series class

### DIFF
--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -474,8 +474,11 @@ public:
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
+ *
+ * This class must be final since there are member methods that copy *this.
+ * In a derived instance, that would lead to object slicing.
  */
-class Series : public SeriesInterface
+class Series final : public SeriesInterface
 {
 private:
     std::shared_ptr< internal::SeriesInternal > m_series;

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -474,14 +474,14 @@ public:
  *
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
- *
- * This class must be final since there are member methods that copy *this.
- * In a derived instance, that would lead to object slicing.
  */
-class Series final : public SeriesInterface
+class Series : public SeriesInterface
 {
 private:
     std::shared_ptr< internal::SeriesInternal > m_series;
+
+    // constructor from private parts
+    Series( std::shared_ptr< internal::SeriesInternal > );
 
 public:
     explicit Series();

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1528,6 +1528,15 @@ SeriesInternal::~SeriesInternal()
 }
 } // namespace internal
 
+Series::Series( std::shared_ptr< internal::SeriesInternal > series_in )
+    : SeriesInterface{
+        series_in.get(),
+        static_cast< internal::AttributableData * >( series_in.get() ) }
+    , m_series{ std::move( series_in ) }
+    , iterations{ m_series->iterations }
+{
+}
+
 Series::Series() : SeriesInterface{ nullptr, nullptr }, iterations{}
 {
 }
@@ -1570,7 +1579,9 @@ Series::operator bool() const
 
 ReadIterations Series::readIterations()
 {
-    return { *this };
+    // Use private constructor instead of copy constructor to avoid
+    // object slicing
+    return { this->m_series };
 }
 
 WriteIterations


### PR DESCRIPTION
The methods `::writeIterations()` and `readIterations()` copy the `Series` object (i.e., they copy `*this`). If Series is derived from, this leads to object slicing. Update: Use a private constructor instead that creates a new `Series` object from raw parts.

TODO
- [x] Try to fix this in a different way
- [ ] Add test for derived classes, maybe for all public classes in a separate PR?
(alternatively we should mark them `final`): #1113