### PR TITLE
Apply new frontend design to Container and deriving classes

### DIFF
--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -37,11 +37,11 @@
 
 namespace openPMD
 {
-class AttributableInterface;
+class Attributable;
 class Writable;
 
 Writable*
-getWritable(AttributableInterface*);
+getWritable(Attributable*);
 
 /** Type of IO operation between logical and persistent data.
  */
@@ -604,7 +604,7 @@ public:
     { }
 
     template< Operation op >
-    explicit IOTask(AttributableInterface* a,
+    explicit IOTask(Attributable* a,
            Parameter< op > const & p)
             : writable{getWritable(a)},
               operation{op},

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -44,7 +44,7 @@ class Iteration : public LegacyAttributable
             typename T_container
     >
     friend class Container;
-    friend class SeriesInterface;
+    friend class Series;
     friend class WriteIterations;
     friend class SeriesIterator;
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -84,8 +84,7 @@ namespace internal
 {
     class RecordComponentData : public BaseRecordComponentData
     {
-        friend class openPMD::RecordComponent;
-
+    public:
         RecordComponentData();
 
         RecordComponentData( RecordComponentData const & ) = delete;
@@ -93,8 +92,6 @@ namespace internal
 
         RecordComponentData & operator=( RecordComponentData const & ) = delete;
         RecordComponentData & operator=( RecordComponentData && ) = delete;
-
-    OPENPMD_private:
 
         std::queue< IOTask > m_chunks;
         Attribute m_constantValue{ -1 };

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -94,6 +94,8 @@ namespace internal
         RecordComponentData & operator=( RecordComponentData const & ) = delete;
         RecordComponentData & operator=( RecordComponentData && ) = delete;
 
+    OPENPMD_private:
+
         std::queue< IOTask > m_chunks;
         Attribute m_constantValue{ -1 };
         /**

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -54,7 +54,7 @@ namespace openPMD
 {
 class ReadIterations;
 class Series;
-class SeriesInterface;
+class Series;
 
 namespace internal
 {
@@ -69,13 +69,13 @@ class SeriesData : public AttributableData
 public:
     explicit SeriesData() = default;
 
+    virtual ~SeriesData();
+
     SeriesData( SeriesData const & ) = delete;
     SeriesData( SeriesData && ) = delete;
 
     SeriesData & operator=( SeriesData const & ) = delete;
     SeriesData & operator=( SeriesData && ) = delete;
-
-    virtual ~SeriesData() = default;
 
     Container< Iteration, uint64_t > iterations{};
 
@@ -96,7 +96,8 @@ public:
      */
     StepStatus m_stepStatus = StepStatus::NoStep;
     bool m_parseLazily = false;
-    bool m_lastFlushSuccessful = true;
+    // only set this true after successful construction
+    bool m_lastFlushSuccessful = false;
 }; // SeriesData
 
 class SeriesInternal;
@@ -109,21 +110,56 @@ class SeriesInternal;
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
  * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
  */
-class SeriesInterface : public AttributableInterface
+class Series : public Attributable
 {
-    friend class AttributableInterface;
+    friend class Attributable;
     friend class Iteration;
     friend class Writable;
     friend class SeriesIterator;
-    friend class internal::SeriesInternal;
-    friend class Series;
+    friend class internal::SeriesData;
     friend class WriteIterations;
 
 protected:
     // Should not be called publicly, only by implementing classes
-    SeriesInterface( internal::SeriesData *, internal::AttributableData * );
+    Series( std::shared_ptr< internal::SeriesData > );
 
 public:
+    explicit Series();
+
+#if openPMD_HAVE_MPI
+    Series(
+        std::string const & filepath,
+        Access at,
+        MPI_Comm comm,
+        std::string const & options = "{}" );
+#endif
+
+    /**
+     * @brief Construct a new Series
+     *
+     * @param filepath The backend will be determined by the filepath extension.
+     * @param at Access mode.
+     * @param options Advanced backend configuration via JSON.
+     *      May be specified as a JSON-formatted string directly, or as a path
+     *      to a JSON textfile, prepended by an at sign '@'.
+     */
+    Series(
+        std::string const & filepath,
+        Access at,
+        std::string const & options = "{}" );
+
+    virtual ~Series() = default;
+
+    Container< Iteration, uint64_t > iterations;
+
+    /**
+     * @brief Is this a usable Series object?
+     *
+     * @return true If a Series has been opened for reading and/or writing.
+     * @return false If the object has been default-constructed.
+     */
+    operator bool() const;
+
     /**
      * @return  String representing the current enforced version of the <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file">openPMD standard</A>.
      */
@@ -133,7 +169,7 @@ public:
      * @param   openPMD   String <CODE>MAJOR.MINOR.REVISION</CODE> of the desired version of the openPMD standard.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setOpenPMD(std::string const& openPMD);
+    Series& setOpenPMD(std::string const& openPMD);
 
     /**
      * @return  32-bit mask of applied extensions to the <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file">openPMD standard</A>.
@@ -144,7 +180,7 @@ public:
      * @param   openPMDextension  Unsigned 32-bit integer used as a bit-mask of applied extensions.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setOpenPMDextension(uint32_t openPMDextension);
+    Series& setOpenPMDextension(uint32_t openPMDextension);
 
     /**
      * @return  String representing the common prefix for all data sets and sub-groups of a specific iteration.
@@ -155,7 +191,7 @@ public:
      * @param   basePath    String of the common prefix for all data sets and sub-groups of a specific iteration.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setBasePath(std::string const& basePath);
+    Series& setBasePath(std::string const& basePath);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -167,7 +203,7 @@ public:
      * @param   meshesPath  String of the path to <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#mesh-based-records">mesh records</A>, relative(!) to <CODE>basePath</CODE>.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setMeshesPath(std::string const& meshesPath);
+    Series& setMeshesPath(std::string const& meshesPath);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -179,7 +215,7 @@ public:
      * @param   particlesPath   String of the path to groups for each <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#particle-records">particle species</A>, relative(!) to <CODE>basePath</CODE>.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setParticlesPath(std::string const& particlesPath);
+    Series& setParticlesPath(std::string const& particlesPath);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -191,7 +227,7 @@ public:
      * @param   author  String indicating author and contact for the information in the file.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setAuthor(std::string const& author);
+    Series& setAuthor(std::string const& author);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -204,7 +240,7 @@ public:
      * @param   newVersion String indicating the version of the software/code/simulation that created the file.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setSoftware(std::string const& newName, std::string const& newVersion = std::string("unspecified"));
+    Series& setSoftware(std::string const& newName, std::string const& newVersion = std::string("unspecified"));
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -219,7 +255,7 @@ public:
      * @return  Reference to modified series.
      */
     [[deprecated("Set the version with the second argument of setSoftware()")]]
-    SeriesInterface& setSoftwareVersion(std::string const& softwareVersion);
+    Series& setSoftwareVersion(std::string const& softwareVersion);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -231,7 +267,7 @@ public:
      * @param   date    String indicating the date of creation.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setDate(std::string const& date);
+    Series& setDate(std::string const& date);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -243,7 +279,7 @@ public:
      * @param   newSoftwareDependencies String indicating dependencies of software that were used to create the file (semicolon-separated list if needed).
      * @return  Reference to modified series.
      */
-    SeriesInterface& setSoftwareDependencies(std::string const& newSoftwareDependencies);
+    Series& setSoftwareDependencies(std::string const& newSoftwareDependencies);
 
     /**
      * @throw   no_such_attribute_error If optional attribute is not present.
@@ -255,7 +291,7 @@ public:
      * @param   newMachine String indicating the machine or relevant hardware that created the file (semicolon-separated list if needed)..
      * @return  Reference to modified series.
      */
-    SeriesInterface& setMachine(std::string const& newMachine);
+    Series& setMachine(std::string const& newMachine);
 
     /**
      * @return  Current encoding style for multiple iterations in this series.
@@ -269,7 +305,7 @@ public:
      * @param   iterationEncoding   Desired <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series">encoding style</A> for multiple iterations in this series.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setIterationEncoding(IterationEncoding iterationEncoding);
+    Series& setIterationEncoding(IterationEncoding iterationEncoding);
 
     /**
      * @return  String describing a <A HREF="https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series">pattern</A> describing how to access single iterations in the raw file.
@@ -285,7 +321,7 @@ public:
      *                          The format depends on the selected iterationEncoding method.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setIterationFormat(std::string const& iterationFormat);
+    Series& setIterationFormat(std::string const& iterationFormat);
 
     /**
      * @return String of a pattern for file names.
@@ -297,7 +333,7 @@ public:
      * @param   name    String of the pattern for file names. Must include iteration regex <CODE>\%T</CODE> for fileBased data.
      * @return  Reference to modified series.
      */
-    SeriesInterface& setName(std::string const& name);
+    Series& setName(std::string const& name);
 
     /** The currently used backend
      *
@@ -311,6 +347,32 @@ public:
      */
     void flush();
 
+    /**
+     * @brief Entry point to the reading end of the streaming API.
+     *
+     * Creates and returns an instance of the ReadIterations class which can
+     * be used for iterating over the openPMD iterations in a C++11-style for
+     * loop.
+     * Look for the ReadIterations class for further documentation.
+     *
+     * @return ReadIterations
+     */
+    ReadIterations readIterations();
+
+    /**
+     * @brief Entry point to the writing end of the streaming API.
+     *
+     * Creates and returns an instance of the WriteIterations class which is a
+     * restricted container of iterations which takes care of
+     * streaming semantics.
+     * The created object is stored as member of the Series object, hence this
+     * method may be called as many times as a user wishes.
+     * Look for the WriteIterations class for further documentation.
+     *
+     * @return WriteIterations
+     */
+    WriteIterations writeIterations();
+
 OPENPMD_private:
     static constexpr char const * const BASEPATH = "/data/%T/";
 
@@ -318,7 +380,7 @@ OPENPMD_private:
     using iterations_t = decltype(internal::SeriesData::iterations);
     using iterations_iterator = iterations_t::iterator;
 
-    internal::SeriesData * m_series = nullptr;
+    std::shared_ptr< internal::SeriesData > m_series = nullptr;
 
     inline internal::SeriesData & get()
     {
@@ -436,118 +498,9 @@ OPENPMD_private:
         internal::AttributableData & file,
         iterations_iterator it,
         Iteration & iteration );
-}; // SeriesInterface
-
-namespace internal
-{
-class SeriesInternal : public SeriesData, public SeriesInterface
-{
-    friend struct SeriesShared;
-    friend class openPMD::Iteration;
-    friend class openPMD::Series;
-    friend class openPMD::Writable;
-
-public:
-#if openPMD_HAVE_MPI
-    SeriesInternal(
-        std::string const & filepath,
-        Access at,
-        MPI_Comm comm,
-        std::string const & options = "{}" );
-#endif
-
-    SeriesInternal(
-        std::string const & filepath,
-        Access at,
-        std::string const & options = "{}" );
-    // @todo make AttributableInterface<>::linkHierarchy non-virtual
-    virtual ~SeriesInternal();
-};
-} // namespace internal
-
-/** @brief  Root level of the openPMD hierarchy.
- *
- * Entry point and common link between all iterations of particle and mesh data.
- *
- * An instance can be created either directly via the given constructors or via
- * the SeriesBuilder class.
- *
- * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#hierarchy-of-the-data-file
- * @see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#iterations-and-time-series
- */
-class Series : public SeriesInterface
-{
-private:
-    std::shared_ptr< internal::SeriesInternal > m_series;
-
-    // constructor from private parts
-    Series( std::shared_ptr< internal::SeriesInternal > );
-
-public:
-    explicit Series();
-
-#if openPMD_HAVE_MPI
-    Series(
-        std::string const & filepath,
-        Access at,
-        MPI_Comm comm,
-        std::string const & options = "{}" );
-#endif
-
-    /**
-     * @brief Construct a new Series
-     *
-     * @param filepath The backend will be determined by the filepath extension.
-     * @param at Access mode.
-     * @param options Advanced backend configuration via JSON.
-     *      May be specified as a JSON-formatted string directly, or as a path
-     *      to a JSON textfile, prepended by an at sign '@'.
-     */
-    Series(
-        std::string const & filepath,
-        Access at,
-        std::string const & options = "{}" );
-
-    virtual ~Series() = default;
-
-    Container< Iteration, uint64_t > iterations;
-
-    /**
-     * @brief Is this a usable Series object?
-     *
-     * @return true If a Series has been opened for reading and/or writing.
-     * @return false If the object has been default-constructed.
-     */
-    operator bool() const;
-
-    /**
-     * @brief Entry point to the reading end of the streaming API.
-     *
-     * Creates and returns an instance of the ReadIterations class which can
-     * be used for iterating over the openPMD iterations in a C++11-style for
-     * loop.
-     * Look for the ReadIterations class for further documentation.
-     *
-     * @return ReadIterations
-     */
-    ReadIterations readIterations();
-
-    /**
-     * @brief Entry point to the writing end of the streaming API.
-     *
-     * Creates and returns an instance of the WriteIterations class which is a
-     * restricted container of iterations which takes care of
-     * streaming semantics.
-     * The created object is stored as member of the Series object, hence this
-     * method may be called as many times as a user wishes.
-     * Look for the WriteIterations class for further documentation.
-     *
-     * @return WriteIterations
-     */
-    WriteIterations writeIterations();
-};
+}; // Series
 } // namespace openPMD
 
 // Make sure that this one is always included if Series.hpp is included,
-// otherwise SeriesInterface::readIterations() cannot be used
+// otherwise Series::readIterations() cannot be used
 #include "openPMD/ReadIterations.hpp"

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -105,6 +105,7 @@ attr_value_check( std::string const key, std::string const value )
                 "' must not be empty!" );
 }
 
+template< typename > class BaseRecordData;
 } // namespace internal
 
 /** @brief Layer to manage storage of attributes associated with file objects.
@@ -119,6 +120,10 @@ class AttributableInterface
     friend Writable* getWritable(AttributableInterface*);
     template< typename T_elem >
     friend class BaseRecord;
+    template< typename T_elem >
+    friend class BaseRecordInterface;
+    template< typename >
+    friend class internal::BaseRecordData;
     template<
         typename T,
         typename T_key,
@@ -352,6 +357,12 @@ OPENPMD_protected:
     }
 
     inline
+    void setData( internal::AttributableData * attri )
+    {
+        m_attri = attri;
+    }
+
+    inline
     internal::AttributableData & get()
     {
         if( m_attri )
@@ -407,7 +418,7 @@ protected:
 public:
     LegacyAttributable() : AttributableInterface{ nullptr }
     {
-        AttributableInterface::m_attri = m_attributableData.get();
+        AttributableInterface::setData( m_attributableData.get() );
     }
 };
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -380,8 +380,6 @@ private:
     virtual void linkHierarchy(Writable& w);
 }; // Attributable
 
-using LegacyAttributable = Attributable;
-
 //TODO explicitly instantiate Attributable::setAttribute for all T in Datatype
 template< typename T >
 inline bool

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -31,20 +31,14 @@
 
 namespace openPMD
 {
-
-template< typename > class BaseRecord;
-
 namespace internal
 {
     template< typename T_elem >
     class BaseRecordData : public ContainerData< T_elem >
     {
-        template< typename > friend class openPMD::BaseRecord;
-
-    protected:
+    public:
         bool m_containsScalar = false;
 
-    public:
         BaseRecordData();
 
         BaseRecordData( BaseRecordData const & ) = delete;
@@ -168,7 +162,7 @@ namespace internal
     template< typename T_elem >
     BaseRecordData< T_elem >::BaseRecordData()
     {
-        AttributableInterface impl{ this };
+        Attributable impl{ { this, []( auto const * ){} } };
         impl.setAttribute(
             "unitDimension",
             std::array< double, 7 >{ { 0., 0., 0., 0., 0., 0., 0. } } );

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -32,31 +32,11 @@
 
 namespace openPMD
 {
-class BaseRecordComponent;
-class Iteration;
-class Mesh;
-class ParticleSpecies;
-class PatchRecordComponent;
-class PatchRecordComponentInterface;
-class Record;
-class RecordComponent;
-class RecordComponentInterface;
-
 namespace internal
 {
     class BaseRecordComponentData : public AttributableData
     {
-        friend class openPMD::BaseRecordComponent;
-        friend class openPMD::Iteration;
-        friend class openPMD::Mesh;
-        friend class openPMD::ParticleSpecies;
-        friend class openPMD::PatchRecordComponent;
-        friend class openPMD::PatchRecordComponentInterface;
-        friend class openPMD::Record;
-        friend class openPMD::RecordComponent;
-        friend class openPMD::RecordComponentInterface;
-
-
+    public:
         Dataset m_dataset{ Datatype::UNDEFINED, {} };
         bool m_isConstant = false;
 
@@ -68,12 +48,11 @@ namespace internal
         BaseRecordComponentData & operator=(
             BaseRecordComponentData && ) = delete;
 
-    protected:
         BaseRecordComponentData() = default;
     };
 }
 
-class BaseRecordComponent : public AttributableInterface
+class BaseRecordComponent : public Attributable
 {
     template<
         typename T,
@@ -140,7 +119,7 @@ protected:
         std::shared_ptr< internal::BaseRecordComponentData > data )
     {
         m_baseRecordComponentData = std::move( data );
-        AttributableInterface::setData( m_baseRecordComponentData.get() );
+        Attributable::setData( m_baseRecordComponentData );
     }
 
     BaseRecordComponent( std::shared_ptr< internal::BaseRecordComponentData > );

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -124,17 +124,17 @@ template<
     typename T,
     typename T_key = std::string,
     typename T_container = std::map< T_key, T > >
-class Container : public AttributableInterface
+class Container : public Attributable
 {
     static_assert(
-        std::is_base_of< AttributableInterface, T >::value,
+        std::is_base_of< Attributable, T >::value,
         "Type of container element must be derived from Writable");
 
     friend class Iteration;
     friend class ParticleSpecies;
     friend class ParticlePatches;
     friend class internal::SeriesData;
-    friend class SeriesInterface;
+    friend class Series;
     friend class Series;
     template< typename > friend class internal::EraseStaleEntries;
 
@@ -148,7 +148,7 @@ protected:
     inline void setData( std::shared_ptr< ContainerData > containerData )
     {
         m_containerData = std::move( containerData );
-        AttributableInterface::setData( m_containerData.get() );
+        Attributable::setData( m_containerData );
     }
 
     inline InternalContainer const & container() const
@@ -342,7 +342,7 @@ public:
 
 OPENPMD_protected:
     Container( std::shared_ptr< ContainerData > containerData )
-        : AttributableInterface{ containerData.get() }
+        : Attributable{ containerData }
         , m_containerData{ std::move( containerData ) }
     {
     }
@@ -368,9 +368,9 @@ OPENPMD_protected:
     }
 
 OPENPMD_private:
-    Container() : AttributableInterface{ nullptr }
+    Container() : Attributable{ nullptr }
     {
-        AttributableInterface::setData( m_containerData.get() );
+        Attributable::setData( m_containerData );
     }
 };
 

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -367,7 +367,7 @@ OPENPMD_protected:
         flushAttributes();
     }
 
-private:
+OPENPMD_private:
     Container() : AttributableInterface{ nullptr }
     {
         AttributableInterface::setData( m_containerData.get() );

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/Error.hpp"
 #include "openPMD/backend/Attributable.hpp"
 
 #include <initializer_list>
@@ -58,8 +59,28 @@ namespace traits
 
 namespace internal
 {
-class SeriesData;
-template< typename > class EraseStaleEntries;
+    class SeriesData;
+    template< typename > class EraseStaleEntries;
+
+    template<
+        typename T,
+        typename T_key = std::string,
+        typename T_container = std::map< T_key, T > >
+    class ContainerData : public AttributableData
+    {
+    public:
+        using InternalContainer = T_container;
+
+        InternalContainer m_container;
+
+        ContainerData() = default;
+
+        ContainerData( ContainerData const & ) = delete;
+        ContainerData( ContainerData && ) = delete;
+
+        ContainerData & operator=( ContainerData const & ) = delete;
+        ContainerData & operator=( ContainerData && ) = delete;
+    };
 }
 
 namespace detail
@@ -100,11 +121,10 @@ std::vector< std::string > keyAsString< std::string >(
  * @tparam T_container  Type of container used for internal storage (must supply the same type traits and interface as std::map)
  */
 template<
-        typename T,
-        typename T_key = std::string,
-        typename T_container = std::map< T_key, T >
->
-class Container : public LegacyAttributable
+    typename T,
+    typename T_key = std::string,
+    typename T_container = std::map< T_key, T > >
+class Container : public AttributableInterface
 {
     static_assert(
         std::is_base_of< AttributableInterface, T >::value,
@@ -112,13 +132,35 @@ class Container : public LegacyAttributable
 
     friend class Iteration;
     friend class ParticleSpecies;
+    friend class ParticlePatches;
     friend class internal::SeriesData;
     friend class SeriesInterface;
     friend class Series;
     template< typename > friend class internal::EraseStaleEntries;
 
 protected:
+    using ContainerData = internal::ContainerData< T, T_key, T_container >;
     using InternalContainer = T_container;
+
+    std::shared_ptr< ContainerData > m_containerData{
+        new ContainerData() };
+
+    inline void setData( std::shared_ptr< ContainerData > containerData )
+    {
+        m_containerData = std::move( containerData );
+        AttributableInterface::setData( m_containerData.get() );
+    }
+
+    inline InternalContainer const & container() const
+    {
+        return m_containerData->m_container;
+    }
+
+    inline InternalContainer & container()
+    {
+        return const_cast< InternalContainer & >(
+            static_cast< Container const * >( this )->container() );
+    }
 
 public:
     using key_type = typename InternalContainer::key_type;
@@ -134,20 +176,17 @@ public:
     using iterator = typename InternalContainer::iterator;
     using const_iterator = typename InternalContainer::const_iterator;
 
-    Container(Container const&) = default;
-    virtual ~Container() = default;
+    iterator begin() noexcept { return container().begin(); }
+    const_iterator begin() const noexcept { return container().begin(); }
+    const_iterator cbegin() const noexcept { return container().cbegin(); }
 
-    iterator begin() noexcept { return m_container->begin(); }
-    const_iterator begin() const noexcept { return m_container->begin(); }
-    const_iterator cbegin() const noexcept { return m_container->cbegin(); }
+    iterator end() noexcept { return container().end(); }
+    const_iterator end() const noexcept { return container().end(); }
+    const_iterator cend() const noexcept { return container().cend(); }
 
-    iterator end() noexcept { return m_container->end(); }
-    const_iterator end() const noexcept { return m_container->end(); }
-    const_iterator cend() const noexcept { return m_container->cend(); }
+    bool empty() const noexcept { return container().empty(); }
 
-    bool empty() const noexcept { return m_container->empty(); }
-
-    size_type size() const noexcept { return m_container->size(); }
+    size_type size() const noexcept { return container().size(); }
 
     /** Remove all objects from the container and (if written) from disk.
      *
@@ -162,20 +201,20 @@ public:
         clear_unchecked();
     }
 
-    std::pair< iterator, bool > insert(value_type const& value) { return m_container->insert(value); }
+    std::pair< iterator, bool > insert(value_type const& value) { return container().insert(value); }
     template< class P >
-    std::pair< iterator, bool > insert(P&& value) { return m_container->insert(value); }
-    iterator insert(const_iterator hint, value_type const& value) { return m_container->insert(hint, value); }
+    std::pair< iterator, bool > insert(P&& value) { return container().insert(value); }
+    iterator insert(const_iterator hint, value_type const& value) { return container().insert(hint, value); }
     template< class P >
-    iterator insert(const_iterator hint, P&& value) { return m_container->insert(hint, value); }
+    iterator insert(const_iterator hint, P&& value) { return container().insert(hint, value); }
     template< class InputIt >
-    void insert(InputIt first, InputIt last) { m_container->insert(first, last); }
-    void insert(std::initializer_list< value_type > ilist) { m_container->insert(ilist); }
+    void insert(InputIt first, InputIt last) { container().insert(first, last); }
+    void insert(std::initializer_list< value_type > ilist) { container().insert(ilist); }
 
-    void swap(Container & other) { m_container->swap(other.m_container); }
+    void swap(Container & other) { container().swap(other.m_container); }
 
-    mapped_type& at(key_type const& key) { return m_container->at(key); }
-    mapped_type const& at(key_type const& key) const { return m_container->at(key); }
+    mapped_type& at(key_type const& key) { return container().at(key); }
+    mapped_type const& at(key_type const& key) const { return container().at(key); }
 
     /** Access the value that is mapped to a key equivalent to key, creating it if such key does not exist already.
      *
@@ -185,8 +224,8 @@ public:
      */
     virtual mapped_type& operator[](key_type const& key)
     {
-        auto it = m_container->find(key);
-        if( it != m_container->end() )
+        auto it = container().find(key);
+        if( it != container().end() )
             return it->second;
         else
         {
@@ -198,7 +237,7 @@ public:
 
             T t = T();
             t.linkHierarchy(writable());
-            auto& ret = m_container->insert({key, std::move(t)}).first->second;
+            auto& ret = container().insert({key, std::move(t)}).first->second;
             ret.writable().ownKeyWithinParent =
                 detail::keyAsString( key, writable().ownKeyWithinParent );
             traits::GenerationPolicy< T > gen;
@@ -214,8 +253,8 @@ public:
      */
     virtual mapped_type& operator[](key_type&& key)
     {
-        auto it = m_container->find(key);
-        if( it != m_container->end() )
+        auto it = container().find(key);
+        if( it != container().end() )
             return it->second;
         else
         {
@@ -227,7 +266,7 @@ public:
 
             T t = T();
             t.linkHierarchy(writable());
-            auto& ret = m_container->insert({key, std::move(t)}).first->second;
+            auto& ret = container().insert({key, std::move(t)}).first->second;
             ret.writable().ownKeyWithinParent = detail::keyAsString(
                 std::move( key ), writable().ownKeyWithinParent );
             traits::GenerationPolicy< T > gen;
@@ -236,22 +275,22 @@ public:
         }
     }
 
-    iterator find(key_type const& key) { return m_container->find(key); }
-    const_iterator find(key_type const& key) const { return m_container->find(key); }
+    iterator find(key_type const& key) { return container().find(key); }
+    const_iterator find(key_type const& key) const { return container().find(key); }
 
     /** This returns either 1 if the key is found in the container of 0 if not.
      *
      * @param key key value of the element to count
      * @return since keys are unique in this container, returns 0 or 1
      */
-    size_type count(key_type const& key) const { return m_container->count(key); }
+    size_type count(key_type const& key) const { return container().count(key); }
 
     /** Checks if there is an element with a key equivalent to an exiting key in the container.
      *
      * @param key key value of the element to search for
      * @return true of key is found, else false
      */
-    bool contains(key_type const& key) const { return m_container->find(key) != m_container->end(); }
+    bool contains(key_type const& key) const { return container().find(key) != container().end(); }
 
     /** Remove a single element from the container and (if written) from disk.
      *
@@ -265,15 +304,15 @@ public:
         if(Access::READ_ONLY == IOHandler()->m_frontendAccess )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
-        auto res = m_container->find(key);
-        if( res != m_container->end() && res->second.written() )
+        auto res = container().find(key);
+        if( res != container().end() && res->second.written() )
         {
             Parameter< Operation::DELETE_PATH > pDelete;
             pDelete.path = ".";
             IOHandler()->enqueue(IOTask(&res->second, pDelete));
             IOHandler()->flush();
         }
-        return m_container->erase(key);
+        return container().erase(key);
     }
 
     //! @todo why does const_iterator not work compile with pybind11?
@@ -282,14 +321,14 @@ public:
         if(Access::READ_ONLY == IOHandler()->m_frontendAccess )
             throw std::runtime_error("Can not erase from a container in a read-only Series.");
 
-        if( res != m_container->end() && res->second.written() )
+        if( res != container().end() && res->second.written() )
         {
             Parameter< Operation::DELETE_PATH > pDelete;
             pDelete.path = ".";
             IOHandler()->enqueue(IOTask(&res->second, pDelete));
             IOHandler()->flush();
         }
-        return m_container->erase(res);
+        return container().erase(res);
     }
     //! @todo add also:
     // virtual iterator erase(const_iterator first, const_iterator last)
@@ -298,20 +337,22 @@ public:
     auto emplace(Args&&... args)
     -> decltype(InternalContainer().emplace(std::forward<Args>(args)...))
     {
-        return m_container->emplace(std::forward<Args>(args)...);
+        return container().emplace(std::forward<Args>(args)...);
     }
 
 OPENPMD_protected:
-    Container()
-        : m_container{std::make_shared< InternalContainer >()}
-    { }
+    Container( std::shared_ptr< ContainerData > containerData )
+        : AttributableInterface{ containerData.get() }
+        , m_containerData{ std::move( containerData ) }
+    {
+    }
 
     void clear_unchecked()
     {
         if( written() )
             throw std::runtime_error("Clearing a written container not (yet) implemented.");
 
-        m_container->clear();
+        container().clear();
     }
 
     virtual void flush(std::string const& path)
@@ -326,7 +367,11 @@ OPENPMD_protected:
         flushAttributes();
     }
 
-    std::shared_ptr< InternalContainer > m_container;
+private:
+    Container() : AttributableInterface{ nullptr }
+    {
+        AttributableInterface::setData( m_containerData.get() );
+    }
 };
 
 namespace internal
@@ -389,7 +434,7 @@ namespace internal
 
         ~EraseStaleEntries()
         {
-            auto & map = *m_originalContainer.m_container;
+            auto & map = m_originalContainer.container();
             using iterator_t = typename BareContainer_t::const_iterator;
             std::vector< iterator_t > deleteMe;
             deleteMe.reserve( map.size() - m_accessedKeys.size() );

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -45,6 +45,8 @@ namespace internal
         friend class openPMD::PatchRecordComponent;
         friend class openPMD::PatchRecordComponent;
 
+    OPENPMD_private:
+
         std::queue< IOTask > m_chunks;
 
         PatchRecordComponentData( PatchRecordComponentData const & ) = delete;
@@ -112,7 +114,7 @@ OPENPMD_private:
 
     PatchRecordComponent();
 
-protected:
+OPENPMD_protected:
     PatchRecordComponent(
         std::shared_ptr< internal::PatchRecordComponentData > );
 

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -35,17 +35,11 @@
 
 namespace openPMD
 {
-
-class PatchRecordComponent;
-class PatchRecordComponent;
 namespace internal
 {
     class PatchRecordComponentData : public BaseRecordComponentData
     {
-        friend class openPMD::PatchRecordComponent;
-        friend class openPMD::PatchRecordComponent;
-
-    OPENPMD_private:
+    public:
 
         std::queue< IOTask > m_chunks;
 
@@ -57,7 +51,6 @@ namespace internal
         PatchRecordComponentData & operator=(
             PatchRecordComponentData && ) = delete;
 
-    protected:
         PatchRecordComponentData();
     };
 }

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -67,6 +67,8 @@ class Writable final
     friend class AttributableInterface;
     template< typename T_elem >
     friend class BaseRecord;
+    template< typename T_elem >
+    friend class BaseRecordInterface;
     template<
             typename T,
             typename T_key,

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -64,7 +64,7 @@ class AttributableData;
 class Writable final
 {
     friend class internal::AttributableData;
-    friend class AttributableInterface;
+    friend class Attributable;
     template< typename T_elem >
     friend class BaseRecord;
     template< typename T_elem >
@@ -78,7 +78,7 @@ class Writable final
     friend class Iteration;
     friend class Mesh;
     friend class ParticleSpecies;
-    friend class SeriesInterface;
+    friend class Series;
     friend class Record;
     template< typename > friend class CommonADIOS1IOHandlerImpl;
     friend class ADIOS1IOHandlerImpl;

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -25,6 +25,6 @@
 namespace openPMD
 {
 Writable*
-getWritable(AttributableInterface* a)
+getWritable(Attributable* a)
 { return &a->writable(); }
 } // openPMD

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -473,7 +473,7 @@ void Iteration::read_impl( std::string const & groupPath )
                 mrc.parent() = m.parent();
                 IOHandler()->enqueue(IOTask(&mrc, pOpen));
                 IOHandler()->flush();
-                *mrc.m_isConstant = true;
+                mrc.get().m_isConstant = true;
             }
             m.read();
         }

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -447,7 +447,7 @@ void Iteration::read_impl( std::string const & groupPath )
 
         meshes.readAttributes( ReadMode::FullyReread );
 
-        auto map = meshes.eraseStaleEntries();
+        internal::EraseStaleEntries< decltype( meshes ) > map{ meshes };
 
         /* obtain all non-scalar meshes */
         IOHandler()->enqueue(IOTask(&meshes, pList));
@@ -517,7 +517,7 @@ void Iteration::read_impl( std::string const & groupPath )
         IOHandler()->enqueue(IOTask(&particles, pList));
         IOHandler()->flush();
 
-        auto map = particles.eraseStaleEntries();
+        internal::EraseStaleEntries< decltype( particles ) > map{ particles };
         for( auto const& species_name : *pList.paths )
         {
             ParticleSpecies& p = map[species_name];

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -366,7 +366,7 @@ Mesh::read()
             MeshRecordComponent& rc = map[ component ];
             pOpen.path = component;
             IOHandler()->enqueue(IOTask(&rc, pOpen));
-            *rc.m_isConstant = true;
+            rc.get().m_isConstant = true;
             rc.read();
         }
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -274,7 +274,7 @@ Mesh::flush_impl(std::string const& name)
 void
 Mesh::read()
 {
-    auto map = eraseStaleEntries();
+    internal::EraseStaleEntries< Mesh & > map{ *this };
 
     using DT = Datatype;
     Parameter< Operation::READ_ATT > aRead;

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -75,7 +75,7 @@ ParticleSpecies::read()
                 rc.parent() = r.parent();
                 IOHandler()->enqueue(IOTask(&rc, pOpen));
                 IOHandler()->flush();
-                *rc.m_isConstant = true;
+                rc.get().m_isConstant = true;
             }
             r.read();
         }
@@ -83,7 +83,7 @@ ParticleSpecies::read()
 
     if( !hasParticlePatches )
     {
-        auto & container = *particlePatches.m_container;
+        auto & container = particlePatches.container();
         container.erase( "numParticles" );
         container.erase( "numParticlesOffset" );
     }

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -42,7 +42,7 @@ ParticleSpecies::read()
     IOHandler()->enqueue(IOTask(this, pList));
     IOHandler()->flush();
 
-    auto map = eraseStaleEntries();
+    internal::EraseStaleEntries< ParticleSpecies & > map{ *this };
 
     Parameter< Operation::OPEN_PATH > pOpen;
     Parameter< Operation::LIST_ATTS > aList;
@@ -70,7 +70,7 @@ ParticleSpecies::read()
             auto shape = std::find(att_begin, att_end, "shape");
             if( value != att_end && shape != att_end )
             {
-                auto scalarMap = r.eraseStaleEntries();
+                internal::EraseStaleEntries< Record & > scalarMap( r );
                 RecordComponent& rc = scalarMap[RecordComponent::SCALAR];
                 rc.parent() = r.parent();
                 IOHandler()->enqueue(IOTask(&rc, pOpen));
@@ -101,7 +101,7 @@ ParticleSpecies::read()
             dOpen.name = record_name;
             IOHandler()->enqueue(IOTask(&r, dOpen));
             IOHandler()->flush();
-            auto scalarMap = r.eraseStaleEntries();
+            internal::EraseStaleEntries< Record & > scalarMap( r );
             RecordComponent& rc = scalarMap[RecordComponent::SCALAR];
             rc.parent() = r.parent();
             IOHandler()->enqueue(IOTask(&rc, dOpen));

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -49,8 +49,8 @@ SeriesIterator::SeriesIterator( Series series )
              * Use case: See Python ApiTest testListSeries:
              * Call listSeries twice.
              */
-            if( *it->second.m_closed !=
-                Iteration::CloseStatus::ClosedInBackend )
+            if( it->second.get().m_closed !=
+                internal::CloseStatus::ClosedInBackend )
             {
                 it->second.open();
             }
@@ -136,7 +136,7 @@ SeriesIterator & SeriesIterator::operator++()
         return *this;
     }
     m_currentIteration = it->first;
-    if( *it->second.m_closed != Iteration::CloseStatus::ClosedInBackend )
+    if( it->second.get().m_closed != internal::CloseStatus::ClosedInBackend )
     {
         it->second.open();
     }

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -112,7 +112,7 @@ Record::read()
             RecordComponent& rc = (*this)[component];
             pOpen.path = component;
             IOHandler()->enqueue(IOTask(&rc, pOpen));
-            *rc.m_isConstant = true;
+            rc.get().m_isConstant = true;
             rc.read();
         }
 

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -36,17 +36,32 @@
 
 namespace openPMD
 {
+namespace internal
+{
+    RecordComponentData::RecordComponentData()
+    {
+        RecordComponent impl{ std::shared_ptr< RecordComponentData >{
+            this, []( auto const * ) {} } };
+        impl.setUnitSI(1);
+        impl.resetDataset(Dataset(Datatype::CHAR, {1}));
+    }
+}
+
+RecordComponent::RecordComponent() : BaseRecordComponent{ nullptr }
+{
+    BaseRecordComponent::setData( m_recordComponentData );
+}
+
+RecordComponent::RecordComponent(
+    std::shared_ptr< internal::RecordComponentData > data )
+    : BaseRecordComponent{ data }
+    , m_recordComponentData{ std::move( data ) }
+{
+}
+
 // We need to instantiate this somewhere otherwise there might be linker issues
 // despite this thing actually being constepxr
 constexpr char const * const RecordComponent::SCALAR;
-
-RecordComponent::RecordComponent()
-        : m_chunks{std::make_shared< std::queue< IOTask > >()},
-          m_constantValue{std::make_shared< Attribute >(-1)}
-{
-    setUnitSI(1);
-    resetDataset(Dataset(Datatype::CHAR, {1}));
-}
 
 RecordComponent&
 RecordComponent::setUnitSI(double usi)
@@ -58,18 +73,19 @@ RecordComponent::setUnitSI(double usi)
 RecordComponent &
 RecordComponent::resetDataset( Dataset d )
 {
+    auto & rc = get();
     if( written() )
     {
         if( d.dtype == Datatype::UNDEFINED )
         {
-            d.dtype = m_dataset->dtype;
+            d.dtype = rc.m_dataset.dtype;
         }
-        else if( d.dtype != m_dataset->dtype )
+        else if( d.dtype != rc.m_dataset.dtype )
         {
             throw std::runtime_error(
                 "Cannot change the datatype of a dataset." );
         }
-        *m_hasBeenExtended = true;
+        rc.m_hasBeenExtended = true;
     }
 
     if( d.dtype == Datatype::UNDEFINED )
@@ -85,14 +101,14 @@ RecordComponent::resetDataset( Dataset d )
             []( Extent::value_type const & i ) { return i == 0u; } ) )
         return makeEmpty( std::move( d ) );
 
-    *m_isEmpty = false;
+    rc.m_isEmpty = false;
     if( written() )
     {
-        m_dataset->extend( std::move( d.extent ) );
+        rc.m_dataset.extend( std::move( d.extent ) );
     }
     else
     {
-        *m_dataset = std::move( d );
+        rc.m_dataset = std::move( d );
     }
 
     dirty() = true;
@@ -102,13 +118,13 @@ RecordComponent::resetDataset( Dataset d )
 uint8_t
 RecordComponent::getDimensionality() const
 {
-    return m_dataset->rank;
+    return get().m_dataset.rank;
 }
 
 Extent
 RecordComponent::getExtent() const
 {
-    return m_dataset->extent;
+    return get().m_dataset.extent;
 }
 
 namespace detail
@@ -116,7 +132,8 @@ namespace detail
 struct MakeEmpty
 {
     template< typename T >
-    static RecordComponent& call( RecordComponent & rc, uint8_t dimensions )
+    static RecordComponent& call(
+        RecordComponent & rc, uint8_t dimensions )
     {
         return rc.makeEmpty< T >( dimensions );
     }
@@ -139,6 +156,7 @@ RecordComponent::makeEmpty( Datatype dt, uint8_t dimensions )
 RecordComponent&
 RecordComponent::makeEmpty( Dataset d )
 {
+    auto & rc = get();
     if( written() )
     {
         if( !constant() )
@@ -150,30 +168,30 @@ RecordComponent::makeEmpty( Dataset d )
         }
         if( d.dtype == Datatype::UNDEFINED )
         {
-            d.dtype = m_dataset->dtype;
+            d.dtype = rc.m_dataset.dtype;
         }
-        else if( d.dtype != m_dataset->dtype )
+        else if( d.dtype != rc.m_dataset.dtype )
         {
             throw std::runtime_error(
                 "Cannot change the datatype of a dataset." );
         }
-        m_dataset->extend( std::move( d.extent ) );
-        *m_hasBeenExtended = true;
+        rc.m_dataset.extend( std::move( d.extent ) );
+        rc.m_hasBeenExtended = true;
     }
     else
     {
-        *m_dataset = std::move( d );
+        rc.m_dataset = std::move( d );
     }
 
-    if( m_dataset->extent.size() == 0 )
+    if( rc.m_dataset.extent.size() == 0 )
         throw std::runtime_error( "Dataset extent must be at least 1D." );
 
-    *m_isEmpty = true;
+    rc.m_isEmpty = true;
     dirty() = true;
     if( !written() )
     {
         switchType< detail::DefaultValue< RecordComponent > >(
-            m_dataset->dtype, *this );
+            rc.m_dataset.dtype, *this );
     }
     return *this;
 }
@@ -181,30 +199,31 @@ RecordComponent::makeEmpty( Dataset d )
 bool
 RecordComponent::empty() const
 {
-    return *m_isEmpty;
+    return get().m_isEmpty;
 }
 
 void
 RecordComponent::flush(std::string const& name)
 {
+    auto & rc = get();
     if( IOHandler()->m_flushLevel == FlushLevel::SkeletonOnly )
     {
-        *this->m_name = name;
+        rc.m_name = name;
         return;
     }
     if(IOHandler()->m_frontendAccess == Access::READ_ONLY )
     {
-        while( !m_chunks->empty() )
+        while( !rc.m_chunks.empty() )
         {
-            IOHandler()->enqueue(m_chunks->front());
-            m_chunks->pop();
+            IOHandler()->enqueue(rc.m_chunks.front());
+            rc.m_chunks.pop();
         }
     } else
     {
         /*
          * This catches when a user forgets to use resetDataset.
          */
-        if( m_dataset->dtype == Datatype::UNDEFINED )
+        if( rc.m_dataset.dtype == Datatype::UNDEFINED )
         {
             throw error::WrongAPIUsage(
                 "[RecordComponent] Must set specific datatype (Use "
@@ -219,8 +238,8 @@ RecordComponent::flush(std::string const& name)
                 IOHandler()->enqueue(IOTask(this, pCreate));
                 Parameter< Operation::WRITE_ATT > aWrite;
                 aWrite.name = "value";
-                aWrite.dtype = m_constantValue->dtype;
-                aWrite.resource = m_constantValue->getResource();
+                aWrite.dtype = rc.m_constantValue.dtype;
+                aWrite.resource = rc.m_constantValue.getResource();
                 IOHandler()->enqueue(IOTask(this, aWrite));
                 aWrite.name = "shape";
                 Attribute a(getExtent());
@@ -233,15 +252,15 @@ RecordComponent::flush(std::string const& name)
                 dCreate.name = name;
                 dCreate.extent = getExtent();
                 dCreate.dtype = getDatatype();
-                dCreate.chunkSize = m_dataset->chunkSize;
-                dCreate.compression = m_dataset->compression;
-                dCreate.transform = m_dataset->transform;
-                dCreate.options = m_dataset->options;
+                dCreate.chunkSize = rc.m_dataset.chunkSize;
+                dCreate.compression = rc.m_dataset.compression;
+                dCreate.transform = rc.m_dataset.transform;
+                dCreate.options = rc.m_dataset.options;
                 IOHandler()->enqueue(IOTask(this, dCreate));
             }
         }
 
-        if( *m_hasBeenExtended )
+        if( rc.m_hasBeenExtended )
         {
             if( constant() )
             {
@@ -255,16 +274,16 @@ RecordComponent::flush(std::string const& name)
             else
             {
                 Parameter< Operation::EXTEND_DATASET > pExtend;
-                pExtend.extent = m_dataset->extent;
+                pExtend.extent = rc.m_dataset.extent;
                 IOHandler()->enqueue( IOTask( this, std::move( pExtend ) ) );
-                *m_hasBeenExtended = false;
+                rc.m_hasBeenExtended = false;
             }
         }
 
-        while( !m_chunks->empty() )
+        while( !rc.m_chunks.empty() )
         {
-            IOHandler()->enqueue(m_chunks->front());
-            m_chunks->pop();
+            IOHandler()->enqueue(rc.m_chunks.front());
+            rc.m_chunks.pop();
         }
 
         flushAttributes();
@@ -281,6 +300,7 @@ void
 RecordComponent::readBase()
 {
     using DT = Datatype;
+    //auto & rc = get();
     Parameter< Operation::READ_ATT > aRead;
 
     if( constant() && !empty() )
@@ -396,6 +416,6 @@ RecordComponent::dirtyRecursive() const
     {
         return true;
     }
-    return !m_chunks->empty();
+    return !get().m_chunks.empty();
 }
 } // namespace openPMD

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -80,7 +80,7 @@ namespace
     matcher(std::string const &prefix, int padding, std::string const &postfix, Format f);
 } // namespace [anonymous]
 
-struct SeriesInterface::ParsedInput
+struct Series::ParsedInput
 {
     std::string path;
     std::string name;
@@ -91,47 +91,40 @@ struct SeriesInterface::ParsedInput
     int filenamePadding = -1;
 };  //ParsedInput
 
-SeriesInterface::SeriesInterface(
-    internal::SeriesData * series, internal::AttributableData * attri )
-    : AttributableInterface{ attri }
-    , m_series{ series }
-{
-}
-
 std::string
-SeriesInterface::openPMD() const
+Series::openPMD() const
 {
     return getAttribute("openPMD").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setOpenPMD(std::string const& o)
+Series&
+Series::setOpenPMD(std::string const& o)
 {
     setAttribute("openPMD", o);
     return *this;
 }
 
 uint32_t
-SeriesInterface::openPMDextension() const
+Series::openPMDextension() const
 {
     return getAttribute("openPMDextension").get< uint32_t >();
 }
 
-SeriesInterface&
-SeriesInterface::setOpenPMDextension(uint32_t oe)
+Series&
+Series::setOpenPMDextension(uint32_t oe)
 {
     setAttribute("openPMDextension", oe);
     return *this;
 }
 
 std::string
-SeriesInterface::basePath() const
+Series::basePath() const
 {
     return getAttribute("basePath").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setBasePath(std::string const& bp)
+Series&
+Series::setBasePath(std::string const& bp)
 {
     std::string version = openPMD();
     if( version == "1.0.0" || version == "1.0.1" || version == "1.1.0" )
@@ -142,13 +135,13 @@ SeriesInterface::setBasePath(std::string const& bp)
 }
 
 std::string
-SeriesInterface::meshesPath() const
+Series::meshesPath() const
 {
     return getAttribute("meshesPath").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setMeshesPath(std::string const& mp)
+Series&
+Series::setMeshesPath(std::string const& mp)
 {
     auto & series = get();
     if( std::any_of(series.iterations.begin(), series.iterations.end(),
@@ -164,13 +157,13 @@ SeriesInterface::setMeshesPath(std::string const& mp)
 }
 
 std::string
-SeriesInterface::particlesPath() const
+Series::particlesPath() const
 {
     return getAttribute("particlesPath").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setParticlesPath(std::string const& pp)
+Series&
+Series::setParticlesPath(std::string const& pp)
 {
     auto & series = get();
     if( std::any_of(series.iterations.begin(), series.iterations.end(),
@@ -186,26 +179,26 @@ SeriesInterface::setParticlesPath(std::string const& pp)
 }
 
 std::string
-SeriesInterface::author() const
+Series::author() const
 {
     return getAttribute("author").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setAuthor(std::string const& a)
+Series&
+Series::setAuthor(std::string const& a)
 {
     setAttribute("author", a);
     return *this;
 }
 
 std::string
-SeriesInterface::software() const
+Series::software() const
 {
     return getAttribute("software").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setSoftware( std::string const& newName, std::string const& newVersion )
+Series&
+Series::setSoftware( std::string const& newName, std::string const& newVersion )
 {
     setAttribute( "software", newName );
     setAttribute( "softwareVersion", newVersion );
@@ -213,65 +206,65 @@ SeriesInterface::setSoftware( std::string const& newName, std::string const& new
 }
 
 std::string
-SeriesInterface::softwareVersion() const
+Series::softwareVersion() const
 {
     return getAttribute("softwareVersion").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setSoftwareVersion(std::string const& sv)
+Series&
+Series::setSoftwareVersion(std::string const& sv)
 {
     setAttribute("softwareVersion", sv);
     return *this;
 }
 
 std::string
-SeriesInterface::date() const
+Series::date() const
 {
     return getAttribute("date").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setDate(std::string const& d)
+Series&
+Series::setDate(std::string const& d)
 {
     setAttribute("date", d);
     return *this;
 }
 
 std::string
-SeriesInterface::softwareDependencies() const
+Series::softwareDependencies() const
 {
     return getAttribute("softwareDependencies").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setSoftwareDependencies(std::string const &newSoftwareDependencies)
+Series&
+Series::setSoftwareDependencies(std::string const &newSoftwareDependencies)
 {
     setAttribute("softwareDependencies", newSoftwareDependencies);
     return *this;
 }
 
 std::string
-SeriesInterface::machine() const
+Series::machine() const
 {
     return getAttribute("machine").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setMachine(std::string const &newMachine)
+Series&
+Series::setMachine(std::string const &newMachine)
 {
     setAttribute("machine", newMachine);
     return *this;
 }
 
 IterationEncoding
-SeriesInterface::iterationEncoding() const
+Series::iterationEncoding() const
 {
     return get().m_iterationEncoding;
 }
 
-SeriesInterface&
-SeriesInterface::setIterationEncoding(IterationEncoding ie)
+Series&
+Series::setIterationEncoding(IterationEncoding ie)
 {
     auto & series = get();
     if( written() )
@@ -310,13 +303,13 @@ SeriesInterface::setIterationEncoding(IterationEncoding ie)
 }
 
 std::string
-SeriesInterface::iterationFormat() const
+Series::iterationFormat() const
 {
     return getAttribute("iterationFormat").get< std::string >();
 }
 
-SeriesInterface&
-SeriesInterface::setIterationFormat(std::string const& i)
+Series&
+Series::setIterationFormat(std::string const& i)
 {
     if( written() )
         throw std::runtime_error("A files iterationFormat can not (yet) be changed after it has been written.");
@@ -331,13 +324,13 @@ SeriesInterface::setIterationFormat(std::string const& i)
 }
 
 std::string
-SeriesInterface::name() const
+Series::name() const
 {
     return get().m_name;
 }
 
-SeriesInterface&
-SeriesInterface::setName(std::string const& n)
+Series&
+Series::setName(std::string const& n)
 {
     auto & series = get();
     if( written() )
@@ -371,13 +364,13 @@ SeriesInterface::setName(std::string const& n)
 }
 
 std::string
-SeriesInterface::backend() const
+Series::backend() const
 {
     return IOHandler()->backendName();
 }
 
 void
-SeriesInterface::flush()
+Series::flush()
 {
     auto & series = get();
     flush_impl(
@@ -386,10 +379,10 @@ SeriesInterface::flush()
         FlushLevel::UserFlush );
 }
 
-std::unique_ptr< SeriesInterface::ParsedInput >
-SeriesInterface::parseInput(std::string filepath)
+std::unique_ptr< Series::ParsedInput >
+Series::parseInput(std::string filepath)
 {
-    std::unique_ptr< SeriesInterface::ParsedInput > input{new SeriesInterface::ParsedInput};
+    std::unique_ptr< Series::ParsedInput > input{new Series::ParsedInput};
 
 #ifdef _WIN32
     if( auxiliary::contains(filepath, '/') )
@@ -450,13 +443,13 @@ SeriesInterface::parseInput(std::string filepath)
     return input;
 }
 
-bool SeriesInterface::hasExpansionPattern( std::string filenameWithExtension )
+bool Series::hasExpansionPattern( std::string filenameWithExtension )
 {
     auto input = parseInput( std::move( filenameWithExtension ) );
     return input->iterationEncoding == IterationEncoding::fileBased;
 }
 
-bool SeriesInterface::reparseExpansionPattern(
+bool Series::reparseExpansionPattern(
     std::string filenameWithExtension )
 {
     auto input = parseInput( std::move( filenameWithExtension ) );
@@ -471,9 +464,9 @@ bool SeriesInterface::reparseExpansionPattern(
     return true;
 }
 
-void SeriesInterface::init(
+void Series::init(
     std::shared_ptr< AbstractIOHandler > ioHandler,
-    std::unique_ptr< SeriesInterface::ParsedInput > input )
+    std::unique_ptr< Series::ParsedInput > input )
 {
     auto & series = get();
     writable().IOHandler = ioHandler;
@@ -519,10 +512,11 @@ void SeriesInterface::init(
         initDefaults( input->iterationEncoding );
         setIterationEncoding(input->iterationEncoding);
     }
+    series.m_lastFlushSuccessful = true;
 }
 
 void
-SeriesInterface::initDefaults( IterationEncoding ie )
+Series::initDefaults( IterationEncoding ie )
 {
     if( !containsAttribute("openPMD"))
         setOpenPMD( getStandard() );
@@ -547,7 +541,7 @@ SeriesInterface::initDefaults( IterationEncoding ie )
 }
 
 std::future< void >
-SeriesInterface::flush_impl(
+Series::flush_impl(
     iterations_iterator begin,
     iterations_iterator end,
     FlushLevel level,
@@ -590,7 +584,7 @@ SeriesInterface::flush_impl(
 }
 
 void
-SeriesInterface::flushFileBased( iterations_iterator begin, iterations_iterator end )
+Series::flushFileBased( iterations_iterator begin, iterations_iterator end )
 {
     auto & series = get();
     if( end == begin )
@@ -677,7 +671,7 @@ SeriesInterface::flushFileBased( iterations_iterator begin, iterations_iterator 
 }
 
 void
-SeriesInterface::flushGorVBased( iterations_iterator begin, iterations_iterator end )
+Series::flushGorVBased( iterations_iterator begin, iterations_iterator end )
 {
     auto & series = get();
     if( IOHandler()->m_frontendAccess == Access::READ_ONLY )
@@ -762,7 +756,7 @@ SeriesInterface::flushGorVBased( iterations_iterator begin, iterations_iterator 
 }
 
 void
-SeriesInterface::flushMeshesPath()
+Series::flushMeshesPath()
 {
     Parameter< Operation::WRITE_ATT > aWrite;
     aWrite.name = "meshesPath";
@@ -773,7 +767,7 @@ SeriesInterface::flushMeshesPath()
 }
 
 void
-SeriesInterface::flushParticlesPath()
+Series::flushParticlesPath()
 {
     Parameter< Operation::WRITE_ATT > aWrite;
     aWrite.name = "particlesPath";
@@ -784,7 +778,7 @@ SeriesInterface::flushParticlesPath()
 }
 
 void
-SeriesInterface::readFileBased( )
+Series::readFileBased( )
 {
     auto & series = get();
     Parameter< Operation::OPEN_FILE > fOpen;
@@ -819,7 +813,7 @@ SeriesInterface::readFileBased( )
 
     if( series.iterations.empty() )
     {
-        /* Frontend access type might change during SeriesInterface::read() to allow parameter modification.
+        /* Frontend access type might change during Series::read() to allow parameter modification.
          * Backend access type stays unchanged for the lifetime of a Series. */
         if(IOHandler()->m_backendAccess == Access::READ_ONLY  )
             throw no_such_file_error("No matching iterations found: " + name());
@@ -859,14 +853,14 @@ SeriesInterface::readFileBased( )
     if( paddings.size() == 1u )
         series.m_filenamePadding = *paddings.begin();
 
-    /* Frontend access type might change during SeriesInterface::read() to allow parameter modification.
+    /* Frontend access type might change during Series::read() to allow parameter modification.
      * Backend access type stays unchanged for the lifetime of a Series. */
     if( paddings.size() > 1u && IOHandler()->m_backendAccess == Access::READ_WRITE )
         throw std::runtime_error("Cannot write to a series with inconsistent iteration padding. "
                                  "Please specify '%0<N>T' or open as read-only.");
 }
 
-void SeriesInterface::readOneIterationFileBased( std::string const & filePath )
+void Series::readOneIterationFileBased( std::string const & filePath )
 {
     auto & series = get();
 
@@ -946,7 +940,7 @@ void SeriesInterface::readOneIterationFileBased( std::string const & filePath )
 }
 
 void
-SeriesInterface::readGorVBased( bool do_init )
+Series::readGorVBased( bool do_init )
 {
     auto & series = get();
     Parameter< Operation::OPEN_FILE > fOpen;
@@ -1087,7 +1081,7 @@ SeriesInterface::readGorVBased( bool do_init )
 }
 
 void
-SeriesInterface::readBase()
+Series::readBase()
 {
     auto & series = get();
     using DT = Datatype;
@@ -1163,7 +1157,7 @@ SeriesInterface::readBase()
 }
 
 std::string
-SeriesInterface::iterationFilename( uint64_t i )
+Series::iterationFilename( uint64_t i )
 {
     auto & series = get();
     if( series.m_overrideFilebasedFilename.has_value() )
@@ -1177,8 +1171,8 @@ SeriesInterface::iterationFilename( uint64_t i )
            + series.m_filenamePostfix;
 }
 
-SeriesInterface::iterations_iterator
-SeriesInterface::indexOf( Iteration const & iteration )
+Series::iterations_iterator
+Series::indexOf( Iteration const & iteration )
 {
     auto & series = get();
     for( auto it = series.iterations.begin(); it != series.iterations.end();
@@ -1194,7 +1188,7 @@ SeriesInterface::indexOf( Iteration const & iteration )
 }
 
 AdvanceStatus
-SeriesInterface::advance(
+Series::advance(
     AdvanceMode mode,
     internal::AttributableData & file,
     iterations_iterator begin,
@@ -1291,7 +1285,7 @@ SeriesInterface::advance(
         }
     }
 
-    // We cannot call SeriesInterface::flush now, since the IO handler is still filled
+    // We cannot call Series::flush now, since the IO handler is still filled
     // from calling flush(Group|File)based, but has not been emptied yet
     // Do that manually
     IOHandler()->m_flushLevel = FlushLevel::UserFlush;
@@ -1309,7 +1303,7 @@ SeriesInterface::advance(
     return *param.status;
 }
 
-auto SeriesInterface::openIterationIfDirty( uint64_t index, Iteration iteration )
+auto Series::openIterationIfDirty( uint64_t index, Iteration iteration )
     -> IterationOpened
 {
     /*
@@ -1371,7 +1365,7 @@ auto SeriesInterface::openIterationIfDirty( uint64_t index, Iteration iteration 
     return IterationOpened::RemainsClosed;
 }
 
-void SeriesInterface::openIteration( uint64_t index, Iteration iteration )
+void Series::openIteration( uint64_t index, Iteration iteration )
 {
     auto oldStatus = *iteration.m_closed;
     switch( *iteration.m_closed )
@@ -1463,47 +1457,13 @@ void parseJsonOptions(
 
 namespace internal
 {
-#if openPMD_HAVE_MPI
-SeriesInternal::SeriesInternal(
-    std::string const & filepath,
-    Access at,
-    MPI_Comm comm,
-    std::string const & options )
-    : SeriesInterface{
-          static_cast< internal::SeriesData * >( this ),
-          static_cast< internal::AttributableData * >( this ) }
-{
-    nlohmann::json optionsJson = auxiliary::parseOptions( options, comm );
-    parseJsonOptions( *this, optionsJson );
-    auto input = parseInput( filepath );
-    auto handler = createIOHandler(
-        input->path, at, input->format, comm, std::move( optionsJson ) );
-    init( handler, std::move( input ) );
-}
-#endif
-
-SeriesInternal::SeriesInternal(
-    std::string const & filepath, Access at, std::string const & options )
-    : SeriesInterface{
-          static_cast< internal::SeriesData * >( this ),
-          static_cast< internal::AttributableData * >( this ) }
-{
-    nlohmann::json optionsJson = auxiliary::parseOptions( options );
-    parseJsonOptions( *this, optionsJson );
-    auto input = parseInput( filepath );
-    auto handler = createIOHandler(
-        input->path, at, input->format, std::move( optionsJson ) );
-    init( handler, std::move( input ) );
-}
-
-SeriesInternal::~SeriesInternal()
+SeriesData::~SeriesData()
 {
     // we must not throw in a destructor
     try
     {
-        auto & series = get();
         // WriteIterations gets the first shot at flushing
-        series.m_writeIterations = auxiliary::Option< WriteIterations >();
+        this->m_writeIterations = auxiliary::Option< WriteIterations >();
         /*
          * Scenario: A user calls `Series::flush()` but does not check for
          * thrown exceptions. The exception will propagate further up, usually
@@ -1512,9 +1472,10 @@ SeriesInternal::~SeriesInternal()
          * needlessly flushed a second time. Otherwise, error messages can get
          * very confusing.
          */
-        if( get().m_lastFlushSuccessful )
+        if( this->m_lastFlushSuccessful )
         {
-            flush();
+            Series impl{ { this, []( auto const * ){} } };
+            impl.flush();
         }
     }
     catch( std::exception const & ex )
@@ -1528,17 +1489,15 @@ SeriesInternal::~SeriesInternal()
 }
 } // namespace internal
 
-Series::Series( std::shared_ptr< internal::SeriesInternal > series_in )
-    : SeriesInterface{
-        series_in.get(),
-        static_cast< internal::AttributableData * >( series_in.get() ) }
-    , m_series{ std::move( series_in ) }
-    , iterations{ m_series->iterations }
+Series::Series() : Attributable{ nullptr }, iterations{}
 {
 }
 
-Series::Series() : SeriesInterface{ nullptr, nullptr }, iterations{}
+Series::Series( std::shared_ptr< internal::SeriesData > data )
+    : Attributable{ data }
+    , m_series{ std::move( data ) }
 {
+    iterations = m_series->iterations;
 }
 
 #if openPMD_HAVE_MPI
@@ -1547,29 +1506,33 @@ Series::Series(
     Access at,
     MPI_Comm comm,
     std::string const & options )
-    : SeriesInterface{ nullptr, nullptr }
-    , m_series{ std::make_shared< internal::SeriesInternal >(
-          filepath, at, comm, options ) }
-    , iterations{ m_series->iterations }
+    : Attributable{ nullptr }
+    , m_series{ new internal::SeriesData }
 {
-    AttributableInterface::m_attri =
-        static_cast< internal::AttributableData * >( m_series.get() );
-    SeriesInterface::m_series = m_series.get();
+    Attributable::setData( m_series );
+    iterations = m_series->iterations;
+    nlohmann::json optionsJson = auxiliary::parseOptions( options, comm );
+    parseJsonOptions( get(), optionsJson );
+    auto input = parseInput( filepath );
+    auto handler = createIOHandler(
+        input->path, at, input->format, comm, std::move( optionsJson ) );
+    init( handler, std::move( input ) );
 }
 #endif
 
 Series::Series(
-    std::string const & filepath,
-    Access at,
-    std::string const & options)
-    : SeriesInterface{ nullptr, nullptr }
-    , m_series{ std::make_shared< internal::SeriesInternal >(
-          filepath, at, options ) }
-    , iterations{ m_series->iterations }
+    std::string const & filepath, Access at, std::string const & options )
+    : Attributable{ nullptr }
+    , m_series{ new internal::SeriesData }
 {
-    AttributableInterface::m_attri =
-        static_cast< internal::AttributableData * >( m_series.get() );
-    SeriesInterface::m_series = m_series.get();
+    Attributable::setData( m_series );
+    iterations = m_series->iterations;
+    nlohmann::json optionsJson = auxiliary::parseOptions( options );
+    parseJsonOptions( get(), optionsJson );
+    auto input = parseInput( filepath );
+    auto handler = createIOHandler(
+        input->path, at, input->format, std::move( optionsJson ) );
+    init( handler, std::move( input ) );
 }
 
 Series::operator bool() const

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -38,13 +38,16 @@ AttributableData::AttributableData() : m_writable{ this }
 }
 }
 
-AttributableInterface::AttributableInterface( internal::AttributableData * attri )
+Attributable::Attributable() = default;
+
+Attributable::Attributable(
+    std::shared_ptr< internal::AttributableData > attri )
+    : m_attri{ std::move( attri ) }
 {
-    setData( attri );
 }
 
 Attribute
-AttributableInterface::getAttribute(std::string const& key) const
+Attributable::getAttribute(std::string const& key) const
 {
     auto & attri = get();
     auto it = attri.m_attributes.find(key);
@@ -55,7 +58,7 @@ AttributableInterface::getAttribute(std::string const& key) const
 }
 
 bool
-AttributableInterface::deleteAttribute(std::string const& key)
+Attributable::deleteAttribute(std::string const& key)
 {
     auto & attri = get();
     if(Access::READ_ONLY == IOHandler()->m_frontendAccess )
@@ -75,7 +78,7 @@ AttributableInterface::deleteAttribute(std::string const& key)
 }
 
 std::vector< std::string >
-AttributableInterface::attributes() const
+Attributable::attributes() const
 {
     auto & attri = get();
     std::vector< std::string > ret;
@@ -87,55 +90,50 @@ AttributableInterface::attributes() const
 }
 
 size_t
-AttributableInterface::numAttributes() const
+Attributable::numAttributes() const
 {
     return get().m_attributes.size();
 }
 
 bool
-AttributableInterface::containsAttribute(std::string const &key) const
+Attributable::containsAttribute(std::string const &key) const
 {
     auto & attri = get();
     return attri.m_attributes.find(key) != attri.m_attributes.end();
 }
 
 std::string
-AttributableInterface::comment() const
+Attributable::comment() const
 {
     return getAttribute("comment").get< std::string >();
 }
 
-AttributableInterface&
-AttributableInterface::setComment(std::string const& c)
+Attributable&
+Attributable::setComment(std::string const& c)
 {
     setAttribute("comment", c);
     return *this;
 }
 
 void
-AttributableInterface::seriesFlush()
+Attributable::seriesFlush()
 {
     writable().seriesFlush();
 }
 
-internal::SeriesInternal const & AttributableInterface::retrieveSeries() const
+Series Attributable::retrieveSeries() const
 {
     Writable const * findSeries = &writable();
     while( findSeries->parent )
     {
         findSeries = findSeries->parent;
     }
-    return auxiliary::deref_dynamic_cast< internal::SeriesInternal >(
+    auto seriesData = &auxiliary::deref_dynamic_cast< internal::SeriesData >(
         findSeries->attributable );
+    return Series{ { seriesData, []( auto const * ){} } };
 }
 
-internal::SeriesInternal & AttributableInterface::retrieveSeries()
-{
-    return const_cast< internal::SeriesInternal & >(
-        static_cast< AttributableInterface const * >( this )->retrieveSeries() );
-}
-
-Iteration const & AttributableInterface::containingIteration() const
+Iteration const & Attributable::containingIteration() const
 {
     std::vector< Writable const * > searchQueue;
     searchQueue.reserve( 7 );
@@ -164,7 +162,7 @@ Iteration const & AttributableInterface::containingIteration() const
      * Since the class Iteration itself still follows the old class design,
      * we will have to take a detour via Series.
      */
-    auto & series = auxiliary::deref_dynamic_cast< internal::SeriesInternal >(
+    auto & series = auxiliary::deref_dynamic_cast< internal::SeriesData >(
         ( *searchQueue.rbegin() )->attributable );
     for( auto const & pair : series.iterations )
     {
@@ -177,10 +175,10 @@ Iteration const & AttributableInterface::containingIteration() const
         "Containing iteration not found in containing Series." );
 }
 
-Iteration & AttributableInterface::containingIteration()
+Iteration & Attributable::containingIteration()
 {
     return const_cast< Iteration & >(
-        static_cast< AttributableInterface const * >( this )
+        static_cast< Attributable const * >( this )
             ->containingIteration() );
 }
 
@@ -189,7 +187,7 @@ std::string Attributable::MyPath::filePath() const
     return directory + seriesName + seriesExtension;
 }
 
-auto AttributableInterface::myPath() const -> MyPath
+auto Attributable::myPath() const -> MyPath
 {
     MyPath res;
     Writable const * findSeries = &writable();
@@ -209,23 +207,24 @@ auto AttributableInterface::myPath() const -> MyPath
         findSeries = findSeries->parent;
     }
     std::reverse(res.group.begin(), res.group.end() );
-    auto const & series =
-        auxiliary::deref_dynamic_cast< internal::SeriesInternal >(
+    auto & seriesData =
+        auxiliary::deref_dynamic_cast< internal::SeriesData >(
             findSeries->attributable );
+    Series series{ { &seriesData, []( auto const * ) {} } };
     res.seriesName = series.name();
-    res.seriesExtension = suffix( series.m_format );
+    res.seriesExtension = suffix( seriesData.m_format );
     res.directory = IOHandler()->directory;
     return res;
 }
 
 void
-AttributableInterface::seriesFlush( FlushLevel level )
+Attributable::seriesFlush( FlushLevel level )
 {
     writable().seriesFlush( level );
 }
 
 void
-AttributableInterface::flushAttributes()
+Attributable::flushAttributes()
 {
     if( IOHandler()->m_flushLevel == FlushLevel::SkeletonOnly )
     {
@@ -247,7 +246,7 @@ AttributableInterface::flushAttributes()
 }
 
 void
-AttributableInterface::readAttributes( ReadMode mode )
+Attributable::readAttributes( ReadMode mode )
 {
     auto & attri = get();
     Parameter< Operation::LIST_ATTS > aList;
@@ -444,7 +443,7 @@ AttributableInterface::readAttributes( ReadMode mode )
 }
 
 void
-AttributableInterface::linkHierarchy(Writable& w)
+Attributable::linkHierarchy(Writable& w)
 {
     auto handler = w.IOHandler;
     writable().IOHandler = handler;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -39,8 +39,8 @@ AttributableData::AttributableData() : m_writable{ this }
 }
 
 AttributableInterface::AttributableInterface( internal::AttributableData * attri )
-    : m_attri{ attri }
 {
+    setData( attri );
 }
 
 Attribute

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -166,7 +166,7 @@ Iteration const & Attributable::containingIteration() const
         ( *searchQueue.rbegin() )->attributable );
     for( auto const & pair : series.iterations )
     {
-        if( &pair.second.get() == attr )
+        if( &static_cast< Attributable const & >( pair.second ).get() == attr )
         {
             return pair.second;
         }

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -70,13 +70,13 @@ BaseRecordComponent::availableChunks()
 
 BaseRecordComponent::BaseRecordComponent(
     std::shared_ptr< internal::BaseRecordComponentData > data)
-    : AttributableInterface{ data.get() }
+    : Attributable{ data }
     , m_baseRecordComponentData{ std::move( data ) }
 {}
 
 BaseRecordComponent::BaseRecordComponent()
-    : AttributableInterface{ nullptr }
+    : Attributable{ nullptr }
 {
-    AttributableInterface::setData( m_baseRecordComponentData.get() );
+    Attributable::setData( m_baseRecordComponentData );
 }
 } // namespace openPMD

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -43,7 +43,8 @@ namespace openPMD
     void
     Writable::seriesFlush( FlushLevel level )
     {
-        auto & series = AttributableInterface( attributable ).retrieveSeries();
+        auto series = Attributable( { attributable, []( auto const * ){} } )
+            .retrieveSeries();
         series.flush_impl(
             series.iterations.begin(), series.iterations.end(), level );
     }

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -32,7 +32,7 @@ namespace openPMD
 {
 namespace test
 {
-struct TestHelper : public LegacyAttributable
+struct TestHelper : public Attributable
 {
     TestHelper()
     {
@@ -302,7 +302,7 @@ TEST_CASE( "container_access_test", "[auxiliary]" )
 
 TEST_CASE( "attributable_default_test", "[auxiliary]" )
 {
-    LegacyAttributable a;
+    Attributable a;
 
     REQUIRE(a.numAttributes() == 0);
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -152,7 +152,7 @@ TEST_CASE( "myPath", "[core]" )
 {
 #if openPMD_USE_INVASIVE_TESTS
     using vec_t = std::vector< std::string >;
-    auto pathOf = []( AttributableInterface & attr )
+    auto pathOf = []( Attributable & attr )
     {
         auto res = attr.myPath();
 #if false
@@ -748,8 +748,8 @@ TEST_CASE( "wrapper_test", "[core]" )
     o.flush();
     REQUIRE(all_data.get()[0] == value);
 #if openPMD_USE_INVASIVE_TESTS
-    REQUIRE(o.iterations[4].meshes["E"]["y"].m_chunks->empty());
-    REQUIRE(mrc2.m_chunks->empty());
+    REQUIRE(o.iterations[4].meshes["E"]["y"].get().m_chunks.empty());
+    REQUIRE(mrc2.get().m_chunks.empty());
 #endif
 
     MeshRecordComponent mrc3 = o.iterations[5].meshes["E"]["y"];
@@ -760,13 +760,13 @@ TEST_CASE( "wrapper_test", "[core]" )
     std::shared_ptr< double > storeData = std::make_shared< double >(44);
     o.iterations[5].meshes["E"]["y"].storeChunk(storeData, {0}, {1});
 #if openPMD_USE_INVASIVE_TESTS
-    REQUIRE(o.iterations[5].meshes["E"]["y"].m_chunks->size() == 1);
-    REQUIRE(mrc3.m_chunks->size() == 1);
+    REQUIRE(o.iterations[5].meshes["E"]["y"].get().m_chunks.size() == 1);
+    REQUIRE(mrc3.get().m_chunks.size() == 1);
 #endif
     o.flush();
 #if openPMD_USE_INVASIVE_TESTS
-    REQUIRE(o.iterations[5].meshes["E"]["y"].m_chunks->empty());
-    REQUIRE(mrc3.m_chunks->empty());
+    REQUIRE(o.iterations[5].meshes["E"]["y"].get().m_chunks.empty());
+    REQUIRE(mrc3.get().m_chunks.empty());
 #endif
 
     o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].resetDataset(Dataset(determineDatatype< uint64_t >(), {4}));
@@ -782,13 +782,13 @@ TEST_CASE( "wrapper_test", "[core]" )
     size_t idx = 0;
     uint64_t val = 10;
 #if openPMD_USE_INVASIVE_TESTS
-    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
-    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
+    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].get().m_chunks.empty());
+    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].get().m_chunks.empty());
 #endif
     pp["numParticles"][RecordComponent::SCALAR].store(idx, val);
 #if openPMD_USE_INVASIVE_TESTS
-    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 1);
-    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 1);
+    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].get().m_chunks.size() == 1);
+    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].get().m_chunks.size() == 1);
 #endif
     std::stringstream u64str;
     u64str << determineDatatype<uint64_t>();
@@ -796,13 +796,13 @@ TEST_CASE( "wrapper_test", "[core]" )
                         Catch::Equals("Datatypes of patch data (DOUBLE) and dataset (" + u64str.str() + ") do not match."));
     o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].store(idx+1, val+1);
 #if openPMD_USE_INVASIVE_TESTS
-    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 2);
-    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->size() == 2);
+    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].get().m_chunks.size() == 2);
+    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].get().m_chunks.size() == 2);
 #endif
     o.flush();
 #if openPMD_USE_INVASIVE_TESTS
-    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
-    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].m_chunks->empty());
+    REQUIRE(o.iterations[6].particles["electrons"].particlePatches["numParticles"][RecordComponent::SCALAR].get().m_chunks.empty());
+    REQUIRE(pp["numParticles"][RecordComponent::SCALAR].get().m_chunks.empty());
 #endif
 }
 
@@ -826,7 +826,7 @@ TEST_CASE( "use_count_test", "[core]" )
     o.iterations[6].particles["electrons"]["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     pprc.resetDataset(Dataset(determineDatatype<uint64_t>(), {4}));
     pprc.store(0, static_cast< uint64_t >(1));
-    REQUIRE(static_cast< Parameter< Operation::WRITE_DATASET >* >(pprc.m_chunks->front().parameter.get())->data.use_count() == 1);
+    REQUIRE(static_cast< Parameter< Operation::WRITE_DATASET >* >(pprc.get().m_chunks.front().parameter.get())->data.use_count() == 1);
 #endif
 }
 


### PR DESCRIPTION
Follow-up to #886.

This splits `Container` and deriving classes into a data and an interface class.

TODO:
- [x] Do this to all those classes. Already done: `Container`, `BaseRecord`, `RecordComponent`, `BaseRecordComponent`, `PatchRecordComponent`, `Iteration`
- [x] Don't split those classes as they don't have extra data members: `PatchRecord`, `ParticlePatches`, `ParticleSpecies` (its only member `ParticlePatches` already has handle semantics), `Mesh`
- [x] Fix Python bindings
- [x] Update documentation

This PR prepares for a necessary UX frontend redesign that will be a follow-up:


* The `SCALAR` trick for instantiating datasets that have no x,y,z components is confusing for users, I've had to explain this several times now and it doesn't really make sense. Make it so that instead of `auto E_x = series.iterations[0].meshes["temperature"][SCALAR]` one can equivalently write `auto E_x = series.iterations[0].meshes["temperature"]`. 
* Allow users to create custom subgroups

To do this, probably do something like:
* Separate the functionality to create subgroups into a class (maybe reuse the class `Record` for that as it has a similar purpose
* Separate the functionality to create datasets into a class (now part of `RecordComponent`)