### PR TITLE
GH Actions: CI Savings

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -3,7 +3,7 @@ name: 🐧 Intel
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-intel
+  group: ${{ github.ref }}-${{ github.head_ref }}-intel
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -2,6 +2,10 @@ name: 🐧 Intel
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-intel
+  cancel-in-progress: true
+
 jobs:
   icc_cxxonly:
     name: ICC C++ only

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -10,6 +10,7 @@ jobs:
   icc_cxxonly:
     name: ICC C++ only
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Install
@@ -32,6 +33,7 @@ jobs:
   icx_cxxonly:
     name: ICX C++ only
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,10 @@ name: 🐧 Linux
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-linux
+  cancel-in-progress: true
+
 jobs:
   clang5_nopy_nompi_h5:
     runs-on: ubuntu-18.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: 🐧 Linux
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-linux
+  group: ${{ github.ref }}-${{ github.head_ref }}-linux
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,6 +9,7 @@ concurrency:
 jobs:
   clang5_nopy_nompi_h5:
     runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache
@@ -37,6 +38,7 @@ jobs:
 
   clang5_nopy_ompi_h5_ad1_ad2_bp3:
     runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache
@@ -72,6 +74,7 @@ jobs:
 
   clang5_nopy_ompi_h5_ad2_newLayout:
     runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache
@@ -105,6 +108,7 @@ jobs:
 
   clang10_py38_nompi_h5_ad1_ad2_libcpp:
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Install
@@ -132,6 +136,7 @@ jobs:
 
   clang8_py38_mpich_h5_ad1_ad2_newLayout:
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache
@@ -177,6 +182,7 @@ jobs:
 
   gcc5_py36_pd_dd_ompi_h5_ad1_ad2:
     runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache
@@ -213,6 +219,7 @@ jobs:
 
   gcc9_py38_pd_nompi_h5_ad1_ad2_libcpp:
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Install
@@ -235,6 +242,7 @@ jobs:
 
   conda_ompi_all:
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,7 @@ jobs:
 
   appleclang12_py_mpi_h5_ad2:
     runs-on: macos-latest
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Install

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: 🍏 macOS
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-macos
+  group: ${{ github.ref }}-${{ github.head_ref }}-macos
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,10 @@ name: 🍏 macOS
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-macos
+  cancel-in-progress: true
+
 jobs:
 # TODO: (old Travis-CI coverage)
 #  appleclang9_py37_nompi_h5_ad1

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -10,6 +10,7 @@ jobs:
   tests-cuda11:
     name: CTK@11.2
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     env: {CXX: nvcc, CXXFLAGS: "--forward-unknown-to-host-compiler -Xcompiler -Werror -Wno-deprecated-declarations"}
     steps:
     - uses: actions/checkout@v2
@@ -34,6 +35,7 @@ jobs:
   tests-nvhpc21-5-nvcc:
     name: NVHPC@21.5
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     # Catch warnings:
     #   line 4314: error: variable "<unnamed>::autoRegistrar73" was declared but never referenced
     # env: {CXXFLAGS: "-Werror -Wno-deprecated-declarations"}

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -3,7 +3,7 @@ name: 🐧 Nvidia
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-nvidia
+  group: ${{ github.ref }}-${{ github.head_ref }}-nvidia
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -2,6 +2,10 @@ name: 🐧 Nvidia
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-nvidia
+  cancel-in-progress: true
+
 jobs:
   tests-cuda11:
     name: CTK@11.2

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -24,6 +24,7 @@ jobs:
 
   static-analysis:
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: pyflakes
@@ -46,6 +47,7 @@ jobs:
 
   urls:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: urls-checker

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -2,6 +2,10 @@ name: 📜 Source
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-source
+  cancel-in-progress: true
+
 jobs:
   style:
     runs-on: ubuntu-20.04

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -3,7 +3,7 @@ name: 📜 Source
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-source
+  group: ${{ github.ref }}-${{ github.head_ref }}-source
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -10,6 +10,7 @@ jobs:
   clangtidy10_nopy_ompi_h5_ad1_ad2:
     name: clang-tidy w/o py
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache
@@ -38,6 +39,7 @@ jobs:
   clangsanitizer10_py38_ompi_h5_ad1_ad2:
     name: Clang ASAN UBSAN
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -2,6 +2,10 @@ name: 🐧 Tooling
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref }}-tooling
+  cancel-in-progress: true
+
 jobs:
   clangtidy10_nopy_ompi_h5_ad1_ad2:
     name: clang-tidy w/o py

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -3,7 +3,7 @@ name: 🐧 Tooling
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-tooling
+  group: ${{ github.ref }}-${{ github.head_ref }}-tooling
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This uses GH Action CI resources more carefully by:

- Abort running pushes in CI if an update was pushed to a PR.
- Skip all but short style checks if a PR is opened as a draft.

## Notes on Starting or Converting a Draft PR

### Convert an open PR to draft:
![convert](https://user-images.githubusercontent.com/1353258/134959925-a197c8cf-f3d2-4df2-acf9-e612cc7f447c.png)

### Open your next PR as a draft PR:
![draft_pr](https://user-images.githubusercontent.com/1353258/134959934-9f2ddd4e-b2cc-40c4-b288-e2c38913f1c2.png)

## Notes on Avoiding to Run GH Actions on Older Forks of this Repo

if you have an older fork of this repo on your account, all tests are run twice. Once on your repo (and not shown anywhere), once on our PR. (This default changed to opt-in if you created a recent fork.)

So, if you own an older fork of this repo on GitHub, you can also safe some CO2 if you like:
Go to your fork, click on the tab `Actions` -> Select workflow -> Click on `...` -> Select "Disable Workflow"