### PR TITLE
Use <mpark/variant.hpp> indiscriminately

### DIFF
--- a/include/openPMD/auxiliary/VariantSrc.hpp
+++ b/include/openPMD/auxiliary/VariantSrc.hpp
@@ -20,7 +20,15 @@
  */
 #pragma once
 
-#if __cplusplus >= 201703L
+/*
+ * For now, always use the backported variant.
+ * Reason: If openPMD-api is built with C++14 and user code is built with C++17,
+ * both must use the same variant implementation because we cannot guarantee
+ * binary compatibility between both.
+ * So, variantSrc must always refer to the lowest common denominator, which is
+ * currently <mpark/variant.hpp>
+ */
+#if false // __cplusplus >= 201703L
 #   include <variant> // IWYU pragma: export
 namespace variantSrc = std;
 #else


### PR DESCRIPTION
Our header `include/openPMD/auxiliary/VariantSrc.hpp` currently inspects the C++ version with a macro and uses either `std::variant` or `mpark::variant` depending on the found version. In a public header, that can lead to trouble if the user code uses a different C++ version compared to openPMD-api.

Bug can be reproduced with the following writer:
```CMake
cmake_minimum_required(VERSION 3.14.0)
set(CMAKE_CXX_STANDARD 17)

project(openpmd_debug)

find_package(openPMD REQUIRED)

add_executable(openpmd_write openpmd_write.cpp)

target_link_libraries(openpmd_write PRIVATE openPMD::openPMD adios2::cxx11)
```

```cpp
#include <openPMD/openPMD.hpp>

// example: data handling
#include <numeric>  // std::iota
#include <vector>   // std::vector

/**@file test example for writing histogram woth openPMD-api from c++ code
  *
  */

int main(){
    /// open
    auto series = openPMD::Series(
        "myOutput/data_%05T.bp",
        openPMD::Access::CREATE);

    /// open iteration
    auto iteration = series.iterations[42];

    constexpr int xExtent = 1;
    constexpr int yExtent = 2;
    constexpr int maxNumBins = 3;

    openPMD::Extent extent = {xExtent, yExtent, maxNumBins};

    /// create test data
    // set up is xExtent x yExtent grid points and for each grid point a histogram with maxNumBins bins
    std::vector<float> x_data(
        xExtent * yExtent * maxNumBins);

    x_data = {1., 2., 3., 4., 5., 6.}; // by convention x is fastest changing index

    // create a new record for mesh
    auto histogramMesh = iteration.meshes["adaptiveHistogram"];

    // create 1 record component each corresponding to one single entry n histogram
    auto entry = histogramMesh[openPMD::MeshRecordComponent::SCALAR];

    ///create new dataset, description of how data is to be stored
    openPMD::Datatype dataType = openPMD::determineDatatype<float>();
    openPMD::Dataset dataSet = openPMD::Dataset(dataType, extent);

    /// set what records actually store(what record components actually are)
    entry.resetDataset(dataSet);

    /// actual data is passed
    entry.storeChunk(
        x_data,
        {0, 0, 0}, // offset
        extent); // extent, artificially inflated

    /// actual write happens
    series.flush();

    // destruct series object,
    // e.g. when out-of-scope

    return 0;
}
```