### PR TITLE
Spack: No More `load -r`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Choose *one* of the install methods below to get started:
 ```bash
 # optional:               +python +adios1 -adios2 -hdf5 -mpi
 spack install openpmd-api
-spack load -r openpmd-api
+spack load openpmd-api
 ```
 
 ### [Conda](https://conda.io)

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -36,7 +36,7 @@ A package for openPMD-api is available via the `Spack <https://spack.io>`_ packa
 
    # optional:               +python +adios1 -adios2 -hdf5 -mpi
    spack install openpmd-api
-   spack load -r openpmd-api
+   spack load openpmd-api
 
 .. _install-conda:
 


### PR DESCRIPTION
The `-r` argument was removed from `spack load` and is now implied.