### PR TITLE
[WIP] ADIOS2: Fix Parallel Resize

### DIFF
--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -390,7 +390,7 @@ extendDataset( std::string const & ext )
     std::iota( data2.begin(), data2.end(), 25 );
     {
         Series write( filename, Access::CREATE, MPI_COMM_WORLD );
-        if( ext == "bp" && write.backend() != "ADIOS2" )
+        if( ext == "bp" && write.backend() != "MPI_ADIOS2" )
         {
             // dataset resizing unsupported in ADIOS1
             return;


### PR DESCRIPTION
We found in WarpX (https://github.com/ECP-WarpX/WarpX/pull/1898) that MPI-parallel resizes (at least in file-based encoding) do not yet work with the ADIOS2 backend (parallel HDF5 is fine).
The current behavior is that following resizes are not performed or do not show up in read as a changed extent/shape at least. (Tests do not crash in write because ADIOS let's data be written independent of extent, which is meta-data.)

- [x] fix test: was uncovered before
- [ ] fix implementation