### PR TITLE
CXX Std: Remember <variant> Impl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,26 +479,36 @@ target_include_directories(openPMD PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
+# is this a C++17 compile? If yes, skip MPark.Variant
+try_compile(openPMD_HAS_CXX17
+    ${openPMD_BINARY_DIR}/try_variant
+    ${openPMD_SOURCE_DIR}/cmake/try_variant.cpp
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+message(STATUS "<variant> supported (C++17 or newer): ${openPMD_HAS_CXX17}")
+
 # C++11 std::variant (C++17 stdlib preview)
-# TODO not needed with C++17 compiler
-add_library(openPMD::thirdparty::mpark_variant INTERFACE IMPORTED)
-set(openPMD_PC_EXTRA_INCLUDE "")
-if(openPMD_USE_INTERNAL_VARIANT)
-    target_include_directories(openPMD::thirdparty::mpark_variant SYSTEM INTERFACE
-        $<BUILD_INTERFACE:${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/variant/include>
-    )
-    message(STATUS "MPark.Variant: Using INTERNAL version '1.4.0'")
-else()
-    find_package(mpark_variant 1.3.0 REQUIRED) # TODO: we want 1.4.1+
-    target_link_libraries(openPMD::thirdparty::mpark_variant
-        INTERFACE mpark_variant)
-    get_target_property(EXTERNAL_MPARK_INCLUDE mpark_variant INTERFACE_INCLUDE_DIRECTORIES)
-    if(openPMD_HAVE_PKGCONFIG AND EXTERNAL_MPARK_INCLUDE)
-        set(openPMD_PC_EXTRA_INCLUDE "-I${EXTERNAL_MPARK_INCLUDE}")
+if(NOT openPMD_HAS_CXX17)
+    add_library(openPMD::thirdparty::mpark_variant INTERFACE IMPORTED)
+    set(openPMD_PC_EXTRA_INCLUDE "")
+    if(openPMD_USE_INTERNAL_VARIANT)
+        target_include_directories(openPMD::thirdparty::mpark_variant SYSTEM INTERFACE
+            $<BUILD_INTERFACE:${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/variant/include>
+        )
+        message(STATUS "MPark.Variant: Using INTERNAL version '1.4.0'")
+    else()
+        find_package(mpark_variant 1.3.0 REQUIRED) # TODO: we want 1.4.1+
+        target_link_libraries(openPMD::thirdparty::mpark_variant
+            INTERFACE mpark_variant)
+        get_target_property(EXTERNAL_MPARK_INCLUDE mpark_variant INTERFACE_INCLUDE_DIRECTORIES)
+        if(openPMD_HAVE_PKGCONFIG AND EXTERNAL_MPARK_INCLUDE)
+            set(openPMD_PC_EXTRA_INCLUDE "-I${EXTERNAL_MPARK_INCLUDE}")
+        endif()
+        message(STATUS "MPark.Variant: Found version '${mpark_variant_VERSION}'")
     endif()
-    message(STATUS "MPark.Variant: Found version '${mpark_variant_VERSION}'")
+    target_link_libraries(openPMD PUBLIC openPMD::thirdparty::mpark_variant)
 endif()
-target_link_libraries(openPMD PUBLIC openPMD::thirdparty::mpark_variant)
 
 # Catch2 for unit tests
 if(openPMD_BUILD_TESTING)
@@ -540,8 +550,10 @@ if(openPMD_HAVE_ADIOS1)
     openpmd_cxx_required(openPMD.ADIOS1.Parallel)
     target_compile_options(openPMD.ADIOS1.Serial PUBLIC ${_msvc_options})
     target_compile_options(openPMD.ADIOS1.Parallel PUBLIC ${_msvc_options})
-    target_link_libraries(openPMD.ADIOS1.Serial PUBLIC openPMD::thirdparty::mpark_variant)
-    target_link_libraries(openPMD.ADIOS1.Parallel PUBLIC openPMD::thirdparty::mpark_variant)
+    if(NOT openPMD_HAS_CXX17)
+        target_link_libraries(openPMD.ADIOS1.Serial PUBLIC openPMD::thirdparty::mpark_variant)
+        target_link_libraries(openPMD.ADIOS1.Parallel PUBLIC openPMD::thirdparty::mpark_variant)
+    endif()
 
     target_include_directories(openPMD.ADIOS1.Serial PRIVATE
         ${openPMD_SOURCE_DIR}/include ${openPMD_BINARY_DIR}/include)
@@ -1031,7 +1043,7 @@ if(openPMD_INSTALL)
     )
     # install third-party libraries
     # TODO not needed with C++17 compiler
-    if(openPMD_USE_INTERNAL_VARIANT)
+    if(NOT openPMD_HAS_CXX17 AND openPMD_USE_INTERNAL_VARIANT)
         install(DIRECTORY "${openPMD_SOURCE_DIR}/share/openPMD/thirdParty/variant/include/mpark"
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
@@ -1394,7 +1406,11 @@ if(openPMD_INSTALL)
     endif()
     message("")
     message("  Additionally, install following third party libraries:")
-    message("    MPark.Variant: ${openPMD_USE_INTERNAL_VARIANT}")
+    if(openPMD_HAS_CXX17)
+        message("    MPark.Variant: OFF")
+    else()
+        message("    MPark.Variant: ${openPMD_USE_INTERNAL_VARIANT}")
+    endif()
 else()
     message("  Installation: OFF")
 endif()

--- a/cmake/try_variant.cpp
+++ b/cmake/try_variant.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2021 Axel Huebl
  *
  * This file is part of openPMD-api.
  *
@@ -20,16 +20,32 @@
  */
 #pragma once
 
-#include "openPMD/config.hpp"
-
-#if openPMD_HAS_CXX17
+#include <cassert>
+#include <iostream>
+#if __cplusplus >= 201703L
 #   include <variant> // IWYU pragma: export
-namespace variantSrc = std;
 #else
-    // see: https://github.com/mpark/variant/pull/76
-#   if defined(__EXCEPTIONS)
-#      define MPARK_EXCEPTIONS
-#   endif
-#   include <mpark/variant.hpp> // IWYU pragma: export
-namespace variantSrc = mpark;
+#   error "Not a C++17 implementation"
 #endif
+
+
+int main()
+{
+    std::variant< int, float > v;
+    v = 42;
+    int i = std::get< int >(v);
+    assert(42 == i);
+    assert(42 == std::get< 0 >(v));
+
+    try
+    {
+      std::get< float >(v);
+    }
+    catch( std::bad_variant_access const & ex )
+    {
+        std::cout << ex.what() << std::endl;
+    }
+
+    v = 13.2f;
+    assert(13.2f == std::get<0>(v));
+}

--- a/include/openPMD/config.hpp.in
+++ b/include/openPMD/config.hpp.in
@@ -20,6 +20,10 @@
  */
 #pragma once
 
+#ifndef openPMD_HAS_CXX17
+#   cmakedefine01 openPMD_HAS_CXX17
+#endif
+
 #ifndef openPMD_HAVE_MPI
 #   cmakedefine01 openPMD_HAVE_MPI
 #endif


### PR DESCRIPTION
We use `<variant>` or `<mpark/variant.hpp>` in our public API interface for datatypes, depending on the C++ standard.

This pull request makes sure that the same implementation is used in downstream code, even if the C++ standard is switched. This avoids ABI issues when, e.g., using a C++14 built openPMD-api in a C++17 downstream code.

Fix #1121

X-ref:
- https://github.com/ECP-WarpX/WarpX/pull/2440
- https://github.com/ECP-WarpX/WarpX/issues/1776#issuecomment-942689086
- https://github.com/conda-forge/warpx-feedstock/pull/30