### PR TITLE
HDF5 I/O optimizations

### DIFF
--- a/.rodare.json
+++ b/.rodare.json
@@ -108,6 +108,12 @@
             "name": "Schnetter, Erik",
             "orcid": "0000-0002-4518-9017",
             "type": "Other"
+        },
+        {
+            "affiliation": "Lawrence Berkeley National Laboratory",
+            "name": "Bez, Jean Luca",
+            "orcid": "0000-0002-3915-1135",
+            "type": "Other"          
         }
     ],
     "title": "C++ & Python API for Scientific I/O with openPMD",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,10 @@ if(openPMD_HAVE_HDF5 AND HDF5_VERSION VERSION_LESS 1.8.13)
         "Found HDF5 version ${HDF5_VERSION} is too old. At least "
         "version 1.8.13 is required.\n")
 endif()
+# check for collective metadata support
+if(openPMD_HAVE_HDF5 AND HDF5_VERSION VERSION_GREATER 1.10.8)
+    set(openPMD_HAVE_COLLECTIVE_METADATA TRUE)
+endif()
 # we imply support for parallel I/O if MPI variant is ON
 if(openPMD_HAVE_MPI AND openPMD_HAVE_HDF5
     AND NOT HDF5_IS_PARALLEL      # FindHDF5.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,10 +236,6 @@ if(openPMD_HAVE_HDF5 AND HDF5_VERSION VERSION_LESS 1.8.13)
         "Found HDF5 version ${HDF5_VERSION} is too old. At least "
         "version 1.8.13 is required.\n")
 endif()
-# check for collective metadata support
-if(openPMD_HAVE_HDF5 AND HDF5_VERSION VERSION_GREATER 1.10.8)
-    set(openPMD_HAVE_COLLECTIVE_METADATA TRUE)
-endif()
 # we imply support for parallel I/O if MPI variant is ON
 if(openPMD_HAVE_MPI AND openPMD_HAVE_HDF5
     AND NOT HDF5_IS_PARALLEL      # FindHDF5.cmake

--- a/README.md
+++ b/README.md
@@ -415,7 +415,6 @@ Further thanks go to improvements and contributions from:
   C++ API bug fixes
 * [Jean Luca Bez (LBNL)](https://github.com/jeanbez):
   HDF5 performance tuning
-  
 
 ### Grants
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,9 @@ Further thanks go to improvements and contributions from:
   Dask guidance & reviews
 * [Erik Schnetter (PITP)](https://github.com/eschnett):
   C++ API bug fixes
+* [Jean Luca Bez (LBNL)](https://github.com/jeanbez):
+  HDF5 performance tuning
+  
 
 ### Grants
 

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -58,7 +58,7 @@ Chunking generally improves performance and only needs to be disabled in corner-
 
 ``OPENPMD_HDF5_COLLECTIVE_METADATA``: this is an option to enable collective MPI calls for HDF5 metadata operations via `H5Pset_all_coll_metadata_ops <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetAllCollMetadataOps>`__ and `H5Pset_coll_metadata_write <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetCollMetadataWrite>`__.
 By default, this optimization is enabled as it has proven to provide performance improvements.
-This option is only available from HDF5 1.10.8 onwards. For previous version it will fallback to independent MPI calls.
+This option is only available from HDF5 1.10.0 onwards. For previous version it will fallback to independent MPI calls.
 
 ``OPENPMD_HDF5_PAGED_ALLOCATION``: this option enables paged allocation for HDF5 operations via `H5Pset_file_space_strategy <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetFileSpaceStrategy>`__.
 The page size can be controlled by the ``OPENPMD_HDF5_PAGED_ALLOCATION_SIZE`` option.

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -21,16 +21,22 @@ Backend-Specific Controls
 
 The following environment variables control HDF5 I/O behavior at runtime.
 
-===================================== ========= ===========================================================================================================
-Environment variable                  Default   Description
-===================================== ========= ===========================================================================================================
-``OPENPMD_HDF5_INDEPENDENT``          ``ON``    Sets the MPI-parallel transfer mode to collective (``OFF``) or independent (``ON``).
-``OPENPMD_HDF5_ALIGNMENT``            ``1``     Tuning parameter for parallel I/O, choose an alignment which is a multiple of the disk block size.
-``OPENPMD_HDF5_CHUNKS``               ``auto``  Defaults for ``H5Pset_chunk``: ``"auto"`` (heuristic) or ``"none"`` (no chunking).
-``H5_COLL_API_SANITY_CHECK``          unset     Debug: Set to ``1`` to perform an ``MPI_Barrier`` inside each meta-data operation.
-``HDF5_USE_FILE_LOCKING``             ``TRUE``  Work-around: Set to ``FALSE`` in case you are on an HPC or network file system that hang in open for reads.
-``OMPI_MCA_io``                       unset     Work-around: Disable OpenMPI's I/O implementation for older releases by setting this to ``^ompio``.
-===================================== ========= ===========================================================================================================
+======================================== ============ ===========================================================================================================
+Environment variable                     Default      Description
+======================================== ============ ===========================================================================================================
+``OPENPMD_HDF5_INDEPENDENT``             ``ON``       Sets the MPI-parallel transfer mode to collective (``OFF``) or independent (``ON``).
+``OPENPMD_HDF5_ALIGNMENT``               ``1``        Tuning parameter for parallel I/O, choose an alignment which is a multiple of the disk block size.
+``OPENPMD_HDF5_THRESHOLD``               ``0``        Tuning parameter for parallel I/O, where ``0`` aligns all requests and other values act as a threshold.
+``OPENPMD_HDF5_CHUNKS``                  ``auto``     Defaults for ``H5Pset_chunk``: ``"auto"`` (heuristic) or ``"none"`` (no chunking).
+``OPENPMD_HDF5_COLLECTIVE_METADATA``     ``ON``       Sets the MPI-parallel transfer mode for metadata operations to collective (``ON``) or independent (``OFF``).
+``OPENPMD_HDF5_PAGED_ALLOCATION``        ``ON``       Tuning parameter for parallel I/O in HDF5 to enable paged allocation.
+``OPENPMD_HDF5_PAGED_ALLOCATION_SIZE``   ``33554432`` Size of the page, in bytes, if HDF5 paged allocation optimization is enabled.
+``OPENPMD_HDF5_DEFER_METADATA``          ``ON``       Tuning parameter for parallel I/O in HDF5 to enable deferred HDF5 metadata operations.
+``OPENPMD_HDF5_DEFER_METADATA_SIZE``     ``ON``       Size of the buffer, in bytes, if HDF5 deferred metadata optimization is enabled.
+``H5_COLL_API_SANITY_CHECK``             unset        Debug: Set to ``1`` to perform an ``MPI_Barrier`` inside each meta-data operation.
+``HDF5_USE_FILE_LOCKING``                ``TRUE``     Work-around: Set to ``FALSE`` in case you are on an HPC or network file system that hang in open for reads.
+``OMPI_MCA_io``                          unset        Work-around: Disable OpenMPI's I/O implementation for older releases by setting this to ``^ompio``.
+======================================== ============ ===========================================================================================================
 
 ``OPENPMD_HDF5_INDEPENDENT``: by default, we implement MPI-parallel data ``storeChunk`` (write) and ``loadChunk`` (read) calls as `none-collective MPI operations <https://www.mpi-forum.org/docs/mpi-2.2/mpi22-report/node87.htm#Node87>`_.
 Attribute writes are always collective in parallel HDF5.
@@ -38,13 +44,33 @@ Although we choose the default to be non-collective (independent) for ease of us
 For independent parallel I/O, potentially prefer using a modern version of the MPICH implementation (especially, use ROMIO instead of OpenMPI's ompio implementation).
 Please refer to the `HDF5 manual, function H5Pset_dxpl_mpio <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_dxpl_mpio.htm>`_ for more details.
 
-``OPENPMD_HDF5_ALIGNMENT`` This sets the alignment in Bytes for writes via the ``H5Pset_alignment`` function.
+``OPENPMD_HDF5_ALIGNMENT``: this sets the alignment in Bytes for writes via the ``H5Pset_alignment`` function.
 According to the `HDF5 documentation <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_alignment.htm>`_:
 *For MPI IO and other parallel systems, choose an alignment which is a multiple of the disk block size.*
 On Lustre filesystems, according to the `NERSC documentation <https://www.nersc.gov/users/training/online-tutorials/introduction-to-scientific-i-o/?start=5>`_, it is advised to set this to the Lustre stripe size. In addition, ORNL Summit GPFS users are recommended to set the alignment value to 16777216(16MB).
 
-``OPENPMD_HDF5_CHUNKS`` This sets defaults for data chunking via `H5Pset_chunk <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_chunk.htm>`__.
+``OPENPMD_HDF5_THRESHOLD``: this sets the threshold for the alignment of HDF5 operations via the ``H5Pset_alignment`` function.
+Setting it to ``0`` will force all requests to be aligned.
+Any file object greater than or equal in size to threshold bytes will be aligned on an address which is a multiple of ``OPENPMD_HDF5_ALIGNMENT``.
+
+``OPENPMD_HDF5_CHUNKS``: this sets defaults for data chunking via `H5Pset_chunk <https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_chunk.htm>`__.
 Chunking generally improves performance and only needs to be disabled in corner-cases, e.g. when heavily relying on independent, parallel I/O that non-collectively declares data records.
+
+``OPENPMD_HDF5_COLLECTIVE_METADATA``: this is an option to enable collective MPI calls for HDF5 metadata operations via `H5Pset_all_coll_metadata_ops <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetAllCollMetadataOps>`__ and `H5Pset_coll_metadata_write <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetCollMetadataWrite>`__.
+By default, this optimization is enabled as it has proven to provide performance improvements.
+This option is only available from HDF5 1.10.8 onwards. For previous version it will fallback to independent MPI calls.
+
+``OPENPMD_HDF5_PAGED_ALLOCATION``: this option enables paged allocation for HDF5 operations via `H5Pset_file_space_strategy <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetFileSpaceStrategy>`__.
+The page size can be controlled by the ``OPENPMD_HDF5_PAGED_ALLOCATION_SIZE`` option.
+
+``OPENPMD_HDF5_PAGED_ALLOCATION_SIZE``: this option configures the size of the page if ``OPENPMD_HDF5_PAGED_ALLOCATION`` optimization is enabled via `H5Pset_file_space_page_size <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetFileSpacePageSize>`__.
+Values are expressed in bytes. Default is set to 32MB.
+
+``OPENPMD_HDF5_DEFER_METADATA``: this option enables deffered HDF5 metadata operations.
+The metadata buffer size can be controlled by the ``OPENPMD_HDF5_DEFER_METADATA_SIZE`` option.
+
+``OPENPMD_HDF5_DEFER_METADATA_SIZE``: this option configures the size of the buffer if ``OPENPMD_HDF5_DEFER_METADATA`` optimization is enabled via `H5Pset_mdc_config <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetMdcConfig>`__.
+Values are expressed in bytes. Default is set to 32MB.
 
 ``H5_COLL_API_SANITY_CHECK``: this is a HDF5 control option for debugging parallel I/O logic (API calls).
 Debugging a parallel program with that option enabled can help to spot bugs such as collective MPI-calls that are not called by all participating MPI ranks.

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -70,6 +70,9 @@ namespace openPMD
 
         hid_t m_datasetTransferProperty;
         hid_t m_fileAccessProperty;
+        hid_t m_fileCreateProperty;
+
+        hbool_t m_hdf5_collective_metadata;
 
         // h5py compatible types for bool and complex
         hid_t m_H5T_BOOL_ENUM;

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -72,7 +72,7 @@ namespace openPMD
         hid_t m_fileAccessProperty;
         hid_t m_fileCreateProperty;
 
-        hbool_t m_hdf5_collective_metadata;
+        hbool_t m_hdf5_collective_metadata = 1;
 
         // h5py compatible types for bool and complex
         hid_t m_H5T_BOOL_ENUM;

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -118,13 +118,13 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
         }
     }
 
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     auto const hdf5_collective_metadata = auxiliary::getEnvString( "OPENPMD_HDF5_COLLECTIVE_METADATA", "ON" );
     if( hdf5_collective_metadata == "ON" )
         m_hdf5_collective_metadata = 1;
     else
         m_hdf5_collective_metadata = 0;
-    #endif
+#endif
 }
 
 HDF5IOHandlerImpl::~HDF5IOHandlerImpl()
@@ -211,12 +211,12 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         throw std::runtime_error("[HDF5] Creating a path in a file opened as read only is not possible.");
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
     }
-    #endif
+#endif
 
     herr_t status;
 
@@ -324,12 +324,12 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         }
 
         hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-        #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
         if( m_hdf5_collective_metadata )
         {
             H5Pset_all_coll_metadata_ops(gapl, true);
         }
-        #endif
+#endif
 
         /* Open H5Object to write into */
         auto res = getFile( writable );
@@ -632,12 +632,12 @@ HDF5IOHandlerImpl::openPath(
     hid_t node_id, path_id;
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
     }
-    #endif
+#endif
 
     node_id = H5Gopen(file.id,
                       concrete_h5_file_position(writable->parent).c_str(),
@@ -683,12 +683,12 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
     hid_t node_id, dataset_id;
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
     }
-    #endif
+#endif
 
     node_id = H5Gopen(file.id,
                       concrete_h5_file_position(writable->parent).c_str(),
@@ -1041,12 +1041,12 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
     hid_t node_id, attribute_id;
 
     hid_t fapl = H5Pcreate(H5P_LINK_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(fapl, true);
     }
-    #endif
+#endif
 
     node_id = H5Oopen(file.id,
                       concrete_h5_file_position(writable).c_str(),
@@ -1412,12 +1412,12 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
     herr_t status;
 
     hid_t fapl = H5Pcreate(H5P_LINK_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(fapl, true);
     }
-    #endif
+#endif
 
     obj_id = H5Oopen(file.id,
                      concrete_h5_file_position(writable).c_str(),
@@ -1850,12 +1850,12 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
         File file = res ? res.get() : getFile( writable->parent ).get();
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
     }
-    #endif
+#endif
 
     hid_t node_id = H5Gopen(file.id,
                             concrete_h5_file_position(writable).c_str(),
@@ -1895,12 +1895,12 @@ HDF5IOHandlerImpl::listDatasets(Writable* writable,
         File file = res ? res.get() : getFile( writable->parent ).get();
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
     }
-    #endif
+#endif
 
     hid_t node_id = H5Gopen(file.id,
                             concrete_h5_file_position(writable).c_str(),
@@ -1940,12 +1940,12 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
     hid_t node_id;
 
     hid_t fapl = H5Pcreate(H5P_LINK_ACCESS);
-    #if openPMD_HAVE_COLLECTIVE_METADATA
+#if H5_VERSION_GE(1,10,0)
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(fapl, true);
     }
-    #endif
+#endif
 
     node_id = H5Oopen(file.id,
                       concrete_h5_file_position(writable).c_str(),

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1823,7 +1823,7 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
     if( m_hdf5_collective_metadata )
     {
-        H5Pset_all_coll_metadata_ops(gapl, true);    
+        H5Pset_all_coll_metadata_ops(gapl, true);
     }
 
     hid_t node_id = H5Gopen(file.id,

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1880,7 +1880,7 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
 
     status = H5Gclose(node_id);
     VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 group " + concrete_h5_file_position(writable) + " during path listing");
-    status = H5Pclose(gapl);    
+    status = H5Pclose(gapl);
     VERIFY(status == 0, "[HDF5] Internal error: Failed to close HDF5 property during path listing");
 }
 

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -118,7 +118,7 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
         }
     }
 
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     auto const hdf5_collective_metadata = auxiliary::getEnvString( "OPENPMD_HDF5_COLLECTIVE_METADATA", "ON" );
     if( hdf5_collective_metadata == "ON" )
         m_hdf5_collective_metadata = 1;
@@ -211,7 +211,7 @@ HDF5IOHandlerImpl::createPath(Writable* writable,
         throw std::runtime_error("[HDF5] Creating a path in a file opened as read only is not possible.");
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
@@ -324,7 +324,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         }
 
         hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
         if( m_hdf5_collective_metadata )
         {
             H5Pset_all_coll_metadata_ops(gapl, true);
@@ -632,7 +632,7 @@ HDF5IOHandlerImpl::openPath(
     hid_t node_id, path_id;
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
@@ -683,7 +683,7 @@ HDF5IOHandlerImpl::openDataset(Writable* writable,
     hid_t node_id, dataset_id;
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
@@ -1041,7 +1041,7 @@ HDF5IOHandlerImpl::writeAttribute(Writable* writable,
     hid_t node_id, attribute_id;
 
     hid_t fapl = H5Pcreate(H5P_LINK_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(fapl, true);
@@ -1412,7 +1412,7 @@ HDF5IOHandlerImpl::readAttribute(Writable* writable,
     herr_t status;
 
     hid_t fapl = H5Pcreate(H5P_LINK_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(fapl, true);
@@ -1850,7 +1850,7 @@ HDF5IOHandlerImpl::listPaths(Writable* writable,
         File file = res ? res.get() : getFile( writable->parent ).get();
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
@@ -1895,7 +1895,7 @@ HDF5IOHandlerImpl::listDatasets(Writable* writable,
         File file = res ? res.get() : getFile( writable->parent ).get();
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(gapl, true);
@@ -1940,7 +1940,7 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
     hid_t node_id;
 
     hid_t fapl = H5Pcreate(H5P_LINK_ACCESS);
-#if H5_VERSION_GE(1,10,0)
+#if H5_VERSION_GE(1,10,0) && openPMD_HAVE_MPI
     if( m_hdf5_collective_metadata )
     {
         H5Pset_all_coll_metadata_ops(fapl, true);

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -118,7 +118,7 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
 
     status = H5Pset_coll_metadata_write(m_fileAccessProperty, collective_metadata);
     VERIFY(status >= 0, "[HDF5] Internal error: Failed to set metadata write HDF5 file access property");
-    
+
     auto const strByte = auxiliary::getEnvString( "OPENPMD_HDF5_ALIGNMENT", "1" );
     std::stringstream sstream(strByte);
     hsize_t bytes;

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <iostream>
+#include <sstream>
 
 
 namespace openPMD
@@ -105,9 +106,9 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
     status = H5Pset_dxpl_mpio(m_datasetTransferProperty, xfer_mode);
 
     hbool_t collective_metadata = 0;
-    auto const hdf5_collective_metadata = auxiliary::getEnvString( "OPENPMD_HDF5_COLLECTIVE_METADATA", "OFF" );
-    if( hdf5_collective_metadata == "ON" )
-        collective_metadata = 1;
+    auto const hdf5_collective_metadata = auxiliary::getEnvString( "OPENPMD_HDF5_COLLECTIVE_METADATA", "ON" );
+    if( hdf5_collective_metadata == "OFF" )
+        collective_metadata = 0;
     else
     {
         VERIFY(hdf5_collective_metadata == "OFF", "[HDF5] Internal error: OPENPMD_HDF5_COLLECTIVE_METADATA property must be either ON or OFF");

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -109,10 +109,6 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
     auto const hdf5_collective_metadata = auxiliary::getEnvString( "OPENPMD_HDF5_COLLECTIVE_METADATA", "ON" );
     if( hdf5_collective_metadata == "OFF" )
         collective_metadata = 0;
-    else
-    {
-        VERIFY(hdf5_collective_metadata == "OFF", "[HDF5] Internal error: OPENPMD_HDF5_COLLECTIVE_METADATA property must be either ON or OFF");
-    }
 
     status = H5Pset_all_coll_metadata_ops(m_fileAccessProperty, collective_metadata);
     VERIFY(status >= 0, "[HDF5] Internal error: Failed to set metadata read HDF5 file access property");

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -110,11 +110,13 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
     if( hdf5_collective_metadata == "OFF" )
         collective_metadata = 0;
 
+#if H5_VERSION_GE(1,10,0)
     status = H5Pset_all_coll_metadata_ops(m_fileAccessProperty, collective_metadata);
     VERIFY(status >= 0, "[HDF5] Internal error: Failed to set metadata read HDF5 file access property");
 
     status = H5Pset_coll_metadata_write(m_fileAccessProperty, collective_metadata);
     VERIFY(status >= 0, "[HDF5] Internal error: Failed to set metadata write HDF5 file access property");
+#endif
 
     auto const strByte = auxiliary::getEnvString( "OPENPMD_HDF5_ALIGNMENT", "1" );
     std::stringstream sstream(strByte);

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -105,16 +105,11 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
     herr_t status;
     status = H5Pset_dxpl_mpio(m_datasetTransferProperty, xfer_mode);
 
-    hbool_t collective_metadata = 0;
-    auto const hdf5_collective_metadata = auxiliary::getEnvString( "OPENPMD_HDF5_COLLECTIVE_METADATA", "ON" );
-    if( hdf5_collective_metadata == "OFF" )
-        collective_metadata = 0;
-
 #if H5_VERSION_GE(1,10,0)
-    status = H5Pset_all_coll_metadata_ops(m_fileAccessProperty, collective_metadata);
+    status = H5Pset_all_coll_metadata_ops(m_fileAccessProperty, m_hdf5_collective_metadata);
     VERIFY(status >= 0, "[HDF5] Internal error: Failed to set metadata read HDF5 file access property");
 
-    status = H5Pset_coll_metadata_write(m_fileAccessProperty, collective_metadata);
+    status = H5Pset_coll_metadata_write(m_fileAccessProperty, m_hdf5_collective_metadata);
     VERIFY(status >= 0, "[HDF5] Internal error: Failed to set metadata write HDF5 file access property");
 #endif
 


### PR DESCRIPTION
This PR adds support for a couple of HDF5 optimizations in openPMD:

- Collective metadata
- Deferred metadata operations
- Paged allocation
- Alignment

All optimizations can be enabled/disabled and tuned by using environment variables.
