### PR TITLE
libfabric 1.6+: Document SST Work-Arounds

### DIFF
--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -167,7 +167,7 @@ Known Issues
 .. warning::
 
    Nov 1st, 2021 (`ADIOS2 2887 <https://github.com/ornladios/ADIOS2/issues/2887>`__):
-   The fabric selection in ADIOS2 has been rewritten for libfabric 1.6.
+   The fabric selection in ADIOS2 has was designed for libfabric 1.6.
    With newer versions of libfabric, the following workaround is needed to guide the selection of a functional fabric for RDMA support:
 
    The following environment variables can be set as work-arounds on Cray systems, when working with ADIOS2 SST:

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -167,7 +167,8 @@ Known Issues
 .. warning::
 
    Nov 1st, 2021 (`ADIOS2 2887 <https://github.com/ornladios/ADIOS2/issues/2887>`__):
-   libfabric 1.6+ introduced a couple of breaking changes that break ADIOS2 SST (staging/streaming) workflows.
+The fabric selection in ADIOS2 has been written for libfabric 1.6.
+With newer versions of libfabric, the following workaround is needed to guide the selection of a functional fabric for RDMA support:
 
    The following environment variables can be set as work-arounds on Cray systems, when working with ADIOS2 SST:
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -160,6 +160,23 @@ Ignore the 30GB initialization phases.
 .. image:: ./memory_groupbased_nosteps.png
   :alt: Memory usage of group-based iteration without using steps
 
+
+Known Issues
+------------
+
+.. warning::
+
+   Nov 1st, 2021 (`ADIOS2 2887 <https://github.com/ornladios/ADIOS2/issues/2887>`__):
+   libfabric 1.6+ introduced a couple of breaking changes that break ADIOS2 SST (staging/streaming) workflows.
+
+   The following environment variables can be set as work-arounds on Cray systems, when working with ADIOS2 SST:
+
+   .. code-block:: bash
+
+      export FABRIC_IFACE=mlx5_0   # ADIOS SST: select interface (1 NIC on Summit)
+      export FI_OFI_RXM_USE_SRX=1  # libfabric: use shared receive context from MSG provider
+
+
 Selected References
 -------------------
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -167,8 +167,8 @@ Known Issues
 .. warning::
 
    Nov 1st, 2021 (`ADIOS2 2887 <https://github.com/ornladios/ADIOS2/issues/2887>`__):
-The fabric selection in ADIOS2 has been written for libfabric 1.6.
-With newer versions of libfabric, the following workaround is needed to guide the selection of a functional fabric for RDMA support:
+   The fabric selection in ADIOS2 has been rewritten for libfabric 1.6.
+   With newer versions of libfabric, the following workaround is needed to guide the selection of a functional fabric for RDMA support:
 
    The following environment variables can be set as work-arounds on Cray systems, when working with ADIOS2 SST:
 


### PR DESCRIPTION
Document work-arounds for libfabric 1.6+ on Cray systems when using data staging / streaming with ADIOS2 SST.

X-ref: https://github.com/ornladios/ADIOS2/issues/2887