### PR TITLE
Fix parsing for grid spacing with type long double

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -331,6 +331,8 @@ Mesh::read()
         setGridSpacing(a.get< std::vector< float > >());
     else if( *aRead.dtype == DT::VEC_DOUBLE || *aRead.dtype == DT::DOUBLE )
         setGridSpacing(a.get< std::vector< double > >());
+    else if( *aRead.dtype == DT::VEC_LONG_DOUBLE || *aRead.dtype == DT::LONG_DOUBLE )
+        setGridSpacing(a.get< std::vector< long double > >());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'gridSpacing'");
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1163,6 +1163,16 @@ void dtype_test( const std::string & backend )
         {
             s.setAttribute("vecULongLong", std::vector< unsigned long long >({65531u, 65529u}));
         }
+
+        // long double grid spacing
+        // should be possible to parse without error upon opening
+        // the series for reading
+        {
+            auto E = s.iterations[ 0 ].meshes[ "E" ];
+            E.setGridSpacing( std::vector< long double >{ 1.0, 1.0 } );
+            auto E_x = E[ "x" ];
+            E_x.makeEmpty< double >( 1 );
+        }
     }
 
     Series s = Series("../samples/dtype_test." + backend, Access::READ_ONLY);


### PR DESCRIPTION
`Mesh.cpp` has an explicit instantiation for long double grid spacings:
```cpp
template
Mesh&
Mesh::setGridSpacing(std::vector< long double > const & gs);
```

This is important for our Python API as floats default to `long double` there:
```python
temperature.grid_spacing = [1.0, 1.0]
```
Result of that:
```
  long double  /data/9/meshes/temperature/gridSpacing       attr   = {1, 1}
```

But upon trying to open that Series again:
```
  Unexpected Attribute datatype for 'gridSpacing'
```
Because our reading routines only check for float and double.

First commit: Failing test
Second commit: Fix

We should maybe scan our codebase for similar errors.