### PR TITLE
Python: 3.10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -240,6 +240,32 @@ jobs:
         cmake --build build --parallel 2
         ctest --test-dir build --output-on-failure
 
+  musllinux_py10:
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
+    container:
+      image: quay.io/pypa/musllinux_1_1_x86_64
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install
+      run: |
+        apk update
+        apk add hdf5-dev
+        python3.10 -m pip install numpy
+    - name: Build
+      env: {CXXFLAGS: -Werror -Wno-deprecated-declarations}
+      run: |
+        share/openPMD/download_samples.sh build
+        chmod u-w build/samples/git-sample/*.h5
+        cmake -S . -B build \
+          -DopenPMD_USE_PYTHON=ON \
+          -DopenPMD_USE_MPI=OFF   \
+          -DopenPMD_USE_HDF5=ON   \
+          -DopenPMD_USE_INVASIVE_TESTS=ON \
+          -DPython_EXECUTABLE=$(which python3.10)
+        cmake --build build --parallel 2
+        ctest --test-dir build --output-on-failure
+
   conda_ompi_all:
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM       quay.io/pypa/manylinux2010_x86_64 as build-env
 # FROM       quay.io/pypa/manylinux1_x86_64 as build-env
 ENV        DEBIAN_FRONTEND noninteractive
 
-# Python 3.6-3.9 via "36m 37m 38 39"
-ARG        PY_VERSIONS="36m 37m 38 39"
+# Python 3.6-3.10 via "36m 37m 38 39 310"
+ARG        PY_VERSIONS="36m 37m 38 39 310"
 
 # static libs need relocatable symbols for linking to shared python lib
 ENV        CFLAGS="-fPIC ${CFLAGS}"
@@ -186,6 +186,21 @@ RUN        python3.9 --version \
            && python3.9 -m pip install openPMD_api-*-cp39-cp39-manylinux2010_x86_64.whl
 RUN        python3.9 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
 RUN        python3.9 -m openpmd_api.ls --help
+RUN        openpmd-ls --help
+
+# test in fresh env: Debian:Bullseye + Python 3.10
+FROM       debian:bullseye
+ENV        DEBIAN_FRONTEND noninteractive
+COPY --from=build-env /wheelhouse/openPMD_api-*-cp310-cp310-manylinux2010_x86_64.whl .
+RUN        apt-get update \
+           && apt-get install -y --no-install-recommends python3.10 python3-distutils ca-certificates curl \
+           && rm -rf /var/lib/apt/lists/*
+RUN        python3.10 --version \
+           && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+           && python3.10 get-pip.py \
+           && python3.10 -m pip install openPMD_api-*-cp310-cp310-manylinux2010_x86_64.whl
+RUN        python3.10 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
+RUN        python3.10 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,6 +3,12 @@
 Upgrade Guide
 =============
 
+0.15.0
+------
+
+Python 3.10 is now supported.
+
+
 0.14.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.6 - 3.9
+  * Python 3.6 - 3.10
   * pybind11 2.6.2+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -39,7 +39,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.6 - 3.9
+  * Python 3.6 - 3.10
   * pybind11 2.6.2+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(
     cmdclass=dict(build_ext=CMakeBuild),
     # scripts=['openpmd-ls'],
     zip_safe=False,
-    python_requires='>=3.6, <3.10',
+    python_requires='>=3.6, <3.11',
     # tests_require=['pytest'],
     install_requires=install_requires,
     # see: src/bindings/python/cli
@@ -211,6 +211,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         ('License :: OSI Approved :: '
          'GNU Lesser General Public License v3 or later (LGPLv3+)'),
     ],


### PR DESCRIPTION
Add support for Python 3.10.

### Test: `musllinux`

PyPA's `musllinux` images use the musl libc on an Alpine stack, especially for docker-ish containers.

This adds coverage while also covering CPython 3.10