### PR TITLE
Add `cmake/` to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.md COPYING COPYING.LESSER
 include pyproject.toml
 include requirements.txt
 global-include CMakeLists.txt *.cmake *.in
+recursive-include cmake *
 recursive-include include *
 recursive-include src *
 recursive-include share *


### PR DESCRIPTION
Forgot to add in #1128, which is then missing in Python sdist files for pip from-source builds.

Seen via nightly install tests.