### PR TITLE
Add new Python-based linear/streaming API tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,6 +796,8 @@ set(openPMD_PYTHON_EXAMPLE_NAMES
     5_write_parallel
     7_extended_write_serial
     9_particle_write_serial
+    10_streaming_write
+    10_streaming_read
     11_particle_dataframe
     12_span_write
 )
@@ -1331,6 +1333,26 @@ if(openPMD_BUILD_TESTING)
         endif()
     endif()
 
+    function(configure_python_test testname)
+        if(WIN32)
+            string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BASEDIR ${openPMD_BINARY_DIR})
+            string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+            string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
+            string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
+            set_property(TEST ${testname}
+                PROPERTY ENVIRONMENT
+                    "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
+                    "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
+            )
+        else()
+            set_tests_properties(${testname}
+                PROPERTIES ENVIRONMENT
+                    "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+            )
+        endif()
+    endfunction()
+
+
     # Python Examples
     # Current examples all use HDF5, elaborate if other backends are used
     if(openPMD_HAVE_PYTHON AND openPMD_HAVE_HDF5)
@@ -1342,7 +1364,10 @@ if(openPMD_BUILD_TESTING)
                     COPYONLY
                 )
                 if(openPMD_BUILD_TESTING)
-                    if(${examplename} MATCHES "^.*_parallel$")
+                    if(${examplename} MATCHES "^10.*$")
+                        # streaming examples are done separately
+                        continue()
+                    elseif(${examplename} MATCHES "^.*_parallel$")
                         if(openPMD_HAVE_MPI AND MPI4PY_RETURN EQUAL 0)
                             # see https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html
                             add_test(NAME Example.py.${examplename}
@@ -1361,24 +1386,15 @@ if(openPMD_BUILD_TESTING)
                                 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
                         )
                     endif()
-                    if(WIN32)
-                        string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BASEDIR ${openPMD_BINARY_DIR})
-                        string(REGEX REPLACE "/" "\\\\" WIN_BUILD_BINDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-                        string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
-                        string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
-                        set_property(TEST Example.py.${examplename}
-                            PROPERTY ENVIRONMENT
-                                "PATH=${WIN_BUILD_BINDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PATH}\n"
-                                "PYTHONPATH=${WIN_BUILD_BASEDIR}\\${CMAKE_INSTALL_PYTHONDIR}\\${CMAKE_BUILD_TYPE}\;${WIN_PYTHONPATH}"
-                        )
-                    else()
-                        set_tests_properties(Example.py.${examplename}
-                            PROPERTIES ENVIRONMENT
-                                "PYTHONPATH=${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
-                        )
-                    endif()
+                    configure_python_test(Example.py.${examplename})
                 endif()
             endforeach()
+            if(openPMD_HAVE_ADIOS2 AND openPMD_BUILD_TESTING AND NOT WIN32)
+                add_test(NAME Asynchronous.10_streaming.py
+                        COMMAND sh -c "${Python_EXECUTABLE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/10_streaming_write.py & sleep 1; ${Python_EXECUTABLE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/10_streaming_read.py"
+                        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+                configure_python_test(Asynchronous.10_streaming.py)
+            endif()
         endif()
     endif()
 endif()

--- a/examples/10_streaming_read.py
+++ b/examples/10_streaming_read.py
@@ -2,18 +2,43 @@
 import openpmd_api as io
 import sys
 
+# pass-through for ADIOS2 engine parameters
+# https://adios2.readthedocs.io/en/latest/engines/engines.html
+config = """
+{
+  "adios2": {
+    "engine": {
+      "parameters": {
+        "Threads": "4"
+      }
+    },
+    "dataset": {
+      "operators": [
+        {
+          "type": "bzip2"
+        }
+      ]
+    }
+  }
+}
+"""
+
 if __name__ == "__main__":
-    if 'adios2' not in io.variants or not io.variants['adios2']:
-        print('This example requires ADIOS2')
-        sys.exit(0)
-
-    series = io.Series("stream.sst", io.Access_Type.read_only)
-
+    # this block is for our CI, SST engine is not present on all systems
     backends = io.file_extensions
     if "sst" not in backends:
         print("SST engine not available in ADIOS2.")
         sys.exit(0)
 
+    series = io.Series("simData.sst", io.Access_Type.read_only, config)
+
+    # Read all available iterations and print electron position data.
+    # Use `series.read_iterations()` instead of `series.iterations`
+    # for streaming support (while still retaining file-reading support).
+    # Direct access to `series.iterations` is only necessary for random-access
+    # of iterations. By using `series.read_iterations()`, the openPMD-api will
+    # step through the iterations one by one, and going back to an iteration is
+    # not possible once it has been closed.
     for iteration in series.read_iterations():
         print("Current iteration {}".format(iteration.iteration_index))
         electronPositions = iteration.particles["e"]["position"]
@@ -26,8 +51,14 @@ if __name__ == "__main__":
             rc = electronPositions[dim]
             loadedChunks.append(rc.load_chunk([0], rc.shape))
             shapes.append(rc.shape)
+
+        # Closing the iteration loads all data and releases the current
+        # streaming step.
+        # If the iteration is not closed, it will be implicitly closed upon
+        # opening the next iteration.
         iteration.close()
 
+        # data is now available for printing
         for i in range(3):
             dim = dimensions[i]
             shape = shapes[i]

--- a/examples/10_streaming_read.py
+++ b/examples/10_streaming_read.py
@@ -1,27 +1,13 @@
 #!/usr/bin/env python
+import json
 import openpmd_api as io
 import sys
 
 # pass-through for ADIOS2 engine parameters
 # https://adios2.readthedocs.io/en/latest/engines/engines.html
-config = """
-{
-  "adios2": {
-    "engine": {
-      "parameters": {
-        "Threads": "4"
-      }
-    },
-    "dataset": {
-      "operators": [
-        {
-          "type": "bzip2"
-        }
-      ]
-    }
-  }
-}
-"""
+config = {'adios2': {'engine': {}, 'dataset': {}}}
+config['adios2']['engine'] = {'parameters': {'Threads': '4'}}
+config['adios2']['dataset'] = {'operators': [{'type': 'bzip2'}]}
 
 if __name__ == "__main__":
     # this block is for our CI, SST engine is not present on all systems
@@ -30,7 +16,8 @@ if __name__ == "__main__":
         print("SST engine not available in ADIOS2.")
         sys.exit(0)
 
-    series = io.Series("simData.sst", io.Access_Type.read_only, config)
+    series = io.Series("simData.sst", io.Access_Type.read_only,
+                       json.dumps(config))
 
     # Read all available iterations and print electron position data.
     # Use `series.read_iterations()` instead of `series.iterations`

--- a/examples/10_streaming_write.py
+++ b/examples/10_streaming_write.py
@@ -34,8 +34,8 @@ if __name__ == "__main__":
     # create a series and specify some global metadata
     # change the file extension to .json, .h5 or .bp for regular file writing
     series = io.Series("simData.sst", io.Access_Type.create, config)
-    series.set_author("Franz")
-    series.set_software("python snippet")
+    series.set_author("Franz Poeschel <f.poeschel@hzdr.de>")
+    series.set_software("openPMD-api-python-examples")
 
     # now, write a number of iterations (or: snapshots, time steps)
     for i in range(10):
@@ -65,7 +65,7 @@ if __name__ == "__main__":
                                dtype=np.dtype("double"))
         for dim in ["x", "y", "z"]:
             pos = electronPositions[dim]
-            pos.reset_dataset(io.Dataset(np.dtype("double"), [length]))
+            pos.reset_dataset(io.Dataset(local_data.dtype, [length]))
             pos[()] = local_data
 
         # optionally: flush now to clear buffers

--- a/examples/10_streaming_write.py
+++ b/examples/10_streaming_write.py
@@ -3,31 +3,92 @@ import openpmd_api as io
 import numpy as np
 import sys
 
+# pass-through for ADIOS2 engine parameters
+# https://adios2.readthedocs.io/en/latest/engines/engines.html
+config = """
+{
+  "adios2": {
+    "engine": {
+      "parameters": {
+        "Threads": "4"
+      }
+    },
+    "dataset": {
+      "operators": [
+        {
+          "type": "bzip2"
+        }
+      ]
+    }
+  }
+}
+"""
+
 if __name__ == "__main__":
-    if 'adios2' not in io.variants or not io.variants['adios2']:
-        print('This example requires ADIOS2')
-        sys.exit(0)
-
-    series = io.Series("stream.sst", io.Access_Type.create)
-
+    # this block is for our CI, SST engine is not present on all systems
     backends = io.file_extensions
     if "sst" not in backends:
         print("SST engine not available in ADIOS2.")
         sys.exit(0)
 
-    datatype = np.dtype("double")
-    length = 10
-    global_extent = [10]
-    dataset = io.Dataset(datatype, global_extent)
+    # create a series and specify some global metadata
+    # change the file extension to .json, .h5 or .bp for regular file writing
+    series = io.Series("simData.sst", io.Access_Type.create, config)
+    series.set_author("Franz")
+    series.set_software("python snippet")
 
-    iterations = series.write_iterations()
-    for i in range(100):
-        iteration = iterations[i]
+    # now, write a number of iterations (or: snapshots, time steps)
+    for i in range(10):
+        # Use `series.write_iterations()` instead of `series.iterations`
+        # for streaming support (while still retaining file-writing support).
+        # Direct access to `series.iterations` is only necessary for random-access
+        # of iterations. By using `series.write_iterations()`, the openPMD-api
+        # will adhere to streaming semantics while writing. In particular, this
+        # means that only one iteration can be written at a time and
+        # an iteration can no longer be modified after closing it.
+        iteration = series.write_iterations()[i]
+
+        #######################
+        # write electron data #
+        #######################
+
         electronPositions = iteration.particles["e"]["position"]
 
-        local_data = np.arange(i * length, (i + 1) * length, dtype=datatype)
+        # openPMD attribute
+        # (this one would also be set automatically for positions)
+        electronPositions.unit_dimension = {io.Unit_Dimension.L: 1.0}
+        # custom attribute
+        electronPositions.set_attribute("comment", "I'm a comment")
+
+        length = 10
+        local_data = np.arange(i * length, (i + 1) * length,
+                               dtype=np.dtype("double"))
         for dim in ["x", "y", "z"]:
             pos = electronPositions[dim]
-            pos.reset_dataset(dataset)
+            pos.reset_dataset(io.Dataset(np.dtype("double"), [length]))
             pos[()] = local_data
+
+        # optionally: flush now to clear buffers
+        iteration.series_flush()  # this is a shortcut for `series.flush()`
+
+        ###############################
+        # write some temperature data #
+        ###############################
+
+        temperature = iteration.meshes["temperature"]
+        temperature.unit_dimension = {io.Unit_Dimension.theta: 1.0}
+        temperature.axis_labels = ["x", "y"]
+        temperature.grid_spacing = [1., 1.]
+        # temperature has no x,y,z components, so skip the last layer:
+        temperature_dataset = temperature[io.Mesh_Record_Component.SCALAR]
+        # let's say we are in a 3x3 mesh
+        temperature_dataset.reset_dataset(
+            io.Dataset(np.dtype("double"), [3, 3]))
+        # temperature is constant
+        temperature_dataset.make_constant(273.15)
+
+        # After closing the iteration, the readers can see the iteration.
+        # It can no longer be modified.
+        # If not closing an iteration explicitly, it will be implicitly closed
+        # upon creating the next iteration.
         iteration.close()

--- a/examples/10_streaming_write.py
+++ b/examples/10_streaming_write.py
@@ -41,11 +41,11 @@ if __name__ == "__main__":
     for i in range(10):
         # Use `series.write_iterations()` instead of `series.iterations`
         # for streaming support (while still retaining file-writing support).
-        # Direct access to `series.iterations` is only necessary for random-access
-        # of iterations. By using `series.write_iterations()`, the openPMD-api
-        # will adhere to streaming semantics while writing. In particular, this
-        # means that only one iteration can be written at a time and
-        # an iteration can no longer be modified after closing it.
+        # Direct access to `series.iterations` is only necessary for
+        # random-access of iterations. By using `series.write_iterations()`,
+        # the openPMD-api will adhere to streaming semantics while writing.
+        # In particular, this means that only one iteration can be written at a
+        # time and an iteration can no longer be modified after closing it.
         iteration = series.write_iterations()[i]
 
         #######################

--- a/examples/10_streaming_write.py
+++ b/examples/10_streaming_write.py
@@ -1,28 +1,14 @@
 #!/usr/bin/env python
+import json
 import openpmd_api as io
 import numpy as np
 import sys
 
 # pass-through for ADIOS2 engine parameters
 # https://adios2.readthedocs.io/en/latest/engines/engines.html
-config = """
-{
-  "adios2": {
-    "engine": {
-      "parameters": {
-        "Threads": "4"
-      }
-    },
-    "dataset": {
-      "operators": [
-        {
-          "type": "bzip2"
-        }
-      ]
-    }
-  }
-}
-"""
+config = {'adios2': {'engine': {}, 'dataset': {}}}
+config['adios2']['engine'] = {'parameters': {'Threads': '4'}}
+config['adios2']['dataset'] = {'operators': [{'type': 'bzip2'}]}
 
 if __name__ == "__main__":
     # this block is for our CI, SST engine is not present on all systems
@@ -33,7 +19,8 @@ if __name__ == "__main__":
 
     # create a series and specify some global metadata
     # change the file extension to .json, .h5 or .bp for regular file writing
-    series = io.Series("simData.sst", io.Access_Type.create, config)
+    series = io.Series("simData.sst", io.Access_Type.create,
+                       json.dumps(config))
     series.set_author("Franz Poeschel <f.poeschel@hzdr.de>")
     series.set_software("openPMD-api-python-examples")
 


### PR DESCRIPTION
TODO:
- [x] Add existing Python-based streaming tests to CMake test suite, we forgot that so far
- [x] Extend that test to include demonstrate some more openPMD-api features from a recent workshop