### PR TITLE
Include prefix (directory) in write and checks for read parameter

### DIFF
--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -389,7 +389,7 @@ void parse(TestInput& input, std::string line)
     return;
   }
 
-  if ( vec[0].compare("prefix") == 0 ) {
+  if ( vec[0].compare("fileLocation") == 0 ) {
     input.m_Prefix = vec[1];
     return;
   }

--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -339,6 +339,8 @@ public:
   unsigned long  m_XFactor = 0; // if not overwritten, use m_MPISize
   unsigned long  m_YFactor = 8;
   unsigned long  m_ZFactor = 8;
+
+  std::string m_Prefix = "../samples";
 }; // class TestInput
 
 
@@ -387,6 +389,11 @@ void parse(TestInput& input, std::string line)
     return;
   }
 
+  if ( vec[0].compare("prefix") == 0 ) {
+    input.m_Prefix = vec[1];
+    return;
+  }
+
   // now vec[1] is N-dim integers
   std::vector<unsigned long> numbers;
   std::istringstream tmp(vec[1]);
@@ -395,7 +402,7 @@ void parse(TestInput& input, std::string line)
 
   if ( (numbers.size() == 0) || ((numbers.size() - input.m_Dim) != 0) ) {
     if ( input.m_MPIRank == 0 )
-      std::cout<<vec[1]<<" Expecting "<<input.m_Dim<<" dimensions. But given input is"<<numbers.size()<<std::endl;
+      std::cout<<vec[1]<<" Expecting "<<input.m_Dim<<" dimensions. But given input is "<<numbers.size()<<std::endl;
     return;
   }
 
@@ -568,7 +575,7 @@ void AbstractPattern::run()
 
     { // file based
       std::ostringstream s;
-      s << "../samples/8a_parallel_"<<m_GlobalMesh.size()<<"D"<<balance<<"_%07T"<<m_Input.m_Backend;
+      s << m_Input.m_Prefix << "/8a_parallel_"<<m_GlobalMesh.size()<<"D"<<balance<<"_%07T"<<m_Input.m_Backend;
 
       std::string filename = s.str();
 
@@ -589,7 +596,7 @@ void AbstractPattern::run()
 #ifdef NEVER // runs into error for ADIOS. so temporarily disabled
     { // group based
       std::ostringstream s;
-      s << "../samples/8a_parallel_"<<m_GlobalMesh.size()<<"D"<<balance<<m_Input.m_Backend;
+      s << m_Input.m_Prefix << "/8a_parallel_"<<m_GlobalMesh.size()<<"D"<<balance<<m_Input.m_Backend;
       std::string filename = s.str();
 
       {

--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -340,6 +340,7 @@ public:
   unsigned long  m_YFactor = 8;
   unsigned long  m_ZFactor = 8;
 
+  //! prefix for the output directory
   std::string m_Prefix = "../samples";
 }; // class TestInput
 

--- a/examples/8b_benchmark_read_parallel.cpp
+++ b/examples/8b_benchmark_read_parallel.cpp
@@ -253,7 +253,6 @@ public:
 
       if ( 0 == m_MPIRank )
       {
-         std::cout << "  "<<series.iterationEncoding() << std::endl;
          std::cout << "  Num Iterations in " << filename << " : " << numIterations << std::endl << std::endl;
       }
 
@@ -744,9 +743,9 @@ main( int argc, char *argv[] )
     MPI_Comm_size( MPI_COMM_WORLD, &input.m_MPISize );
     MPI_Comm_rank( MPI_COMM_WORLD, &input.m_MPIRank );
 
-    if (argc < 2) {
+    if (argc < 3) {
       if (input.m_MPIRank == 0)
-          std::cout<<"Usage: "<<argv[0]<<" input_file_prefix"<<std::endl;
+          std::cout<<"Usage: "<<argv[0]<<" input_file_prefix pattern"<<std::endl;
       MPI_Finalize();
       return 0;
     }
@@ -764,19 +763,23 @@ main( int argc, char *argv[] )
       } else if ( types[0] == 's' ) {
         if ( types[1] == 'x')
           input.m_Pattern = 5;
-        if ( types[1] == 'y')
+        else if ( types[1] == 'y')
           input.m_Pattern = 15;
-        if ( types[1] == 'z')
+        else if ( types[1] == 'z')
           input.m_Pattern = 25;
+        else
+          std::cout << "For pattern 's' you should provide the dimension as well: sx, sy, or sz" << std::endl;
       } else if ( types[0] == 'f' ) {
         if ( types[1] == 'x')
           input.m_Pattern = 55;
-        if ( types[1] == 'y')
+        else if ( types[1] == 'y')
           input.m_Pattern = 65;
-        if ( types[1] == 'z')
+        else if ( types[1] == 'z')
           input.m_Pattern = 75;
+        else
+          std::cout << "For pattern 'f' you should provide the dimension as well: fx, fy, or fz" << std::endl;
       } else {
-          input.m_Pattern = atoi(argv[2]);
+        std::cout << "Unknown pattern. Available options are: m, sx, sy, sz, fx, fy, fz" << std::endl;
       }
     }
 

--- a/examples/8b_benchmark_read_parallel.cpp
+++ b/examples/8b_benchmark_read_parallel.cpp
@@ -268,8 +268,12 @@ public:
          if ( 0 == m_MPIRank )
             std::cout << "  Total Num iterations read: " << (counter - 1) << std::endl << std::endl;
       }
-    } catch (std::exception& ex)
-      {}
+    } catch (std::exception& ex) {
+        if ( 0 == m_MPIRank )
+        {
+           std::cerr << ex.what() << std::endl;
+        }
+    }
   }
 
 
@@ -756,32 +760,30 @@ main( int argc, char *argv[] )
 
     std::string prefix = argv[1];
 
-    if (argc >= 3) {
-      std::string types = argv[2];
+    std::string types = argv[2];
 
-      if ( types[0] == 'm' ) {
-       input.m_Pattern = 1;
-      } else if ( types[0] == 's' ) {
-        if ( types[1] == 'x')
-          input.m_Pattern = 5;
-        else if ( types[1] == 'y')
-          input.m_Pattern = 15;
-        else if ( types[1] == 'z')
-          input.m_Pattern = 25;
-        else
-          std::cout << "For pattern 's' you should provide the dimension as well: sx, sy, or sz" << std::endl;
-      } else if ( types[0] == 'f' ) {
-        if ( types[1] == 'x')
-          input.m_Pattern = 55;
-        else if ( types[1] == 'y')
-          input.m_Pattern = 65;
-        else if ( types[1] == 'z')
-          input.m_Pattern = 75;
-        else
-          std::cout << "For pattern 'f' you should provide the dimension as well: fx, fy, or fz" << std::endl;
-      } else {
-        input.m_Pattern = atoi(argv[2]);
-      }
+    if ( types[0] == 'm' ) {
+     input.m_Pattern = 1;
+    } else if ( types[0] == 's' ) {
+      if ( types[1] == 'x')
+        input.m_Pattern = 5;
+      else if ( types[1] == 'y')
+        input.m_Pattern = 15;
+      else if ( types[1] == 'z')
+        input.m_Pattern = 25;
+      else
+        std::cout << "For pattern 's' you should provide the dimension as well: sx, sy, or sz" << std::endl;
+    } else if ( types[0] == 'f' ) {
+      if ( types[1] == 'x')
+        input.m_Pattern = 55;
+      else if ( types[1] == 'y')
+        input.m_Pattern = 65;
+      else if ( types[1] == 'z')
+        input.m_Pattern = 75;
+      else
+        std::cout << "For pattern 'f' you should provide the dimension as well: fx, fy, or fz" << std::endl;
+    } else {
+      input.m_Pattern = atoi(argv[2]);
     }
 
     auto backends = getBackends();

--- a/examples/8b_benchmark_read_parallel.cpp
+++ b/examples/8b_benchmark_read_parallel.cpp
@@ -253,6 +253,7 @@ public:
 
       if ( 0 == m_MPIRank )
       {
+         std::cout << "  "<<series.iterationEncoding() << std::endl;
          std::cout << "  Num Iterations in " << filename << " : " << numIterations << std::endl << std::endl;
       }
 
@@ -779,7 +780,7 @@ main( int argc, char *argv[] )
         else
           std::cout << "For pattern 'f' you should provide the dimension as well: fx, fy, or fz" << std::endl;
       } else {
-        std::cout << "Unknown pattern. Available options are: m, sx, sy, sz, fx, fy, fz" << std::endl;
+        input.m_Pattern = atoi(argv[2]);
       }
     }
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -840,8 +840,10 @@ SeriesInterface::readFileBased( )
     {
         /* Frontend access type might change during SeriesInterface::read() to allow parameter modification.
          * Backend access type stays unchanged for the lifetime of a Series. */
-        if(IOHandler()->m_backendAccess == Access::READ_ONLY  )
+        if(IOHandler()->m_backendAccess == Access::READ_ONLY  ) {
+            std::cerr << "Unable to find the given file." << std::endl;
             throw no_such_file_error("No matching iterations found: " + name());
+        }
         else
             std::cerr << "No matching iterations found: " << name() << std::endl;
     }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -840,10 +840,8 @@ SeriesInterface::readFileBased( )
     {
         /* Frontend access type might change during SeriesInterface::read() to allow parameter modification.
          * Backend access type stays unchanged for the lifetime of a Series. */
-        if(IOHandler()->m_backendAccess == Access::READ_ONLY  ) {
-            std::cerr << "Unable to find the given file." << std::endl;
+        if(IOHandler()->m_backendAccess == Access::READ_ONLY  )
             throw no_such_file_error("No matching iterations found: " + name());
-        }
         else
             std::cerr << "No matching iterations found: " << name() << std::endl;
     }


### PR DESCRIPTION
Some updates on the 8a/8b benchmarks:
- 8a (write) add an additional option to the configuration input file to specify a custom path to write the files (by default keep using `../samples/`
- 8b (read) check for valid file (show message if we do not find a file) and valid pattern (from those available in the documentation)