### PR TITLE
Read backend configuration from .toml files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -868,7 +868,8 @@ if(openPMD_BUILD_TESTING)
 
         if(${testname} STREQUAL JSON)
             target_include_directories(${testname}Tests SYSTEM PRIVATE
-                $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+                $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
+                $<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
         endif()
     endforeach()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,7 @@ set(openPMD_EXAMPLE_NAMES
     10_streaming_write
     10_streaming_read
     12_span_write
+    13_write_dynamic_configuration
 )
 set(openPMD_PYTHON_EXAMPLE_NAMES
     2_read_serial
@@ -822,6 +823,7 @@ set(openPMD_PYTHON_EXAMPLE_NAMES
     10_streaming_read
     11_particle_dataframe
     12_span_write
+    13_write_dynamic_configuration
 )
 
 if(openPMD_USE_INVASIVE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,9 +582,11 @@ if(openPMD_HAVE_ADIOS1)
     endif()
 
     target_include_directories(openPMD.ADIOS1.Serial SYSTEM PRIVATE
-        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(openPMD.ADIOS1.Parallel SYSTEM PRIVATE
-        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+        $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
 
     set_target_properties(openPMD.ADIOS1.Serial PROPERTIES
         POSITION_INDEPENDENT_CODE ON

--- a/docs/source/details/adios1.toml
+++ b/docs/source/details/adios1.toml
@@ -1,0 +1,2 @@
+[adios.dataset]
+transform = "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"

--- a/docs/source/details/adios2.toml
+++ b/docs/source/details/adios2.toml
@@ -1,0 +1,24 @@
+[adios2.engine]
+type = "sst"
+
+[adios2.engine.parameters]
+BufferGrowthFactor = "2.0"
+QueueLimit = "2"
+
+# use double brackets to indicate lists
+[[adios2.dataset.operators]]
+type = "blosc"
+
+# specify parameters for the current operator
+[adios2.dataset.operators.parameters]
+clevel = "1"
+doshuffle = "BLOSC_BITSHUFFLE"
+
+# use double brackets a second time to indicate a further entry
+[[adios2.dataset.operators]]
+# specify a second operator here
+type = "some other operator"
+
+# the parameters dictionary can also be specified in-line
+parameters.clevel = "1"
+parameters.doshuffle = "BLOSC_BITSHUFFLE"

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -1,7 +1,7 @@
 .. _backendconfig:
 
 JSON/TOML configuration
-==================
+=======================
 
 While the openPMD API intends to be a backend-*independent* implementation of the openPMD standard, it is sometimes useful to pass configuration parameters to the specific backend in use.
 :ref:`For each backend <backends-overview>`, configuration options can be passed via a JSON- or TOML-formatted string or via environment variables.

--- a/docs/source/details/config_layout.json
+++ b/docs/source/details/config_layout.json
@@ -1,5 +1,5 @@
 {
-    "adios": "put ADIOS config here",
+    "adios1": "put ADIOS config here",
     "adios2": "put ADIOS2 config here",
     "hdf5": "put HDF5 config here",
     "json": "put JSON config here"

--- a/docs/source/details/config_layout.toml
+++ b/docs/source/details/config_layout.toml
@@ -1,0 +1,11 @@
+[adios1]
+# put ADIOS config here
+
+[adios2]
+# put ADIOS2 config here
+
+[hdf5]
+# put HDF5 config here
+
+[json]
+# put JSON config here

--- a/examples/13_write_dynamic_configuration.cpp
+++ b/examples/13_write_dynamic_configuration.cpp
@@ -8,16 +8,10 @@
 using std::cout;
 using namespace openPMD;
 
-bool hasAdios2()
-{
-    auto variants = getVariants();
-    auto iterator = variants.find( "adios2" );
-    return iterator != variants.end() && iterator->second;
-}
 
 int main()
 {
-    if( !hasAdios2() )
+    if( !getVariants()["adios2"] )
     {
         // Example configuration below selects the ADIOS2 backend
         return 0;

--- a/examples/13_write_dynamic_configuration.cpp
+++ b/examples/13_write_dynamic_configuration.cpp
@@ -8,10 +8,30 @@
 using std::cout;
 using namespace openPMD;
 
+bool hasAdios2()
+{
+    auto variants = getVariants();
+    auto iterator = variants.find( "adios2" );
+    return iterator != variants.end() && iterator->second;
+}
+
 int main()
 {
-    using position_t = double;
+    if( !hasAdios2() )
+    {
+        // Example configuration below selects the ADIOS2 backend
+        return 0;
+    }
 
+    using position_t = double;
+    /*
+     * This example demonstrates how to use JSON/TOML-based dynamic
+     * configuration for openPMD.
+     * The following configuration is passed to the constructor of the Series
+     * class and specifies the defaults to used for that Series.
+     * This configuration can later be overridden as needed on a per-dataset
+     * level.
+     */
     std::string const defaults = R"END(
 # This configuration is TOML-based
 # JSON can be used alternatively, the openPMD-api will automatically detect

--- a/examples/13_write_dynamic_configuration.cpp
+++ b/examples/13_write_dynamic_configuration.cpp
@@ -1,0 +1,120 @@
+#include <openPMD/openPMD.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <numeric> // std::iota
+
+using std::cout;
+using namespace openPMD;
+
+int main()
+{
+    using position_t = double;
+
+    std::string const defaults = R"END(
+# This configuration is TOML-based
+# JSON can be used alternatively, the openPMD-api will automatically detect
+# the language being used
+#
+# Alternatively, the location of a JSON/TOML-file on the filesystem can
+# be passed by adding an at-sign `@` in front of the path
+# The format will then be recognized by filename extension, i.e. .json or .toml
+
+backend = "adios2"
+iteration_encoding = "group_based"
+# The following is only relevant in read mode
+defer_iteration_parsing = true
+
+[adios1.dataset]
+transform = "blosc:compressor=zlib,shuffle=bit,lvl=5;nometa"
+
+[adios2.engine]
+type = "bp4"
+
+# ADIOS2 allows adding several operators
+# Lists are given in TOML by using double brackets
+[[adios2.dataset.operators]]
+type = "zlib"
+
+parameters.clevel = 5
+# Alternatively:
+# [adios2.dataset.operators.parameters]
+# clevel = 9
+
+# For adding a further parameter:
+# [[adios2.dataset.operators]]
+# type = "some other parameter"
+# # ...
+
+[hdf5.dataset]
+chunks = "auto"
+)END";
+
+    // open file for writing
+    Series series =
+        Series( "../samples/dynamicConfig.bp", Access::CREATE, defaults );
+
+    Datatype datatype = determineDatatype< position_t >();
+    constexpr unsigned long length = 10ul;
+    Extent global_extent = { length };
+    Dataset dataset = Dataset( datatype, global_extent );
+    std::shared_ptr< position_t > local_data(
+        new position_t[ length ],
+        []( position_t const * ptr ) { delete[] ptr; } );
+
+    WriteIterations iterations = series.writeIterations();
+    for( size_t i = 0; i < 100; ++i )
+    {
+        Iteration iteration = iterations[ i ];
+        Record electronPositions = iteration.particles[ "e" ][ "position" ];
+
+        std::iota( local_data.get(), local_data.get() + length, i * length );
+        for( auto const & dim : { "x", "y", "z" } )
+        {
+            RecordComponent pos = electronPositions[ dim ];
+            pos.resetDataset( dataset );
+            pos.storeChunk( local_data, Offset{ 0 }, global_extent );
+        }
+
+        /*
+         * We want different compression settings for this dataset, so we pass
+         * a dataset-specific configuration.
+         * Also showcase how to define an resizable dataset.
+         * This time in JSON.
+         */
+        std::string const differentCompressionSettings = R"END(
+{
+  "resizable": true,
+  "adios1": {
+    "dataset": {
+      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
+    }
+  },
+  "adios2": {
+    "dataset": {
+      "operators": [
+        {
+          "type": "zlib",
+          "parameters": {
+            "clevel": 9
+          }
+        }
+      ]
+    }
+  }
+})END";
+        Dataset differentlyCompressedDataset{ Datatype::INT, { 10 } };
+        differentlyCompressedDataset.options = differentCompressionSettings;
+
+        auto someMesh = iteration.meshes[ "differentCompressionSettings" ]
+                                        [ RecordComponent::SCALAR ];
+        someMesh.resetDataset( differentlyCompressedDataset );
+        std::vector< int > dataVec( 10, i );
+        someMesh.storeChunk( dataVec, { 0 }, { 10 } );
+
+        iteration.close();
+    }
+
+    return 0;
+}

--- a/examples/13_write_dynamic_configuration.py
+++ b/examples/13_write_dynamic_configuration.py
@@ -4,10 +4,6 @@ import openpmd_api as io
 import numpy as np
 
 
-def hasAdios2():
-    return 'adios2' in io.variants and io.variants['adios2']
-
-
 # This example demonstrates how to use JSON/TOML-based dynamic
 # configuration for openPMD.
 # The following configuration is passed to the constructor of the Series
@@ -56,7 +52,7 @@ chunks = "auto"
 
 
 def main():
-    if not hasAdios2():
+    if not io.variants['adios2']:
         # Example configuration below selects the ADIOS2 backend
         return
 

--- a/examples/13_write_dynamic_configuration.py
+++ b/examples/13_write_dynamic_configuration.py
@@ -2,7 +2,18 @@
 import json
 import openpmd_api as io
 import numpy as np
-import sys
+
+
+def hasAdios2():
+    return 'adios2' in io.variants and io.variants['adios2']
+
+
+# This example demonstrates how to use JSON/TOML-based dynamic
+# configuration for openPMD.
+# The following configuration is passed to the constructor of the Series
+# class and specifies the defaults to used for that Series.
+# This configuration can later be overridden as needed on a per-dataset
+# level.
 
 defaults = """
 # This configuration is TOML-based
@@ -43,7 +54,12 @@ parameters.clevel = 5
 chunks = "auto"
 """
 
-if __name__ == "__main__":
+
+def main():
+    if not hasAdios2():
+        # Example configuration below selects the ADIOS2 backend
+        return
+
     # create a series and specify some global metadata
     # change the file extension to .json, .h5 or .bp for regular file writing
     series = io.Series("../samples/dynamicConfig.bp", io.Access_Type.create,
@@ -133,3 +149,7 @@ if __name__ == "__main__":
         # If not closing an iteration explicitly, it will be implicitly closed
         # upon creating the next iteration.
         iteration.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/13_write_dynamic_configuration.py
+++ b/examples/13_write_dynamic_configuration.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+import json
+import openpmd_api as io
+import numpy as np
+import sys
+
+defaults = """
+# This configuration is TOML-based
+# JSON can be used alternatively, the openPMD-api will automatically detect
+# the language being used
+#
+# Alternatively, the location of a JSON/TOML-file on the filesystem can
+# be passed by adding an at-sign `@` in front of the path
+# The format will then be recognized by filename extension, i.e. .json or .toml
+
+backend = "adios2"
+iteration_encoding = "group_based"
+# The following is only relevant in read mode
+defer_iteration_parsing = true
+
+[adios1.dataset]
+transform = "blosc:compressor=zlib,shuffle=bit,lvl=5;nometa"
+
+[adios2.engine]
+type = "bp4"
+
+# ADIOS2 allows adding several operators
+# Lists are given in TOML by using double brackets
+[[adios2.dataset.operators]]
+type = "zlib"
+
+parameters.clevel = 5
+# Alternatively:
+# [adios2.dataset.operators.parameters]
+# clevel = 9
+
+# For adding a further parameter:
+# [[adios2.dataset.operators]]
+# type = "some other parameter"
+# # ...
+
+[hdf5.dataset]
+chunks = "auto"
+"""
+
+if __name__ == "__main__":
+    # create a series and specify some global metadata
+    # change the file extension to .json, .h5 or .bp for regular file writing
+    series = io.Series("../samples/dynamicConfig.bp", io.Access_Type.create,
+                       defaults)
+
+    # now, write a number of iterations (or: snapshots, time steps)
+    for i in range(10):
+        # Use `series.write_iterations()` instead of `series.iterations`
+        # for streaming support (while still retaining file-writing support).
+        # Direct access to `series.iterations` is only necessary for
+        # random-access of iterations. By using `series.write_iterations()`,
+        # the openPMD-api will adhere to streaming semantics while writing.
+        # In particular, this means that only one iteration can be written at a
+        # time and an iteration can no longer be modified after closing it.
+        iteration = series.write_iterations()[i]
+
+        #######################
+        # write electron data #
+        #######################
+
+        electronPositions = iteration.particles["e"]["position"]
+
+        # openPMD attribute
+        # (this one would also be set automatically for positions)
+        electronPositions.unit_dimension = {io.Unit_Dimension.L: 1.0}
+        # custom attribute
+        electronPositions.set_attribute("comment", "I'm a comment")
+
+        length = 10
+        local_data = np.arange(i * length, (i + 1) * length,
+                               dtype=np.dtype("double"))
+        for dim in ["x", "y", "z"]:
+            pos = electronPositions[dim]
+            pos.reset_dataset(io.Dataset(local_data.dtype, [length]))
+            pos[()] = local_data
+
+        # optionally: flush now to clear buffers
+        iteration.series_flush()  # this is a shortcut for `series.flush()`
+
+        ###############################
+        # write some temperature data #
+        ###############################
+
+        # we want different compression settings here,
+        # so we override the defaults
+        # let's use JSON this time
+        config = {
+            'resizable': True,
+            'adios2': {
+                'dataset': {
+                    'operators': []
+                }
+            },
+            'adios1': {
+                'dataset': {}
+            }
+        }
+        config['adios2']['dataset'] = {
+            'operators': [{
+                'type': 'zlib',
+                'parameters': {
+                    'clevel': 9
+                }
+            }]
+        }
+        config['adios1']['dataset'] = {
+            'transform': 'blosc:compressor=zlib,shuffle=bit,lvl=1;nometa'
+        }
+
+        temperature = iteration.meshes["temperature"]
+        temperature.unit_dimension = {io.Unit_Dimension.theta: 1.0}
+        temperature.axis_labels = ["x", "y"]
+        temperature.grid_spacing = [1., 1.]
+        # temperature has no x,y,z components, so skip the last layer:
+        temperature_dataset = temperature[io.Mesh_Record_Component.SCALAR]
+        # let's say we are in a 3x3 mesh
+        dataset = io.Dataset(np.dtype("double"), [3, 3])
+        dataset.options = json.dumps(config)
+        temperature_dataset.reset_dataset(dataset)
+        # temperature is constant
+        local_data = np.arange(i * 9, (i + 1) * 9, dtype=np.dtype("double"))
+        local_data = local_data.reshape([3, 3])
+        temperature_dataset[()] = local_data
+
+        # After closing the iteration, the readers can see the iteration.
+        # It can no longer be modified.
+        # If not closing an iteration explicitly, it will be implicitly closed
+        # upon creating the next iteration.
+        iteration.close()

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -153,6 +153,7 @@ namespace json
             std::shared_ptr< nlohmann::json > shadow,
             nlohmann::json * positionInOriginal,
             nlohmann::json * positionInShadow,
+            SupportedLanguages originallySpecifiedAs,
             bool trace );
     };
 
@@ -175,6 +176,7 @@ namespace json
             m_shadow,
             newPositionInOriginal,
             newPositionInShadow,
+            originallySpecifiedAs,
             traceFurther );
     }
 

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -43,7 +43,7 @@ namespace error
     BackendConfigSchema::BackendConfigSchema(
         std::vector< std::string > errorLocation_in, std::string what )
         : Error(
-              "Wrong JSON schema at index '" +
+              "Wrong JSON/TOML schema at index '" +
               concatVector( errorLocation_in ) + "': " + std::move( what ) )
         , errorLocation( std::move( errorLocation_in ) )
     {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2410,9 +2410,22 @@ namespace detail
         auto shadow = impl.m_config.invertShadow();
         if( shadow.size() > 0 )
         {
-            std::cerr << "Warning: parts of the backend configuration for "
-                         "ADIOS2 remain unused:\n"
-                      << shadow << std::endl;
+            switch( impl.m_config.originallySpecifiedAs )
+            {
+            case json::SupportedLanguages::JSON:
+                std::cerr << "Warning: parts of the backend configuration for "
+                            "ADIOS2 remain unused:\n"
+                        << shadow << std::endl;
+                break;
+            case json::SupportedLanguages::TOML:
+            {
+                auto asToml = json::jsonToToml( shadow );
+                std::cerr << "Warning: parts of the backend configuration for "
+                            "ADIOS2 remain unused:\n"
+                        << asToml << std::endl;
+                break;
+            }
+            }
         }
         auto notYetConfigured =
             [ &alreadyConfigured ]( std::string const & param ) {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -398,7 +398,7 @@ void ADIOS2IOHandlerImpl::createDataset(
         parameters.warnUnusedParameters(
             options,
             "adios2",
-            "Warning: parts of the JSON configuration for ADIOS2 dataset '" +
+            "Warning: parts of the backend configuration for ADIOS2 dataset '" +
                 varName + "' remain unused:\n" );
 
         // cast from openPMD::Extent to adios2::Dims
@@ -1129,7 +1129,8 @@ ADIOS2IOHandlerImpl::adios2AccessMode( std::string const & fullPath )
     }
 }
 
-json::TracingJSON ADIOS2IOHandlerImpl::nullvalue = nlohmann::json();
+json::TracingJSON ADIOS2IOHandlerImpl::nullvalue = {
+    nlohmann::json(), json::SupportedLanguages::JSON };
 
 std::string
 ADIOS2IOHandlerImpl::filePositionToString(
@@ -2409,8 +2410,8 @@ namespace detail
         auto shadow = impl.m_config.invertShadow();
         if( shadow.size() > 0 )
         {
-            std::cerr << "Warning: parts of the JSON configuration for ADIOS2 "
-                         "remain unused:\n"
+            std::cerr << "Warning: parts of the backend configuration for "
+                         "ADIOS2 remain unused:\n"
                       << shadow << std::endl;
         }
         auto notYetConfigured =

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -561,14 +561,11 @@ CommonADIOS1IOHandlerImpl< ChildClass >::createDataset(Writable* writable,
                     transform = maybeTransform.get();
                 }
 
-                auto shadow = options.invertShadow();
-                if( shadow.size() > 0 )
-                {
-                    std::cerr << "Warning: parts of the JSON configuration for "
-                                "ADIOS1 dataset '"
-                            << name << "' remain unused:\n"
-                            << shadow << std::endl;
-                }
+                parameters.warnUnusedParameters(
+                    options,
+                    "ADIOS1",
+                    "Warning: parts of the backend configuration for "
+                    "ADIOS1 dataset '" + name + "' remain unused:\n" );
             }
         }
         // Fallback: global option
@@ -1769,9 +1766,22 @@ void CommonADIOS1IOHandlerImpl< ChildClass >::initJson(
     auto shadow = config.invertShadow();
     if( shadow.size() > 0 )
     {
-        std::cerr << "Warning: parts of the JSON configuration for ADIOS1 "
-                        "remain unused:\n"
-                    << shadow << std::endl;
+        switch( config.originallySpecifiedAs )
+        {
+        case json::SupportedLanguages::JSON:
+            std::cerr << "Warning: parts of the JSON configuration for ADIOS1 "
+                         "remain unused:\n"
+                      << shadow << std::endl;
+            break;
+        case json::SupportedLanguages::TOML:
+        {
+            auto asToml = json::jsonToToml( shadow );
+            std::cerr << "Warning: parts of the JSON configuration for ADIOS1 "
+                         "remain unused:\n"
+                      << asToml << std::endl;
+            break;
+        }
+        }
     }
 }
 

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -117,6 +117,6 @@ namespace openPMD
             std::move( path ),
             access,
             format,
-            json::TracingJSON( nlohmann::json::object() ));
+            json::TracingJSON( json::ParsedConfig{} ));
     }
 } // namespace openPMD

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -124,9 +124,22 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
         auto shadow = m_config.invertShadow();
         if( shadow.size() > 0 )
         {
-            std::cerr << "Warning: parts of the JSON configuration for "
-                         "HDF5 remain unused:\n"
-                      << shadow << std::endl;
+            switch( m_config.originallySpecifiedAs )
+            {
+            case json::SupportedLanguages::JSON:
+                std::cerr << "Warning: parts of the backend configuration for "
+                            "HDF5 remain unused:\n"
+                        << shadow << std::endl;
+                break;
+            case json::SupportedLanguages::TOML:
+            {
+                auto asToml = json::jsonToToml( shadow );
+                std::cerr << "Warning: parts of the backend configuration for "
+                            "HDF5 remain unused:\n"
+                        << asToml << std::endl;
+                break;
+            }
+            }
         }
     }
 
@@ -331,7 +344,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         parameters.warnUnusedParameters(
             config,
             "hdf5",
-            "Warning: parts of the JSON configuration for HDF5 dataset '" +
+            "Warning: parts of the backend configuration for HDF5 dataset '" +
                 name + "' remain unused:\n" );
 
         hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -59,7 +59,18 @@ void Parameter< Operation::CREATE_DATASET >::warnUnusedParameters<
     }
     if( shadow.size() > 0 )
     {
-        std::cerr << warningMessage << shadow.dump() << std::endl;
+        switch( config.originallySpecifiedAs )
+        {
+        case json::SupportedLanguages::JSON:
+            std::cerr << warningMessage << shadow.dump() << std::endl;
+            break;
+        case json::SupportedLanguages::TOML:
+        {
+            auto asToml = json::jsonToToml( shadow );
+            std::cerr << warningMessage << asToml << std::endl;
+            break;
+        }
+        }
     }
 }
 } // openPMD

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -221,7 +221,8 @@ namespace json
             if( filename.has_value() )
             {
                 std::fstream handle;
-                handle.open( filename.get(), std::ios_base::in );
+                handle.open(
+                    filename.get(), std::ios_base::binary | std::ios_base::in );
                 nlohmann::json res;
                 if( auxiliary::ends_with( filename.get(), ".toml" ) )
                 {
@@ -262,7 +263,9 @@ namespace json
                     auxiliary::collective_file_read( filename.get(), comm );
                 if( auxiliary::ends_with( filename.get(), ".toml" ) )
                 {
-                    std::istringstream istream( fileContent.c_str() );
+                    std::istringstream istream(
+                        fileContent.c_str(),
+                        std::ios_base::binary | std::ios_base::in );
                     res = tomlToJson( toml::parse( istream, filename.get() ) );
                 }
                 else

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -212,6 +212,35 @@ namespace json
     }
     }
 
+    namespace
+    {
+        nlohmann::json parseInlineOptions( std::string const & options )
+        {
+            std::string trimmed = auxiliary::trim(
+                options, []( char c ) { return std::isspace( c ); } );
+            nlohmann::json res;
+            if( trimmed.empty() )
+            {
+                return res;
+            }
+            if( trimmed.at( 0 ) == '{' )
+            {
+                res = nlohmann::json::parse( options );
+            }
+            else
+            {
+                std::istringstream istream(
+                    options.c_str(),
+                    std::ios_base::binary | std::ios_base::in );
+                toml::value tomlVal =
+                    toml::parse( istream, "[inline TOML specification]" );
+                res = tomlToJson( tomlVal );
+            }
+            lowerCase( res );
+            return res;
+        }
+    }
+
     nlohmann::json
     parseOptions( std::string const & options, bool considerFiles )
     {
@@ -244,9 +273,7 @@ namespace json
                 return res;
             }
         }
-        auto res = nlohmann::json::parse( options );
-        lowerCase( res );
-        return res;
+        return parseInlineOptions( options );
     }
 
 #if openPMD_HAVE_MPI
@@ -277,9 +304,7 @@ namespace json
                 return res;
             }
         }
-        auto res = nlohmann::json::parse( options );
-        lowerCase( res );
-        return res;
+        return parseInlineOptions( options );
     }
 #endif
 

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -50,12 +50,12 @@ TEST_CASE( "json_parsing", "[auxiliary]" )
   }
 })";
     REQUIRE(
-        json::parseOptions( same1, false ).dump() ==
-        json::parseOptions( same2, false ).dump() );
+        json::parseOptions( same1, false ).config.dump() ==
+        json::parseOptions( same2, false ).config.dump() );
     // Only keys should be transformed to lower case, values must stay the same
     REQUIRE(
-        json::parseOptions( same1, false ).dump() !=
-        json::parseOptions( different, false ).dump() );
+        json::parseOptions( same1, false ).config.dump() !=
+        json::parseOptions( different, false ).config.dump() );
 
     // Keys forwarded to ADIOS2 should remain untouched
     std::string upper = R"END(
@@ -168,7 +168,7 @@ TEST_CASE( "json_merging", "auxiliary" )
 })END";
     REQUIRE(
         json::merge( defaultVal, overwrite ) ==
-        json::parseOptions( expect, false ).dump() );
+        json::parseOptions( expect, false ).config.dump() );
 }
 
 TEST_CASE( "optional", "[auxiliary]" ) {

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1108,7 +1108,9 @@ doshuffle = "BLOSC_BITSHUFFLE"
         if( rank == 0 )
         {
             std::fstream file;
-            file.open( "../samples/write_config.toml", std::ios_base::out );
+            file.open(
+                "../samples/write_config.toml",
+                std::ios_base::out | std::ios_base::binary );
             file << config;
             file.flush();
         }

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1064,62 +1064,60 @@ TEST_CASE( "parallel_adios2_json_config", "[parallel][adios2]" )
     MPI_Comm_rank( MPI_COMM_WORLD, &rank );
 
     std::string writeConfigBP3 = R"END(
-{
-  "adios2": {
-    "engine": {
-      "type": "bp3",
-      "unused": "parameter",
-      "parameters": {
-        "BufferGrowthFactor": "2.0",
-        "Profile": "On"
-      }
-    },
-    "unused": "as well",
-    "dataset": {
-      "operators": [
-        {
-          "type": "blosc",
-          "parameters": {
-              "clevel": "1",
-              "doshuffle": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  }
-}
+[adios2]
+unused = "parameter"
+
+[adios2.engine]
+type = "bp3"
+unused = "as well"
+
+[adios2.engine.parameters]
+BufferGrowthFactor = "2.0"
+Profile = "On"
+
+[[adios2.dataset.operators]]
+type = "blosc"
+
+[adios2.dataset.operators.parameters]
+clevel = "1"
+doshuffle = "BLOSC_BITSHUFFLE"
 )END";
+
     std::string writeConfigBP4 = R"END(
-{
-  "adios2": {
-    "engine": {
-      "type": "bp4",
-      "unused": "parameter",
-      "parameters": {
-        "BufferGrowthFactor": "2.0",
-        "Profile": "On"
-      }
-    },
-    "unused": "as well",
-    "dataset": {
-      "operators": [
-        {
-          "type": "blosc",
-          "parameters": {
-              "clevel": "1",
-              "doshuffle": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  }
-}
+[adios2]
+unused = "parameter"
+
+[adios2.engine]
+type = "bp4"
+unused = "as well"
+
+[adios2.engine.parameters]
+BufferGrowthFactor = "2.0"
+Profile = "On"
+
+[[adios2.dataset.operators]]
+type = "blosc"
+
+[adios2.dataset.operators.parameters]
+clevel = 1
+doshuffle = "BLOSC_BITSHUFFLE"
 )END";
     auto const write = [ size, rank ](
                            std::string const & filename,
                            std::string const & config ) {
+        if( rank == 0 )
+        {
+            std::fstream file;
+            file.open( "../samples/write_config.toml", std::ios_base::out );
+            file << config;
+            file.flush();
+        }
+        MPI_Barrier( MPI_COMM_WORLD );
         openPMD::Series series(
-            filename, openPMD::Access::CREATE, MPI_COMM_WORLD, config );
+            filename,
+            openPMD::Access::CREATE,
+            MPI_COMM_WORLD,
+            "@../samples/write_config.toml" );
         auto E_x = series.iterations[ 0 ].meshes[ "E" ][ "x" ];
         openPMD::Dataset ds(
             openPMD::Datatype::INT, { unsigned( size ), 1000 } );

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1003,20 +1003,11 @@ adios2_streaming( bool variableBasedLayout )
          */
         using namespace std::chrono_literals;
         std::this_thread::sleep_for( 1s );
-        std::string options = R"(
-        {
-          "adios2": {
-            "engine": {
-              "type": "SST"
-            }
-          }
-        }
-        )";
 
         Series readSeries(
             "../samples/adios2_stream.sst",
             Access::READ_ONLY,
-            "{\"defer_iteration_parsing\": true}" );
+            "defer_iteration_parsing = true" ); // inline TOML
 
         size_t last_iteration_index = 0;
         for( auto iteration : readSeries.readIterations() )

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3531,30 +3531,24 @@ parameters.doshuffle = "BLOSC_BITSHUFFLE"
      * >  "asdf":"asdf"}
      */
 
-    // @todo how to write this in TOML?
     std::string datasetConfig = R"END(
-{
-  "resizable": true,
-  "asdf": "asdf",
-  "adios2": {
-    "unused": "dataset parameter",
-    "dataset": {
-      "unused": "too",
-      "operators": [
-        {
-          "type": "blosc",
-          "parameters": {
-            "clevel": 3,
-            "doshuffle": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  },
-  "hdf5": {
-    "this": "should not warn"
-  }
-}
+resizable = true
+asdf = "asdf"
+
+[adios2]
+unused = "dataset parameter"
+
+[adios2.dataset]
+unused = "too"
+
+[[adios2.dataset.operators]]
+type = "blosc"
+[adios2.dataset.operators.parameters]
+clevel = 3
+doshuffle = "BLOSC_BITSHUFFLE"
+
+[hdf5]
+this = "should not warn"
 )END";
     auto const write = [ &datasetConfig ](
                            std::string const & filename,
@@ -3721,14 +3715,10 @@ TEST_CASE( "bp4_steps", "[serial][adios2]" )
     }
     )";
     std::string dontUseSteps = R"(
-    {
-        "adios2": {
-            "engine": {
-                "type": "bp4",
-                "UseSteps": false
-            }
-        }
-    }
+        # let's use TOML for this one
+        [adios2.engine]
+        type = "bp4"
+        UseSteps = false
     )";
     // sing the yes no song
     bp4_steps( "../samples/bp4steps_yes_yes.bp", useSteps, useSteps );

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3560,7 +3560,9 @@ parameters.doshuffle = "BLOSC_BITSHUFFLE"
                            std::string const & filename,
                            std::string const & config ) {
         std::fstream file;
-        file.open( "../samples/write_config.toml", std::ios_base::out );
+        file.open(
+            "../samples/write_config.toml",
+            std::ios_base::out | std::ios::binary );
         file << config;
         file.flush();
         openPMD::Series series(

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3445,7 +3445,7 @@ TEST_CASE( "git_adios2_early_chunk_query", "[serial][adios2]" )
         R"({"backend": "adios2"})" );
 }
 
-TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
+TEST_CASE( "serial_adios2_backend_config", "[serial][adios2]" )
 {
     if( auxiliary::getEnvString( "OPENPMD_BP_BACKEND", "NOT_SET" ) == "ADIOS1" )
     {
@@ -3453,86 +3453,67 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
         return;
     }
     std::string writeConfigBP3 = R"END(
-{
-  "unused": "global parameter",
-  "hdf5": {
-    "unused": "hdf5 parameter please do not warn"
-  },
-  "adios2": {
-    "engine": {
-      "type": "bp3",
-      "unused": "parameter",
-      "parameters": {
-        "BufferGrowthFactor": 2,
-        "Profile": "On"
-      }
-    },
-    "unused": "as well",
-    "dataset": {
-      "operators": [
-        {
-          "type": "blosc",
-          "parameters": {
-              "clevel": "1",
-              "doshuffle": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  }
-}
+unused = "global parameter"
+
+[hdf5]
+unused = "hdf5 parameter please do not warn"
+
+[adios2]
+unused = "parameter"
+
+[adios2.engine]
+type = "bp3"
+unused = "as well"
+
+[adios2.engine.parameters]
+BufferGrowthFactor = 2
+Profile = "On"
+
+# double brackets, because the operators are a list
+[[adios2.dataset.operators]]
+type = "blosc"
+# It's possible to give parameters inline
+parameters.clevel = "1"
+parameters.doshuffle = "BLOSC_BITSHUFFLE"
 )END";
+
     std::string writeConfigBP4 = R"END(
-{
-  "adios2": {
-    "engine": {
-      "type": "bp4",
-      "unused": "parameter",
-      "parameters": {
-        "BufferGrowthFactor": 2.0,
-        "Profile": "On"
-      }
-    },
-    "unused": "as well",
-    "dataset": {
-      "operators": [
-        {
-          "type": "blosc",
-          "parameters": {
-              "clevel": 1,
-              "doshuffle": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  }
-}
+[adios2]
+unused = "parameter"
+
+[adios2.engine]
+type = "bp4"
+unused = "as well"
+
+[adios2.engine.parameters]
+BufferGrowthFactor = 2.0
+Profile = "On"
+
+[[adios2.dataset.operators]]
+type = "blosc"
+
+# even inside double brackets, we can go on with single brackets
+[adios2.dataset.operators.parameters]
+clevel = 1
+doshuffle = "BLOSC_BITSHUFFLE"
 )END";
+
     std::string writeConfigNull = R"END(
-{
-  "adios2": {
-    "engine": {
-      "type": "nullcore",
-      "unused": "parameter",
-      "parameters": {
-        "BufferGrowthFactor": "2.0",
-        "Profile": "On"
-      }
-    },
-    "unused": "as well",
-    "dataset": {
-      "operators": [
-        {
-          "type": "blosc",
-          "parameters": {
-              "clevel": "1",
-              "doshuffle": "BLOSC_BITSHUFFLE"
-          }
-        }
-      ]
-    }
-  }
-}
+[adios2]
+unused = "parameter"
+
+[adios2.engine]
+type = "nullcore"
+unused = "as well"
+
+[adios2.engine.parameters]
+BufferGrowthFactor = "2.0"
+Profile = "On"
+
+[[adios2.dataset.operators]]
+type = "blosc"
+parameters.clevel = "1"
+parameters.doshuffle = "BLOSC_BITSHUFFLE"
 )END";
     /*
      * Notes on the upcoming dataset JSON configuration:
@@ -3549,6 +3530,8 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
      * > {"adios2":{"dataset":{"unused":"too"},"unused":"dataset parameter"},
      * >  "asdf":"asdf"}
      */
+
+    // @todo how to write this in TOML?
     std::string datasetConfig = R"END(
 {
   "resizable": true,
@@ -3576,7 +3559,14 @@ TEST_CASE( "serial_adios2_json_config", "[serial][adios2]" )
     auto const write = [ &datasetConfig ](
                            std::string const & filename,
                            std::string const & config ) {
-        openPMD::Series series( filename, openPMD::Access::CREATE, config );
+        std::fstream file;
+        file.open( "../samples/write_config.toml", std::ios_base::out );
+        file << config;
+        file.flush();
+        openPMD::Series series(
+            filename,
+            openPMD::Access::CREATE,
+            "@../samples/write_config.toml  " );
         auto E_x = series.iterations[ 0 ].meshes[ "E" ][ "x" ];
         openPMD::Dataset ds( openPMD::Datatype::INT, { 1000 } );
         E_x.resetDataset( ds );


### PR DESCRIPTION
Approach for implementation: Read from .toml file, but convert to nlohmann::json internally

Config files are much more readable in TOML:
```toml
unused = "global parameter"

[hdf5]
unused = "hdf5 parameter please dont warn"

[adios2]
unused = "parameter"

[adios2.engine]
type = "bp3"
unused = "as well"

[adios2.engine.parameters]
BufferGrowthFactor = 2
Profile = "On"

# double brackets, because the operators are a list
[[adios2.dataset.operators]]
type = "blosc"

# parameters for the current list entry
[adios2.dataset.operators.parameters]
parameters.clevel = "1"
parameters.doshuffle = "BLOSC_BITSHUFFLE"
```

TODO:
- [x] parallel testing
- [x] merge #1043 and #1148 first
- [x] error messages don't yet distinguish between JSON and TOML
- [x] make TOML usable for `Dataset` config too (how to do that?)
- [x] ~~Make TOML an optional dependency?~~ discussed: compiler coverage here is good.
- [x] Separate toml11 thirdparty lib addition into separate PR #1148
- [x] Documentation thirdparty lib: as with nlohmann::json (news file, readme, ...) #1148
- [x] Update `CommonADIOS1IOHandlerImpl< ChildClass >::initJson()` after merging #1162 (there will be no merge conflict)
- Add a CI config that tests this again upstream toml11 -> covered in nightly install tests