### PR TITLE
Parsing: Remove invalid records from data structures entirely

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -104,6 +104,9 @@ namespace detail
      * @param IO The IO within which to retrieve the attribute.
      * @param attributeName The full ADIOS name of the attribute.
      * @param verbose If true, print a warning if not finding the attribute.
+     * @param voa This function is used by the old and new ADIOS2 schema alike.
+     *            The old one uses ADIOS2 attributes, the new one uses
+     *            ADIOS2 variables.
      * @return The openPMD datatype corresponding to the type of the attribute.
      *         UNDEFINED if attribute is not found.
      */
@@ -112,7 +115,7 @@ namespace detail
         adios2::IO & IO,
         std::string const & attributeName,
         bool verbose,
-        VariableOrAttribute = VariableOrAttribute::Attribute );
+        VariableOrAttribute voa = VariableOrAttribute::Attribute );
 } // namespace detail
 
 /**

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -366,6 +366,17 @@ OPENPMD_protected:
             return m_originalContainer.at( std::forward< K >( k ) );
         }
 
+        /**
+         * Remove key from the list of accessed keys.
+         * If the key is not accessed after this again, it will be deleted along
+         * with all other unaccessed keys upon destruction.
+         */
+        template< typename K >
+        void forget( K && k )
+        {
+            m_accessedKeys.erase( std::forward< K >( k ) );
+        }
+
         ~EraseStaleEntries()
         {
             auto & map = *m_originalContainer.m_container;

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -118,6 +118,7 @@ ParticleSpecies::read()
             while( ! IOHandler()->m_work.empty() )
                 IOHandler()->m_work.pop();
 
+            map.forget( record_name );
             //(*this)[record_name].erase(RecordComponent::SCALAR);
             //this->erase(record_name);
         }


### PR DESCRIPTION
Our parsing logic in `ParticleSpecies.cpp` catches runtime errors when parsing a record, and if such an error happens, ignores the record. (Needed for old ADIOS1 output from PIConGPU that contained some nonstandard records).
Until now, the half-parsed records were not deleted.
Our checks in `Series::~Series()` caught up on that and threw errors.
This PR makes sure to delete records whose parsing has been canceled.