### PR TITLE
Don't apply compression operators multipe times in variable-based iteration encoding

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1560,6 +1560,8 @@ namespace detail
             {
                 var.SetSelection( { start, count } );
             }
+            // don't add compression operators multiple times
+            return;
         }
 
         if( !var )


### PR DESCRIPTION
I just noticed this while reading the source file that we apply compression operators in every step anew