### PR TITLE
Automatically deactive span based Put API in ADIOS2 when operators are present

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -94,6 +94,11 @@ Explanation of the single keys:
 
   * ``type`` supported ADIOS operator type, e.g. zfp, sz
   * ``parameters`` is an associative map of string parameters for the operator (e.g. compression levels)
+* ``adios2.use_span_based_put``: The openPMD-api exposes the `span-based Put() API <https://adios2.readthedocs.io/en/latest/components/components.html#put-modes-and-memory-contracts>`_ of ADIOS2 via an overload of ``RecordComponent::storeChunk()``.
+  This API is incompatible with compression operators as described above.
+  The openPMD-api will automatically use a fallback implementation for the span-based Put() API if any operator is added to a dataset.
+  This workaround is enabled on a per-dataset level.
+  The workaround can be completely deactivated by specifying ``{"adios2": {"use_span_based_put": true}}`` or it can alternatively be activated indiscriminately for all datasets by specifying ``{"adios2": {"use_span_based_put": false}}``.
 
 Any setting specified under ``adios2.dataset`` is applicable globally as well as on a per-dataset level.
 Any setting under ``adios2.engine`` is applicable globally only.

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -236,6 +236,15 @@ private:
     std::string m_engineType;
     ADIOS2Schema::schema_t m_schema = ADIOS2Schema::schema_0000_00_00;
 
+    enum class UseSpan : char
+    {
+        Yes,
+        No,
+        Auto
+    };
+
+    UseSpan m_useSpanBasedPutByDefault = UseSpan::Auto;
+
     enum class AttributeLayout : char
     {
         ByAdiosAttributes,

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4280,6 +4280,174 @@ TEST_CASE( "variableBasedParticleData", "[serial][adios2]" )
 }
 #endif
 
+#if openPMD_HAVE_ADIOS2
+#ifdef ADIOS2_HAVE_BZIP2
+TEST_CASE( "automatically_deactivate_span", "[serial][adios2]" )
+{
+    // automatically (de)activate span-based storeChunking
+    {
+        Series write( "../samples/span_based.bp", Access::CREATE );
+        auto E_uncompressed = write.iterations[ 0 ].meshes[ "E" ][ "x" ];
+        auto E_compressed = write.iterations[ 0 ].meshes[ "E" ][ "y" ];
+
+        Dataset ds{ Datatype::INT, { 10 } };
+
+        E_uncompressed.resetDataset( ds );
+
+        std::string compression = R"END(
+{
+  "adios2": {
+    "dataset": {
+      "operators": [
+        {
+          "type": "bzip2"
+        }
+      ]
+    }
+  }
+})END";
+
+        ds.options = compression;
+        E_compressed.resetDataset( ds );
+
+        bool spanWorkaround = false;
+        E_uncompressed.storeChunk< int >(
+            { 0 }, { 10 }, [ &spanWorkaround ]( size_t size ) {
+                spanWorkaround = true;
+                return std::shared_ptr< int >(
+                    new int[ size ]{}, []( auto * ptr ) { delete[] ptr; } );
+            } );
+
+        REQUIRE( !spanWorkaround );
+
+        E_compressed.storeChunk< int >(
+            { 0 }, { 10 }, [ &spanWorkaround ]( size_t size ) {
+                spanWorkaround = true;
+                return std::shared_ptr< int >(
+                    new int[ size ]{}, []( auto * ptr ) { delete[] ptr; } );
+            } );
+
+        REQUIRE( spanWorkaround );
+    }
+
+    // enable span-based API indiscriminately
+    try
+    {
+        std::string enable = R"END(
+{
+  "adios2": {
+    "use_span_based_put": true
+  }
+})END";
+        Series write( "../samples/span_based.bp", Access::CREATE, enable );
+        auto E_uncompressed = write.iterations[ 0 ].meshes[ "E" ][ "x" ];
+        auto E_compressed = write.iterations[ 0 ].meshes[ "E" ][ "y" ];
+
+        Dataset ds{ Datatype::INT, { 10 } };
+
+        E_uncompressed.resetDataset( ds );
+
+        std::string compression = R"END(
+{
+  "adios2": {
+    "dataset": {
+      "operators": [
+        {
+          "type": "bzip2"
+        }
+      ]
+    }
+  }
+})END";
+
+        ds.options = compression;
+        E_compressed.resetDataset( ds );
+
+        bool spanWorkaround = false;
+        E_uncompressed.storeChunk< int >(
+            { 0 }, { 10 }, [ &spanWorkaround ]( size_t size ) {
+                spanWorkaround = true;
+                return std::shared_ptr< int >(
+                    new int[ size ]{}, []( auto * ptr ) { delete[] ptr; } );
+            } );
+
+        REQUIRE( !spanWorkaround );
+
+        E_compressed.storeChunk< int >(
+            { 0 }, { 10 }, [ &spanWorkaround ]( size_t size ) {
+                spanWorkaround = true;
+                return std::shared_ptr< int >(
+                    new int[ size ]{}, []( auto * ptr ) { delete[] ptr; } );
+            } );
+
+        REQUIRE( !spanWorkaround );
+    }
+    catch( std::exception const & e )
+    {
+        /*
+         * Using the span-based API in combination with compression is
+         * unsupported in ADIOS2.
+         * Currently, this is silently ignored, but in future there might be
+         * an error of some sort.
+         */
+        std::cerr << "Ignoring expected error: " << e.what() << std::endl;
+    }
+
+    // disable span-based API indiscriminately
+    {
+        std::string disable = R"END(
+{
+  "adios2": {
+    "use_span_based_put": false
+  }
+})END";
+        Series write( "../samples/span_based.bp", Access::CREATE, disable );
+        auto E_uncompressed = write.iterations[ 0 ].meshes[ "E" ][ "x" ];
+        auto E_compressed = write.iterations[ 0 ].meshes[ "E" ][ "y" ];
+
+        Dataset ds{ Datatype::INT, { 10 } };
+
+        E_uncompressed.resetDataset( ds );
+
+        std::string compression = R"END(
+{
+  "adios2": {
+    "dataset": {
+      "operators": [
+        {
+          "type": "bzip2"
+        }
+      ]
+    }
+  }
+})END";
+
+        ds.options = compression;
+        E_compressed.resetDataset( ds );
+
+        bool spanWorkaround = false;
+        E_uncompressed.storeChunk< int >(
+            { 0 }, { 10 }, [ &spanWorkaround ]( size_t size ) {
+                spanWorkaround = true;
+                return std::shared_ptr< int >(
+                    new int[ size ]{}, []( auto * ptr ) { delete[] ptr; } );
+            } );
+
+        REQUIRE( spanWorkaround );
+
+        E_compressed.storeChunk< int >(
+            { 0 }, { 10 }, [ &spanWorkaround ]( size_t size ) {
+                spanWorkaround = true;
+                return std::shared_ptr< int >(
+                    new int[ size ]{}, []( auto * ptr ) { delete[] ptr; } );
+            } );
+
+        REQUIRE( spanWorkaround );
+    }
+}
+#endif
+#endif
+
 // @todo Upon switching to ADIOS2 2.7.0, test this the other way around also
 void iterate_nonstreaming_series(
     std::string const & file, bool variableBasedLayout, std::string jsonConfig )


### PR DESCRIPTION
Ref. [this issue](https://github.com/ornladios/ADIOS2/issues/2965)
Tldr: Span-based Put API can help save memory, but is incompatible with compression operators

This PR automatically deactivates the span-based Put API on a per-variable basis if the variable has operators defined.
Alternatively, a JSON option can be used to activate / deactivate it completely.

TODO:
- [x] Documentation
- [x] Testing
- [x] Merge #1043 first