### PR TITLE
ICC 19.1.2: CXX17 Work-Arounds (Variant)

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -346,7 +346,12 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
             std::cerr << "[HDF5] Datatype::UNDEFINED caught during dataset creation (serial HDF5)" << std::endl;
             d = Datatype::BOOL;
         }
-        Attribute a(0);
+
+        // note: due to a C++17 issue with ICC 19.1.2 we write the
+        //       T value to variant conversion explicitly
+        //       https://github.com/openPMD/openPMD-api/pull/...
+        // Attribute a(0);
+        Attribute a(static_cast<Attribute::resource>(0));
         a.dtype = d;
         std::vector< hsize_t > dims;
         std::uint64_t num_elements = 1u;

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -223,7 +223,11 @@ RecordComponent::flush(std::string const& name)
                 aWrite.resource = m_constantValue->getResource();
                 IOHandler()->enqueue(IOTask(this, aWrite));
                 aWrite.name = "shape";
-                Attribute a(getExtent());
+                // note: due to a C++17 issue with ICC 19.1.2 we write the
+                //       T value to variant conversion explicitly
+                //       https://github.com/openPMD/openPMD-api/pull/...
+                // Attribute a(getExtent());
+                Attribute a(static_cast<Attribute::resource>(getExtent()));
                 aWrite.dtype = a.dtype;
                 aWrite.resource = a.getResource();
                 IOHandler()->enqueue(IOTask(this, aWrite));

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -37,7 +37,11 @@ TEST_CASE( "versions_test", "[core]" )
 
 TEST_CASE( "attribute_dtype_test", "[core]" )
 {
-    Attribute a = Attribute(static_cast< char >(' '));
+    // note: due to a C++17 issue with ICC 19.1.2 we write the
+    //       T value to variant conversion explicitly
+    //       https://github.com/openPMD/openPMD-api/pull/...
+    // Attribute a = Attribute(static_cast< char >(' '));
+    Attribute a = Attribute(static_cast<Attribute::resource>(static_cast< char >(' ')));
     REQUIRE(Datatype::CHAR == a.dtype);
     a = Attribute(static_cast< unsigned char >(' '));
     REQUIRE(Datatype::UCHAR == a.dtype);


### PR DESCRIPTION
The `Attribute` constructors with implicit variant conversion sometimes do not work in ICC 19.1.2.

```
openPMD-api/src/RecordComponent.cpp(226): error: no instance of constructor "openPMD::Attribute::Attribute" matches the argument list
            argument types are: (openPMD::Extent)
                  Attribute a(getExtent());
                              ^
openPMD-api/include/openPMD/backend/Attribute.hpp(50): note: this candidate was rejected because arguments do not match
  class Attribute :
        ^
openPMD-api/include/openPMD/backend/Attribute.hpp(50): note: this candidate was rejected because arguments do not match
  class Attribute :
        ^
openPMD-api/include/openPMD/backend/Attribute.hpp(79): note: this candidate was rejected because arguments do not match
      Attribute(resource r) : Variant(std::move(r))
      ^
```

Same work-around as for NVCC in #1103

Seen on LLNL's Quartz supercomputer.

X-ref: https://github.com/ECP-WarpX/WarpX/pull/2300