### PR TITLE
Wheels: Musllinux (Alpine) Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Install cibuildwheel
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install cibuildwheel==2.0.1
+        python -m pip install cibuildwheel==2.2.2
 
 #    - name: Download Patch 1/1
 #      uses: suisei-cn/actions-download-file@v1
@@ -93,9 +93,8 @@ jobs:
         #       typename T = lib::type_pack_element_t<I, Ts...>,
         # (3) Disable PyPy (manylinux image: yum repo issues)
         #     https://github.com/pypa/manylinux/issues/899
-        # (4) musllinux: requires alternative to "yum" in library_builders.sh
-        # (5) CPython 3.10: requires 0.14.4+ (https://github.com/openPMD/openPMD-api/pull/1139)
-        CIBW_SKIP: "*-win32 *-manylinux_i686 pp*-manylinux* *-musllinux_* cp310-*"
+        # (4) CPython 3.10: requires 0.14.4+ (https://github.com/openPMD/openPMD-api/pull/1139)
+        CIBW_SKIP: "*-win32 *-manylinux_i686 pp*-manylinux* cp310-*"
         CIBW_ARCHS: "${{ matrix.arch }}"
         CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6"
         # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,18 @@ jobs:
       env:
         - CIBW_BUILD="*_aarch64"
         - CIBW_SKIP="cp38-* cp39-* cp36-* cp37-* cp310-* *-musllinux_*"
+    - services: docker
+      arch: arm64
+      dist: focal
+      env:
+        - CIBW_BUILD="*-musllinux_aarch64"
+        - CIBW_SKIP="cp38-* cp39-* cp310-*"
+    - services: docker
+      arch: arm64
+      dist: focal
+      env:
+        - CIBW_BUILD="*-musllinux_aarch64"
+        - CIBW_SKIP="cp36-* cp37-* cp310-*"
 
     # perform a linux PPC64LE build
     - services: docker
@@ -66,6 +78,31 @@ jobs:
 #      dist: focal
 #      env:
 #        - CIBW_BUILD="cp310-manylinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp36-musllinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp37-musllinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp38-musllinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp39-musllinux_ppc64le"
+#    - services: docker
+#      arch: ppc64le
+#      dist: focal
+#      env:
+#        - CIBW_BUILD="cp310-musllinux_ppc64le"
 
     # perform a linux S390X build
     # blocked by https://github.com/GTkorvo/dill/issues/15


### PR DESCRIPTION
Update our `library_builders.sh` to support dependency builds on the new PEP 656 `musllinux` standard.

~~The C++ compiler toolchain does not yet seem to work well: https://github.com/pypa/manylinux/pull/1135#discussion_r770139003 / https://github.com/pypa/manylinux/issues/1242~~

Tested locally via:
```console
$ docker run -v $PWD:/opt/build -it quay.io/pypa/musllinux_1_1_x86_64
> cd /opt/build
> ./library_builders.sh 
```