### PR TITLE
Fix reading of dataset-specific configuration in ADIOS1

### DIFF
--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -552,19 +552,23 @@ CommonADIOS1IOHandlerImpl< ChildClass >::createDataset(Writable* writable,
         {
             json::TracingJSON options = json::parseOptions(
                 parameters.options, /* considerFiles = */ false );
-            auto maybeTransform = datasetTransform( options );
-            if( maybeTransform.has_value() )
+            if( options.json().contains( "adios1" ) )
             {
-                transform = maybeTransform.get();
-            }
+                options = options["adios1"];
+                auto maybeTransform = datasetTransform( options );
+                if( maybeTransform.has_value() )
+                {
+                    transform = maybeTransform.get();
+                }
 
-            auto shadow = options.invertShadow();
-            if( shadow.size() > 0 )
-            {
-                std::cerr << "Warning: parts of the JSON configuration for "
-                             "ADIOS1 dataset '"
-                          << name << "' remain unused:\n"
-                          << shadow << std::endl;
+                auto shadow = options.invertShadow();
+                if( shadow.size() > 0 )
+                {
+                    std::cerr << "Warning: parts of the JSON configuration for "
+                                "ADIOS1 dataset '"
+                            << name << "' remain unused:\n"
+                            << shadow << std::endl;
+                }
             }
         }
         // Fallback: global option
@@ -577,7 +581,7 @@ CommonADIOS1IOHandlerImpl< ChildClass >::createDataset(Writable* writable,
         {
             int status;
             status = adios_set_transform(id, transform.c_str());
-            VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to set ADIOS transform during Dataset cretaion");
+            VERIFY(status == err_no_error, "[ADIOS1] Internal error: Failed to set ADIOS transform during Dataset creation");
         }
 
         writable->written = true;
@@ -1761,6 +1765,13 @@ void CommonADIOS1IOHandlerImpl< ChildClass >::initJson(
     if( maybeTransform.has_value() )
     {
         m_defaultTransform = std::move( maybeTransform.get() );
+    }
+    auto shadow = config.invertShadow();
+    if( shadow.size() > 0 )
+    {
+        std::cerr << "Warning: parts of the JSON configuration for ADIOS1 "
+                        "remain unused:\n"
+                    << shadow << std::endl;
     }
 }
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3339,6 +3339,72 @@ TEST_CASE( "no_serial_adios1", "[serial][adios]")
 }
 #endif
 
+#if openPMD_HAVE_ADIOS1
+TEST_CASE( "serial_adios1_json_config", "[serial][adios1]" )
+{
+    std::string globalConfig = R"END(
+{
+  "backend": "adios1",
+  "adios1": {
+    "dataset": {
+      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
+    }
+  }
+})END";
+    std::string localConfig = R"END(
+{
+  "adios1": {
+    "dataset": {
+      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=5;nometa"
+    }
+  }
+})END";
+
+    try
+    {
+        Series write(
+            "../samples/adios1_dataset_transform.bp",
+            Access::CREATE,
+            globalConfig );
+        auto meshes = write.writeIterations()[ 0 ].meshes;
+
+        auto defaultConfiguredMesh =
+            meshes[ "defaultConfigured" ][ RecordComponent::SCALAR ];
+        auto overridenTransformMesh =
+            meshes[ "overridenConfig" ][ RecordComponent::SCALAR ];
+
+        Dataset ds{ Datatype::INT, { 10 } };
+
+        defaultConfiguredMesh.resetDataset( ds );
+
+        ds.options = localConfig;
+        overridenTransformMesh.resetDataset( ds );
+
+        std::vector< int > data( 10, 2345 );
+
+        defaultConfiguredMesh.storeChunk( data, { 0 }, { 10 } );
+        overridenTransformMesh.storeChunk( data, { 0 }, { 10 } );
+
+        write.flush();
+    }
+    catch( std::runtime_error const & e )
+    {
+        if( std::string( e.what() ) ==
+            "[ADIOS1] Internal error: Failed to set ADIOS transform during "
+            "Dataset creation" )
+        {
+            std::cerr
+                << "Skipping serial_adios1_json_config test since the ADIOS1 "
+                   "installation does not support blosc compression.";
+        }
+        else
+        {
+            throw;
+        }
+    }
+}
+#endif
+
 #if openPMD_HAVE_ADIOS2
 TEST_CASE( "git_adios2_early_chunk_query", "[serial][adios2]" )
 {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3347,21 +3347,26 @@ TEST_CASE( "serial_adios1_json_config", "[serial][adios1]" )
   "backend": "adios1",
   "adios1": {
     "dataset": {
-      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
-    }
-  }
-})END";
-    std::string localConfig = R"END(
-{
-  "adios1": {
-    "dataset": {
-      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=5;nometa"
+      "transform": "deliberately use a wrong configuration..."
     }
   }
 })END";
 
-    try
-    {
+    std::string globalConfigWithoutCompression = R"END(
+{
+  "backend": "adios1"
+})END";
+
+    std::string localConfig = R"END(
+{
+  "adios1": {
+    "dataset": {
+      "transform": "...so we can check for the resulting errors"
+    }
+  }
+})END";
+
+    auto test1 = [ & ]() {
         Series write(
             "../samples/adios1_dataset_transform.bp",
             Access::CREATE,
@@ -3370,38 +3375,63 @@ TEST_CASE( "serial_adios1_json_config", "[serial][adios1]" )
 
         auto defaultConfiguredMesh =
             meshes[ "defaultConfigured" ][ RecordComponent::SCALAR ];
-        auto overridenTransformMesh =
-            meshes[ "overridenConfig" ][ RecordComponent::SCALAR ];
 
         Dataset ds{ Datatype::INT, { 10 } };
 
         defaultConfiguredMesh.resetDataset( ds );
 
+        std::vector< int > data( 10, 2345 );
+        defaultConfiguredMesh.storeChunk( data, { 0 }, { 10 } );
+
+        write.flush();
+    };
+    REQUIRE_THROWS_WITH(
+        test1(),
+        Catch::Equals( "[ADIOS1] Internal error: Failed to set ADIOS transform "
+                       "during Dataset creation" ) );
+
+    auto test2 = [ & ]() {
+        Series write(
+            "../samples/adios1_dataset_transform.bp",
+            Access::CREATE,
+            globalConfig );
+        auto meshes = write.writeIterations()[ 0 ].meshes;
+        auto overridenTransformMesh =
+            meshes[ "overridenConfig" ][ RecordComponent::SCALAR ];
+
+        Dataset ds{ Datatype::INT, { 10 } };
         ds.options = localConfig;
         overridenTransformMesh.resetDataset( ds );
 
         std::vector< int > data( 10, 2345 );
-
-        defaultConfiguredMesh.storeChunk( data, { 0 }, { 10 } );
         overridenTransformMesh.storeChunk( data, { 0 }, { 10 } );
 
         write.flush();
-    }
-    catch( std::runtime_error const & e )
-    {
-        if( std::string( e.what() ) ==
-            "[ADIOS1] Internal error: Failed to set ADIOS transform during "
-            "Dataset creation" )
-        {
-            std::cerr
-                << "Skipping serial_adios1_json_config test since the ADIOS1 "
-                   "installation does not support blosc compression.";
-        }
-        else
-        {
-            throw;
-        }
-    }
+    };
+    REQUIRE_THROWS_WITH(
+        test2(),
+        Catch::Equals( "[ADIOS1] Internal error: Failed to set ADIOS transform "
+                       "during Dataset creation" ) );
+
+    auto test3 = [ & ]() {
+        // use no dataset transform at all
+        Series write(
+            "../samples/adios1_dataset_transform.bp",
+            Access::CREATE,
+            globalConfigWithoutCompression );
+        auto meshes = write.writeIterations()[ 0 ].meshes;
+        auto defaultConfiguredMesh =
+            meshes[ "defaultConfigured" ][ RecordComponent::SCALAR ];
+
+        Dataset ds{ Datatype::INT, { 10 } };
+        defaultConfiguredMesh.resetDataset( ds );
+
+        std::vector< int > data( 10, 2345 );
+        defaultConfiguredMesh.storeChunk( data, { 0 }, { 10 } );
+
+        write.flush();
+    };
+    test3(); // should run without exception
 }
 #endif
 


### PR DESCRIPTION
Follow-up to #1043, I forgot one layer in the JSON schema inside `createDataset`. This fixes that and adds a small test.