### PR TITLE
ADIOS2 fixes: Incompatibilites with current ADIOS2 master branch

### DIFF
--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -25,6 +25,7 @@
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
 
 #include <future>
+#include <iostream>
 
 
 namespace openPMD
@@ -123,8 +124,14 @@ public:
                         availableChunks(i.writable, deref_dynamic_cast< Parameter< O::AVAILABLE_CHUNKS > >(i.parameter.get()));
                         break;
                 }
-            } catch (unsupported_data_error&)
+            } catch (...)
             {
+                std::cerr
+                    << "[AbstractIOHandlerImpl] IO Task "
+                    << internal::operationAsString( i.operation )
+                    << " failed with exception. Removing task"
+                    << " from IO queue and passing on the exception."
+                    << std::endl;
                 (*m_handler).m_work.pop();
                 throw;
             }

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -76,6 +76,15 @@ OPENPMDAPI_EXPORT_ENUM_CLASS(Operation)
     AVAILABLE_CHUNKS //!< Query chunks that can be loaded in a dataset
 }; // note: if you change the enum members here, please update docs/source/dev/design.rst
 
+namespace internal
+{
+    /*
+     * The returned strings are compile-time constants, so no worries about
+     * pointer validity.
+     */
+    std::string operationAsString( Operation );
+}
+
 struct OPENPMDAPI_EXPORT AbstractParameter
 {
     virtual ~AbstractParameter() = default;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1167,11 +1167,21 @@ ADIOS2IOHandlerImpl::getCompressionOperator( std::string const & compression )
         try {
             res = m_ADIOS.DefineOperator( compression, compression );
         }
-        catch ( std::invalid_argument const & )
+        catch ( std::invalid_argument const & e )
         {
             std::cerr << "Warning: ADIOS2 backend does not support compression "
                          "method "
                       << compression << ". Continuing without compression."
+                      << "\nOriginal error: " << e.what()
+                      << std::endl;
+            return auxiliary::Option< adios2::Operator >();
+        }
+        catch(std::string const & s)
+        {
+            std::cerr << "Warning: ADIOS2 backend does not support compression "
+                         "method "
+                      << compression << ". Continuing without compression."
+                      << "\nOriginal error: " << s
                       << std::endl;
             return auxiliary::Option< adios2::Operator >();
         }

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -73,4 +73,87 @@ void Parameter< Operation::CREATE_DATASET >::warnUnusedParameters<
         }
     }
 }
+
+namespace internal
+{
+    std::string
+    operationAsString( Operation op )
+    {
+        switch( op )
+        {
+        case Operation::CREATE_FILE:
+            return "CREATE_FILE";
+            break;
+        case Operation::OPEN_FILE:
+            return "OPEN_FILE";
+            break;
+        case Operation::CLOSE_FILE:
+            return "CLOSE_FILE";
+            break;
+        case Operation::DELETE_FILE:
+            return "DELETE_FILE";
+            break;
+        case Operation::CREATE_PATH:
+            return "CREATE_PATH";
+            break;
+        case Operation::CLOSE_PATH:
+            return "CLOSE_PATH";
+            break;
+        case Operation::OPEN_PATH:
+            return "OPEN_PATH";
+            break;
+        case Operation::DELETE_PATH:
+            return "DELETE_PATH";
+            break;
+        case Operation::LIST_PATHS:
+            return "LIST_PATHS";
+            break;
+        case Operation::CREATE_DATASET:
+            return "CREATE_DATASET";
+            break;
+        case Operation::EXTEND_DATASET:
+            return "EXTEND_DATASET";
+            break;
+        case Operation::OPEN_DATASET:
+            return "OPEN_DATASET";
+            break;
+        case Operation::DELETE_DATASET:
+            return "DELETE_DATASET";
+            break;
+        case Operation::WRITE_DATASET:
+            return "WRITE_DATASET";
+            break;
+        case Operation::READ_DATASET:
+            return "READ_DATASET";
+            break;
+        case Operation::LIST_DATASETS:
+            return "LIST_DATASETS";
+            break;
+        case Operation::GET_BUFFER_VIEW:
+            return "GET_BUFFER_VIEW";
+            break;
+        case Operation::DELETE_ATT:
+            return "DELETE_ATT";
+            break;
+        case Operation::WRITE_ATT:
+            return "WRITE_ATT";
+            break;
+        case Operation::READ_ATT:
+            return "READ_ATT";
+            break;
+        case Operation::LIST_ATTS:
+            return "LIST_ATTS";
+            break;
+        case Operation::ADVANCE:
+            return "ADVANCE";
+            break;
+        case Operation::AVAILABLE_CHUNKS:
+            return "AVAILABLE_CHUNKS";
+            break;
+        default:
+            return "unknown";
+            break;
+        }
+    }
+}
 } // openPMD


### PR DESCRIPTION
Fix #1163:

1. ADIOS2 now sometimes throws different exception types, so we must catch different types
2. ADIOS2 now throws an error if using the span-based Put() API in combination with operators, so we must adapt our tests

Notes on the second point:
* Destructing should always work, even if errors are thrown. We cannot do much against segfaults in our flushing routines during destruction, but we should check if this can be solved without leaking the memory.
* Should we add an API call `Series::invalidate()` to indicate that this `Series` object should perform no further operations (especially: only free memory during destruction, do nothing else, no flushing)?