### PR TITLE
Docs: Minor Warnings

### DIFF
--- a/docs/source/details/mpi.rst
+++ b/docs/source/details/mpi.rst
@@ -43,7 +43,7 @@ Functionality                Behavior           Description
        Note that openPMD represents constant record components with attributes, thus inheriting this for ``::makeConstant``.
 
 .. [4] We usually open iterations delayed on first access. This first access is usually the ``flush()`` call after a ``storeChunk``/``loadChunk`` operation. If the first access is non-collective, an explicit, collective ``Iteration::open()`` can be used to have the files already open.
-Alternatively, iterations might be accessed for the first time by immediate operations such as ``::availableChunks()``.
+       Alternatively, iterations might be accessed for the first time by immediate operations such as ``::availableChunks()``.
 
 .. tip::
 

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -21,7 +21,7 @@ The following libraries are shipped internally in ``share/openPMD/thirdParty/`` 
 * `Catch2 <https://github.com/catchorg/Catch2>`_ 2.13.4+ (`BSL-1.0 <https://github.com/catchorg/Catch2/blob/master/LICENSE.txt>`__)
 * `pybind11 <https://github.com/pybind/pybind11>`_ 2.6.2+ (`new BSD <https://github.com/pybind/pybind11/blob/master/LICENSE>`_)
 * `NLohmann-JSON <https://github.com/nlohmann/json>`_ 3.9.1+ (`MIT <https://github.com/nlohmann/json/blob/develop/LICENSE.MIT>`_)
-* `toml11 <https://github.com/ToruNiina/toml11>`_ 3.7.0+ (`MIT <https://github.com/ToruNiina/toml11/blob/master/LICENSE>`_)
+* `toml11 <https://github.com/ToruNiina/toml11>`_ 3.7.0+ (`MIT <https://github.com/ToruNiina/toml11/blob/master/LICENSE>`__)
 
 Optional: I/O backends
 ----------------------


### PR DESCRIPTION
Fix minor warnings in the docs:
- double reference (make 2nd ref annonymous)
- misaligned reference