### PR TITLE
ADIOS1: Remove task from IO queue if it fails with exception

### DIFF
--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -111,8 +111,14 @@ ADIOS1IOHandlerImpl::flush()
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS setup queue");
             }
-        } catch (unsupported_data_error& e)
+        } catch (...)
         {
+            std::cerr
+                << "[AbstractIOHandlerImpl] IO Task "
+                << internal::operationAsString( i.operation )
+                << " failed with exception. Removing task"
+                << " from IO queue and passing on the exception."
+                << std::endl;
             handler->m_setup.pop();
             throw;
         }
@@ -184,9 +190,15 @@ ADIOS1IOHandlerImpl::flush()
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS work queue");
             }
-        } catch (unsupported_data_error& e)
+        } catch (...)
         {
-            handler->m_work.pop();
+            std::cerr
+                << "[AbstractIOHandlerImpl] IO Task "
+                << internal::operationAsString( i.operation )
+                << " failed with exception. Removing task"
+                << " from IO queue and passing on the exception."
+                << std::endl;
+            m_handler->m_work.pop();
             throw;
         }
         handler->m_work.pop();

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -133,8 +133,14 @@ ParallelADIOS1IOHandlerImpl::flush()
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS setup queue");
             }
-        } catch (unsupported_data_error& e)
+        } catch (...)
         {
+            std::cerr
+                << "[AbstractIOHandlerImpl] IO Task "
+                << internal::operationAsString( i.operation )
+                << " failed with exception. Removing task"
+                << " from IO queue and passing on the exception."
+                << std::endl;
             handler->m_setup.pop();
             throw;
         }
@@ -204,9 +210,15 @@ ParallelADIOS1IOHandlerImpl::flush()
                 default:
                     VERIFY(false, "[ADIOS1] Internal error: Wrong operation in ADIOS work queue");
             }
-        } catch (unsupported_data_error& e)
+        } catch (...)
         {
-            handler->m_work.pop();
+            std::cerr
+                << "[AbstractIOHandlerImpl] IO Task "
+                << internal::operationAsString( i.operation )
+                << " failed with exception. Removing task"
+                << " from IO queue and passing on the exception."
+                << std::endl;
+            m_handler->m_work.pop();
             throw;
         }
         handler->m_work.pop();


### PR DESCRIPTION
Follow-up to #1166, see [this comment](https://github.com/openPMD/openPMD-api/pull/1166#discussion_r788045146)

We could theoretically put it into 0.14.4, it's the same change we already did for the other backends. It doesn't really fix any bugs, but it makes errors a lot easier to debug if they occur.