### PR TITLE
Wheels: 0.14.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'src'
-        ref: '0.14.3'
+        ref: '0.14.4'
 
     - uses: actions/checkout@v2
       with:
@@ -93,8 +93,7 @@ jobs:
         #       typename T = lib::type_pack_element_t<I, Ts...>,
         # (3) Disable PyPy (manylinux image: yum repo issues)
         #     https://github.com/pypa/manylinux/issues/899
-        # (4) CPython 3.10: requires 0.14.4+ (https://github.com/openPMD/openPMD-api/pull/1139)
-        CIBW_SKIP: "*-win32 *-manylinux_i686 pp*-manylinux* cp310-*"
+        CIBW_SKIP: "*-win32 *-manylinux_i686 pp*-manylinux*"
         CIBW_ARCHS: "${{ matrix.arch }}"
         CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6"
         # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.14.3"
+    - OPENPMD_GIT_REF="0.14.4"
 
     - CIBW_PROJECT_REQUIRES_PYTHON=">=3.6"
     # Install dependencies on Linux and OSX
@@ -51,6 +51,11 @@ jobs:
       env:
         - CIBW_BUILD="*-musllinux_aarch64"
         - CIBW_SKIP="cp36-* cp37-* cp310-*"
+    - services: docker
+      arch: arm64
+      dist: focal
+      env:
+        - CIBW_BUILD="cp310-musllinux_aarch64"
 
     # perform a linux PPC64LE build
     - services: docker
@@ -73,11 +78,11 @@ jobs:
       dist: focal
       env:
         - CIBW_BUILD="cp39-manylinux_ppc64le"
-#    - services: docker
-#      arch: ppc64le
-#      dist: focal
-#      env:
-#        - CIBW_BUILD="cp310-manylinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp310-manylinux_ppc64le"
     - services: docker
       arch: ppc64le
       dist: focal
@@ -98,11 +103,11 @@ jobs:
       dist: focal
       env:
         - CIBW_BUILD="cp39-musllinux_ppc64le"
-#    - services: docker
-#      arch: ppc64le
-#      dist: focal
-#      env:
-#        - CIBW_BUILD="cp310-musllinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp310-musllinux_ppc64le"
 
     # perform a linux S390X build
     # blocked by https://github.com/GTkorvo/dill/issues/15


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.14.4 release.
Include Python 3.10 builds.