### PR TITLE
Avoid SFINAE in Attribute conversion

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -441,32 +441,6 @@ namespace detail
 {
     // Helper structs for calls to the switchType function
 
-    template< typename > struct IsVector
-    {
-        static constexpr bool value = false;
-    };
-
-    template< typename T > struct IsVector< std::vector< T > >
-    {
-        static constexpr bool value = true;
-    };
-
-    template< typename T >
-    inline constexpr bool IsVector_v = IsVector< T >::value;
-
-    template< typename > struct IsArray
-    {
-        static constexpr bool value = false;
-    };
-
-    template< typename T, size_t n > struct IsArray< std::array< T, n > >
-    {
-        static constexpr bool value = true;
-    };
-
-    template< typename T >
-    inline constexpr bool IsArray_v = IsArray< T >::value;
-
     template< typename T >
     inline constexpr bool IsUnsupportedComplex_v =
         std::is_same_v< T, std::complex< long double > > ||

--- a/include/openPMD/auxiliary/TypeTraits.hpp
+++ b/include/openPMD/auxiliary/TypeTraits.hpp
@@ -1,0 +1,62 @@
+/* Copyright 2022 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef> // size_t
+#include <vector>
+
+namespace openPMD::auxiliary
+{
+namespace detail
+{
+    template< typename >
+    struct IsVector
+    {
+        static constexpr bool value = false;
+    };
+
+    template< typename T >
+    struct IsVector< std::vector< T > >
+    {
+        static constexpr bool value = true;
+    };
+
+    template< typename >
+    struct IsArray
+    {
+        static constexpr bool value = false;
+    };
+
+    template< typename T, size_t n >
+    struct IsArray< std::array< T, n > >
+    {
+        static constexpr bool value = true;
+    };
+}
+
+template< typename T >
+inline constexpr bool IsVector_v = detail::IsVector< T >::value;
+
+template< typename T >
+inline constexpr bool IsArray_v = detail::IsArray< T >::value;
+}

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -20,8 +20,9 @@
  */
 #pragma once
 
-#include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/Datatype.hpp"
+#include "openPMD/auxiliary/TypeTraits.hpp"
+#include "openPMD/auxiliary/Variant.hpp"
 
 #include <algorithm>
 #include <array>
@@ -92,136 +93,91 @@ public:
     U get() const;
 };
 
-template< typename T, typename U, bool isConvertible = std::is_convertible<T, U>::value >
-struct DoConvert;
-
 template< typename T, typename U >
-struct DoConvert<T, U, false>
+auto doConvert( T * pv ) -> U
 {
-    U operator()( T * )
-    {
-        throw std::runtime_error("getCast: no cast possible.");
-    }
-};
-
-template< typename T, typename U >
-struct DoConvert<T, U, true>
-{
-    U operator()( T * pv )
+    if constexpr( std::is_convertible_v< T, U > )
     {
         return static_cast< U >( *pv );
     }
-};
-
-template< typename T, typename U >
-struct DoConvert<std::vector< T >, std::vector< U >, false>
-{
-    static constexpr bool convertible = std::is_convertible<T, U>::value;
-
-    template< typename UU = U >
-    auto operator()( std::vector< T > const * pv )
-    -> typename std::enable_if< convertible, std::vector< UU > >::type
+    else if constexpr(
+        auxiliary::IsVector_v< T > && auxiliary::IsVector_v< U > )
     {
-        std::vector< U > u;
-        u.reserve( pv->size() );
-        std::copy( pv->begin(), pv->end(), std::back_inserter(u) );
-        return u;
-    }
-
-    template< typename UU = U >
-    auto operator()( std::vector< T > const * )
-    -> typename std::enable_if< !convertible, std::vector< UU > >::type
-    {
-        throw std::runtime_error("getCast: no vector cast possible.");
-    }
-};
-
-// conversion cast: turn a single value into a 1-element vector
-template< typename T, typename U >
-struct DoConvert<T, std::vector< U >, false>
-{
-    static constexpr bool convertible = std::is_convertible<T, U>::value;
-
-    template< typename UU = U >
-    auto operator()( T const * pv )
-    -> typename std::enable_if< convertible, std::vector< UU > >::type
-    {
-        std::vector< U > u;
-        u.reserve( 1 );
-        u.push_back( static_cast< U >( *pv ) );
-        return u;
-    }
-
-    template< typename UU = U >
-    auto operator()( T const * )
-    -> typename std::enable_if< !convertible, std::vector< UU > >::type
-    {
-        throw std::runtime_error(
-            "getCast: no scalar to vector conversion possible.");
-    }
-};
-
-// conversion cast: array to vector
-// if a backend reports a std::array<> for something where the frontend expects
-// a vector
-template< typename T, typename U, size_t n >
-struct DoConvert<std::array< T, n >, std::vector< U >, false>
-{
-    static constexpr bool convertible = std::is_convertible<T, U>::value;
-
-    template< typename UU = U >
-    auto operator()( std::array< T, n > const * pv )
-    -> typename std::enable_if< convertible, std::vector< UU > >::type
-    {
-        std::vector< U > u;
-        u.reserve( n );
-        std::copy( pv->begin(), pv->end(), std::back_inserter(u) );
-        return u;
-    }
-
-    template< typename UU = U >
-    auto operator()( std::array< T, n > const * )
-    -> typename std::enable_if< !convertible, std::vector< UU > >::type
-    {
-        throw std::runtime_error(
-            "getCast: no array to vector conversion possible.");
-    }
-};
-
-// conversion cast: vector to array
-// if a backend reports a std::vector<> for something where the frontend expects
-// an array
-template< typename T, typename U, size_t n >
-struct DoConvert<std::vector< T >, std::array< U, n >, false>
-{
-    static constexpr bool convertible = std::is_convertible<T, U>::value;
-
-    template< typename UU = U >
-    auto operator()( std::vector< T > const * pv )
-    -> typename std::enable_if< convertible, std::array< UU, n > >::type
-    {
-        std::array< U, n > u;
-        if( n != pv->size() )
+        if constexpr( std::is_convertible_v<
+                          typename T::value_type,
+                          typename U::value_type > )
         {
-            throw std::runtime_error(
-                "getCast: no vector to array conversion possible "
-                "(wrong requested array size).");
+            U res;
+            res.reserve( pv->size() );
+            std::copy( pv->begin(), pv->end(), std::back_inserter( res ) );
+            return res;
         }
-        for( size_t i = 0; i < n; ++i )
+
+        throw std::runtime_error( "getCast: no vector cast possible." );
+    }
+    // conversion cast: array to vector
+    // if a backend reports a std::array<> for something where
+    // the frontend expects a vector
+    else if constexpr( auxiliary::IsArray_v< T > && auxiliary::IsVector_v< U > )
+    {
+        if constexpr( std::is_convertible_v<
+                          typename T::value_type,
+                          typename U::value_type > )
         {
-            u[ i ] = static_cast< U >( ( *pv )[ i ] );
+            U res;
+            res.reserve( pv->size() );
+            std::copy( pv->begin(), pv->end(), std::back_inserter( res ) );
+            return res;
         }
-        return u;
+
+        throw std::runtime_error(
+            "getCast: no array to vector conversion possible." );
+    }
+    // conversion cast: vector to array
+    // if a backend reports a std::vector<> for something where
+    // the frontend expects an array
+    else if constexpr( auxiliary::IsVector_v< T > && auxiliary::IsArray_v< U > )
+    {
+        if constexpr( std::is_convertible_v<
+                          typename T::value_type,
+                          typename U::value_type > )
+        {
+            U res;
+            if( res.size() != pv->size() )
+            {
+                throw std::runtime_error(
+                    "getCast: no vector to array conversion possible (wrong "
+                    "requested array size)." );
+            }
+            for( size_t i = 0; i < res.size(); ++i )
+            {
+                res[ i ] =
+                    static_cast< typename U::value_type >( ( *pv )[ i ] );
+            }
+            return res;
+        }
+
+        throw std::runtime_error(
+            "getCast: no vector to array conversion possible." );
+    }
+    // conversion cast: turn a single value into a 1-element vector
+    else if constexpr( auxiliary::IsVector_v< U > )
+    {
+        if constexpr( std::is_convertible_v< T, typename U::value_type > )
+        {
+            U res;
+            res.reserve( 1 );
+            res.push_back( static_cast< typename U::value_type >( *pv ) );
+            return res;
+        }
+
+        throw std::runtime_error(
+            "getCast: no scalar to vector conversion possible." );
     }
 
-    template< typename UU = U >
-    auto operator()( std::vector< T > const * )
-    -> typename std::enable_if< !convertible, std::array< UU, n > >::type
-    {
-        throw std::runtime_error(
-            "getCast: no vector to array conversion possible.");
-    }
-};
+    ( void )pv;
+    throw std::runtime_error( "getCast: no cast possible." );
+}
 
 /** Retrieve a stored specific Attribute and cast if convertible.
  *
@@ -238,7 +194,7 @@ getCast( Attribute const & a )
     return std::visit(
         []( auto && containedValue ) -> U {
             using containedType = std::decay_t< decltype( containedValue ) >;
-            return DoConvert< containedType, U >{}( &containedValue );
+            return doConvert< containedType, U >( &containedValue );
         },
         v );
 }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -28,6 +28,7 @@
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
+#include "openPMD/auxiliary/TypeTraits.hpp"
 
 #include <algorithm>
 #include <cctype> // std::tolower
@@ -1401,7 +1402,7 @@ namespace detail
                 "[ADIOS2] Internal error: no support for long double complex "
                 "attribute types" );
         }
-        else if constexpr( IsVector_v< T > )
+        else if constexpr( auxiliary::IsVector_v< T > )
         {
             auto attr = IO.InquireAttribute< typename T::value_type >( name );
             if ( !attr )
@@ -1411,7 +1412,7 @@ namespace detail
             }
             *resource = attr.Data();
         }
-        else if constexpr( IsArray_v< T > )
+        else if constexpr( auxiliary::IsArray_v< T > )
         {
             auto attr = IO.InquireAttribute< typename T::value_type >( name );
             if ( !attr )
@@ -1568,7 +1569,7 @@ namespace detail
                 "[ADIOS2] Internal error: no support for long double complex "
                 "attribute types" );
         }
-        else if constexpr( IsVector_v< T > )
+        else if constexpr( auxiliary::IsVector_v< T > )
         {
             auto attr = IO.DefineAttribute( fullName, value.data(), value.size() );
             if( !attr )
@@ -1578,7 +1579,7 @@ namespace detail
                     "'." );
             }
         }
-        else if constexpr( IsArray_v< T > )
+        else if constexpr( auxiliary::IsArray_v< T > )
         {
             auto attr = IO.DefineAttribute( fullName, value.data(), value.size() );
             if( !attr )


### PR DESCRIPTION
`Attribute.hpp` is included near everywhere, including user code. 
For attribute datatype conversion we can now use `if constexpr` and avoid SFINAE constructs.