### PR TITLE
Fix Attribute constructor error on NVCC

### DIFF
--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -79,6 +79,19 @@ public:
     Attribute(resource r) : Variant(std::move(r))
     { }
 
+    /**
+     * Compiler bug: NVCCC release 11.1, V11.1.105:
+     * > no instance of constructor "openPMD::Attribute::Attribute"
+     * > matches the argument list
+     * > argument types are: (int)
+     *
+     * Fix by explicitly instantiating resource
+     */
+    template< typename T >
+    Attribute( T && val ) : Variant( resource( std::forward< T >( val ) ) )
+    {
+    }
+
     /** Retrieve a stored specific Attribute and cast if convertible.
      *
      * @note This performs a static_cast and might introduce precision loss if


### PR DESCRIPTION
Observed in PIConGPU since both PIConGPU and openPMD-api switched to C++17:
```
[ 69%] Building CUDA object CMakeFiles/picongpu.dir/main.cpp.o
/usr/local/cuda/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/usr/bin/mpic++ -DADIOS2_USE_MPI -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY_MODE -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -DALPAKA_DEBUG=0 -DALPAKA_DEBUG_OFFLOAD_ASSUME_HOST -DALPAKA_OFFLOAD_MAX_BLOCK_SIZE=256 -DBOOST_ALL_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_MATH_TR1_DYN_LINK -DBOOST_NO_AUTO_PTR -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_ID=GNU -DCMAKE_CXX_COMPILER_VERSION=7.5.0 -DCMAKE_SYSTEM=Linux-5.4.0-89-generic -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_VERSION=3.21.3 -DCUPLA_STREAM_ASYNC_ENABLED=1 -DENABLE_OPENPMD=1 -DNO_FREETYPE -DPIC_ENABLE_PNG=1 -DPIC_VERBOSE_LVL=63 -DPMACC_VERBOSE_LVL=0 -I/home/franzpoeschel/singularity_build/PIC_build/include -I/home/franzpoeschel/git-repos/picongpu/thirdParty/mallocMC/src/include -I/home/franzpoeschel/git-repos/picongpu/include/pmacc/.. -I/home/franzpoeschel/git-repos/picongpu/include/picongpu/.. -I/home/franzpoeschel/git-repos/picongpu/thirdParty/cupla/include -isystem=/usr/local/cuda/targets/x86_64-linux/include -isystem=/home/franzpoeschel/git-repos/picongpu/thirdParty/cupla/alpaka/include -isystem=/usr/local/cuda/include -isystem=/home/franzpoeschel/singularity_build/local/include -O3 -DNDEBUG --generate-code=arch=compute_35,code=[compute_35,sm_35] --expt-extended-lambda --expt-relaxed-constexpr -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=esa_on_defaulted_function_ignored -std=c++17 -MD -MT CMakeFiles/picongpu.dir/main.cpp.o -MF CMakeFiles/picongpu.dir/main.cpp.o.d -x cu -c /home/franzpoeschel/git-repos/picongpu/include/picongpu/main.cpp -o CMakeFiles/picongpu.dir/main.cpp.o
nvcc warning : The 'compute_35', 'compute_37', 'compute_50', 'sm_35', 'sm_37' and 'sm_50' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
/home/franzpoeschel/singularity_build/local/include/openPMD/RecordComponent.hpp(104): error #289: no instance of constructor "openPMD::Attribute::Attribute" matches the argument list
            argument types are: (int)
```

Fix by explicitly instantiating `resource`.

```
> nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2020 NVIDIA Corporation
Built on Mon_Oct_12_20:09:46_PDT_2020
Cuda compilation tools, release 11.1, V11.1.105
Build cuda_11.1.TC455_06.29190527_0
```