### PR TITLE
C++17: Remove Earlier EDG Attribute Work-Arounds

### DIFF
--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -410,12 +410,7 @@ Attributable::setAttribute( std::string const & key, T value )
         && !attri.m_attributes.key_comp()(key, it->first) )
     {
         // key already exists in map, just replace the value
-
-        // note: due to a C++17 issue with NVCC 11.0.2 we write the
-        //       T value to variant conversion explicitly
-        //       https://github.com/openPMD/openPMD-api/pull/1103
-        //it->second = Attribute(std::move(value));
-        it->second = Attribute(Attribute::resource(std::move(value)));
+        it->second = Attribute(std::move(value));
         return true;
     } else
     {

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -80,10 +80,11 @@ public:
     { }
 
     /**
-     * Compiler bug: NVCCC release 11.1, V11.1.105:
+     * Compiler bug: CUDA (nvcc) releases 11.0.3 (v11.0.221), 11.1 (v11.1.105):
      * > no instance of constructor "openPMD::Attribute::Attribute"
      * > matches the argument list
      * > argument types are: (int)
+     * Same with ICC 19.1.2 (both use EDG compiler frontends).
      *
      * Fix by explicitly instantiating resource
      */

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -371,11 +371,7 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
             d = Datatype::BOOL;
         }
 
-        // note: due to a C++17 issue with ICC 19.1.2 we write the
-        //       T value to variant conversion explicitly
-        //       https://github.com/openPMD/openPMD-api/pull/...
-        // Attribute a(0);
-        Attribute a(static_cast<Attribute::resource>(0));
+        Attribute a(0);
         a.dtype = d;
         std::vector< hsize_t > dims;
         std::uint64_t num_elements = 1u;

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -242,11 +242,7 @@ RecordComponent::flush(std::string const& name)
                 aWrite.resource = rc.m_constantValue.getResource();
                 IOHandler()->enqueue(IOTask(this, aWrite));
                 aWrite.name = "shape";
-                // note: due to a C++17 issue with ICC 19.1.2 we write the
-                //       T value to variant conversion explicitly
-                //       https://github.com/openPMD/openPMD-api/pull/...
-                // Attribute a(getExtent());
-                Attribute a(static_cast<Attribute::resource>(getExtent()));
+                Attribute a(getExtent());
                 aWrite.dtype = a.dtype;
                 aWrite.resource = a.getResource();
                 IOHandler()->enqueue(IOTask(this, aWrite));

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -42,11 +42,7 @@ TEST_CASE( "versions_test", "[core]" )
 
 TEST_CASE( "attribute_dtype_test", "[core]" )
 {
-    // note: due to a C++17 issue with ICC 19.1.2 we write the
-    //       T value to variant conversion explicitly
-    //       https://github.com/openPMD/openPMD-api/pull/...
-    // Attribute a = Attribute(static_cast< char >(' '));
-    Attribute a = Attribute(static_cast<Attribute::resource>(static_cast< char >(' ')));
+    Attribute a = Attribute(static_cast< char >(' '));
     REQUIRE(Datatype::CHAR == a.dtype);
     a = Attribute(static_cast< unsigned char >(' '));
     REQUIRE(Datatype::UCHAR == a.dtype);


### PR DESCRIPTION
With a general work-around in the `Attribute` move constructor, we can remove scattered work-arounds from earlier C++17 patches that address compilers with EDG front-end (`nvcc`, `icpc`).


Follow-up to:
- #1184
- #1157
- #1103