### PR TITLE
Print warning if mpi4py is not found in openpmd-pipe

### DIFF
--- a/src/binding/python/openpmd_api/pipe/__main__.py
+++ b/src/binding/python/openpmd_api/pipe/__main__.py
@@ -15,10 +15,18 @@ import sys  # sys.stderr.write
 from .. import openpmd_api_cxx as io
 
 # MPI is an optional dependency
-try:
-    from mpi4py import MPI
-    HAVE_MPI = True
-except ImportError:
+if io.variants['mpi']:
+    try:
+        from mpi4py import MPI
+        HAVE_MPI = True
+    except (ImportError, ModuleNotFoundError):
+        print("""
+openPMD-api was built with support for MPI,
+but mpi4py Python package was not found.
+Will continue in serial mode.""",
+              file=sys.stderr)
+        HAVE_MPI = False
+else:
     HAVE_MPI = False
 
 debug = False


### PR DESCRIPTION
This one trapped me badly and it took me far longer than I want to admit that this was the reason why things were not working.
So: If openPMD-api is built with MPI, but the mpi4py package is not found, print a warning before going on in serial.