### PR TITLE
Allow setting operations in ADIOS2 read API

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -35,6 +35,7 @@ Parameters that are directly passed through to an external library and not inter
 
 The configuration string may refer to the complete ``openPMD::Series`` or may additionally be specified per ``openPMD::Dataset``, passed in the respective constructors.
 This reflects the fact that certain backend-specific parameters may refer to the whole Series (such as storage engines and their parameters) and others refer to actual datasets (such as compression).
+Dataset-specific configurations are (currently) only available during dataset creation, but not when reading datasets.
 
 A JSON/TOML configuration may either be specified as an inline string that can be parsed as a JSON/TOML object, or  alternatively as a path to a JSON/TOML-formatted text file (only in the constructor of ``openPMD::Series``):
 
@@ -128,6 +129,29 @@ Explanation of the single keys:
   The openPMD-api will automatically use a fallback implementation for the span-based Put() API if any operator is added to a dataset.
   This workaround is enabled on a per-dataset level.
   The workaround can be completely deactivated by specifying ``{"adios2": {"use_span_based_put": true}}`` or it can alternatively be activated indiscriminately for all datasets by specifying ``{"adios2": {"use_span_based_put": false}}``.
+
+Operations specified inside ``adios2.dataset.operators`` will be applied to ADIOS2 datasets in writing as well as in reading.
+Beginning with ADIOS2 2.8.0, this can be used to specify decompressor settings:
+
+.. code-block:: json
+
+  {
+    "adios2": {
+      "dataset": {
+        "operators": [
+          {
+            "type": "blosc",
+            "parameters": {
+              "nthreads": 2
+            }
+          }
+        ]
+      }
+    }
+  }
+
+In older ADIOS2 versions, this specification will be without effect in read mode.
+Dataset-specific configurations are (currently) only possible when creating datasets, not when reading.
 
 Any setting specified under ``adios2.dataset`` is applicable globally as well as on a per-dataset level.
 Any setting under ``adios2.engine`` is applicable globally only.

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1660,6 +1660,14 @@ namespace detail
                 "' from file " + *file + "." );
         }
 
+        // Operators in reading needed e.g. for setting decompression threads
+        for( auto const & operation : impl->defaultOperators )
+        {
+            if( operation.op )
+            {
+                var.AddOperation( operation.op, operation.params );
+            }
+        }
         // cast from adios2::Dims to openPMD::Extent
         auto const shape = var.Shape();
         parameters.extent->clear();

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3592,6 +3592,16 @@ this = "should not warn"
     "engine": {
       "type": "bp3",
       "unused": "parameter"
+    },
+    "dataset": {
+      "operators": [
+        {
+          "type": "blosc",
+          "parameters": {
+            "nthreads": 8
+          }
+        }
+      ]
     }
   }
 }
@@ -3602,6 +3612,16 @@ this = "should not warn"
     "engine": {
       "type": "bp4",
       "unused": "parameter"
+    },
+    "dataset": {
+      "operators": [
+        {
+          "type": "blosc",
+          "parameters": {
+            "nthreads": 8
+          }
+        }
+      ]
     }
   }
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3598,7 +3598,7 @@ this = "should not warn"
         {
           "type": "blosc",
           "parameters": {
-            "nthreads": 8
+            "nthreads": 2
           }
         }
       ]
@@ -3618,7 +3618,7 @@ this = "should not warn"
         {
           "type": "blosc",
           "parameters": {
-            "nthreads": 8
+            "nthreads": 2
           }
         }
       ]


### PR DESCRIPTION
We don't currently have an API for setting *dataset-specific* JSON configurations in the read API, so this addition is only for the global JSON/TOML config passed via the `Series` constructor.

Usage example:
```cpp
std::string readConfig = R"END(
{
  "adios2": {
    "engine": {
      "type": "bp4"
    },
    "dataset": {
      "operators": [
        {
          "type": "blosc",
          "parameters": {
            "nthreads": 8
          }
        }
      ]
    }
  }
}
)END";
Series read( "mydataset.bp", Access::READ_ONLY, readConfig );
```

TODO:
- [x] Before merging this, can you check that this does what you need? @guj 