### PR TITLE
Improve HDF5 write time by disabling fill

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -390,6 +390,8 @@ HDF5IOHandlerImpl::createDataset(Writable* writable,
         /* enable chunking on the created dataspace */
         hid_t datasetCreationProperty = H5Pcreate(H5P_DATASET_CREATE);
 
+        H5Pset_fill_time(datasetCreationProperty, H5D_FILL_TIME_NEVER);
+
         if( num_elements != 0u && m_chunks != "none" )
         {
             //! @todo add per dataset chunk control from JSON config


### PR DESCRIPTION
In some experiments, we noticed the HDF5 implementation for openPMD was transferring twice the data volume to file, effectively overriding fill values. The default behavior of HDF5 is not to use fill values unless explicitly told to do so, and openPMD does not set those fill values on dataset creation, so the library should not be doing this. It turns out that there are some situations where this can still happen in the library, i.e. exceptions to what is documented. This has been reported and confirmed with the HDF5 group.  