### PR TITLE
clang-tidy: performance-for-range-copy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,5 +2,5 @@
 # FIXME: all performance-* reports
 # FIXME: all cert-* reports
 # FIXME: all bugprone-* reports
-Checks: -*,bugprone-*,-bugprone-unhandled-self-assignment,-bugprone-parent-virtual-call,-bugprone-narrowing-conversions,-bugprone-exception-escape,-bugprone-string-literal-with-embedded-nul,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,modernize-*,-modernize-use-trailing-return-type,-modernize-use-bool-literals,-modernize-avoid-c-arrays,-modernize-use-auto,-modernize-return-braced-init-list
+Checks: -*,bugprone-*,-bugprone-unhandled-self-assignment,-bugprone-parent-virtual-call,-bugprone-narrowing-conversions,-bugprone-exception-escape,-bugprone-string-literal-with-embedded-nul,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,performance-for-range-copy,modernize-*,-modernize-use-trailing-return-type,-modernize-use-bool-literals,-modernize-avoid-c-arrays,-modernize-use-auto,-modernize-return-braced-init-list
 HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/examples/8b_benchmark_read_parallel.cpp
+++ b/examples/8b_benchmark_read_parallel.cpp
@@ -787,7 +787,7 @@ main( int argc, char *argv[] )
     }
 
     auto backends = getBackends();
-    for ( auto which: backends )
+    for ( const auto& which: backends )
       {
          input.m_Backend = which;
          input.run(prefix);

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4986,7 +4986,7 @@ void no_explicit_flush( std::string filename )
     {
         Series series( filename, Access::READ_ONLY );
         size_t index = 0;
-        for( auto iteration : series.readIterations() )
+        for( const auto& iteration : series.readIterations() )
         {
             REQUIRE( iteration.iterationIndex == index );
             ++index;


### PR DESCRIPTION
Add a new check category to `clang-tidy`: [performance-for-range-copy](https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html)

Inspired by https://github.com/ECP-WarpX/WarpX/pull/2833