### PR TITLE
Fix: macOS ADIOS1 w/ cctools ld64 w/o XCode

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,5 +44,41 @@ jobs:
         cmake --build build --parallel 2
         ctest --test-dir build --output-on-failure
 
+  conda_ompi_vanillaclang_all:
+    runs-on: macos-latest
+    if: github.event.pull_request.draft == false
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      name: Setup conda
+      with:
+        auto-update-conda: true
+        activate-environment: testing
+        auto-activate-base: false
+        channels: conda-forge,defaults
+        channel-priority: true
+    - name: Install
+      shell: bash -eo pipefail -l {0}
+      run: |
+        conda env create --file conda.yml
+    - name: Build
+      shell: bash -eo pipefail -l {0}
+      env: {CXXFLAGS: -Werror -Wno-deprecated-declarations}
+      run: |
+        conda activate openpmd-api-dev
+
+        share/openPMD/download_samples.sh build
+        chmod u-w build/samples/git-sample/*.h5
+        cmake -S . -B build \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DopenPMD_USE_PYTHON=ON \
+          -DopenPMD_USE_MPI=ON    \
+          -DopenPMD_USE_HDF5=ON   \
+          -DopenPMD_USE_ADIOS1=ON \
+          -DopenPMD_USE_ADIOS2=ON \
+          -DopenPMD_USE_INVASIVE_TESTS=ON
+        cmake --build build --parallel 2
+        ctest --test-dir build --output-on-failure
+
 # TODO: apple_conda_ompi_all (similar to conda_ompi_all on Linux)
 #   both OpenMPI and MPICH cause startup (MPI_Init) issues on GitHub Actions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,15 +459,19 @@ set(IO_SOURCE
 set(IO_ADIOS1_SEQUENTIAL_SOURCE
         src/Error.cpp
         src/auxiliary/Filesystem.cpp
+        src/auxiliary/JSON.cpp
         src/ChunkInfo.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
-        src/IO/ADIOS/ADIOS1IOHandler.cpp)
+        src/IO/ADIOS/ADIOS1IOHandler.cpp
+        src/IO/IOTask.cpp)
 set(IO_ADIOS1_SOURCE
         src/Error.cpp
         src/auxiliary/Filesystem.cpp
+        src/auxiliary/JSON.cpp
         src/ChunkInfo.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
-        src/IO/ADIOS/ParallelADIOS1IOHandler.cpp)
+        src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+        src/IO/IOTask.cpp)
 
 # library
 if(openPMD_BUILD_SHARED_LIBS)
@@ -554,15 +558,41 @@ if(openPMD_HAVE_ADIOS1)
         $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
 
+    # Strip all symbols from wrapped library objects, so we can link parallel
+    # and serial ADIOS1 (with MPI mock/stubs) at the same time.
+    include(CheckLinkerFlag)
+    # Vanilla Clang, g++, etc., e.g., on conda-forge
+    set(_GNU_LINKSTRIP "LINKER:SHELL:--exclude-libs,ALL")
+    set(_LLVM_LINKSTRIP "LINKER:SHELL:--exclude-libs=ALL")
+    set(_LD64_LINKSTRIP "LINKER:SHELL:-unexported_symbol,_*")  # cctools
+    set(_LD64_LINKSTRIP "LINKER:-s")  # cctools/ld: strip all unexported
+    check_linker_flag(CXX "${_GNU_LINKSTRIP}" SUPP_GNU_LINKSTRIP)
+    check_linker_flag(CXX "${_LLVM_LINKSTRIP}" SUPP_LLVM_LINKSTRIP)
+    check_linker_flag(CXX "${_LD64_LINKSTRIP}" SUPP_LD64_LINKSTRIP)
+
     set_target_properties(openPMD.ADIOS1.Serial PROPERTIES
         POSITION_INDEPENDENT_CODE ON
         CXX_VISIBILITY_PRESET hidden
         VISIBILITY_INLINES_HIDDEN ON
     )
     if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-        set_target_properties(openPMD.ADIOS1.Serial PROPERTIES
-            LINK_FLAGS "-Wl,--exclude-libs,ALL")
+        if(SUPP_GNU_LINKSTRIP)
+            target_link_options(openPMD.ADIOS1.Serial PRIVATE "${_GNU_LINKSTRIP}")
+        elseif(SUPP_LLVM_LINKSTRIP)
+            target_link_options(openPMD.ADIOS1.Serial PRIVATE "${_LLVM_LINKSTRIP}")
+        elseif(SUPP_LD64_LINKSTRIP)
+            target_link_options(openPMD.ADIOS1.Serial PRIVATE "${_LD64_LINKSTRIP}")
+        else()
+            message(WARNING "Cannot strip serial ADIOS1 MPI mock")
+        endif()
     elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+        if(SUPP_GNU_LINKSTRIP)
+            target_link_options(openPMD.ADIOS1.Serial PRIVATE "${_GNU_LINKSTRIP}")
+        elseif(SUPP_LLVM_LINKSTRIP)
+            target_link_options(openPMD.ADIOS1.Serial PRIVATE "${_LLVM_LINKSTRIP}")
+        elseif(SUPP_LD64_LINKSTRIP)
+            target_link_options(openPMD.ADIOS1.Serial PRIVATE "${_LD64_LINKSTRIP}")
+        endif()
         set_target_properties(openPMD.ADIOS1.Serial PROPERTIES
             XCODE_ATTRIBUTE_STRIP_STYLE "non-global"
             XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING "YES"
@@ -585,9 +615,23 @@ if(openPMD_HAVE_ADIOS1)
             VISIBILITY_INLINES_HIDDEN 1
         )
         if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-            set_target_properties(openPMD.ADIOS1.Parallel PROPERTIES
-                LINK_FLAGS "-Wl,--exclude-libs,ALL")
+            if(SUPP_GNU_LINKSTRIP)
+                target_link_options(openPMD.ADIOS1.Parallel PRIVATE "${_GNU_LINKSTRIP}")
+            elseif(SUPP_LLVM_LINKSTRIP)
+                target_link_options(openPMD.ADIOS1.Parallel PRIVATE "${_LLVM_LINKSTRIP}")
+            elseif(SUPP_LD64_LINKSTRIP)
+                target_link_options(openPMD.ADIOS1.Parallel PRIVATE "${_LD64_LINKSTRIP}")
+            else()
+                message(WARNING "Cannot strip serial ADIOS1 MPI mock")
+            endif()
         elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+            if(SUPP_GNU_LINKSTRIP)
+                target_link_options(openPMD.ADIOS1.Parallel PRIVATE "${_GNU_LINKSTRIP}")
+            elseif(SUPP_LLVM_LINKSTRIP)
+                target_link_options(openPMD.ADIOS1.Parallel PRIVATE "${_LLVM_LINKSTRIP}")
+            elseif(SUPP_LD64_LINKSTRIP)
+                target_link_options(openPMD.ADIOS1.Parallel PRIVATE "${_LD64_LINKSTRIP}")
+            endif()
             set_target_properties(openPMD.ADIOS1.Parallel PROPERTIES
                 XCODE_ATTRIBUTE_STRIP_STYLE "non-global"
                 XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING "YES"

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -1786,9 +1786,10 @@ void CommonADIOS1IOHandlerImpl< ChildClass >::initJson(
     }
 }
 
-template class CommonADIOS1IOHandlerImpl< ADIOS1IOHandlerImpl >;
 #if openPMD_HAVE_MPI
 template class CommonADIOS1IOHandlerImpl< ParallelADIOS1IOHandlerImpl >;
+#else
+template class CommonADIOS1IOHandlerImpl< ADIOS1IOHandlerImpl >;
 #endif // openPMD_HAVE_MPI
 
 } // namespace openPMD


### PR DESCRIPTION
Some compiler toolchains on macOS do not use the XCode tools. For instance, conda-forge uses vanilla clang to build packages combined with a cctools `ld64` (similar to the macOS system linker) but without XCode.

In that case, the symbol hiding instructions we used on macOS were not effective, leading to errors like #1195.

This also fixes regressions from #1101, similar to #1167.

The current patch checks if the toolchain understands GCC/LLVM/ld64-ish linker flags on macOS and if it does, it adds them.

### Attention

- [ ] `llvm-strip` < 14 is also broken, which is used in Conda-Forge `compilers` - `CMAKE_STRIP` should use `cctools`' `strip` command (needs to be set manually): https://github.com/AMReX-Codes/pyamrex/issues/35