### PR TITLE
Patch MSVC pybind11 debug bug

### DIFF
--- a/share/openPMD/thirdParty/pybind11/include/pybind11/pybind11.h
+++ b/share/openPMD/thirdParty/pybind11/include/pybind11/pybind11.h
@@ -10,6 +10,24 @@
 
 #pragma once
 
+/*
+ * https://github.com/microsoft/onnxruntime/issues/9735#issuecomment-970718821
+ * The following block patches an MSVC bug.
+ */
+
+#if defined(_MSC_VER)
+#    if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
+#        define HAVE_ROUND 1
+#    endif
+#    include <corecrt.h>
+#    pragma warning(push)
+#    pragma warning(disable : 4510 4610 4512 4005)
+#    if defined(_DEBUG) && !defined(Py_DEBUG)
+#        define PYBIND11_DEBUG_MARKER
+#        undef _DEBUG
+#    endif
+#endif
+
 #if defined(__INTEL_COMPILER)
 #  pragma warning push
 #  pragma warning disable 68    // integer conversion resulted in a change of sign

--- a/share/openPMD/thirdParty/pybind11/include/pybind11/pybind11.h
+++ b/share/openPMD/thirdParty/pybind11/include/pybind11/pybind11.h
@@ -10,11 +10,10 @@
 
 #pragma once
 
-/*
- * https://github.com/microsoft/onnxruntime/issues/9735#issuecomment-970718821
- * The following block patches an MSVC bug.
+/* https://github.com/microsoft/onnxruntime/issues/9735#issuecomment-970718821
+ * The following block patches MSVC debug builds:
+ * Include Python header, disable linking to pythonX_d.lib on Windows in debug mode.
  */
-
 #if defined(_MSC_VER)
 #    if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
 #        define HAVE_ROUND 1


### PR DESCRIPTION
Our MSVC CI seems to be [broken](https://github.com/openPMD/openPMD-api/runs/5323849404?check_suite_focus=true) currently due to an include order error in pybind11

This PR patches our internal version of pybind11 based on [this comment](https://github.com/microsoft/onnxruntime/issues/9735#issuecomment-970718821) to fix the issue.

TODO:

- [ ] Maybe try if upgrading pybind11 to a recent version will fix it instead? (According to the linked thread, it won't): #1220