### PR TITLE
Fix GCC 11 Compiler Warnings

### DIFF
--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -122,6 +122,7 @@ public:
 template <typename T, typename U>
 auto doConvert(T *pv) -> U
 {
+    (void)pv;
     if constexpr (std::is_convertible_v<T, U>)
     {
         return static_cast<U>(*pv);
@@ -199,7 +200,6 @@ auto doConvert(T *pv) -> U
             "getCast: no scalar to vector conversion possible.");
     }
 
-    (void)pv;
     throw std::runtime_error("getCast: no cast possible.");
 }
 

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -199,8 +199,10 @@ auto doConvert(T *pv) -> U
         throw std::runtime_error(
             "getCast: no scalar to vector conversion possible.");
     }
-
-    throw std::runtime_error("getCast: no cast possible.");
+    else
+    {
+        throw std::runtime_error("getCast: no cast possible.");
+    }
 }
 
 /** Retrieve a stored specific Attribute and cast if convertible.

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -132,7 +132,7 @@ auto doConvert(T *pv) -> U
                           typename T::value_type,
                           typename U::value_type>)
         {
-            U res;
+            U res{};
             res.reserve(pv->size());
             std::copy(pv->begin(), pv->end(), std::back_inserter(res));
             return res;
@@ -149,7 +149,7 @@ auto doConvert(T *pv) -> U
                           typename T::value_type,
                           typename U::value_type>)
         {
-            U res;
+            U res{};
             res.reserve(pv->size());
             std::copy(pv->begin(), pv->end(), std::back_inserter(res));
             return res;
@@ -167,7 +167,7 @@ auto doConvert(T *pv) -> U
                           typename T::value_type,
                           typename U::value_type>)
         {
-            U res;
+            U res{};
             if (res.size() != pv->size())
             {
                 throw std::runtime_error(
@@ -189,7 +189,7 @@ auto doConvert(T *pv) -> U
     {
         if constexpr (std::is_convertible_v<T, typename U::value_type>)
         {
-            U res;
+            U res{};
             res.reserve(1);
             res.push_back(static_cast<typename U::value_type>(*pv));
             return res;

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -220,8 +220,11 @@ auto doConvert(T *pv) -> U
  * https://community.intel.com/t5/Intel-C-Compiler/quot-if-constexpr-quot-and-quot-missing-return-statement-quot-in/td-p/1154551
  */
 #pragma warning(disable : 1011)
-#endif
 }
+#pragma warning(default : 1011)
+#else
+}
+#endif
 
 /** Retrieve a stored specific Attribute and cast if convertible.
  *

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -138,8 +138,10 @@ auto doConvert(T *pv) -> U
             std::copy(pv->begin(), pv->end(), std::back_inserter(res));
             return res;
         }
-
-        throw std::runtime_error("getCast: no vector cast possible.");
+        else
+        {
+            throw std::runtime_error("getCast: no vector cast possible.");
+        }
     }
     // conversion cast: array to vector
     // if a backend reports a std::array<> for something where
@@ -155,9 +157,11 @@ auto doConvert(T *pv) -> U
             std::copy(pv->begin(), pv->end(), std::back_inserter(res));
             return res;
         }
-
-        throw std::runtime_error(
-            "getCast: no array to vector conversion possible.");
+        else
+        {
+            throw std::runtime_error(
+                "getCast: no array to vector conversion possible.");
+        }
     }
     // conversion cast: vector to array
     // if a backend reports a std::vector<> for something where
@@ -181,9 +185,11 @@ auto doConvert(T *pv) -> U
             }
             return res;
         }
-
-        throw std::runtime_error(
-            "getCast: no vector to array conversion possible.");
+        else
+        {
+            throw std::runtime_error(
+                "getCast: no vector to array conversion possible.");
+        }
     }
     // conversion cast: turn a single value into a 1-element vector
     else if constexpr (auxiliary::IsVector_v<U>)
@@ -195,14 +201,26 @@ auto doConvert(T *pv) -> U
             res.push_back(static_cast<typename U::value_type>(*pv));
             return res;
         }
-
-        throw std::runtime_error(
-            "getCast: no scalar to vector conversion possible.");
+        else
+        {
+            throw std::runtime_error(
+                "getCast: no scalar to vector conversion possible.");
+        }
     }
     else
     {
         throw std::runtime_error("getCast: no cast possible.");
     }
+#if defined(__INTEL_COMPILER)
+/*
+ * ICPC has trouble with if constexpr, thinking that return statements are
+ * missing afterwards. Deactivate the warning.
+ * Note that putting a statement here will not help to fix this since it will
+ * then complain about unreachable code.
+ * https://community.intel.com/t5/Intel-C-Compiler/quot-if-constexpr-quot-and-quot-missing-return-statement-quot-in/td-p/1154551
+ */
+#pragma warning(disable : 1011)
+#endif
 }
 
 /** Retrieve a stored specific Attribute and cast if convertible.

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -414,11 +414,16 @@ TEST_CASE("available_chunks_test_json", "[serial][json]")
 
 TEST_CASE("multiple_series_handles_test", "[serial]")
 {
+#if defined(__INTEL_COMPILER)
+#pragma warning(disable : 2282)
+#endif
     /*
      * clang also understands these pragmas.
      */
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     /*
      * First test: No premature flushes through destructor when another copy
      * is still around
@@ -461,7 +466,12 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
          */
         series_ptr->flush();
     }
+#if defined(__INTEL_COMPILER)
+#pragma warning(disable : 2282)
+#endif
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 }
 
 void close_iteration_test(std::string file_ending)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -415,6 +415,11 @@ TEST_CASE("available_chunks_test_json", "[serial][json]")
 TEST_CASE("multiple_series_handles_test", "[serial]")
 {
     /*
+     * clang also understands these pragmas.
+     */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    /*
      * First test: No premature flushes through destructor when another copy
      * is still around
      */
@@ -456,6 +461,7 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
          */
         series_ptr->flush();
     }
+#pragma GCC diagnostic pop
 }
 
 void close_iteration_test(std::string file_ending)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -414,13 +414,10 @@ TEST_CASE("available_chunks_test_json", "[serial][json]")
 
 TEST_CASE("multiple_series_handles_test", "[serial]")
 {
-#if defined(__INTEL_COMPILER)
-#pragma warning(disable : 2282)
-#endif
     /*
      * clang also understands these pragmas.
      */
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__MINOR__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -469,7 +466,7 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
 #if defined(__INTEL_COMPILER)
 #pragma warning(disable : 2282)
 #endif
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__MINOR__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 }


### PR DESCRIPTION
1. Compile warnings in Attribute.hpp:
    g++ 11 does not understand that these variables are not primitive types
    and complains about possibly uninitialized values. Use the {}
    constructor to fix this.
2. We still had two instances of AccessType in the tests, replace this with Access
