### PR TITLE
Clearly fail when users select a wrong backend

### DIFF
--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -53,6 +53,7 @@ namespace
                 "backend '" +
                 backendName + "'.");
         }
+        throw "Unreachable";
     }
 } // namespace
 

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1296,3 +1296,108 @@ TEST_CASE("DoConvert_single_value_to_vector", "[core]")
             std::vector<int>{0, 1, 2, 3, 4, 5, 6});
     }
 }
+
+TEST_CASE("unavailable_backend", "[core]")
+{
+#if !openPMD_HAVE_ADIOS1
+    {
+        auto fail = []() {
+            Series("unavailable.bp", Access::CREATE, "backend = \"ADIOS1\"");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS1'.");
+    }
+#endif
+#if !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() {
+            Series("unavailable.bp", Access::CREATE, "backend = \"ADIOS2\"");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+#if !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() { Series("unavailable.bp", Access::CREATE); };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+#if !openPMD_HAVE_HDF5
+    {
+        auto fail = []() {
+            Series("unavailable.h5", Access::CREATE, "backend = \"HDF5\"");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'HDF5'.");
+    }
+#endif
+
+#if openPMD_HAVE_MPI
+#if !openPMD_HAVE_ADIOS1
+    {
+        auto fail = []() {
+            Series(
+                "unavailable.bp",
+                Access::CREATE,
+                MPI_COMM_WORLD,
+                "backend = \"ADIOS1\"");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS1'.");
+    }
+#endif
+#if !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() {
+            Series(
+                "unavailable.bp",
+                Access::CREATE,
+                MPI_COMM_WORLD,
+                "backend = \"ADIOS2\"");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+#if !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() {
+            Series("unavailable.bp", Access::CREATE, MPI_COMM_WORLD);
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+#if !openPMD_HAVE_HDF5
+    {
+        auto fail = []() {
+            Series(
+                "unavailable.h5",
+                Access::CREATE,
+                MPI_COMM_WORLD,
+                "backend = \"HDF5\"");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'HDF5'.");
+    }
+#endif
+#endif
+}

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1302,7 +1302,7 @@ TEST_CASE("unavailable_backend", "[core]")
 #if !openPMD_HAVE_ADIOS1
     {
         auto fail = []() {
-            Series("unavailable.bp", Access::CREATE, "backend = \"ADIOS1\"");
+            Series("unavailable.bp", Access::CREATE, R"({"backend": "ADIOS1"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),
@@ -1313,7 +1313,7 @@ TEST_CASE("unavailable_backend", "[core]")
 #if !openPMD_HAVE_ADIOS2
     {
         auto fail = []() {
-            Series("unavailable.bp", Access::CREATE, "backend = \"ADIOS2\"");
+            Series("unavailable.bp", Access::CREATE, R"({"backend": "ADIOS2"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),
@@ -1333,7 +1333,7 @@ TEST_CASE("unavailable_backend", "[core]")
 #if !openPMD_HAVE_HDF5
     {
         auto fail = []() {
-            Series("unavailable.h5", Access::CREATE, "backend = \"HDF5\"");
+            Series("unavailable.h5", Access::CREATE, R"({"backend": "HDF5"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),
@@ -1350,7 +1350,7 @@ TEST_CASE("unavailable_backend", "[core]")
                 "unavailable.bp",
                 Access::CREATE,
                 MPI_COMM_WORLD,
-                "backend = \"ADIOS1\"");
+                R"({"backend": "ADIOS1"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),
@@ -1365,7 +1365,7 @@ TEST_CASE("unavailable_backend", "[core]")
                 "unavailable.bp",
                 Access::CREATE,
                 MPI_COMM_WORLD,
-                "backend = \"ADIOS2\"");
+                R"({"backend": "ADIOS2"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),
@@ -1391,7 +1391,7 @@ TEST_CASE("unavailable_backend", "[core]")
                 "unavailable.h5",
                 Access::CREATE,
                 MPI_COMM_WORLD,
-                "backend = \"HDF5\"");
+                R"({"backend": "HDF5"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1302,7 +1302,8 @@ TEST_CASE("unavailable_backend", "[core]")
 #if !openPMD_HAVE_ADIOS1
     {
         auto fail = []() {
-            Series("unavailable.bp", Access::CREATE, R"({"backend": "ADIOS1"})");
+            Series(
+                "unavailable.bp", Access::CREATE, R"({"backend": "ADIOS1"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),
@@ -1313,7 +1314,8 @@ TEST_CASE("unavailable_backend", "[core]")
 #if !openPMD_HAVE_ADIOS2
     {
         auto fail = []() {
-            Series("unavailable.bp", Access::CREATE, R"({"backend": "ADIOS2"})");
+            Series(
+                "unavailable.bp", Access::CREATE, R"({"backend": "ADIOS2"})");
         };
         REQUIRE_THROWS_WITH(
             fail(),


### PR DESCRIPTION
Original issue: https://github.com/ComputationalRadiationPhysics/picongpu/issues/4004

When selecting a wrong backend, it might currently happen that openPMD activates a dummy backend, resulting in error messages like
```
[~Series] An error occurred: [Series] Closed iteration has not been written. This is an internal error.
Unhandled exception of type 'St13runtime_error' with message '[Series] Closed iteration has not been written. This is an internal error.', terminating
```

This fixes that