### PR TITLE
Fixes for BP5 engine

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -1075,9 +1075,15 @@ namespace detail
          * @brief Begin or end an ADIOS step.
          *
          * @param mode Whether to begin or end a step.
+         * @param calledExplicitly True if called due to a public API call.
+         *     False if called from requireActiveStep.
+         *     Some engines (BP5) require that every interaction happens within
+         *     an active step, meaning that we need to call advance()
+         *     implicitly at times. When doing that, do not tag the dataset
+         *     with __openPMD_internal/useSteps (yet).
          * @return AdvanceStatus
          */
-        AdvanceStatus advance(AdvanceMode mode);
+        AdvanceStatus advance(AdvanceMode mode, bool calledExplicitly);
 
         /*
          * Delete all buffered actions without running them.
@@ -1201,7 +1207,6 @@ namespace detail
             Undecided
         };
         StreamStatus streamStatus = StreamStatus::OutsideOfStep;
-        adios2::StepStatus m_lastStepStatus = adios2::StepStatus::OK;
 
         /**
          * See documentation for StreamStatus::Parsing.

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -703,7 +703,7 @@ void ADIOS2IOHandlerImpl::getBufferView(
     Writable *writable, Parameter<Operation::GET_BUFFER_VIEW> &parameters)
 {
     // @todo check access mode
-    if (m_engineType != "bp4")
+    if (m_engineType != "bp4" && m_engineType != "bp5")
     {
         parameters.out->backendManagedBuffer = false;
         return;

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5145,6 +5145,21 @@ TEST_CASE("iterate_nonstreaming_series", "[serial][adios2]")
                 backend.extension,
             false,
             backend.jsonBaseConfig());
+        if (backend.extension == "bp")
+        {
+            iterate_nonstreaming_series(
+                "../samples/iterate_nonstreaming_series_filebased_bp5_%T." +
+                    backend.extension,
+                false,
+                json::merge(
+                    backend.jsonBaseConfig(), "adios2.engine = \"bp5\""));
+            iterate_nonstreaming_series(
+                "../samples/iterate_nonstreaming_series_groupbased_bp5." +
+                    backend.extension,
+                false,
+                json::merge(
+                    backend.jsonBaseConfig(), "adios2.engine = \"bp5\""));
+        }
     }
 #if openPMD_HAVE_ADIOS2
     iterate_nonstreaming_series(

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5145,6 +5145,10 @@ TEST_CASE("iterate_nonstreaming_series", "[serial][adios2]")
                 backend.extension,
             false,
             backend.jsonBaseConfig());
+#if openPMD_HAVE_ADIOS2 &&                                                     \
+    ADIOS2_VERSION_MAJOR * 1000000000 + ADIOS2_VERSION_MINOR * 100000000 +     \
+            ADIOS2_VERSION_PATCH * 1000000 + ADIOS2_VERSION_TWEAK >=           \
+        2701001223
         if (backend.extension == "bp")
         {
             iterate_nonstreaming_series(
@@ -5160,6 +5164,7 @@ TEST_CASE("iterate_nonstreaming_series", "[serial][adios2]")
                 json::merge(
                     backend.jsonBaseConfig(), "adios2.engine = \"bp5\""));
         }
+#endif
     }
 #if openPMD_HAVE_ADIOS2
     iterate_nonstreaming_series(


### PR DESCRIPTION
1. See [this comment](https://github.com/ornladios/ADIOS2/issues/2649#issuecomment-1058095101), the Span-based API is still very much relevant for performance in BP5.
2. The BP5 engine requires that every interaction with it happens inside an active IO step, take care of this
