### PR TITLE
ADIOS2: more fine-grained control for file endings

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -52,7 +52,7 @@ jobs:
         python3 -m pip install -U numpy
         sudo .github/workflows/dependencies/install_spack
     - name: Build
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
+      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100, SKIP_ADIOS2_FILE_ENDINGS_TEST: 0}
       run: |
         eval $(spack env activate --sh .github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad1_ad2/)
         spack install

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -52,7 +52,7 @@ jobs:
         python3 -m pip install -U numpy
         sudo .github/workflows/dependencies/install_spack
     - name: Build
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100, SKIP_ADIOS2_FILE_ENDINGS_TEST: 0}
+      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-10, OMPI_CXX: clang++-10, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
       run: |
         eval $(spack env activate --sh .github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad1_ad2/)
         spack install

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -10,12 +10,43 @@ For further information, check out the :ref:`installation guide <install>`,
 :ref:`build dependencies <development-dependencies>` and the :ref:`build options <development-buildoptions>`.
 
 
-I/O Method
-----------
+I/O Method and Engine Selection
+-------------------------------
 
 ADIOS2 has several engines for alternative file formats and other kinds of backends, yet natively writes to ``.bp`` files.
-The openPMD API uses the BP4 engine as the default file engine and the SST engine for streaming support.
-We currently leverage the default ADIOS2 transport parameters, i.e. ``POSIX`` on Unix systems and ``FStream`` on Windows.
+The openPMD API uses the File meta engine as the default file engine and the SST engine for streaming support.
+
+The ADIOS2 engine can be selected in different ways:
+
+1. Automatic detection via the selected file ending
+2. Explicit selection of an engine by specifying the environment variable ``OPENPMD_ADIOS2_ENGINE`` (case-independent).
+   This overrides the automatically detected engine.
+3. Explicit selection of an engine by specifying the JSON/TOML key ``adios2.engine.type`` as a case-independent string.
+   This overrides both previous options.
+
+Automatic engine detection supports the following extensions:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Extension
+     - Selected ADIOS2 Engine
+   * - ``.bp``
+     - ``"file"``
+   * - ``.bp4``
+     - ``"bp4"``
+   * - ``.bp5``
+     - ``"bp5"``
+   * - ``.sst``
+     - ``"sst"``
+   * - ``.ssc``
+     - ``"ssc"``
+
+Specifying any of these extensions will automatically activate the ADIOS2 backend.
+The ADIOS2 backend will create file system paths exactly as they were specified and not change file extensions.
+Exceptions to this are the BP3 and SST engines which require their endings ``.bp`` and ``.sst`` respectively.
+
+For file engines, we currently leverage the default ADIOS2 transport parameters, i.e. ``POSIX`` on Unix systems and ``FStream`` on Windows.
 
 Steps
 -----

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -132,12 +132,16 @@ public:
         AbstractIOHandler *,
         MPI_Comm,
         json::TracingJSON config,
-        std::string engineType);
+        std::string engineType,
+        std::string specifiedExtension);
 
 #endif // openPMD_HAVE_MPI
 
     explicit ADIOS2IOHandlerImpl(
-        AbstractIOHandler *, json::TracingJSON config, std::string engineType);
+        AbstractIOHandler *,
+        json::TracingJSON config,
+        std::string engineType,
+        std::string specifiedExtension);
 
     ~ADIOS2IOHandlerImpl() override;
 
@@ -231,6 +235,11 @@ private:
      * The ADIOS2 engine type, to be passed to adios2::IO::SetEngine
      */
     std::string m_engineType;
+    /*
+     * The filename extension specified by the user.
+     */
+    std::string m_userSpecifiedExtension;
+
     ADIOS2Schema::schema_t m_schema = ADIOS2Schema::schema_0000_00_00;
 
     enum class UseSpan : char
@@ -1320,7 +1329,8 @@ public:
         Access,
         MPI_Comm,
         json::TracingJSON options,
-        std::string engineType);
+        std::string engineType,
+        std::string specifiedExtension);
 
 #endif
 
@@ -1328,7 +1338,8 @@ public:
         std::string path,
         Access,
         json::TracingJSON options,
-        std::string engineType);
+        std::string engineType,
+        std::string specifiedExtension);
 
     std::string backendName() const override
     {

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -35,6 +35,8 @@ namespace openPMD
  * @param   access      Access mode describing desired operations and
  permissions of the desired handler.
  * @param   format      Format describing the IO backend of the desired handler.
+ * @param   originalExtension The filename extension as it was originally
+ *                            specified by the user.
  * @param   comm        MPI communicator used for IO.
  * @param   options     JSON-formatted option string, to be interpreted by
  *                      the backend.
@@ -47,6 +49,7 @@ std::shared_ptr<AbstractIOHandler> createIOHandler(
     std::string path,
     Access access,
     Format format,
+    std::string originalExtension,
     MPI_Comm comm,
     JSON options);
 #endif
@@ -58,6 +61,8 @@ std::shared_ptr<AbstractIOHandler> createIOHandler(
  * @param   access      Access describing desired operations and permissions
  * of the desired handler.
  * @param   format      Format describing the IO backend of the desired handler.
+ * @param   originalExtension The filename extension as it was originally
+ *                            specified by the user.
  * @param   options     JSON-formatted option string, to be interpreted by
  *                      the backend.
  * @tparam  JSON        Substitute for nlohmann::json. Templated to avoid
@@ -66,9 +71,16 @@ std::shared_ptr<AbstractIOHandler> createIOHandler(
  */
 template <typename JSON>
 std::shared_ptr<AbstractIOHandler> createIOHandler(
-    std::string path, Access access, Format format, JSON options = JSON());
+    std::string path,
+    Access access,
+    Format format,
+    std::string originalExtension,
+    JSON options = JSON());
 
 // version without configuration to use in AuxiliaryTest
-std::shared_ptr<AbstractIOHandler>
-createIOHandler(std::string path, Access access, Format format);
+std::shared_ptr<AbstractIOHandler> createIOHandler(
+    std::string path,
+    Access access,
+    Format format,
+    std::string originalExtension);
 } // namespace openPMD

--- a/include/openPMD/IO/Format.hpp
+++ b/include/openPMD/IO/Format.hpp
@@ -30,7 +30,9 @@ enum class Format
 {
     HDF5,
     ADIOS1,
-    ADIOS2,
+    ADIOS2_BP,
+    ADIOS2_BP4,
+    ADIOS2_BP5,
     ADIOS2_SST,
     ADIOS2_SSC,
     JSON,

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -109,6 +109,11 @@ namespace internal
          */
         std::string m_filenamePostfix;
         /**
+         * Filename extension as specified by the user.
+         * (Not necessarily the backend's default suffix)
+         */
+        std::string m_filenameExtension;
+        /**
          * The padding in file-based iteration encoding.
          * 0 if no padding is given (%T pattern).
          * -1 if no expansion pattern has been parsed.

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -45,7 +45,7 @@ Format determineFormat(std::string const &filename)
         );
 
         if (bp_backend == "ADIOS2")
-            return Format::ADIOS2;
+            return Format::ADIOS2_BP;
         else if (bp_backend == "ADIOS1")
             return Format::ADIOS1;
         else
@@ -54,6 +54,10 @@ Format determineFormat(std::string const &filename)
                 "neither ADIOS1 nor ADIOS2: " +
                 bp_backend);
     }
+    if (auxiliary::ends_with(filename, ".bp4"))
+        return Format::ADIOS2_BP4;
+    if (auxiliary::ends_with(filename, ".bp5"))
+        return Format::ADIOS2_BP5;
     if (auxiliary::ends_with(filename, ".sst"))
         return Format::ADIOS2_SST;
     if (auxiliary::ends_with(filename, ".ssc"))
@@ -72,8 +76,12 @@ std::string suffix(Format f)
     case Format::HDF5:
         return ".h5";
     case Format::ADIOS1:
-    case Format::ADIOS2:
+    case Format::ADIOS2_BP:
         return ".bp";
+    case Format::ADIOS2_BP4:
+        return ".bp4";
+    case Format::ADIOS2_BP5:
+        return ".bp5";
     case Format::ADIOS2_SST:
         return ".sst";
     case Format::ADIOS2_SSC:

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -124,6 +124,14 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
 
 void ADIOS2IOHandlerImpl::init(json::TracingJSON cfg)
 {
+    // allow overriding through environment variable
+    m_engineType =
+        auxiliary::getEnvString("OPENPMD_ADIOS2_ENGINE", m_engineType);
+    std::transform(
+        m_engineType.begin(),
+        m_engineType.end(),
+        m_engineType.begin(),
+        [](unsigned char c) { return std::tolower(c); });
     if (cfg.json().contains("adios2"))
     {
         m_config = cfg["adios2"];
@@ -152,6 +160,7 @@ void ADIOS2IOHandlerImpl::init(json::TracingJSON cfg)
                     json::asLowerCaseStringDynamic(engineTypeConfig);
                 if (maybeEngine.has_value())
                 {
+                    // override engine type by JSON/TOML configuration
                     m_engineType = std::move(maybeEngine.value());
                 }
                 else
@@ -2352,15 +2361,6 @@ namespace detail
         // set engine type
         bool isStreaming = false;
         {
-            // allow overriding through environment variable
-            m_engineType =
-                auxiliary::getEnvString("OPENPMD_ADIOS2_ENGINE", m_engineType);
-            std::transform(
-                m_engineType.begin(),
-                m_engineType.end(),
-                m_engineType.begin(),
-                [](unsigned char c) { return std::tolower(c); });
-            impl.m_engineType = this->m_engineType;
             m_IO.SetEngine(m_engineType);
             auto it = streamingEngines.find(m_engineType);
             if (it != streamingEngines.end())

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -63,6 +63,7 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     std::string path,
     Access access,
     Format format,
+    std::string /* filenameExtension */,
     MPI_Comm comm,
     json::TracingJSON options)
 {
@@ -75,9 +76,11 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     case Format::ADIOS1:
         return constructIOHandler<ParallelADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options), comm);
-    case Format::ADIOS2:
+    case Format::ADIOS2_BP:
+    case Format::ADIOS2_BP4:
+    case Format::ADIOS2_BP5:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, comm, std::move(options), "bp4");
+            "ADIOS2", path, access, comm, std::move(options), "file");
     case Format::ADIOS2_SST:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
             "ADIOS2", path, access, comm, std::move(options), "sst");
@@ -93,7 +96,11 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
 
 template <>
 std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
-    std::string path, Access access, Format format, json::TracingJSON options)
+    std::string path,
+    Access access,
+    Format format,
+    std::string /* filenameExtension */,
+    json::TracingJSON options)
 {
     (void)options;
     switch (format)
@@ -104,9 +111,11 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     case Format::ADIOS1:
         return constructIOHandler<ADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options));
-    case Format::ADIOS2:
+    case Format::ADIOS2_BP:
+    case Format::ADIOS2_BP4:
+    case Format::ADIOS2_BP5:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, std::move(options), "bp4");
+            "ADIOS2", path, access, std::move(options), "file");
     case Format::ADIOS2_SST:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
             "ADIOS2", path, access, std::move(options), "sst");
@@ -122,13 +131,17 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     }
 }
 
-std::shared_ptr<AbstractIOHandler>
-createIOHandler(std::string path, Access access, Format format)
+std::shared_ptr<AbstractIOHandler> createIOHandler(
+    std::string path,
+    Access access,
+    Format format,
+    std::string originalExtension)
 {
     return createIOHandler(
         std::move(path),
         access,
         format,
+        std::move(originalExtension),
         json::TracingJSON(json::ParsedConfig{}));
 }
 } // namespace openPMD

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -63,7 +63,8 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     std::string path,
     Access access,
     Format format,
-    std::string /* filenameExtension */,
+    std::string originalExtension,
+
     MPI_Comm comm,
     json::TracingJSON options)
 {
@@ -77,16 +78,50 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<ParallelADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options), comm);
     case Format::ADIOS2_BP:
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2",
+            path,
+            access,
+            comm,
+            std::move(options),
+            "file",
+            std::move(originalExtension));
     case Format::ADIOS2_BP4:
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2",
+            path,
+            access,
+            comm,
+            std::move(options),
+            "bp4",
+            std::move(originalExtension));
     case Format::ADIOS2_BP5:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, comm, std::move(options), "file");
+            "ADIOS2",
+            path,
+            access,
+            comm,
+            std::move(options),
+            "bp5",
+            std::move(originalExtension));
     case Format::ADIOS2_SST:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, comm, std::move(options), "sst");
+            "ADIOS2",
+            path,
+            access,
+            comm,
+            std::move(options),
+            "sst",
+            std::move(originalExtension));
     case Format::ADIOS2_SSC:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, comm, std::move(options), "ssc");
+            "ADIOS2",
+            path,
+            access,
+            comm,
+            std::move(options),
+            "ssc",
+            std::move(originalExtension));
     default:
         throw std::runtime_error(
             "Unknown file format! Did you specify a file ending?");
@@ -99,7 +134,7 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     std::string path,
     Access access,
     Format format,
-    std::string /* filenameExtension */,
+    std::string originalExtension,
     json::TracingJSON options)
 {
     (void)options;
@@ -112,16 +147,45 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<ADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options));
     case Format::ADIOS2_BP:
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2",
+            path,
+            access,
+            std::move(options),
+            "file",
+            std::move(originalExtension));
     case Format::ADIOS2_BP4:
+        return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
+            "ADIOS2",
+            path,
+            access,
+            std::move(options),
+            "bp4",
+            std::move(originalExtension));
     case Format::ADIOS2_BP5:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, std::move(options), "file");
+            "ADIOS2",
+            path,
+            access,
+            std::move(options),
+            "bp5",
+            std::move(originalExtension));
     case Format::ADIOS2_SST:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, std::move(options), "sst");
+            "ADIOS2",
+            path,
+            access,
+            std::move(options),
+            "sst",
+            std::move(originalExtension));
     case Format::ADIOS2_SSC:
         return constructIOHandler<ADIOS2IOHandler, openPMD_HAVE_ADIOS2>(
-            "ADIOS2", path, access, std::move(options), "ssc");
+            "ADIOS2",
+            path,
+            access,
+            std::move(options),
+            "ssc",
+            std::move(originalExtension));
     case Format::JSON:
         return constructIOHandler<JSONIOHandler, openPMD_HAVE_JSON>(
             "JSON", path, access);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -45,6 +45,13 @@ std::vector<std::string> openPMD::getFileExtensions()
 #if openPMD_HAVE_ADIOS1 || openPMD_HAVE_ADIOS2
     fext.emplace_back("bp");
 #endif
+#if openPMD_HAVE_ADIOS2
+    // BP4 is always available in ADIOS2
+    fext.emplace_back("bp4");
+#endif
+#ifdef ADIOS2_HAVE_BP5
+    fext.emplace_back("bp5");
+#endif
 #ifdef ADIOS2_HAVE_SST
     fext.emplace_back("sst");
 #endif

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -34,7 +34,7 @@ struct TestHelper : public Attributable
     TestHelper()
     {
         writable().IOHandler =
-            createIOHandler(".", Access::CREATE, Format::JSON);
+            createIOHandler(".", Access::CREATE, Format::JSON, ".json");
     }
 };
 } // namespace openPMD::test
@@ -146,7 +146,8 @@ TEST_CASE("container_default_test", "[auxiliary]")
 {
 #if openPMD_USE_INVASIVE_TESTS
     Container<openPMD::test::S> c = Container<openPMD::test::S>();
-    c.writable().IOHandler = createIOHandler(".", Access::CREATE, Format::JSON);
+    c.writable().IOHandler =
+        createIOHandler(".", Access::CREATE, Format::JSON, ".json");
 
     REQUIRE(c.empty());
     REQUIRE(c.erase("nonExistentKey") == false);
@@ -183,7 +184,8 @@ TEST_CASE("container_retrieve_test", "[auxiliary]")
 #if openPMD_USE_INVASIVE_TESTS
     using structure = openPMD::test::structure;
     Container<structure> c = Container<structure>();
-    c.writable().IOHandler = createIOHandler(".", Access::CREATE, Format::JSON);
+    c.writable().IOHandler =
+        createIOHandler(".", Access::CREATE, Format::JSON, ".json");
 
     structure s;
     std::string text =
@@ -255,7 +257,8 @@ TEST_CASE("container_access_test", "[auxiliary]")
 #if openPMD_USE_INVASIVE_TESTS
     using Widget = openPMD::test::Widget;
     Container<Widget> c = Container<Widget>();
-    c.writable().IOHandler = createIOHandler(".", Access::CREATE, Format::JSON);
+    c.writable().IOHandler =
+        createIOHandler(".", Access::CREATE, Format::JSON, ".json");
 
     c["1firstWidget"] = Widget(0);
     REQUIRE(c.size() == 1);

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1074,12 +1074,24 @@ TEST_CASE("backend_via_json", "[core]")
          * BP4 engine should be selected even if ending .sst is given
          */
         Series series(
-            "../samples/optionsViaJsonOverwritesAutomaticDetection.sst",
+            "../samples/optionsViaJsonOverwritesAutomaticDetectionFile.sst",
+            Access::CREATE,
+            R"({"adios2": {"engine": {"type": "file"}}})");
+    }
+    REQUIRE(auxiliary::directory_exists(
+        "../samples/optionsViaJsonOverwritesAutomaticDetectionFile.sst"));
+
+    {
+        /*
+         * BP4 engine should be selected even if ending .sst is given
+         */
+        Series series(
+            "../samples/optionsViaJsonOverwritesAutomaticDetectionBp4.sst",
             Access::CREATE,
             R"({"adios2": {"engine": {"type": "bp4"}}})");
     }
     REQUIRE(auxiliary::directory_exists(
-        "../samples/optionsViaJsonOverwritesAutomaticDetection.bp"));
+        "../samples/optionsViaJsonOverwritesAutomaticDetectionBp4.sst"));
 
 #if openPMD_HAVE_ADIOS1
     setenv("OPENPMD_BP_BACKEND", "ADIOS1", 1);

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1066,7 +1066,10 @@ void adios2_streaming(bool variableBasedLayout)
     if (rank == 0)
     {
         // write
-        Series writeSeries("../samples/adios2_stream.sst", Access::CREATE);
+        Series writeSeries(
+            "../samples/adios2_stream.sst",
+            Access::CREATE,
+            "adios2.engine.type = \"sst\"");
         if (variableBasedLayout)
         {
             writeSeries.setIterationEncoding(IterationEncoding::variableBased);
@@ -1109,7 +1112,8 @@ void adios2_streaming(bool variableBasedLayout)
         Series readSeries(
             "../samples/adios2_stream.sst",
             Access::READ_ONLY,
-            "defer_iteration_parsing = true"); // inline TOML
+            // inline TOML
+            R"(defer_iteration_parsing = true)");
 
         size_t last_iteration_index = 0;
         for (auto iteration : readSeries.readIterations())

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4237,6 +4237,12 @@ BufferChunkSize = 2147483646 # 2^31 - 2
 
 TEST_CASE("adios2_engines_and_file_endings")
 {
+    if (auxiliary::getEnvNum("SKIP_ADIOS2_FILE_ENDINGS_TEST", 0) != 0)
+    {
+        std::cout << "SKIPPING TEST adios2_engines_and_file_endings"
+                  << std::endl;
+        return;
+    }
     size_t filenameCounter = 0;
     auto groupbased_test_explicit_backend =
         [&filenameCounter](
@@ -4250,6 +4256,8 @@ TEST_CASE("adios2_engines_and_file_endings")
             auto basename = "../samples/file_endings/groupbased" +
                 std::to_string(filenameCounter++);
             auto name = basename + ext;
+            std::cout << "Writing to file '" << name << "', should be engine "
+                      << requiredEngine << " (explicit backend)." << std::endl;
             auto filesystemname =
                 filesystemExt.empty() ? name : basename + filesystemExt;
             {
@@ -4315,6 +4323,9 @@ TEST_CASE("adios2_engines_and_file_endings")
             auto basename = "../samples/file_endings/groupbased" +
                 std::to_string(filenameCounter++);
             auto name = basename + ext;
+            std::cout << "Writing to file '" << name << "', should be engine "
+                      << requiredEngine << " (no explicit backend)."
+                      << std::endl;
             auto filesystemname =
                 filesystemExt.empty() ? name : basename + filesystemExt;
             {
@@ -4383,6 +4394,8 @@ TEST_CASE("adios2_engines_and_file_endings")
             auto basename = "../samples/file_endings/filebased" +
                 std::to_string(filenameCounter++);
             auto name = basename + "_%T" + ext;
+            std::cout << "Writing to file '" << name << "', should be engine "
+                      << requiredEngine << " (explicit backend)." << std::endl;
             auto filesystemname =
                 basename + "_0" + (filesystemExt.empty() ? ext : filesystemExt);
             {
@@ -4459,6 +4472,9 @@ TEST_CASE("adios2_engines_and_file_endings")
             auto basename = "../samples/file_endings/filebased" +
                 std::to_string(filenameCounter++);
             auto name = basename + "_%T" + ext;
+            std::cout << "Writing to file '" << name << "', should be engine "
+                      << requiredEngine << " (no explicit backend)."
+                      << std::endl;
             auto filesystemname =
                 basename + "_0" + (filesystemExt.empty() ? ext : filesystemExt);
             {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -55,7 +55,10 @@ std::vector<BackendSelection> testedBackends()
 {
     auto variants = getVariants();
     std::map<std::string, std::string> extensions{
-        {"json", "json"}, {"adios1", "bp1"}, {"adios2", "bp"}, {"hdf5", "h5"}};
+        {"json", "json"},
+        {"adios1", "adios1.bp"},
+        {"adios2", "bp"},
+        {"hdf5", "h5"}};
     std::vector<BackendSelection> res;
     for (auto const &pair : variants)
     {
@@ -77,7 +80,9 @@ std::vector<std::string> testedFileExtensions()
     auto allExtensions = getFileExtensions();
     auto newEnd = std::remove_if(
         allExtensions.begin(), allExtensions.end(), [](std::string const &ext) {
-            return ext == "sst" || ext == "ssc";
+            // sst and ssc need a receiver for testing
+            // bp4 is already tested via bp
+            return ext == "sst" || ext == "ssc" || ext == "bp4";
         });
     return {allExtensions.begin(), newEnd};
 }
@@ -279,6 +284,10 @@ TEST_CASE("write_and_read_many_iterations", "[serial]")
         auxiliary::remove_directory("../samples/many_iterations");
     for (auto const &t : testedFileExtensions())
     {
+        if (t == "bp4" || t == "bp5")
+        {
+            continue;
+        }
         write_and_read_many_iterations(t, intermittentFlushes);
         intermittentFlushes = !intermittentFlushes;
     }
@@ -1484,7 +1493,9 @@ inline void dtype_test(const std::string &backend)
 TEST_CASE("dtype_test", "[serial]")
 {
     for (auto const &t : testedFileExtensions())
+    {
         dtype_test(t);
+    }
 }
 
 inline void write_test(const std::string &backend)
@@ -1604,7 +1615,8 @@ void test_complex(const std::string &backend)
             "../samples/serial_write_complex." + backend, Access::CREATE);
         o.setAttribute("lifeIsComplex", std::complex<double>(4.56, 7.89));
         o.setAttribute("butComplexFloats", std::complex<float>(42.3, -99.3));
-        if (backend != "bp")
+        if (o.backend() != "ADIOS2" && o.backend() != "ADIOS1" &&
+            o.backend() != "MPI_ADIOS1")
             o.setAttribute(
                 "longDoublesYouSay", std::complex<long double>(5.5, -4.55));
 
@@ -1625,7 +1637,8 @@ void test_complex(const std::string &backend)
         Cdbl.storeChunk(cdoubles, {0});
 
         std::vector<std::complex<long double> > cldoubles(3);
-        if (backend != "bp")
+        if (o.backend() != "ADIOS2" && o.backend() != "ADIOS1" &&
+            o.backend() != "MPI_ADIOS1")
         {
             auto Cldbl =
                 o.iterations[0].meshes["Cldbl"][RecordComponent::SCALAR];
@@ -1649,7 +1662,8 @@ void test_complex(const std::string &backend)
         REQUIRE(
             i.getAttribute("butComplexFloats").get<std::complex<float> >() ==
             std::complex<float>(42.3, -99.3));
-        if (backend != "bp")
+        if (i.backend() != "ADIOS2" && i.backend() != "ADIOS1" &&
+            i.backend() != "MPI_ADIOS1")
         {
             REQUIRE(
                 i.getAttribute("longDoublesYouSay")
@@ -1668,7 +1682,8 @@ void test_complex(const std::string &backend)
         REQUIRE(rcflt.get()[1] == std::complex<float>(-3., 4.));
         REQUIRE(rcdbl.get()[2] == std::complex<double>(6, -5.));
 
-        if (backend != "bp")
+        if (i.backend() != "ADIOS2" && i.backend() != "ADIOS1" &&
+            i.backend() != "MPI_ADIOS1")
         {
             auto rcldbl = i.iterations[0]
                               .meshes["Cldbl"][RecordComponent::SCALAR]
@@ -2176,8 +2191,8 @@ inline void bool_test(const std::string &backend)
         Series o = Series("../samples/serial_bool." + backend, Access::CREATE);
 
         REQUIRE_THROWS_AS(o.setAuthor(""), std::runtime_error);
-        o.setAttribute("Bool attribute (true)", true);
-        o.setAttribute("Bool attribute (false)", false);
+        o.setAttribute("Bool attribute true", true);
+        o.setAttribute("Bool attribute false", false);
     }
     {
         Series o =
@@ -2185,13 +2200,12 @@ inline void bool_test(const std::string &backend)
 
         auto attrs = o.attributes();
         REQUIRE(
-            std::count(attrs.begin(), attrs.end(), "Bool attribute (true)") ==
-            1);
+            std::count(attrs.begin(), attrs.end(), "Bool attribute true") == 1);
         REQUIRE(
-            std::count(attrs.begin(), attrs.end(), "Bool attribute (false)") ==
+            std::count(attrs.begin(), attrs.end(), "Bool attribute false") ==
             1);
-        REQUIRE(o.getAttribute("Bool attribute (true)").get<bool>() == true);
-        REQUIRE(o.getAttribute("Bool attribute (false)").get<bool>() == false);
+        REQUIRE(o.getAttribute("Bool attribute true").get<bool>() == true);
+        REQUIRE(o.getAttribute("Bool attribute false").get<bool>() == false);
     }
     {
         Series list{"../samples/serial_bool." + backend, Access::READ_ONLY};
@@ -4221,6 +4235,299 @@ BufferChunkSize = 2147483646 # 2^31 - 2
 }
 #endif
 
+TEST_CASE("adios2_engines_and_file_endings")
+{
+    size_t filenameCounter = 0;
+    auto groupbased_test_explicit_backend =
+        [&filenameCounter](
+            std::string const &ext,
+            bool directory,
+            std::string const &requiredEngine,
+            std::string const &filesystemExt,
+            std::string const &jsonCfg = "{}") mutable {
+            // Env. var. OPENPMD_BP_BACKEND does not matter for this test as
+            // we always override it in the JSON config
+            auto basename = "../samples/file_endings/groupbased" +
+                std::to_string(filenameCounter++);
+            auto name = basename + ext;
+            auto filesystemname =
+                filesystemExt.empty() ? name : basename + filesystemExt;
+            {
+                Series write(
+                    name,
+                    Access::CREATE,
+                    json::merge("backend = \"adios2\"", jsonCfg));
+            }
+            if (directory)
+            {
+                REQUIRE(auxiliary::directory_exists(filesystemname));
+            }
+            else
+            {
+                REQUIRE(auxiliary::file_exists(filesystemname));
+            }
+            {
+                Series read(
+                    name,
+                    Access::READ_ONLY,
+                    "backend = \"adios2\"\nadios2.engine.type = \"" +
+                        requiredEngine + "\"");
+            }
+        };
+
+    groupbased_test_explicit_backend(".bp", true, "file", "");
+    groupbased_test_explicit_backend(".bp4", true, "bp4", "");
+    groupbased_test_explicit_backend(
+        ".bp", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    groupbased_test_explicit_backend(
+        ".bp4", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    groupbased_test_explicit_backend(
+        ".bp5", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    groupbased_test_explicit_backend(
+        ".bp", false, "bp3", "", "adios2.engine.type = \"bp3\"");
+    groupbased_test_explicit_backend(
+        ".sst", false, "bp3", ".sst.bp", "adios2.engine.type = \"bp3\"");
+    groupbased_test_explicit_backend(
+        "", false, "bp3", ".bp", "adios2.engine.type = \"bp3\"");
+    groupbased_test_explicit_backend(
+        "", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+
+#ifdef ADIOS2_HAVE_BP5
+    // BP5 tests
+    groupbased_test_explicit_backend(".bp5", true, "bp5", "");
+    groupbased_test_explicit_backend(
+        ".bp", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    groupbased_test_explicit_backend(
+        ".bp4", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    groupbased_test_explicit_backend(
+        ".bp5", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    groupbased_test_explicit_backend(
+        "", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+#endif
+
+    auto groupbased_test_no_explicit_backend =
+        [&filenameCounter](
+            std::string const &ext,
+            bool directory,
+            std::string const &requiredEngine,
+            std::string const &filesystemExt,
+            std::string const &jsonCfg = "{}") mutable {
+            auto basename = "../samples/file_endings/groupbased" +
+                std::to_string(filenameCounter++);
+            auto name = basename + ext;
+            auto filesystemname =
+                filesystemExt.empty() ? name : basename + filesystemExt;
+            {
+                Series write(name, Access::CREATE, jsonCfg);
+            }
+            bool isThisADIOS1 =
+                auxiliary::getEnvString("OPENPMD_BP_BACKEND", "") == "ADIOS1" &&
+                ext == ".bp";
+            if (directory && !isThisADIOS1)
+            {
+                REQUIRE(auxiliary::directory_exists(filesystemname));
+            }
+            else
+            {
+                REQUIRE(auxiliary::file_exists(filesystemname));
+            }
+            {
+                Series read(
+                    name,
+                    Access::READ_ONLY,
+                    isThisADIOS1
+                        ? "backend = \"adios1\""
+                        : "backend = \"adios2\"\nadios2.engine.type = \"" +
+                            requiredEngine + "\"");
+            }
+        };
+
+    groupbased_test_no_explicit_backend(".bp", true, "file", "");
+    groupbased_test_no_explicit_backend(".bp4", true, "bp4", "");
+    groupbased_test_no_explicit_backend(
+        ".bp", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    groupbased_test_no_explicit_backend(
+        ".bp4", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    groupbased_test_no_explicit_backend(
+        ".bp5", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    groupbased_test_no_explicit_backend(
+        ".bp", false, "bp3", "", "adios2.engine.type = \"bp3\"");
+    groupbased_test_no_explicit_backend(
+        ".sst", false, "bp3", ".sst.bp", "adios2.engine.type = \"bp3\"");
+    REQUIRE_THROWS(groupbased_test_no_explicit_backend(
+        "", false, "bp3", ".bp", "adios2.engine.type = \"bp3\""));
+    REQUIRE_THROWS(groupbased_test_no_explicit_backend(
+        "", true, "bp4", "", "adios2.engine.type = \"bp4\""));
+
+#ifdef ADIOS2_HAVE_BP5
+    // BP5 tests
+    groupbased_test_no_explicit_backend(".bp5", true, "bp5", "");
+    groupbased_test_no_explicit_backend(
+        ".bp", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    groupbased_test_no_explicit_backend(
+        ".bp4", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    groupbased_test_no_explicit_backend(
+        ".bp5", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    REQUIRE_THROWS(groupbased_test_no_explicit_backend(
+        "", true, "bp5", "", "adios2.engine.type = \"bp5\""));
+#endif
+
+    filenameCounter = 0;
+    auto filebased_test_explicit_backend =
+        [&filenameCounter](
+            std::string const &ext,
+            bool directory,
+            std::string const &requiredEngine,
+            std::string const &filesystemExt,
+            std::string const &jsonCfg = "{}") mutable {
+            auto basename = "../samples/file_endings/filebased" +
+                std::to_string(filenameCounter++);
+            auto name = basename + "_%T" + ext;
+            auto filesystemname =
+                basename + "_0" + (filesystemExt.empty() ? ext : filesystemExt);
+            {
+                Series write(
+                    name,
+                    Access::CREATE,
+                    json::merge("backend = \"adios2\"", jsonCfg));
+                write.writeIterations()[0];
+            }
+            if (directory)
+            {
+                REQUIRE(auxiliary::directory_exists(filesystemname));
+            }
+            else
+            {
+                REQUIRE(auxiliary::file_exists(filesystemname));
+            }
+            {
+                if (requiredEngine == "bp3" &&
+                    !auxiliary::ends_with(name, ".bp"))
+                {
+                    /*
+                     * File-based parsing procedures are not aware that BP3
+                     * engine adds its ending and won't find the iterations if
+                     * we don't give it a little nudge.
+                     */
+                    name += ".bp";
+                }
+                Series read(
+                    name,
+                    Access::READ_ONLY,
+                    "backend = \"adios2\"\nadios2.engine.type = \"" +
+                        requiredEngine + "\"");
+            }
+        };
+
+    filebased_test_explicit_backend(".bp", true, "file", "");
+    filebased_test_explicit_backend(".bp4", true, "bp4", "");
+    filebased_test_explicit_backend(
+        ".bp", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    filebased_test_explicit_backend(
+        ".bp4", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    filebased_test_explicit_backend(
+        ".bp5", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    filebased_test_explicit_backend(
+        ".bp", false, "bp3", "", "adios2.engine.type = \"bp3\"");
+    filebased_test_explicit_backend(
+        ".sst", false, "bp3", ".sst.bp", "adios2.engine.type = \"bp3\"");
+    filebased_test_explicit_backend(
+        "", false, "bp3", ".bp", "adios2.engine.type = \"bp3\"");
+    filebased_test_explicit_backend(
+        "", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+
+#ifdef ADIOS2_HAVE_BP5
+    // BP5 tests
+    filebased_test_explicit_backend(".bp5", true, "bp5", "");
+    filebased_test_explicit_backend(
+        ".bp", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    filebased_test_explicit_backend(
+        ".bp4", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    filebased_test_explicit_backend(
+        ".bp5", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    filebased_test_explicit_backend(
+        "", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+#endif
+
+    auto filebased_test_no_explicit_backend =
+        [&filenameCounter](
+            std::string const &ext,
+            bool directory,
+            std::string const &requiredEngine,
+            std::string const &filesystemExt,
+            std::string const &jsonCfg = "{}") mutable {
+            auto basename = "../samples/file_endings/filebased" +
+                std::to_string(filenameCounter++);
+            auto name = basename + "_%T" + ext;
+            auto filesystemname =
+                basename + "_0" + (filesystemExt.empty() ? ext : filesystemExt);
+            {
+                Series write(name, Access::CREATE, jsonCfg);
+                write.writeIterations()[0];
+            }
+            bool isThisADIOS1 =
+                auxiliary::getEnvString("OPENPMD_BP_BACKEND", "") == "ADIOS1" &&
+                ext == ".bp";
+            if (directory && !isThisADIOS1)
+            {
+                REQUIRE(auxiliary::directory_exists(filesystemname));
+            }
+            else
+            {
+                REQUIRE(auxiliary::file_exists(filesystemname));
+            }
+            {
+                if (requiredEngine == "bp3" &&
+                    !auxiliary::ends_with(name, ".bp"))
+                {
+                    /*
+                     * File-based parsing procedures are not aware that BP3
+                     * engine adds its ending and won't find the iterations if
+                     * we don't give it a little nudge.
+                     */
+                    name += ".bp";
+                }
+                Series read(
+                    name,
+                    Access::READ_ONLY,
+                    isThisADIOS1
+                        ? "backend = \"adios1\""
+                        : "backend = \"adios2\"\nadios2.engine.type = \"" +
+                            requiredEngine + "\"");
+            }
+        };
+
+    filebased_test_no_explicit_backend(".bp", true, "file", "");
+    filebased_test_no_explicit_backend(".bp4", true, "bp4", "");
+    filebased_test_no_explicit_backend(
+        ".bp", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    filebased_test_no_explicit_backend(
+        ".bp4", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    filebased_test_no_explicit_backend(
+        ".bp5", true, "bp4", "", "adios2.engine.type = \"bp4\"");
+    filebased_test_no_explicit_backend(
+        ".bp", false, "bp3", "", "adios2.engine.type = \"bp3\"");
+    filebased_test_no_explicit_backend(
+        ".sst", false, "bp3", ".sst.bp", "adios2.engine.type = \"bp3\"");
+    REQUIRE_THROWS(filebased_test_no_explicit_backend(
+        "", false, "bp3", ".bp", "adios2.engine.type = \"bp3\""));
+    REQUIRE_THROWS(filebased_test_no_explicit_backend(
+        "", true, "bp4", "", "adios2.engine.type = \"bp4\""));
+
+#ifdef ADIOS2_HAVE_BP5
+    // BP5 tests
+    filebased_test_no_explicit_backend(".bp5", true, "bp5", "");
+    filebased_test_no_explicit_backend(
+        ".bp", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    filebased_test_no_explicit_backend(
+        ".bp4", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    filebased_test_no_explicit_backend(
+        ".bp5", true, "bp5", "", "adios2.engine.type = \"bp5\"");
+    REQUIRE_THROWS(filebased_test_no_explicit_backend(
+        "", true, "bp5", "", "adios2.engine.type = \"bp5\""));
+#endif
+}
+
 TEST_CASE("serial_adios2_backend_config", "[serial][adios2]")
 {
     if (auxiliary::getEnvString("OPENPMD_BP_BACKEND", "NOT_SET") == "ADIOS1")
@@ -5867,7 +6174,6 @@ void no_explicit_flush(std::string filename)
     "adios2": {
         "schema": 20210209,
         "engine": {
-            "type": "bp4",
             "usesteps": true
         }
     }
@@ -6103,6 +6409,54 @@ void append_mode(
          */
         helper::listSeries(read);
     }
+#if 100000000 * ADIOS2_VERSION_MAJOR + 1000000 * ADIOS2_VERSION_MINOR +        \
+        10000 * ADIOS2_VERSION_PATCH + 100 * ADIOS2_VERSION_TWEAK >=           \
+    208002700
+    // AppendAfterSteps has a bug before that version
+    if (extension == "bp5")
+    {
+        {
+            Series write(
+                filename,
+                Access::APPEND,
+                json::merge(
+                    jsonConfig,
+                    R"({"adios2":{"engine":{"parameters":{"AppendAfterSteps":-3}}}})"));
+            if (variableBased)
+            {
+                write.setIterationEncoding(IterationEncoding::variableBased);
+            }
+            if (write.backend() == "ADIOS1")
+            {
+                REQUIRE_THROWS_WITH(
+                    write.flush(),
+                    Catch::Equals(
+                        "Operation unsupported in ADIOS1: Appending to "
+                        "existing "
+                        "file on disk (use Access::CREATE to overwrite)"));
+                // destructor will be noisy now
+                return;
+            }
+
+            writeSomeIterations(
+                write.writeIterations(), std::vector<uint64_t>{4, 5});
+            write.flush();
+        }
+        {
+            Series read(filename, Access::READ_ONLY);
+            // in variable-based encodings, iterations are not parsed ahead of
+            // time but as they go
+            unsigned counter = 0;
+            for (auto const &iteration : read.readIterations())
+            {
+                REQUIRE(iteration.iterationIndex == counter);
+                ++counter;
+            }
+            REQUIRE(counter == 6);
+            helper::listSeries(read);
+        }
+    }
+#endif
 }
 
 TEST_CASE("append_mode", "[serial]")

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4237,12 +4237,6 @@ BufferChunkSize = 2147483646 # 2^31 - 2
 
 TEST_CASE("adios2_engines_and_file_endings")
 {
-    if (auxiliary::getEnvNum("SKIP_ADIOS2_FILE_ENDINGS_TEST", 0) != 0)
-    {
-        std::cout << "SKIPPING TEST adios2_engines_and_file_endings"
-                  << std::endl;
-        return;
-    }
     size_t filenameCounter = 0;
     auto groupbased_test_explicit_backend =
         [&filenameCounter](

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -167,7 +167,7 @@ class APITest(unittest.TestCase):
             series.set_attribute("longdouble", np.longdouble(1.23456789))
             series.set_attribute("csingle", np.complex64(1.+2.j))
             series.set_attribute("cdouble", np.complex128(3.+4.j))
-            if file_ending != "bp":
+            if file_ending not in ["bp", "bp4", "bp5"]:
                 series.set_attribute("clongdouble", np.clongdouble(5.+6.j))
             # array of ...
             series.set_attribute("arr_int16", (np.int16(23), np.int16(26), ))
@@ -202,7 +202,7 @@ class APITest(unittest.TestCase):
             # series.set_attribute("l_cdouble",
             #                      [np.complex_(6.7+6.8j),
             #                       np.complex_(7.1+7.2j)])
-            # if file_ending != "bp":
+            # if file_ending not in ["bp", "bp4", "bp5"]:
             #     series.set_attribute("l_clongdouble",
             #                          [np.clongfloat(7.8e9-6.5e9j),
             #                           np.clongfloat(8.2e3-9.1e3j)])
@@ -231,7 +231,7 @@ class APITest(unittest.TestCase):
                 series.set_attribute("nparr_cdouble",
                                      np.array([4.5 + 1.1j, 6.7 - 2.2j],
                                               dtype=np.complex128))
-            if file_ending != "bp":
+            if file_ending not in ["bp", "bp4", "bp5"]:
                 series.set_attribute("nparr_clongdouble",
                                      np.array([8.9 + 7.8j, 7.6 + 9.2j],
                                               dtype=np.clongdouble))
@@ -286,7 +286,7 @@ class APITest(unittest.TestCase):
                                            np.complex64(1.+2.j))
             self.assertAlmostEqual(series.get_attribute("cdouble"),
                                    3.+4.j)
-            if file_ending != "bp":
+            if file_ending not in ["bp", "bp4", "bp5"]:
                 self.assertAlmostEqual(series.get_attribute("clongdouble"),
                                        5.+6.j)
             # array of ... (will be returned as list)
@@ -315,7 +315,7 @@ class APITest(unittest.TestCase):
             # self.assertListEqual(series.get_attribute("l_cdouble"),
             #                      [np.complex128(6.7 + 6.8j),
             #                       np.double(7.1 + 7.2j)])
-            # if file_ending != "bp":
+            # if file_ending not in ["bp", "bp4", "bp5"]:
             #     self.assertListEqual(series.get_attribute("l_clongdouble"),
             #                          [np.clongdouble(7.8e9 - 6.5e9j),
             #                           np.clongdouble(8.2e3 - 9.1e3j)])
@@ -342,7 +342,8 @@ class APITest(unittest.TestCase):
                 np.testing.assert_almost_equal(
                     series.get_attribute("nparr_cdouble"),
                     [4.5 + 1.1j, 6.7 - 2.2j])
-            if file_ending != "bp":  # not in ADIOS 1.13.1 nor ADIOS 2.7.0
+            # not in ADIOS 1.13.1 nor ADIOS 2.7.0
+            if file_ending not in ["bp", "bp4", "bp5"]:
                 np.testing.assert_almost_equal(
                     series.get_attribute("nparr_clongdouble"),
                     [8.9 + 7.8j, 7.6 + 9.2j])
@@ -453,7 +454,7 @@ class APITest(unittest.TestCase):
                 DS(np.dtype("complex128"), extent))
             ms["complex128"][SCALAR].make_constant(
                 np.complex128(1.234567 + 2.345678j))
-            if file_ending != "bp":
+            if file_ending not in ["bp", "bp4", "bp5"]:
                 ms["clongdouble"][SCALAR].reset_dataset(
                     DS(np.dtype("clongdouble"), extent))
                 ms["clongdouble"][SCALAR].make_constant(
@@ -534,7 +535,7 @@ class APITest(unittest.TestCase):
                             == np.dtype('complex64'))
             self.assertTrue(ms["complex128"][SCALAR].load_chunk(o, e).dtype
                             == np.dtype('complex128'))
-            if file_ending != "bp":
+            if file_ending not in ["bp", "bp4", "bp5"]:
                 self.assertTrue(ms["clongdouble"][SCALAR].load_chunk(o, e)
                                 .dtype == np.dtype('clongdouble'))
 
@@ -561,7 +562,7 @@ class APITest(unittest.TestCase):
                              np.complex64(1.234 + 2.345j))
             self.assertEqual(ms["complex128"][SCALAR].load_chunk(o, e),
                              np.complex128(1.234567 + 2.345678j))
-            if file_ending != "bp":
+            if file_ending not in ["bp", "bp4", "bp5"]:
                 self.assertEqual(ms["clongdouble"][SCALAR].load_chunk(o, e),
                                  np.clongdouble(1.23456789 + 2.34567890j))
 
@@ -600,7 +601,7 @@ class APITest(unittest.TestCase):
         ms["complex128"][SCALAR].store_chunk(
             np.ones(extent, dtype=np.complex128) *
             np.complex128(1.234567 + 2.345678j))
-        if file_ending != "bp":
+        if file_ending not in ["bp", "bp4", "bp5"]:
             ms["clongdouble"][SCALAR].reset_dataset(
                 DS(np.dtype("clongdouble"), extent))
             ms["clongdouble"][SCALAR].store_chunk(
@@ -630,12 +631,12 @@ class APITest(unittest.TestCase):
 
         dc64 = ms["complex64"][SCALAR].load_chunk(o, e)
         dc128 = ms["complex128"][SCALAR].load_chunk(o, e)
-        if file_ending != "bp":
+        if file_ending not in ["bp", "bp4", "bp5"]:
             dc256 = ms["clongdouble"][SCALAR].load_chunk(o, e)
 
         self.assertTrue(dc64.dtype == np.dtype('complex64'))
         self.assertTrue(dc128.dtype == np.dtype('complex128'))
-        if file_ending != "bp":
+        if file_ending not in ["bp", "bp4", "bp5"]:
             self.assertTrue(
                 dc256.dtype == np.dtype('clongdouble'))
 
@@ -645,7 +646,7 @@ class APITest(unittest.TestCase):
                          np.complex64(1.234 + 2.345j))
         self.assertEqual(dc128,
                          np.complex128(1.234567 + 2.345678j))
-        if file_ending != "bp":
+        if file_ending not in ["bp", "bp4", "bp5"]:
             self.assertEqual(dc256,
                              np.clongdouble(1.23456789 + 2.34567890j))
 


### PR DESCRIPTION
Close #1205

TODO:

- [x] Frontend implementation
- [x] Backend implementation
- [x] Ensure that ideally the filename on disk is the same as specified by the user in most cases
- [x] Testing
- [x] Merge #1214 first (they would conflict else)
- [x] What to do for `Series("asdf.bp5", Access::CREATE, "adios2.engine.type = \"file\"")`?
    Current implementation: Accept this in the backend, but warn the user that the `file` engine will decide the BP version independent of the extension: `[ADIOS2] Specified explicit ending '.bp5' in combination with generic file engine 'file'. ADIOS2 will pick a default file ending independent of specified suffix. (E.g. 'simData.bp5' might actually be written as a BP4 dataset.)`
- [x] Test that `Series("asdf.bp5", Access::CREATE, "backend = \"adios2\"")` is handled correctly
- [x] Merge #1215 first and delete those commits from this branch
- [x] Documentation
- [x] Merge #1262 first
- [x] extend `openPMD::getFileExtensions()`
- [x] Merge #1275 first