### PR TITLE
Python: Do Not Strip Symbols In Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,7 +692,9 @@ if(openPMD_HAVE_PYTHON)
     else()
         pybind11_extension(openPMD.py)
     endif()
-    pybind11_strip(openPMD.py)
+    if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+        pybind11_strip(openPMD.py)
+    endif()
 
     set_target_properties(openPMD.py PROPERTIES CXX_VISIBILITY_PRESET "hidden"
                                                 CUDA_VISIBILITY_PRESET "hidden")


### PR DESCRIPTION
Avoid stripping symbols for Python debug builds, so we can see code lines in coredumps and debugger runs.

X-ref.: https://github.com/pybind/pybind11/pull/3779