### PR TITLE
Fix use after free in ADIOS1IOHandler

### DIFF
--- a/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
@@ -103,7 +103,12 @@ protected:
         m_openWriteFileHandles;
     std::unordered_map<std::shared_ptr<std::string>, ADIOS_FILE *>
         m_openReadFileHandles;
-    std::unordered_map<ADIOS_FILE *, std::vector<ADIOS_SELECTION *> >
+    struct ScheduledRead
+    {
+        ADIOS_SELECTION *selection;
+        std::shared_ptr<void> data; // needed to avoid early freeing
+    };
+    std::unordered_map<ADIOS_FILE *, std::vector<ScheduledRead> >
         m_scheduledReads;
     std::unordered_map<int64_t, std::unordered_map<std::string, Attribute> >
         m_attributeWrites;

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -296,7 +296,7 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             "dataset reading");
 
         for (auto &sel : file.second)
-            adios_selection_delete(sel);
+            adios_selection_delete(sel.selection);
     }
     m_scheduledReads.clear();
 

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -728,7 +728,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::closeFile(
                 "dataset reading");
 
             for (auto &sel : scheduled->second)
-                adios_selection_delete(sel);
+                adios_selection_delete(sel.selection);
             m_scheduledReads.erase(scheduled);
         }
         close(handle_read->second);
@@ -1183,7 +1183,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readDataset(
         "[ADIOS1] Internal error: Failed to schedule ADIOS read during dataset "
         "reading");
 
-    m_scheduledReads[f].push_back(sel);
+    m_scheduledReads[f].push_back({sel, parameters.data});
 }
 
 template <typename ChildClass>

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -316,7 +316,7 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             "dataset reading");
 
         for (auto &sel : file.second)
-            adios_selection_delete(sel);
+            adios_selection_delete(sel.selection);
     }
     m_scheduledReads.clear();
 


### PR DESCRIPTION
Extracted from #1197

There is currently a (low-key) use after free in ADIOS1, happening if a user calls `loadChunk()` without storing the buffer. #1197 will add a test.