### PR TITLE
Pass-through flushing parameters

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
@@ -50,7 +50,7 @@ public:
         return "ADIOS1";
     }
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 
     void enqueue(IOTask const &) override;
 
@@ -72,7 +72,7 @@ public:
         return "DUMMY_ADIOS1";
     }
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 
 private:
     std::unique_ptr<ADIOS1IOHandlerImpl> m_impl;

--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
@@ -51,7 +51,7 @@ public:
 
     virtual void init();
 
-    std::future<void> flush() override;
+    std::future<void> flush();
 
     virtual int64_t open_write(Writable *);
     virtual ADIOS_FILE *open_read(std::string const &name);

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -142,7 +142,7 @@ public:
 
     ~ADIOS2IOHandlerImpl() override;
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &);
 
     void
     createFile(Writable *, Parameter<Operation::CREATE_FILE> const &) override;
@@ -1262,7 +1262,7 @@ public:
         // we must not throw in a destructor
         try
         {
-            this->flush();
+            this->flush(internal::defaultFlushParams);
         }
         catch (std::exception const &ex)
         {
@@ -1301,6 +1301,6 @@ public:
         return "ADIOS2";
     }
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 }; // ADIOS2IOHandler
 } // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
@@ -54,7 +54,7 @@ public:
         return "MPI_ADIOS1";
     }
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 #if openPMD_HAVE_ADIOS1
     void enqueue(IOTask const &) override;
 #endif

--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
@@ -53,7 +53,7 @@ public:
 
     virtual void init();
 
-    std::future<void> flush() override;
+    std::future<void> flush();
 
     virtual int64_t open_write(Writable *);
     virtual ADIOS_FILE *open_read(std::string const &name);

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -87,6 +87,24 @@ enum class FlushLevel : unsigned char
     SkeletonOnly
 };
 
+namespace internal
+{
+    /**
+     * Parameters recursively passed through the openPMD hierarchy when
+     * flushing.
+     *
+     */
+    struct FlushParams
+    {
+        FlushLevel flushLevel = FlushLevel::InternalFlush;
+    };
+
+    /*
+     * To be used for reading
+     */
+    constexpr FlushParams defaultFlushParams{};
+} // namespace internal
+
 /** Interface for communicating between logical and physically persistent data.
  *
  * Input and output operations are channeled through a task queue that is
@@ -123,7 +141,7 @@ public:
      * @return  Future indicating the completion state of the operation for
      * backends that decide to implement this operation asynchronously.
      */
-    virtual std::future<void> flush() = 0;
+    virtual std::future<void> flush(internal::FlushParams const &) = 0;
 
     /** The currently used backend */
     virtual std::string backendName() const = 0;
@@ -132,7 +150,6 @@ public:
     Access const m_backendAccess;
     Access const m_frontendAccess;
     std::queue<IOTask> m_work;
-    FlushLevel m_flushLevel = FlushLevel::InternalFlush;
 }; // AbstractIOHandler
 
 } // namespace openPMD

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -40,7 +40,7 @@ public:
 
     virtual ~AbstractIOHandlerImpl() = default;
 
-    virtual std::future<void> flush()
+    std::future<void> flush()
     {
         using namespace auxiliary;
 

--- a/include/openPMD/IO/DummyIOHandler.hpp
+++ b/include/openPMD/IO/DummyIOHandler.hpp
@@ -44,6 +44,6 @@ public:
     /** No-op consistent with the IOHandler interface to enable library use
      * without IO.
      */
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 }; // DummyIOHandler
 } // namespace openPMD

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -42,7 +42,7 @@ public:
         return "HDF5";
     }
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 
 private:
     std::unique_ptr<HDF5IOHandlerImpl> m_impl;

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -48,7 +48,7 @@ public:
         return "MPI_HDF5";
     }
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 
 private:
     std::unique_ptr<ParallelHDF5IOHandlerImpl> m_impl;

--- a/include/openPMD/IO/JSON/JSONIOHandler.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandler.hpp
@@ -38,7 +38,7 @@ public:
         return "JSON";
     }
 
-    std::future<void> flush() override;
+    std::future<void> flush(internal::FlushParams const &) override;
 
 private:
     JSONIOHandlerImpl m_impl;

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -210,7 +210,7 @@ public:
 
     void listAttributes(Writable *, Parameter<Operation::LIST_ATTS> &) override;
 
-    std::future<void> flush() override;
+    std::future<void> flush();
 
 private:
     using FILEHANDLE = std::fstream;

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -242,10 +242,11 @@ private:
         return *m_iterationData;
     }
 
-    void flushFileBased(std::string const &, uint64_t);
-    void flushGroupBased(uint64_t);
-    void flushVariableBased(uint64_t);
-    void flush();
+    void flushFileBased(
+        std::string const &, uint64_t, internal::FlushParams const &);
+    void flushGroupBased(uint64_t, internal::FlushParams const &);
+    void flushVariableBased(uint64_t, internal::FlushParams const &);
+    void flush(internal::FlushParams const &);
     void deferParseAccess(internal::DeferredParseAccess);
     /*
      * Control flow for read(), readFileBased(), readGroupBased() and

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -228,7 +228,8 @@ public:
 private:
     Mesh();
 
-    void flush_impl(std::string const &) override;
+    void
+    flush_impl(std::string const &, internal::FlushParams const &) override;
     void read() override;
 }; // Mesh
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -43,7 +43,7 @@ private:
     ParticleSpecies();
 
     void read();
-    void flush(std::string const &) override;
+    void flush(std::string const &, internal::FlushParams const &) override;
 
     /**
      * @brief Check recursively whether this ParticleSpecies is dirty.

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -50,7 +50,8 @@ public:
 private:
     Record();
 
-    void flush_impl(std::string const &) override;
+    void
+    flush_impl(std::string const &, internal::FlushParams const &) override;
     void read() override;
 }; // Record
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -289,7 +289,7 @@ public:
     static constexpr char const *const SCALAR = "\vScalar";
 
 private:
-    void flush(std::string const &);
+    void flush(std::string const &, internal::FlushParams const &);
     virtual void read();
 
     /**

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -280,7 +280,7 @@ RecordComponent::storeChunk( Offset o, Extent e, F && createBuffer )
      * Flush the openPMD hierarchy to the backend without flushing any actual
      * data yet.
      */
-    seriesFlush( FlushLevel::SkeletonOnly );
+    seriesFlush({FlushLevel::SkeletonOnly});
 
     size_t size = 1;
     for( auto ext : e )
@@ -305,16 +305,16 @@ RecordComponent::storeChunk( Offset o, Extent e, F && createBuffer )
     getBufferView.offset = o;
     getBufferView.extent = e;
     getBufferView.dtype = getDatatype();
-    IOHandler()->enqueue( IOTask( this, getBufferView ) );
-    IOHandler()->flush();
+    IOHandler()->enqueue(IOTask(this, getBufferView));
+    IOHandler()->flush(internal::defaultFlushParams);
     auto &out = *getBufferView.out;
-    if( !out.backendManagedBuffer )
+    if (!out.backendManagedBuffer)
     {
-        auto data = std::forward< F >( createBuffer )( size );
-        out.ptr = static_cast< void * >( data.get() );
-        storeChunk( std::move( data ), std::move( o ), std::move( e ) );
+        auto data = std::forward<F>(createBuffer)(size);
+        out.ptr = static_cast<void *>(data.get());
+        storeChunk(std::move(data), std::move(o), std::move(e));
     }
-    return DynamicMemoryView< T >{ std::move( getBufferView ), size, *this };
+    return DynamicMemoryView<T>{std::move(getBufferView), size, *this};
 }
 
 template< typename T >

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -532,7 +532,7 @@ OPENPMD_private
      *
      * @param begin Start of the range of iterations to flush.
      * @param end End of the range of iterations to flush.
-     * @param level Flush level, as documented in AbstractIOHandler.hpp.
+     * @param flushParams Flush params, as documented in AbstractIOHandler.hpp.
      * @param flushIOHandler Tasks will always be enqueued to the backend.
      *     If this flag is true, tasks will be flushed to the backend.
      */

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -539,9 +539,12 @@ OPENPMD_private
     std::future<void> flush_impl(
         iterations_iterator begin,
         iterations_iterator end,
-        FlushLevel level,
+        internal::FlushParams flushParams,
         bool flushIOHandler = true);
-    void flushFileBased(iterations_iterator begin, iterations_iterator end);
+    void flushFileBased(
+        iterations_iterator begin,
+        iterations_iterator end,
+        internal::FlushParams flushParams);
     /*
      * Group-based and variable-based iteration layouts share a lot of logic
      * (realistically, the variable-based iteration layout only throws out
@@ -549,7 +552,10 @@ OPENPMD_private
      * As a convention, methods that deal with both layouts are called
      * .*GorVBased, short for .*GroupOrVariableBased
      */
-    void flushGorVBased(iterations_iterator begin, iterations_iterator end);
+    void flushGorVBased(
+        iterations_iterator begin,
+        iterations_iterator end,
+        internal::FlushParams flushParams);
     void flushMeshesPath();
     void flushParticlesPath();
     void readFileBased();

--- a/include/openPMD/Span.hpp
+++ b/include/openPMD/Span.hpp
@@ -125,7 +125,7 @@ public:
             // might need to update
             m_recordComponent.IOHandler()->enqueue(
                 IOTask(&m_recordComponent, m_param));
-            m_recordComponent.IOHandler()->flush();
+            m_recordComponent.IOHandler()->flush(internal::defaultFlushParams);
         }
         return Span<T>{static_cast<T *>(m_param.out->ptr), m_size};
     }

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -273,9 +273,9 @@ OPENPMD_protected
     Iteration &containingIteration();
     /** @} */
 
-    void seriesFlush(FlushLevel);
+    void seriesFlush(internal::FlushParams);
 
-    void flushAttributes();
+    void flushAttributes(internal::FlushParams const &);
     enum ReadMode
     {
         /**

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -141,8 +141,9 @@ protected:
     void readBase();
 
 private:
-    void flush(std::string const &) final;
-    virtual void flush_impl(std::string const &) = 0;
+    void flush(std::string const &, internal::FlushParams const &) final;
+    virtual void
+    flush_impl(std::string const &, internal::FlushParams const &) = 0;
     virtual void read() = 0;
 
     /**
@@ -250,7 +251,7 @@ BaseRecord<T_elem>::erase(key_type const &key)
             Parameter<Operation::DELETE_DATASET> dDelete;
             dDelete.name = ".";
             this->IOHandler()->enqueue(IOTask(&rc, dDelete));
-            this->IOHandler()->flush();
+            this->IOHandler()->flush(internal::defaultFlushParams);
         }
         res = Container<T_elem>::erase(key);
     }
@@ -280,7 +281,7 @@ BaseRecord<T_elem>::erase(iterator res)
             Parameter<Operation::DELETE_DATASET> dDelete;
             dDelete.name = ".";
             this->IOHandler()->enqueue(IOTask(&rc, dDelete));
-            this->IOHandler()->flush();
+            this->IOHandler()->flush(internal::defaultFlushParams);
         }
         ret = Container<T_elem>::erase(res);
     }
@@ -315,7 +316,7 @@ inline void BaseRecord<T_elem>::readBase()
 
     aRead.name = "unitDimension";
     this->IOHandler()->enqueue(IOTask(this, aRead));
-    this->IOHandler()->flush();
+    this->IOHandler()->flush(internal::defaultFlushParams);
     if (*aRead.dtype == DT::ARR_DBL_7)
         this->setAttribute(
             "unitDimension",
@@ -340,7 +341,7 @@ inline void BaseRecord<T_elem>::readBase()
 
     aRead.name = "timeOffset";
     this->IOHandler()->enqueue(IOTask(this, aRead));
-    this->IOHandler()->flush();
+    this->IOHandler()->flush(internal::defaultFlushParams);
     if (*aRead.dtype == DT::FLOAT)
         this->setAttribute(
             "timeOffset", Attribute(*aRead.resource).template get<float>());
@@ -353,7 +354,8 @@ inline void BaseRecord<T_elem>::readBase()
 }
 
 template <typename T_elem>
-inline void BaseRecord<T_elem>::flush(std::string const &name)
+inline void BaseRecord<T_elem>::flush(
+    std::string const &name, internal::FlushParams const &flushParams)
 {
     if (!this->written() && this->empty())
         throw std::runtime_error(
@@ -361,7 +363,7 @@ inline void BaseRecord<T_elem>::flush(std::string const &name)
             "RecordComponents: " +
             name);
 
-    this->flush_impl(name);
+    this->flush_impl(name, flushParams);
     // flush_impl must take care to correctly set the dirty() flag so this
     // method doesn't do it
 }

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -388,7 +388,7 @@ public:
             Parameter<Operation::DELETE_PATH> pDelete;
             pDelete.path = ".";
             IOHandler()->enqueue(IOTask(&res->second, pDelete));
-            IOHandler()->flush();
+            IOHandler()->flush(internal::defaultFlushParams);
         }
         return container().erase(key);
     }
@@ -405,7 +405,7 @@ public:
             Parameter<Operation::DELETE_PATH> pDelete;
             pDelete.path = ".";
             IOHandler()->enqueue(IOTask(&res->second, pDelete));
-            IOHandler()->flush();
+            IOHandler()->flush(internal::defaultFlushParams);
         }
         return container().erase(res);
     }
@@ -436,7 +436,8 @@ OPENPMD_protected
         container().clear();
     }
 
-    virtual void flush(std::string const &path)
+    virtual void
+    flush(std::string const &path, internal::FlushParams const &flushParams)
     {
         if (!written())
         {
@@ -445,7 +446,7 @@ OPENPMD_protected
             IOHandler()->enqueue(IOTask(this, pCreate));
         }
 
-        flushAttributes();
+        flushAttributes(flushParams);
     }
 
     // clang-format off

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -41,7 +41,8 @@ public:
 private:
     PatchRecord() = default;
 
-    void flush_impl(std::string const &) override;
+    void
+    flush_impl(std::string const &, internal::FlushParams const &) override;
     void read() override;
 }; // PatchRecord
 } // namespace openPMD

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -91,7 +91,7 @@ public:
 OPENPMD_private
     // clang-format on
 
-    void flush(std::string const &);
+    void flush(std::string const &, internal::FlushParams const &);
     void read();
 
     /**

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -114,7 +114,7 @@ public:
 OPENPMD_private
     // clang-format on
 
-    void seriesFlush(FlushLevel);
+    void seriesFlush(internal::FlushParams);
     /*
      * These members need to be shared pointers since distinct instances of
      * Writable may share them.

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -330,7 +330,7 @@ ADIOS1IOHandler::ADIOS1IOHandler(
 
 ADIOS1IOHandler::~ADIOS1IOHandler() = default;
 
-std::future<void> ADIOS1IOHandler::flush()
+std::future<void> ADIOS1IOHandler::flush(internal::FlushParams const &)
 {
     return m_impl->flush();
 }
@@ -431,7 +431,7 @@ ADIOS1IOHandler::ADIOS1IOHandler(std::string path, Access at, json::TracingJSON)
 
 ADIOS1IOHandler::~ADIOS1IOHandler() = default;
 
-std::future<void> ADIOS1IOHandler::flush()
+std::future<void> ADIOS1IOHandler::flush(internal::FlushParams const &)
 {
     return std::future<void>();
 }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -253,7 +253,8 @@ std::string ADIOS2IOHandlerImpl::fileSuffix() const
     }
 }
 
-std::future<void> ADIOS2IOHandlerImpl::flush()
+std::future<void>
+ADIOS2IOHandlerImpl::flush(internal::FlushParams const &flushParams)
 {
     auto res = AbstractIOHandlerImpl::flush();
     for (auto &p : m_fileData)
@@ -261,7 +262,7 @@ std::future<void> ADIOS2IOHandlerImpl::flush()
         if (m_dirty.find(p.first) != m_dirty.end())
         {
             p.second->flush(
-                m_handler->m_flushLevel, /* writeAttributes = */ false);
+                flushParams.flushLevel, /* writeAttributes = */ false);
         }
         else
         {
@@ -2869,9 +2870,10 @@ ADIOS2IOHandler::ADIOS2IOHandler(
     , m_impl{this, std::move(options), std::move(engineType)}
 {}
 
-std::future<void> ADIOS2IOHandler::flush()
+std::future<void>
+ADIOS2IOHandler::flush(internal::FlushParams const &flushParams)
 {
-    return m_impl.flush();
+    return m_impl.flush(flushParams);
 }
 
 #else // openPMD_HAVE_ADIOS2
@@ -2889,7 +2891,7 @@ ADIOS2IOHandler::ADIOS2IOHandler(
     : AbstractIOHandler(std::move(path), at)
 {}
 
-std::future<void> ADIOS2IOHandler::flush()
+std::future<void> ADIOS2IOHandler::flush(internal::FlushParams const &)
 {
     return std::future<void>();
 }

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -349,7 +349,7 @@ ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(
 
 ParallelADIOS1IOHandler::~ParallelADIOS1IOHandler() = default;
 
-std::future<void> ParallelADIOS1IOHandler::flush()
+std::future<void> ParallelADIOS1IOHandler::flush(internal::FlushParams const &)
 {
     return m_impl->flush();
 }
@@ -471,7 +471,7 @@ ParallelADIOS1IOHandler::ParallelADIOS1IOHandler(
 
 ParallelADIOS1IOHandler::~ParallelADIOS1IOHandler() = default;
 
-std::future<void> ParallelADIOS1IOHandler::flush()
+std::future<void> ParallelADIOS1IOHandler::flush(internal::FlushParams const &)
 {
     return std::future<void>();
 }

--- a/src/IO/DummyIOHandler.cpp
+++ b/src/IO/DummyIOHandler.cpp
@@ -32,7 +32,7 @@ DummyIOHandler::DummyIOHandler(std::string path, Access at)
 void DummyIOHandler::enqueue(IOTask const &)
 {}
 
-std::future<void> DummyIOHandler::flush()
+std::future<void> DummyIOHandler::flush(internal::FlushParams const &)
 {
     return std::future<void>();
 }

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -2292,7 +2292,7 @@ HDF5IOHandler::HDF5IOHandler(
 
 HDF5IOHandler::~HDF5IOHandler() = default;
 
-std::future<void> HDF5IOHandler::flush()
+std::future<void> HDF5IOHandler::flush(internal::FlushParams const &)
 {
     return m_impl->flush();
 }
@@ -2306,7 +2306,7 @@ HDF5IOHandler::HDF5IOHandler(
 
 HDF5IOHandler::~HDF5IOHandler() = default;
 
-std::future<void> HDF5IOHandler::flush()
+std::future<void> HDF5IOHandler::flush(internal::FlushParams const &)
 {
     return std::future<void>();
 }

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -54,7 +54,7 @@ ParallelHDF5IOHandler::ParallelHDF5IOHandler(
 
 ParallelHDF5IOHandler::~ParallelHDF5IOHandler() = default;
 
-std::future<void> ParallelHDF5IOHandler::flush()
+std::future<void> ParallelHDF5IOHandler::flush(internal::FlushParams const &)
 {
     return m_impl->flush();
 }
@@ -196,7 +196,7 @@ ParallelHDF5IOHandler::ParallelHDF5IOHandler(
 
 ParallelHDF5IOHandler::~ParallelHDF5IOHandler() = default;
 
-std::future<void> ParallelHDF5IOHandler::flush()
+std::future<void> ParallelHDF5IOHandler::flush(internal::FlushParams const &)
 {
     return std::future<void>();
 }

--- a/src/IO/JSON/JSONIOHandler.cpp
+++ b/src/IO/JSON/JSONIOHandler.cpp
@@ -29,7 +29,7 @@ JSONIOHandler::JSONIOHandler(std::string path, Access at)
     : AbstractIOHandler{path, at}, m_impl{JSONIOHandlerImpl{this}}
 {}
 
-std::future<void> JSONIOHandler::flush()
+std::future<void> JSONIOHandler::flush(internal::FlushParams const &)
 {
     return m_impl.flush();
 }

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -35,7 +35,7 @@ void ParticlePatches::read()
 {
     Parameter<Operation::LIST_PATHS> pList;
     IOHandler()->enqueue(IOTask(this, pList));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
 
     Parameter<Operation::OPEN_PATH> pOpen;
     for (auto const &record_name : *pList.paths)
@@ -48,7 +48,7 @@ void ParticlePatches::read()
 
     Parameter<Operation::LIST_DATASETS> dList;
     IOHandler()->enqueue(IOTask(this, dList));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
 
     Parameter<Operation::OPEN_DATASET> dOpen;
     for (auto const &component_name : *dList.datasets)
@@ -65,7 +65,7 @@ void ParticlePatches::read()
         dOpen.name = component_name;
         IOHandler()->enqueue(IOTask(&pr, dOpen));
         IOHandler()->enqueue(IOTask(&prc, dOpen));
-        IOHandler()->flush();
+        IOHandler()->flush(internal::defaultFlushParams);
 
         if (determineDatatype<uint64_t>() != *dOpen.dtype)
             throw std::runtime_error(

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -38,7 +38,7 @@ void ParticleSpecies::read()
     /* obtain all non-scalar records */
     Parameter<Operation::LIST_PATHS> pList;
     IOHandler()->enqueue(IOTask(this, pList));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
 
     internal::EraseStaleEntries<ParticleSpecies &> map{*this};
 
@@ -61,7 +61,7 @@ void ParticleSpecies::read()
             aList.attributes->clear();
             IOHandler()->enqueue(IOTask(&r, pOpen));
             IOHandler()->enqueue(IOTask(&r, aList));
-            IOHandler()->flush();
+            IOHandler()->flush(internal::defaultFlushParams);
 
             auto att_begin = aList.attributes->begin();
             auto att_end = aList.attributes->end();
@@ -73,7 +73,7 @@ void ParticleSpecies::read()
                 RecordComponent &rc = scalarMap[RecordComponent::SCALAR];
                 rc.parent() = r.parent();
                 IOHandler()->enqueue(IOTask(&rc, pOpen));
-                IOHandler()->flush();
+                IOHandler()->flush(internal::defaultFlushParams);
                 rc.get().m_isConstant = true;
             }
             r.read();
@@ -90,7 +90,7 @@ void ParticleSpecies::read()
     /* obtain all scalar records */
     Parameter<Operation::LIST_DATASETS> dList;
     IOHandler()->enqueue(IOTask(this, dList));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
 
     Parameter<Operation::OPEN_DATASET> dOpen;
     for (auto const &record_name : *dList.datasets)
@@ -100,12 +100,12 @@ void ParticleSpecies::read()
             Record &r = map[record_name];
             dOpen.name = record_name;
             IOHandler()->enqueue(IOTask(&r, dOpen));
-            IOHandler()->flush();
+            IOHandler()->flush(internal::defaultFlushParams);
             internal::EraseStaleEntries<Record &> scalarMap(r);
             RecordComponent &rc = scalarMap[RecordComponent::SCALAR];
             rc.parent() = r.parent();
             IOHandler()->enqueue(IOTask(&rc, dOpen));
-            IOHandler()->flush();
+            IOHandler()->flush(internal::defaultFlushParams);
             rc.written() = false;
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
             rc.written() = true;
@@ -138,14 +138,15 @@ namespace
     }
 } // namespace
 
-void ParticleSpecies::flush(std::string const &path)
+void ParticleSpecies::flush(
+    std::string const &path, internal::FlushParams const &flushParams)
 {
     if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
     {
         for (auto &record : *this)
-            record.second.flush(record.first);
+            record.second.flush(record.first, flushParams);
         for (auto &patch : particlePatches)
-            patch.second.flush(patch.first);
+            patch.second.flush(patch.first, flushParams);
     }
     else
     {
@@ -156,16 +157,16 @@ void ParticleSpecies::flush(std::string const &path)
         if (it != end())
             it->second.setUnitDimension({{UnitDimension::L, 1}});
 
-        Container<Record>::flush(path);
+        Container<Record>::flush(path, flushParams);
 
         for (auto &record : *this)
-            record.second.flush(record.first);
+            record.second.flush(record.first, flushParams);
 
         if (flushParticlePatches(particlePatches))
         {
-            particlePatches.flush("particlePatches");
+            particlePatches.flush("particlePatches", flushParams);
             for (auto &patch : particlePatches)
-                patch.second.flush(patch.first);
+                patch.second.flush(patch.first, flushParams);
         }
     }
 }

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -191,10 +191,11 @@ bool RecordComponent::empty() const
     return get().m_isEmpty;
 }
 
-void RecordComponent::flush(std::string const &name)
+void RecordComponent::flush(
+    std::string const &name, internal::FlushParams const &flushParams)
 {
     auto &rc = get();
-    if (IOHandler()->m_flushLevel == FlushLevel::SkeletonOnly)
+    if (flushParams.flushLevel == FlushLevel::SkeletonOnly)
     {
         rc.m_name = name;
         return;
@@ -273,7 +274,7 @@ void RecordComponent::flush(std::string const &name)
             rc.m_chunks.pop();
         }
 
-        flushAttributes();
+        flushAttributes(flushParams);
     }
 }
 
@@ -292,7 +293,7 @@ void RecordComponent::readBase()
     {
         aRead.name = "value";
         IOHandler()->enqueue(IOTask(this, aRead));
-        IOHandler()->flush();
+        IOHandler()->flush(internal::defaultFlushParams);
 
         Attribute a(*aRead.resource);
         DT dtype = *aRead.dtype;
@@ -357,7 +358,7 @@ void RecordComponent::readBase()
 
         aRead.name = "shape";
         IOHandler()->enqueue(IOTask(this, aRead));
-        IOHandler()->flush();
+        IOHandler()->flush(internal::defaultFlushParams);
         a = Attribute(*aRead.resource);
         Extent e;
 
@@ -383,7 +384,7 @@ void RecordComponent::readBase()
 
     aRead.name = "unitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
     if (*aRead.dtype == DT::DOUBLE)
         setUnitSI(Attribute(*aRead.resource).get<double>());
     else

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -66,7 +66,7 @@ bool Attributable::deleteAttribute(std::string const &key)
         Parameter<Operation::DELETE_ATT> aDelete;
         aDelete.name = key;
         IOHandler()->enqueue(IOTask(this, aDelete));
-        IOHandler()->flush();
+        IOHandler()->flush(internal::defaultFlushParams);
         attri.m_attributes.erase(it);
         return true;
     }
@@ -206,14 +206,14 @@ auto Attributable::myPath() const -> MyPath
     return res;
 }
 
-void Attributable::seriesFlush(FlushLevel level)
+void Attributable::seriesFlush(internal::FlushParams flushParams)
 {
-    writable().seriesFlush(level);
+    writable().seriesFlush(flushParams);
 }
 
-void Attributable::flushAttributes()
+void Attributable::flushAttributes(internal::FlushParams const &flushParams)
 {
-    if (IOHandler()->m_flushLevel == FlushLevel::SkeletonOnly)
+    if (flushParams.flushLevel == FlushLevel::SkeletonOnly)
     {
         return;
     }
@@ -237,7 +237,7 @@ void Attributable::readAttributes(ReadMode mode)
     auto &attri = get();
     Parameter<Operation::LIST_ATTS> aList;
     IOHandler()->enqueue(IOTask(this, aList));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
     std::vector<std::string> written_attributes = attributes();
 
     /* std::set_difference requires sorted ranges */
@@ -277,7 +277,7 @@ void Attributable::readAttributes(ReadMode mode)
         IOHandler()->enqueue(IOTask(this, aRead));
         try
         {
-            IOHandler()->flush();
+            IOHandler()->flush(internal::defaultFlushParams);
         }
         catch (unsupported_data_error const &e)
         {

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -61,7 +61,7 @@ ChunkTable BaseRecordComponent::availableChunks()
     Parameter<Operation::AVAILABLE_CHUNKS> param;
     IOTask task(this, param);
     IOHandler()->enqueue(task);
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
     return std::move(*param.chunks);
 }
 

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -34,7 +34,7 @@ void MeshRecordComponent::read()
 
     aRead.name = "position";
     IOHandler()->enqueue(IOTask(this, aRead));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
     Attribute a = Attribute(*aRead.resource);
     if (*aRead.dtype == DT::VEC_FLOAT || *aRead.dtype == DT::FLOAT)
         setPosition(a.get<std::vector<float> >());

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -80,7 +80,8 @@ PatchRecordComponent::PatchRecordComponent(
     : BaseRecordComponent{data}, m_patchRecordComponentData{std::move(data)}
 {}
 
-void PatchRecordComponent::flush(std::string const &name)
+void PatchRecordComponent::flush(
+    std::string const &name, internal::FlushParams const &flushParams)
 {
     auto &rc = get();
     if (IOHandler()->m_frontendAccess == Access::READ_ONLY)
@@ -109,7 +110,7 @@ void PatchRecordComponent::flush(std::string const &name)
             rc.m_chunks.pop();
         }
 
-        flushAttributes();
+        flushAttributes(flushParams);
     }
 }
 
@@ -119,7 +120,7 @@ void PatchRecordComponent::read()
 
     aRead.name = "unitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
-    IOHandler()->flush();
+    IOHandler()->flush(internal::defaultFlushParams);
     if (*aRead.dtype == Datatype::DOUBLE)
         setUnitSI(Attribute(*aRead.resource).get<double>());
     else

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -35,15 +35,15 @@ Writable::Writable(internal::AttributableData *a)
 
 void Writable::seriesFlush()
 {
-    seriesFlush(FlushLevel::UserFlush);
+    seriesFlush({FlushLevel::UserFlush});
 }
 
-void Writable::seriesFlush(FlushLevel level)
+void Writable::seriesFlush(internal::FlushParams flushParams)
 {
     auto series =
         Attributable({attributable, [](auto const *) {}}).retrieveSeries();
     series.flush_impl(
-        series.iterations.begin(), series.iterations.end(), level);
+        series.iterations.begin(), series.iterations.end(), flushParams);
 }
 
 } // namespace openPMD


### PR DESCRIPTION
Factored out from #1207 and not needed there any more.

Introduce a struct `FlushParams` that can be passed through the openPMD hierarchy without polluting `AbstractIOHandler` with extra fields. This simplifies debugging by removing some `try...catch..finally` blocks whose purpose was to restore that state.