### PR TITLE
[WIP] Pre-Commit: Clang-Format CXX Endings

### DIFF
--- a/.github/workflows/clang-format/clang-format.sh
+++ b/.github/workflows/clang-format/clang-format.sh
@@ -7,6 +7,6 @@ else
     # received no arguments, find files on our own
     find include/ src/ test/ examples/ \
             -regextype egrep \
-            -type f -regex '.*\.(hpp|cpp|hpp\.in)$' \
+            -type f -regex '.*\.(c|cpp|cxx|h|hpp|tpp)(\.in)?$' \
         | xargs clang-format-13 -i
 fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,8 @@ repos:
   rev: v13.0.1
   hooks:
   - id: clang-format
+    types: [file]
+    files: '.*\.(c|cpp|cxx|h|hpp|tpp)(\.in)?$'
 
 # Autoremoves unused Python imports
 - repo: https://github.com/hadialqattan/pycln


### PR DESCRIPTION
`identify` used to detect our files does not catch all our file endings.

Refs.:
- https://pre-commit.com/#pre-commit-configyaml---hooks
- https://pre-commit.com/#filtering-files-with-types
  - https://pre-commit.com/#regular-expressions
- https://github.com/pre-commit/mirrors-clang-format
- https://github.com/ssciwr/clang-format-wheel#use-from-pre-commit
- https://github.com/pre-commit/identify/issues/119
- https://github.com/pybind/pybind11/blob/v2.9.1/.pre-commit-config.yaml#L96-L103