### PR TITLE
Deprecate shareRaw

### DIFF
--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     cout << "Created a scalar mesh Record with all required openPMD "
             "attributes\n";
 
-    Datatype datatype = determineDatatypeContiguous(global_data);
+    Datatype datatype = determineDatatype(global_data.data());
     Extent extent = {size, size};
     Dataset dataset = Dataset(datatype, extent);
     cout << "Created a Dataset of size " << dataset.extent[0] << 'x'

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     cout << "Created a scalar mesh Record with all required openPMD "
             "attributes\n";
 
-    Datatype datatype = determineDatatype(global_data.data());
+    Datatype datatype = determineDatatypeContiguous(global_data);
     Extent extent = {size, size};
     Dataset dataset = Dataset(datatype, extent);
     cout << "Created a Dataset of size " << dataset.extent[0] << 'x'

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     cout << "Created a scalar mesh Record with all required openPMD "
             "attributes\n";
 
-    Datatype datatype = determineDatatype(shareRaw(global_data));
+    Datatype datatype = determineDatatype(global_data.data());
     Extent extent = {size, size};
     Dataset dataset = Dataset(datatype, extent);
     cout << "Created a Dataset of size " << dataset.extent[0] << 'x'
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     cout << "File structure and required attributes have been written\n";
 
     Offset offset = {0, 0};
-    rho.storeChunk(shareRaw(global_data), offset, extent);
+    rho.storeChunk(global_data, offset, extent);
     cout << "Stored the whole Dataset contents as a single chunk, "
             "ready to write content\n";
 

--- a/examples/3b_write_resizable_particles.cpp
+++ b/examples/3b_write_resizable_particles.cpp
@@ -39,7 +39,7 @@ int main()
     std::vector<double> y{-2., -3., -4., -5., -6.};
 
     // both x and y the same type, otherwise we use two distinct datasets
-    Datatype dtype = determineDatatype(x.data());
+    Datatype dtype = determineDatatypeContiguous(x);
     Extent size = {x.size()};
     auto dataset = Dataset(dtype, size, "{ \"resizable\": true }");
 

--- a/examples/3b_write_resizable_particles.cpp
+++ b/examples/3b_write_resizable_particles.cpp
@@ -39,7 +39,7 @@ int main()
     std::vector<double> y{-2., -3., -4., -5., -6.};
 
     // both x and y the same type, otherwise we use two distinct datasets
-    Datatype dtype = determineDatatypeContiguous(x);
+    Datatype dtype = determineDatatype(x.data());
     Extent size = {x.size()};
     auto dataset = Dataset(dtype, size, "{ \"resizable\": true }");
 

--- a/examples/3b_write_resizable_particles.cpp
+++ b/examples/3b_write_resizable_particles.cpp
@@ -39,7 +39,7 @@ int main()
     std::vector<double> y{-2., -3., -4., -5., -6.};
 
     // both x and y the same type, otherwise we use two distinct datasets
-    Datatype dtype = determineDatatype(shareRaw(x));
+    Datatype dtype = determineDatatype(x.data());
     Extent size = {x.size()};
     auto dataset = Dataset(dtype, size, "{ \"resizable\": true }");
 

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -275,6 +275,12 @@ inline constexpr Datatype determineDatatype()
 }
 
 template <typename T>
+inline constexpr Datatype determineDatatype(T const *)
+{
+    return determineDatatype<T>();
+}
+
+template <typename T>
 inline constexpr Datatype determineDatatype(std::shared_ptr<T>)
 {
     using DT = Datatype;

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -20,6 +20,8 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/TypeTraits.hpp"
+
 #include <array>
 #include <climits>
 #include <complex>
@@ -275,169 +277,32 @@ inline constexpr Datatype determineDatatype()
 }
 
 template <typename T>
-inline constexpr Datatype determineDatatype(T const *)
+inline constexpr Datatype determineDatatype(std::shared_ptr<T>)
 {
     return determineDatatype<T>();
 }
 
 template <typename T>
-inline constexpr Datatype determineDatatype(std::shared_ptr<T>)
+inline constexpr Datatype determineDatatypeRaw(T const *)
 {
-    using DT = Datatype;
-    if (decay_equiv<T, char>::value)
+    return determineDatatype<T>();
+}
+
+template <typename T_ContiguousContainer>
+inline constexpr Datatype determineDatatypeContiguous(T_ContiguousContainer &&)
+{
+    using T_ContiguousContainer_stripped =
+        std::remove_reference_t<T_ContiguousContainer>;
+    if constexpr (auxiliary::IsContiguousContainer_v<
+                      T_ContiguousContainer_stripped>)
     {
-        return DT::CHAR;
-    }
-    else if (decay_equiv<T, unsigned char>::value)
-    {
-        return DT::UCHAR;
-    }
-    else if (decay_equiv<T, signed char>::value)
-    {
-        return DT::SCHAR;
-    }
-    else if (decay_equiv<T, short>::value)
-    {
-        return DT::SHORT;
-    }
-    else if (decay_equiv<T, int>::value)
-    {
-        return DT::INT;
-    }
-    else if (decay_equiv<T, long>::value)
-    {
-        return DT::LONG;
-    }
-    else if (decay_equiv<T, long long>::value)
-    {
-        return DT::LONGLONG;
-    }
-    else if (decay_equiv<T, unsigned short>::value)
-    {
-        return DT::USHORT;
-    }
-    else if (decay_equiv<T, unsigned int>::value)
-    {
-        return DT::UINT;
-    }
-    else if (decay_equiv<T, unsigned long>::value)
-    {
-        return DT::ULONG;
-    }
-    else if (decay_equiv<T, unsigned long long>::value)
-    {
-        return DT::ULONGLONG;
-    }
-    else if (decay_equiv<T, float>::value)
-    {
-        return DT::FLOAT;
-    }
-    else if (decay_equiv<T, double>::value)
-    {
-        return DT::DOUBLE;
-    }
-    else if (decay_equiv<T, long double>::value)
-    {
-        return DT::LONG_DOUBLE;
-    }
-    else if (decay_equiv<T, std::complex<float>>::value)
-    {
-        return DT::CFLOAT;
-    }
-    else if (decay_equiv<T, std::complex<double>>::value)
-    {
-        return DT::CDOUBLE;
-    }
-    else if (decay_equiv<T, std::complex<long double>>::value)
-    {
-        return DT::CLONG_DOUBLE;
-    }
-    else if (decay_equiv<T, std::string>::value)
-    {
-        return DT::STRING;
-    }
-    else if (decay_equiv<T, std::vector<char>>::value)
-    {
-        return DT::VEC_CHAR;
-    }
-    else if (decay_equiv<T, std::vector<short>>::value)
-    {
-        return DT::VEC_SHORT;
-    }
-    else if (decay_equiv<T, std::vector<int>>::value)
-    {
-        return DT::VEC_INT;
-    }
-    else if (decay_equiv<T, std::vector<long>>::value)
-    {
-        return DT::VEC_LONG;
-    }
-    else if (decay_equiv<T, std::vector<long long>>::value)
-    {
-        return DT::VEC_LONGLONG;
-    }
-    else if (decay_equiv<T, std::vector<unsigned char>>::value)
-    {
-        return DT::VEC_UCHAR;
-    }
-    else if (decay_equiv<T, std::vector<signed char>>::value)
-    {
-        return DT::VEC_SCHAR;
-    }
-    else if (decay_equiv<T, std::vector<unsigned short>>::value)
-    {
-        return DT::VEC_USHORT;
-    }
-    else if (decay_equiv<T, std::vector<unsigned int>>::value)
-    {
-        return DT::VEC_UINT;
-    }
-    else if (decay_equiv<T, std::vector<unsigned long>>::value)
-    {
-        return DT::VEC_ULONG;
-    }
-    else if (decay_equiv<T, std::vector<unsigned long long>>::value)
-    {
-        return DT::VEC_ULONGLONG;
-    }
-    else if (decay_equiv<T, std::vector<float>>::value)
-    {
-        return DT::VEC_FLOAT;
-    }
-    else if (decay_equiv<T, std::vector<double>>::value)
-    {
-        return DT::VEC_DOUBLE;
-    }
-    else if (decay_equiv<T, std::vector<long double>>::value)
-    {
-        return DT::VEC_LONG_DOUBLE;
-    }
-    else if (decay_equiv<T, std::vector<std::complex<float>>>::value)
-    {
-        return DT::VEC_CFLOAT;
-    }
-    else if (decay_equiv<T, std::vector<std::complex<double>>>::value)
-    {
-        return DT::VEC_CDOUBLE;
-    }
-    else if (decay_equiv<T, std::vector<std::complex<long double>>>::value)
-    {
-        return DT::VEC_CLONG_DOUBLE;
-    }
-    else if (decay_equiv<T, std::vector<std::string>>::value)
-    {
-        return DT::VEC_STRING;
-    }
-    else if (decay_equiv<T, std::array<double, 7>>::value)
-    {
-        return DT::ARR_DBL_7;
-    }
-    else if (decay_equiv<T, bool>::value)
-    {
-        return DT::BOOL;
+        return determineDatatype<
+            typename T_ContiguousContainer_stripped::value_type>();
     }
     else
-        return DT::UNDEFINED;
+    {
+        return Datatype::UNDEFINED;
+    }
 }
 
 /** Return number of bytes representing a Datatype

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "openPMD/Dataset.hpp"
-#include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -238,7 +238,7 @@ public:
      *               extent in the record component will be selected.
      */
     template <typename T>
-    void loadChunkRaw(T * data, Offset offset, Extent extent);
+    void loadChunkRaw(T *data, Offset offset, Extent extent);
 
     /** Store a chunk of data from a chunk of memory.
      *

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -270,7 +270,7 @@ public:
      * @param extent Extent within the dataset, counted from the offset.
      */
     template <typename T>
-    void storeChunk(std::shared_ptr<T[]>, Offset, Extent);
+    void storeChunk(std::shared_ptr<T[]> data, Offset offset, Extent extent);
 
     /** Store a chunk of data from a chunk of memory, raw pointer version.
      *

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -303,8 +303,8 @@ public:
      * @param extent Extent within the dataset, counted from the offset.
      */
     template <typename T_ContiguousContainer>
-    typename std::enable_if<
-        auxiliary::IsContiguousContainer_v<T_ContiguousContainer>>::type
+    typename std::enable_if_t<
+        auxiliary::IsContiguousContainer_v<T_ContiguousContainer>>
     storeChunk(
         T_ContiguousContainer &data,
         Offset offset = {0u},

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -198,35 +198,118 @@ public:
     template <typename T>
     std::shared_ptr<T> loadChunk(Offset = {0u}, Extent = {-1u});
 
-    /** Load a chunk of data into pre-allocated memory
+    /** Load a chunk of data into pre-allocated memory.
      *
-     * shared_ptr for data must be pre-allocated, contiguous and large enough
-     * for extent
-     *
-     * Set offset to {0u} and extent to {-1u} for full selection.
-     *
-     * If offset is non-zero and extent is {-1u} the leftover extent in the
-     * record component will be selected.
+     * @param data   Preallocated, contiguous buffer, large enough to load the
+     *               the requested data into it.
+     *               The shared pointer must either own and manage the buffer
+     *               or have been created via shareRaw().
+     *               If using shareRaw(), it is in the user of this API call's
+     *               responsibility to ensure that the lifetime of the buffer
+     *               exceeds the next <a
+     * href="https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#deferred-data-api-contract">
+     *               flush point</a>.
+     *               Optimizations might be implemented based on this
+     *               assumption (e.g. skipping the operation if the backend
+     *               is the unique owner).
+     *               For raw pointers, use loadChunkRaw().
+     * @param offset Offset within the dataset. Set to {0u} for full selection.
+     * @param extent Extent within the dataset, counted from the offset.
+     *               Set to {-1u} for full selection.
+     *               If offset is non-zero and extent is {-1u} the leftover
+     *               extent in the record component will be selected.
      */
     template <typename T>
-    void loadChunk(std::shared_ptr<T>, Offset, Extent);
+    void loadChunk(std::shared_ptr<T> data, Offset offset, Extent extent);
 
+    /** Load a chunk of data into pre-allocated memory, raw pointer version.
+     *
+     * @param data   Preallocated, contiguous buffer, large enough to load the
+     *               the requested data into it.
+     *               It is in the user of this API call's responsibility to
+     *               ensure that the lifetime of the buffer exceeds the next
+     *               <a
+     * href="https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#deferred-data-api-contract">
+     *               flush point</a>.
+     * @param offset Offset within the dataset. Set to {0u} for full selection.
+     * @param extent Extent within the dataset, counted from the offset.
+     *               Set to {-1u} for full selection.
+     *               If offset is non-zero and extent is {-1u} the leftover
+     *               extent in the record component will be selected.
+     */
     template <typename T>
-    void loadChunkRaw(T *, Offset, Extent);
+    void loadChunkRaw(T * data, Offset offset, Extent extent);
 
+    /** Store a chunk of data from a chunk of memory.
+     *
+     * @param data   Preallocated, contiguous buffer, large enough to read the
+     *               the specified data from it.
+     *               The shared pointer must either own and manage the buffer
+     *               or have been created via shareRaw().
+     *               If using shareRaw(), it is in the user of this API call's
+     *               responsibility to ensure that the lifetime of the buffer
+     *               exceeds the next <a
+     * href="https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#deferred-data-api-contract">
+     *               flush point</a>.
+     *               Optimizations might be implemented based on this
+     *               assumption (e.g. further deferring the operation if the
+     *               backend is the unique owner).
+     *               For raw pointers, use storeChunkRaw().
+     * @param offset Offset within the dataset.
+     * @param extent Extent within the dataset, counted from the offset.
+     */
     template <typename T>
-    void storeChunk(std::shared_ptr<T>, Offset, Extent);
+    void storeChunk(std::shared_ptr<T> data, Offset offset, Extent extent);
 
+    /** Store a chunk of data from a chunk of memory, array version.
+     *
+     * @param data   Preallocated, contiguous buffer, large enough to read the
+     *               the specified data from it.
+     *               The array-based overload helps avoid having to manually
+     *               specify the delete[] destructor (C++17 feature).
+     * @param offset Offset within the dataset.
+     * @param extent Extent within the dataset, counted from the offset.
+     */
     template <typename T>
     void storeChunk(std::shared_ptr<T[]>, Offset, Extent);
 
+    /** Store a chunk of data from a chunk of memory, raw pointer version.
+     *
+     * @param data   Preallocated, contiguous buffer, large enough to read the
+     *               the specified data from it.
+     *               It is in the user of this API call's responsibility to
+     *               ensure that the lifetime of the buffer exceeds the next
+     *               <a
+     * href="https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#deferred-data-api-contract">
+     *               flush point</a>.
+     * @param offset Offset within the dataset.
+     * @param extent Extent within the dataset, counted from the offset.
+     */
     template <typename T>
-    void storeChunkRaw(T *, Offset, Extent);
+    void storeChunkRaw(T *data, Offset offset, Extent extent);
 
+    /** Store a chunk of data from a contiguous container.
+     *
+     * @param data   <a
+     *               href="https://en.cppreference.com/w/cpp/named_req/ContiguousContainer">
+     *               Contiguous container</a>, large enough to read the the
+     *               specified data from it. A contiguous container in here is
+     *               either a std::vector or a std::array.
+     *               It is in the user of this API call's responsibility to
+     *               ensure that the lifetime of the container exceeds the next
+     *               <a
+     * href="https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#deferred-data-api-contract">
+     *               flush point</a>.
+     * @param offset Offset within the dataset.
+     * @param extent Extent within the dataset, counted from the offset.
+     */
     template <typename T_ContiguousContainer>
     typename std::enable_if<
         auxiliary::IsContiguousContainer_v<T_ContiguousContainer>>::type
-    storeChunk(T_ContiguousContainer &, Offset = {0u}, Extent = {-1u});
+    storeChunk(
+        T_ContiguousContainer &data,
+        Offset offset = {0u},
+        Extent extent = {-1u});
 
     /**
      * @brief Overload of storeChunk() that lets the openPMD API allocate
@@ -236,14 +319,17 @@ public:
      * users a view into its own buffers, avoiding the need to allocate
      * a new buffer.
      *
-     * Data can be written into the returned buffer until the next call to
-     * Series::flush() at which time the data will be read from.
+     * Data can be written into the returned buffer until the next <a
+     * href="https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#deferred-data-api-contract">
+     * flush point </a> at which time the data will be read from.
      *
      * In order to provide a view into backend buffers, this call must possibly
      * create files and datasets in the backend, making it MPI-collective.
      * In order to avoid this, calling Series::flush() prior to this is
      * recommended to flush definitions.
      *
+     * @param offset Offset within the dataset.
+     * @param extent Extent within the dataset, counted from the offset.
      * @param createBuffer If the backend in use has no special support for this
      *        operation, the openPMD API will fall back to creating a buffer,
      *        queuing it for writing and returning a view into that buffer to
@@ -259,7 +345,8 @@ public:
      * @return View into a buffer that can be filled with data.
      */
     template <typename T, typename F>
-    DynamicMemoryView<T> storeChunk(Offset, Extent, F &&createBuffer);
+    DynamicMemoryView<T>
+    storeChunk(Offset offset, Extent extent, F &&createBuffer);
 
     /**
      * Overload of span-based storeChunk() that uses operator new() to create

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -221,6 +221,25 @@ public:
     template <typename T>
     void loadChunk(std::shared_ptr<T> data, Offset offset, Extent extent);
 
+    /** Load a chunk of data into pre-allocated memory, array version.
+     *
+     * @param data   Preallocated, contiguous buffer, large enough to load the
+     *               the requested data into it.
+     *               The shared pointer must own and manage the buffer.
+     *               Optimizations might be implemented based on this
+     *               assumption (e.g. skipping the operation if the backend
+     *               is the unique owner).
+     *               The array-based overload helps avoid having to manually
+     *               specify the delete[] destructor (C++17 feature).
+     * @param offset Offset within the dataset. Set to {0u} for full selection.
+     * @param extent Extent within the dataset, counted from the offset.
+     *               Set to {-1u} for full selection.
+     *               If offset is non-zero and extent is {-1u} the leftover
+     *               extent in the record component will be selected.
+     */
+    template <typename T>
+    void loadChunk(std::shared_ptr<T[]> data, Offset offset, Extent extent);
+
     /** Load a chunk of data into pre-allocated memory, raw pointer version.
      *
      * @param data   Preallocated, contiguous buffer, large enough to load the

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -22,6 +22,7 @@
 
 #include "openPMD/Dataset.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"
+#include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 
 #include <array>
@@ -42,34 +43,6 @@
 
 namespace openPMD
 {
-namespace traits
-{
-    /** Emulate in the C++17 concept ContiguousContainer
-     *
-     * Users can implement this trait for a type to signal it can be used as
-     * contiguous container.
-     *
-     * See:
-     *   https://en.cppreference.com/w/cpp/named_req/ContiguousContainer
-     */
-    template <typename T>
-    struct IsContiguousContainer
-    {
-        static constexpr bool value = false;
-    };
-
-    template <typename T_Value>
-    struct IsContiguousContainer<std::vector<T_Value> >
-    {
-        static constexpr bool value = true;
-    };
-
-    template <typename T_Value, std::size_t N>
-    struct IsContiguousContainer<std::array<T_Value, N> >
-    {
-        static constexpr bool value = true;
-    };
-} // namespace traits
 
 template <typename T>
 class DynamicMemoryView;
@@ -239,14 +212,20 @@ public:
     void loadChunk(std::shared_ptr<T>, Offset, Extent);
 
     template <typename T>
+    void loadChunkRaw(T *, Offset, Extent);
+
+    template <typename T>
     void storeChunk(std::shared_ptr<T>, Offset, Extent);
 
     template <typename T>
     void storeChunk(std::shared_ptr<T[]>, Offset, Extent);
 
+    template <typename T>
+    void storeChunkRaw(T *, Offset, Extent);
+
     template <typename T_ContiguousContainer>
     typename std::enable_if<
-        traits::IsContiguousContainer<T_ContiguousContainer>::value>::type
+        auxiliary::IsContiguousContainer_v<T_ContiguousContainer>>::type
     storeChunk(T_ContiguousContainer &, Offset = {0u}, Extent = {-1u});
 
     /**

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -23,6 +23,7 @@
 
 #include "openPMD/RecordComponent.hpp"
 #include "openPMD/Span.hpp"
+#include "openPMD/auxiliary/ShareRawInternal.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
 
 namespace openPMD
@@ -162,7 +163,7 @@ template <typename T>
 inline void RecordComponent::loadChunkRaw(T *ptr, Offset offset, Extent extent)
 {
     loadChunk(
-        std::shared_ptr<T>{ptr, [](auto const *) {}},
+        auxiliary::shareRaw(ptr),
         std::move(offset),
         std::move(extent));
 }
@@ -232,7 +233,7 @@ template <typename T>
 void RecordComponent::storeChunkRaw(T *ptr, Offset offset, Extent extent)
 {
     storeChunk(
-        std::shared_ptr<T>{ptr, [](auto const *) {}},
+        auxiliary::shareRaw(ptr),
         std::move(offset),
         std::move(extent));
 }
@@ -259,9 +260,8 @@ RecordComponent::storeChunk(T_ContiguousContainer &data, Offset o, Extent e)
     else
         extent = e;
 
-    using value_type = typename T_ContiguousContainer::value_type;
     storeChunk(
-        std::shared_ptr<value_type>{data.data(), [](auto const *) {}},
+        auxiliary::shareRaw(data.data()),
         offset,
         extent);
 }

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -256,8 +256,8 @@ void RecordComponent::storeChunkRaw(T *ptr, Offset offset, Extent extent)
 }
 
 template< typename T_ContiguousContainer >
-inline typename std::enable_if<
-    auxiliary::IsContiguousContainer_v<T_ContiguousContainer> >::type
+inline typename std::enable_if_t<
+    auxiliary::IsContiguousContainer_v<T_ContiguousContainer> >
 RecordComponent::storeChunk(T_ContiguousContainer &data, Offset o, Extent e)
 {
     uint8_t dim = getDimensionality();

--- a/include/openPMD/auxiliary/Mpi.hpp
+++ b/include/openPMD/auxiliary/Mpi.hpp
@@ -22,6 +22,8 @@
 
 #include "openPMD/config.hpp"
 
+#include "openPMD/auxiliary/TypeTraits.hpp"
+
 #if openPMD_HAVE_MPI
 #include <mpi.h>
 #endif
@@ -31,16 +33,6 @@
 namespace openPMD::auxiliary
 {
 #if openPMD_HAVE_MPI
-
-namespace detail
-{
-    namespace
-    {
-        // see https://en.cppreference.com/w/cpp/language/if
-        template <typename>
-        inline constexpr bool dependent_false_v = false;
-    } // namespace
-} // namespace detail
 
 namespace
 {
@@ -67,8 +59,7 @@ namespace
         else
         {
             static_assert(
-                detail::dependent_false_v<T>,
-                "openPMD_MPI_type: Unsupported type.");
+                dependent_false_v<T>, "openPMD_MPI_type: Unsupported type.");
         }
     }
 } // namespace

--- a/include/openPMD/auxiliary/ShareRaw.hpp
+++ b/include/openPMD/auxiliary/ShareRaw.hpp
@@ -42,18 +42,29 @@ namespace openPMD
  *          reference counting.
  */
 template <typename T>
-std::shared_ptr<T> shareRaw(T *x)
+[[deprecated(
+    "For storing/loading data via raw pointers use "
+    "storeChunkRaw<>()/loadChunkRaw<>()")]] //
+std::shared_ptr<T>
+shareRaw(T *x)
 {
     return std::shared_ptr<T>(x, [](T *) {});
 }
 
 template <typename T>
-std::shared_ptr<T const> shareRaw(T const *x)
+[[deprecated(
+    "For storing/loading data via raw pointers use "
+    "storeChunkRaw<>()/loadChunkRaw<>()")]] //
+std::shared_ptr<T const>
+shareRaw(T const *x)
 {
     return std::shared_ptr<T const>(x, [](T const *) {});
 }
 
 template <typename T>
+[[deprecated(
+    "For storing/loading data via raw pointers use "
+    "storeChunkRaw<>()/loadChunkRaw<>()")]] //
 auto shareRaw(T &c)
     -> std::shared_ptr<typename std::remove_pointer<decltype(c.data())>::type>
 {
@@ -62,6 +73,9 @@ auto shareRaw(T &c)
 }
 
 template <typename T>
+[[deprecated(
+    "For storing/loading data via raw pointers use "
+    "storeChunkRaw<>()/loadChunkRaw<>()")]] //
 auto shareRaw(T const &c)
     -> std::shared_ptr<typename std::remove_pointer<decltype(c.data())>::type>
 {

--- a/include/openPMD/auxiliary/ShareRawInternal.hpp
+++ b/include/openPMD/auxiliary/ShareRawInternal.hpp
@@ -49,15 +49,13 @@ namespace openPMD::auxiliary
  *          reference counting.
  */
 template <typename T>
-std::shared_ptr<T>
-shareRaw(T *x)
+std::shared_ptr<T> shareRaw(T *x)
 {
     return std::shared_ptr<T>(x, [](T *) {});
 }
 
 template <typename T>
-std::shared_ptr<T const>
-shareRaw(T const *x)
+std::shared_ptr<T const> shareRaw(T const *x)
 {
     return std::shared_ptr<T const>(x, [](T const *) {});
 }
@@ -78,4 +76,4 @@ auto shareRaw(T const &c)
     return std::shared_ptr<value_type>(c.data(), [](value_type *) {});
 }
 //! @}
-} // namespace openPMD
+} // namespace openPMD::auxiliary

--- a/include/openPMD/auxiliary/ShareRawInternal.hpp
+++ b/include/openPMD/auxiliary/ShareRawInternal.hpp
@@ -1,0 +1,81 @@
+/* Copyright 2018-2021 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <array>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+/*
+ * This header copies ShareRaw.hpp, but:
+ * 1. without deprecation markings
+ * 2. for internal usage only
+ * 3. inside auxiliary namespace
+ */
+
+namespace openPMD::auxiliary
+{
+//! @{
+/** Share ownership with a raw pointer
+ *
+ * Helper function to share load/store data ownership
+ * unprotected and without reference counting with a
+ * raw pointer or stdlib container (that implements a
+ * contiguous data storage).
+ *
+ * @warning this is a helper function to bypass the shared-pointer
+ *          API for storing data behind raw pointers. Using it puts
+ *          the responsibility of buffer-consistency between stores
+ *          and flushes to the users side without an indication via
+ *          reference counting.
+ */
+template <typename T>
+std::shared_ptr<T>
+shareRaw(T *x)
+{
+    return std::shared_ptr<T>(x, [](T *) {});
+}
+
+template <typename T>
+std::shared_ptr<T const>
+shareRaw(T const *x)
+{
+    return std::shared_ptr<T const>(x, [](T const *) {});
+}
+
+template <typename T>
+auto shareRaw(T &c)
+    -> std::shared_ptr<typename std::remove_pointer<decltype(c.data())>::type>
+{
+    using value_type = typename std::remove_pointer<decltype(c.data())>::type;
+    return std::shared_ptr<value_type>(c.data(), [](value_type *) {});
+}
+
+template <typename T>
+auto shareRaw(T const &c)
+    -> std::shared_ptr<typename std::remove_pointer<decltype(c.data())>::type>
+{
+    using value_type = typename std::remove_pointer<decltype(c.data())>::type;
+    return std::shared_ptr<value_type>(c.data(), [](value_type *) {});
+}
+//! @}
+} // namespace openPMD

--- a/include/openPMD/auxiliary/TypeTraits.hpp
+++ b/include/openPMD/auxiliary/TypeTraits.hpp
@@ -70,4 +70,11 @@ inline constexpr bool IsArray_v = detail::IsArray<T>::value;
  */
 template <typename T>
 inline constexpr bool IsContiguousContainer_v = IsVector_v<T> || IsArray_v<T>;
+
+namespace
+{
+    // see https://en.cppreference.com/w/cpp/language/if
+    template <typename>
+    inline constexpr bool dependent_false_v = false;
+} // namespace
 } // namespace openPMD::auxiliary

--- a/include/openPMD/auxiliary/TypeTraits.hpp
+++ b/include/openPMD/auxiliary/TypeTraits.hpp
@@ -59,4 +59,15 @@ inline constexpr bool IsVector_v = detail::IsVector<T>::value;
 
 template <typename T>
 inline constexpr bool IsArray_v = detail::IsArray<T>::value;
+
+/** Emulate in the C++ concept ContiguousContainer
+ *
+ * Users can implement this trait for a type to signal it can be used as
+ * contiguous container.
+ *
+ * See:
+ *   https://en.cppreference.com/w/cpp/named_req/ContiguousContainer
+ */
+template <typename T>
+inline constexpr bool IsContiguousContainer_v = IsVector_v<T> || IsArray_v<T>;
 } // namespace openPMD::auxiliary

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/ShareRawInternal.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 
 #include <sstream>
@@ -175,9 +176,7 @@ inline void PatchRecordComponent::load(std::shared_ptr<T> data)
 template <typename T>
 inline void PatchRecordComponent::loadRaw(T *data)
 {
-    // @todo maybe use an internal shareraw version to avoid overlooking
-    // this instance in future
-    load<T>(std::shared_ptr<T>{data, [](auto const *) {}});
+    load<T>(auxiliary::shareRaw(data));
 }
 
 template <typename T>

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -85,6 +85,9 @@ public:
     void load(std::shared_ptr<T>);
 
     template <typename T>
+    void loadRaw(T *);
+
+    template <typename T>
     void store(uint64_t idx, T);
 
     // clang-format off
@@ -167,6 +170,14 @@ inline void PatchRecordComponent::load(std::shared_ptr<T> data)
     dRead.data = std::static_pointer_cast<void>(data);
     auto &rc = get();
     rc.m_chunks.push(IOTask(this, dRead));
+}
+
+template <typename T>
+inline void PatchRecordComponent::loadRaw(T *data)
+{
+    // @todo maybe use an internal shareraw version to avoid overlooking
+    // this instance in future
+    load<T>(std::shared_ptr<T>{data, [](auto const *) {}});
 }
 
 template <typename T>

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -86,6 +86,9 @@ public:
     void load(std::shared_ptr<T>);
 
     template <typename T>
+    void load(std::shared_ptr<T[]>);
+
+    template <typename T>
     void loadRaw(T *);
 
     template <typename T>
@@ -141,10 +144,16 @@ template <typename T>
 inline std::shared_ptr<T> PatchRecordComponent::load()
 {
     uint64_t numPoints = getExtent()[0];
+#if defined(__clang_major__) && __clang_major__ < 7
     auto newData =
         std::shared_ptr<T>(new T[numPoints], [](T *p) { delete[] p; });
     load(newData);
     return newData;
+#else
+    auto newData = std::shared_ptr<T[]>(new T[numPoints]);
+    load(newData);
+    return std::static_pointer_cast<T>(std::move(newData));
+#endif
 }
 
 template <typename T>
@@ -171,6 +180,12 @@ inline void PatchRecordComponent::load(std::shared_ptr<T> data)
     dRead.data = std::static_pointer_cast<void>(data);
     auto &rc = get();
     rc.m_chunks.push(IOTask(this, dRead));
+}
+
+template <typename T>
+inline void PatchRecordComponent::load(std::shared_ptr<T[]> data)
+{
+    load(std::static_pointer_cast<T>(std::move(data)));
 }
 
 template <typename T>

--- a/src/binding/python/PatchRecordComponent.cpp
+++ b/src/binding/python/PatchRecordComponent.cpp
@@ -22,7 +22,6 @@
 #include <pybind11/stl.h>
 
 #include "openPMD/DatatypeHelpers.hpp"
-#include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"
 #include "openPMD/binding/python/Numpy.hpp"
@@ -37,7 +36,7 @@ struct Prc_Load
     template <typename T>
     static void call(PatchRecordComponent &prc, py::array &a)
     {
-        prc.load<T>(shareRaw((T *)a.mutable_data()));
+        prc.loadRaw<T>((T *)a.mutable_data());
     }
 
     static constexpr char const *errorMsg = "Datatype not known in 'load'!";

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -25,7 +25,6 @@
 #include "openPMD/DatatypeHelpers.hpp"
 #include "openPMD/RecordComponent.hpp"
 #include "openPMD/Series.hpp"
-#include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/binding/python/Numpy.hpp"
 #include "openPMD/binding/python/Pickle.hpp"

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -836,7 +836,7 @@ TEST_CASE("wrapper_test", "[core]")
     MeshRecordComponent mrc2 = o.iterations[4].meshes["E"]["y"];
     REQUIRE(mrc2.constant());
     double loadData;
-    mrc2.loadChunk(shareRaw(&loadData), {0}, {1});
+    mrc2.loadChunkRaw(&loadData, {0}, {1});
     o.flush();
     REQUIRE(loadData == value);
     // TODO: do we want to be able to make data constant after already writing
@@ -846,7 +846,7 @@ TEST_CASE("wrapper_test", "[core]")
         Catch::Equals("A recordComponent can not (yet) be made constant after "
                       "it has been written."));
     std::array<double, 1> moreData = {{112233.}};
-    o.iterations[4].meshes["E"]["y"].loadChunk(shareRaw(moreData), {0}, {1});
+    o.iterations[4].meshes["E"]["y"].loadChunkRaw(moreData.data(), {0}, {1});
     o.flush();
     REQUIRE(moreData[0] == value);
     auto all_data = o.iterations[4].meshes["E"]["y"].loadChunk<double>();
@@ -862,8 +862,7 @@ TEST_CASE("wrapper_test", "[core]")
         Dataset(Datatype::DOUBLE, {1}));
     int wrongData = 42;
     REQUIRE_THROWS_WITH(
-        o.iterations[5].meshes["E"]["y"].storeChunk(
-            shareRaw(&wrongData), {0}, {1}),
+        o.iterations[5].meshes["E"]["y"].storeChunkRaw(&wrongData, {0}, {1}),
         Catch::Equals("Datatypes of chunk data (INT) and record component "
                       "(DOUBLE) do not match."));
     std::shared_ptr<double> storeData = std::make_shared<double>(44);

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -858,7 +858,7 @@ void file_based_write_read(std::string file_ending)
 
             Offset chunk_offset = {0, local_Nz * mpi_rank};
             Extent chunk_extent = {global_Nx, local_Nz};
-            E_x.storeChunk(io::shareRaw(E_x_data), chunk_offset, chunk_extent);
+            E_x.storeChunk(E_x_data, chunk_offset, chunk_extent);
             series.flush();
         }
     }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1814,8 +1814,7 @@ inline void fileBased_write_test(const std::string &backend)
         for (uint64_t i = 0; i < 4; ++i)
         {
             double const position_local_2 = position_global.at(i);
-            e_2["position"]["x"].storeChunk(
-                shareRaw(&position_local_2), {i}, {1});
+            e_2["position"]["x"].storeChunkRaw(&position_local_2, {i}, {1});
             *positionOffset_local_2 = positionOffset_global[i];
             e_2["positionOffset"]["x"].storeChunk(
                 positionOffset_local_2, {i}, {1});
@@ -3572,7 +3571,7 @@ TEST_CASE("hzdr_hdf5_sample_content_test", "[serial][hdf5]")
             isSame(e_extent_z.getDatatype(), determineDatatype<uint64_t>()));
 
         std::vector<uint64_t> data(e_patches.size());
-        e_extent_z.load(shareRaw(data.data()));
+        e_extent_z.loadRaw(data.data());
         species_e.seriesFlush();
         REQUIRE(data.at(0) == static_cast<uint64_t>(80));
         REQUIRE(data.at(1) == static_cast<uint64_t>(80));
@@ -3594,7 +3593,7 @@ TEST_CASE("hzdr_hdf5_sample_content_test", "[serial][hdf5]")
             e_numParticles_scalar.getDatatype(),
             determineDatatype<uint64_t>()));
 
-        e_numParticles_scalar.load(shareRaw(data.data()));
+        e_numParticles_scalar.loadRaw(data.data());
         o.flush();
         REQUIRE(data.at(0) == static_cast<uint64_t>(512000));
         REQUIRE(data.at(1) == static_cast<uint64_t>(819200));
@@ -3640,7 +3639,7 @@ TEST_CASE("hzdr_hdf5_sample_content_test", "[serial][hdf5]")
         REQUIRE(
             isSame(e_offset_y.getDatatype(), determineDatatype<uint64_t>()));
 
-        e_offset_y.load(shareRaw(data.data()));
+        e_offset_y.loadRaw(data.data());
         o.flush();
         REQUIRE(data.at(0) == static_cast<uint64_t>(0));
         REQUIRE(data.at(1) == static_cast<uint64_t>(128));

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6614,8 +6614,8 @@ void groupbased_read_write(std::string const &ext)
         auto E_y = write.iterations[0].meshes["E"]["y"];
         E_x.resetDataset(ds);
         E_y.resetDataset(ds);
-        E_x.storeChunk(shareRaw(&data), {0}, {1});
-        E_y.storeChunk(shareRaw(&data), {0}, {1});
+        E_x.storeChunkRaw(&data, {0}, {1});
+        E_y.storeChunkRaw(&data, {0}, {1});
 
         E_x.setAttribute("updated_in_run", 0);
         E_y.setAttribute("updated_in_run", 0);
@@ -6632,8 +6632,8 @@ void groupbased_read_write(std::string const &ext)
 
         data = 1;
 
-        E_x.storeChunk(shareRaw(&data), {0}, {1});
-        E_y.storeChunk(shareRaw(&data), {0}, {1});
+        E_x.storeChunkRaw(&data, {0}, {1});
+        E_y.storeChunkRaw(&data, {0}, {1});
 
         E_x.setAttribute("updated_in_run", 1);
         E_y.setAttribute("updated_in_run", 1);
@@ -6669,7 +6669,7 @@ void groupbased_read_write(std::string const &ext)
 
         data = 2;
 
-        E_x.storeChunk(shareRaw(&data), {0}, {1});
+        E_x.storeChunkRaw(&data, {0}, {1});
         E_x.setAttribute("updated_in_run", 2);
     }
 


### PR DESCRIPTION
Idea: Instead of `rc.storeChunk(shareRaw(ptr), …)`, have users write `rc.storeChunkRaw(ptr, …)` which is a bit more transparent in what is happening. Partially resolves #1216 by introducing a clearer API that distinguishes between owned and non-owned resources.

TODO

- [x] Documentation
- [x] The diff on examples, tests and Python bindings shows the proposed API changes. Discuss if they are ok like this. (Especially the changes in `determineDatatype`)
- [ ] Maybe revert some usage changes, so the CI can test if shareRaw continues working
- [x] Introduce an internal version of shareRaw, so every creation of a non-owning shared pointer goes through the same function. Ideally, in the end a shared pointer is either owning or has been created by that function.