### PR TITLE
Wheels: Fix macOS arm64 (M1) builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64"
               MACOSX_DEPLOYMENT_TARGET: 11.0
-          - os: macos-10.15
+          - os: macos-11
             arch: "universal2"
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,13 @@ jobs:
           # Needs extra treatment of all librarys that are not CMake controlled
           # the dependencies:
           #   https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
-          - os: macos-11
-            arch: "universal2"
-            env:
-              CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
-              MACOSX_DEPLOYMENT_TARGET: 11.0
+          # ADIOS1 tricky to build and HDF5 even with CMake as well (as of 1.12)
+          # We could build them twice and use `lipo` to combine the lib artifacts.
+          #- os: macos-11
+          #  arch: "universal2"
+          #  env:
+          #    CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
+          #    MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,16 @@ jobs:
             arch: "arm64"
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64"
+              CMAKE_APPLE_SILICON_PROCESSOR: "x86_64"
               MACOSX_DEPLOYMENT_TARGET: 11.0
+          # Needs extra treatment of all librarys that are not CMake controlled
+          # the dependencies:
+          #   https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
           - os: macos-11
             arch: "universal2"
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
+              CMAKE_APPLE_SILICON_PROCESSOR: "x86_64"
               MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
@@ -118,6 +123,7 @@ jobs:
         # arm64 Python interpreters are built with 11.0
         MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.MACOSX_DEPLOYMENT_TARGET }}"
         CMAKE_OSX_ARCHITECTURES: "${{ matrix.env.CMAKE_OSX_ARCHITECTURES }}"
+        CMAKE_APPLE_SILICON_PROCESSOR: "${{ matrix.env.CMAKE_APPLE_SILICON_PROCESSOR }}"
         # Show a bit more output (pip -v)
         CIBW_BUILD_VERBOSITY: 1
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           # CPython 3.8:
           #   https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
           #   https://github.com/pypa/cibuildwheel/pull/704
-          - os: macos-10.15
+          - os: macos-11
             arch: "arm64"
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
             arch: "arm64"
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64"
-              CMAKE_APPLE_SILICON_PROCESSOR: "x86_64"
               MACOSX_DEPLOYMENT_TARGET: 11.0
           # Needs extra treatment of all librarys that are not CMake controlled
           # the dependencies:
@@ -60,7 +59,6 @@ jobs:
             arch: "universal2"
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
-              CMAKE_APPLE_SILICON_PROCESSOR: "x86_64"
               MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
@@ -123,7 +121,6 @@ jobs:
         # arm64 Python interpreters are built with 11.0
         MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.MACOSX_DEPLOYMENT_TARGET }}"
         CMAKE_OSX_ARCHITECTURES: "${{ matrix.env.CMAKE_OSX_ARCHITECTURES }}"
-        CMAKE_APPLE_SILICON_PROCESSOR: "${{ matrix.env.CMAKE_APPLE_SILICON_PROCESSOR }}"
         # Show a bit more output (pip -v)
         CIBW_BUILD_VERBOSITY: 1
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,22 @@ jobs:
 
           - os: macos-10.15
             arch: "x86_64"
+            env:
+              MACOSX_DEPLOYMENT_TARGET: 10.9
           # not really needed separately, yet arm64 also creates a wheel for
           # CPython 3.8:
           #   https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
           #   https://github.com/pypa/cibuildwheel/pull/704
           - os: macos-10.15
             arch: "arm64"
+            env:
+              CMAKE_OSX_ARCHITECTURES: "arm64"
+              MACOSX_DEPLOYMENT_TARGET: 11.0
           - os: macos-10.15
             arch: "universal2"
+            env:
+              CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
+              MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
     - uses: actions/checkout@v2
@@ -107,7 +115,9 @@ jobs:
         # C++11 & 14 support in macOS 10.9+
         # C++17 support in macOS 10.13+/10.14+
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
-        MACOSX_DEPLOYMENT_TARGET: 10.9
+        # arm64 Python interpreters are built with 11.0
+        MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.MACOSX_DEPLOYMENT_TARGET }}"
+        CMAKE_OSX_ARCHITECTURES: "${{ matrix.env.CMAKE_OSX_ARCHITECTURES }}"
         # Show a bit more output (pip -v)
         CIBW_BUILD_VERBOSITY: 1
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,17 +43,19 @@ jobs:
             arch: "x86_64"
             env:
               MACOSX_DEPLOYMENT_TARGET: 10.9
-          # Apple Silicon M1 arm64 builds:
-          #   TODO HDF5 cross-compilation builds still tricky
-          # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-          # https://github.com/pypa/cibuildwheel/pull/704
-          #- os: macos-11
-          #  arch: "arm64"
-          #  env:
-          #    CMAKE_OSX_ARCHITECTURES: "arm64"
-          #    MACOSX_DEPLOYMENT_TARGET: 11.0
-          # Needs extra treatment of all librarys that are not CMake controlled
-          # the dependencies:
+
+          # Apple Silicon M1/arm64/aarch64 builds:
+          #   https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
+          #   https://github.com/pypa/cibuildwheel/pull/704
+          - os: macos-11
+            arch: "arm64"
+            env:
+              CMAKE_OSX_ARCHITECTURES: "arm64"
+              MACOSX_DEPLOYMENT_TARGET: 11.0
+
+          # Apple universal builds that contain x86-64 and arm64 binary code
+          #   Needs extra treatment of all librarys that are not CMake
+          #   controlled the dependencies:
           #   https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
           # ADIOS1 tricky to build and HDF5 even with CMake as well (as of 1.12)
           # We could build them twice and use `lipo` to combine the lib artifacts.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,15 +43,15 @@ jobs:
             arch: "x86_64"
             env:
               MACOSX_DEPLOYMENT_TARGET: 10.9
-          # not really needed separately, yet arm64 also creates a wheel for
-          # CPython 3.8:
-          #   https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-          #   https://github.com/pypa/cibuildwheel/pull/704
-          - os: macos-11
-            arch: "arm64"
-            env:
-              CMAKE_OSX_ARCHITECTURES: "arm64"
-              MACOSX_DEPLOYMENT_TARGET: 11.0
+          # Apple Silicon M1 arm64 builds:
+          #   TODO HDF5 cross-compilation builds still tricky
+          # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
+          # https://github.com/pypa/cibuildwheel/pull/704
+          #- os: macos-11
+          #  arch: "arm64"
+          #  env:
+          #    CMAKE_OSX_ARCHITECTURES: "arm64"
+          #    MACOSX_DEPLOYMENT_TARGET: 11.0
           # Needs extra treatment of all librarys that are not CMake controlled
           # the dependencies:
           #   https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -143,14 +143,14 @@ exit /b 0
 :build_zlib
   if exist zlib-stamp exit /b 0
 
-  curl -sLo zlib-1.2.11.zip ^
-    https://github.com/madler/zlib/archive/v1.2.11.zip
-  powershell Expand-Archive zlib-1.2.11.zip -DestinationPath dep-zlib
+  curl -sLo zlib-1.2.12.zip ^
+    https://github.com/madler/zlib/archive/v1.2.12.zip
+  powershell Expand-Archive zlib-1.2.12.zip -DestinationPath dep-zlib
 
-  cmake -S dep-zlib/zlib-1.2.11 -B build-zlib ^
-    -DBUILD_SHARED_LIBS=OFF
+  cmake -S dep-zlib/zlib-1.2.12 -B build-zlib ^
+    -DBUILD_SHARED_LIBS=OFF ^
+    -DCMAKE_BUILD_TYPE=Release
   if errorlevel 1 exit 1
-  :: TODO: zlib 1.2.11 ignores -DCMAKE_BUILD_TYPE=Release
 
   cmake --build build-zlib --parallel %CPU_COUNT%
   if errorlevel 1 exit 1

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -84,11 +84,11 @@ exit /b 0
 :build_hdf5
   if exist hdf5-stamp exit /b 0
 
-  curl -sLo hdf5-1.12.0.zip ^
-    https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.zip
-  powershell Expand-Archive hdf5-1.12.0.zip -DestinationPath dep-hdf5
+  curl -sLo hdf5-1.12.2.zip ^
+    https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.2/src/hdf5-1.12.2.zip
+  powershell Expand-Archive hdf5-1.12.2.zip -DestinationPath dep-hdf5
 
-  cmake -S dep-hdf5/hdf5-1.12.0 -B build-hdf5 ^
+  cmake -S dep-hdf5/hdf5-1.12.2 -B build-hdf5 ^
     -DCMAKE_BUILD_TYPE=Release  ^
     -DCMAKE_VERBOSE_MAKEFILE=ON ^
     -DBUILD_SHARED_LIBS=OFF     ^

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -16,11 +16,6 @@ function install_buildessentials {
         brew unlink hdf5 || true
         brew uninstall --ignore-dependencies hdf5 || true
         rm -rf /usr/local/Cellar/hdf5
-
-        # we need Rosetta2 to configure cross-compiles for HDF5
-        if [[ "${CMAKE_OSX_ARCHITECTURES-}" == *"arm64"* ]]; then
-            softwareupdate --install-rosetta --agree-to-license
-        fi
     fi
 
     # musllinux: Alpine Linux

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -9,13 +9,18 @@ CPU_COUNT="${CPU_COUNT:-2}"
 function install_buildessentials {
     if [ -e buildessentials-stamp ]; then return; fi
 
-    # Cleanup:
-    #   - Travis-CI macOS ships a pre-installed HDF5
     if [ "$(uname -s)" = "Darwin" ]
     then
+        # Cleanup:
+        #   - Travis-CI macOS ships a pre-installed HDF5
         brew unlink hdf5 || true
         brew uninstall --ignore-dependencies hdf5 || true
         rm -rf /usr/local/Cellar/hdf5
+
+        # we need Rosetta2 to configure cross-compiles for HDF5
+        if [[ "${CMAKE_OSX_ARCHITECTURES-}" == *"arm64"* ]]; then
+            softwareupdate --install-rosetta --agree-to-license
+        fi
     fi
 
     # musllinux: Alpine Linux

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -261,7 +261,7 @@ build_blosc
 build_zfp
 build_hdf5
 # skip for macOS universal builds
-if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64;x86_64" ]]; then
+if [[ "${CMAKE_OSX_ARCHITECTURES-}" != "arm64;x86_64" ]]; then
     build_adios1
 fi
 build_adios2

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -16,6 +16,11 @@ function install_buildessentials {
         brew unlink hdf5 || true
         brew uninstall --ignore-dependencies hdf5 || true
         rm -rf /usr/local/Cellar/hdf5
+
+        # we need qemu to configure cross-compiles for HDF5
+        if [[ "${CMAKE_OSX_ARCHITECTURES-}" == *"arm64"* ]]; then
+            brew install qemu || true
+        fi
     fi
 
     # musllinux: Alpine Linux
@@ -228,7 +233,7 @@ function build_hdf5 {
 
     CMAKE_CROSSCOMPILING_EMULATOR=""
     if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64" ]]; then
-        CMAKE_CROSSCOMPILING_EMULATOR="arch -x86_64"
+        CMAKE_CROSSCOMPILING_EMULATOR="qemu-system-aarch64;-M;virt"
     fi
 
     PY_BIN=$(which python3)

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -101,9 +101,15 @@ function build_adios2 {
     python3 -m patch -p 1 -d ADIOS2-2.7.1 adios-pthread.patch
 
     # DILL macOS universal2 binary
-    curl -sLo dill-universal.patch \
-        https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/3118.patch
-    python3 -m patch -p 1 -d ADIOS2-2.7.1 dill-universal.patch
+    #   https://github.com/ornladios/ADIOS2/issues/3116
+    #   needs rebase (or use ADIOS2-2.8.0)
+    #curl -sLo dill-universal.patch \
+    #    https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/3118.patch
+    #python3 -m patch -p 1 -d ADIOS2-2.7.1 dill-universal.patch
+    DADIOS2_USE_SST=ON
+    if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64;x86_64" ]]; then
+        DADIOS2_USE_SST=OFF
+    fi
 
     mkdir build-ADIOS2
     cd build-ADIOS2
@@ -126,6 +132,7 @@ function build_adios2 {
         -DADIOS2_USE_Fortran=OFF                  \
         -DADIOS2_USE_MPI=OFF                      \
         -DADIOS2_USE_PNG=OFF                      \
+        -DADIOS2_USE_SST=${DADIOS2_USE_SST}       \
         -DADIOS2_USE_ZFP=ON                       \
         -DADIOS2_RUN_INSTALL_TEST=OFF             \
         -DEVPATH_USE_ZPL_ENET=${EVPATH_ZPL}       \

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -19,7 +19,16 @@ function install_buildessentials {
 
         # we need qemu to configure cross-compiles for HDF5
         if [[ "${CMAKE_OSX_ARCHITECTURES-}" == *"arm64"* ]]; then
-            brew install qemu || true
+            brew install qemu libvirt || true
+
+            # TODO: patch libvirt?
+            #https://raw.githubusercontent.com/yoonsikp/vm_configs/master/libvirt.rb
+
+            # https://www.naut.ca/blog/2021/12/09/arm64-vm-on-macos-with-libvirt-qemu/
+            echo 'security_driver = "none"' >> /opt/homebrew/etc/libvirt/qemu.conf
+            echo "dynamic_ownership = 0" >> /opt/homebrew/etc/libvirt/qemu.conf
+            echo "remember_owner = 0" >> /opt/homebrew/etc/libvirt/qemu.conf
+            brew services start libvirt || true
         fi
     fi
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -111,9 +111,9 @@ function build_adios2 {
     #curl -sLo dill-universal.patch \
     #    https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/3118.patch
     #python3 -m patch -p 1 -d ADIOS2-2.7.1 dill-universal.patch
-    DADIOS2_USE_SST=ON
+    ADIOS2_USE_SST=ON
     if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64;x86_64" ]]; then
-        DADIOS2_USE_SST=OFF
+        ADIOS2_USE_SST=OFF
     fi
 
     mkdir build-ADIOS2
@@ -137,7 +137,7 @@ function build_adios2 {
         -DADIOS2_USE_Fortran=OFF                  \
         -DADIOS2_USE_MPI=OFF                      \
         -DADIOS2_USE_PNG=OFF                      \
-        -DADIOS2_USE_SST=${DADIOS2_USE_SST}       \
+        -DADIOS2_USE_SST=${ADIOS2_USE_SST}        \
         -DADIOS2_USE_ZFP=ON                       \
         -DADIOS2_RUN_INSTALL_TEST=OFF             \
         -DEVPATH_USE_ZPL_ENET=${EVPATH_ZPL}       \

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -100,14 +100,14 @@ function build_adios2 {
         https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/2768.patch
     python3 -m patch -p 1 -d ADIOS2-2.7.1 adios-pthread.patch
 
-    # DILL macOS universal2 binary
+    # DILL macOS arm64 or universal2 binary
     #   https://github.com/ornladios/ADIOS2/issues/3116
     #   needs rebase (or use ADIOS2-2.8.0)
     #curl -sLo dill-universal.patch \
     #    https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/3118.patch
     #python3 -m patch -p 1 -d ADIOS2-2.7.1 dill-universal.patch
     ADIOS2_USE_SST=ON
-    if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64;x86_64" ]]; then
+    if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64" ]]; then
         ADIOS2_USE_SST=OFF
     fi
 
@@ -260,8 +260,5 @@ install_buildessentials
 build_blosc
 build_zfp
 build_hdf5
-# skip for macOS universal builds
-if [[ "${CMAKE_OSX_ARCHITECTURES-}" != "arm64;x86_64" ]]; then
-    build_adios1
-fi
+build_adios1
 build_adios2

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -147,6 +147,14 @@ function build_blosc {
         https://patch-diff.githubusercontent.com/raw/Blosc/c-blosc/pull/318.patch
     python3 -m patch -p 1 -d c-blosc-1.21.0 blosc-pthread.patch
 
+    # SSE2 support
+    #   https://github.com/Blosc/c-blosc/issues/334
+    DEACTIVATE_SSE2=OFF
+    if [[ "$CMAKE_OSX_ARCHITECTURES" == *"arm64"* ]]; then
+      # error: SSE2 is not supported by the target architecture/platform and/or this compiler.
+      DEACTIVATE_SSE2=ON
+    fi
+
     mkdir build-c-blosc
     cd build-c-blosc
     PY_BIN=$(which python3)

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -96,6 +96,11 @@ function build_adios2 {
         https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/2768.patch
     python3 -m patch -p 1 -d ADIOS2-2.7.1 adios-pthread.patch
 
+    # DILL macOS universal2 binary
+    curl -sLo dill-universal.patch \
+        https://patch-diff.githubusercontent.com/raw/ornladios/ADIOS2/pull/3118.patch
+    python3 -m patch -p 1 -d ADIOS2-2.7.1 dill-universal.patch
+
     mkdir build-ADIOS2
     cd build-ADIOS2
     PY_BIN=$(which python3)

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -16,20 +16,6 @@ function install_buildessentials {
         brew unlink hdf5 || true
         brew uninstall --ignore-dependencies hdf5 || true
         rm -rf /usr/local/Cellar/hdf5
-
-        # we need qemu to configure cross-compiles for HDF5
-        if [[ "${CMAKE_OSX_ARCHITECTURES-}" == *"arm64"* ]]; then
-            brew install qemu libvirt || true
-
-            # TODO: patch libvirt?
-            #https://raw.githubusercontent.com/yoonsikp/vm_configs/master/libvirt.rb
-
-            # https://www.naut.ca/blog/2021/12/09/arm64-vm-on-macos-with-libvirt-qemu/
-            echo 'security_driver = "none"' >> /opt/homebrew/etc/libvirt/qemu.conf
-            echo "dynamic_ownership = 0" >> /opt/homebrew/etc/libvirt/qemu.conf
-            echo "remember_owner = 0" >> /opt/homebrew/etc/libvirt/qemu.conf
-            brew services start libvirt || true
-        fi
     fi
 
     # musllinux: Alpine Linux

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -226,6 +226,11 @@ function build_hdf5 {
     tar -xzf hdf5*.tar.gz
     rm hdf5*.tar.gz
 
+    CMAKE_CROSSCOMPILING_EMULATOR=""
+    if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64" ]]; then
+        CMAKE_CROSSCOMPILING_EMULATOR="arch -x86_64"
+    fi
+
     PY_BIN=$(which python3)
     CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/"
     PATH=${CMAKE_BIN}:${PATH} cmake          \
@@ -239,6 +244,7 @@ function build_hdf5 {
       -DHDF5_BUILD_TOOLS=OFF                 \
       -DHDF5_BUILD_UTILS=OFF                 \
       -DHDF5_INSTALL_CMAKE_DIR=share/cmake/hdf5 \
+      -DCMAKE_CROSSCOMPILING_EMULATOR="${CMAKE_CROSSCOMPILING_EMULATOR}" \
       -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX}
     cmake --build build-hdf5 -j ${CPU_COUNT}
     cmake --build build-hdf5 --target install

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -150,7 +150,7 @@ function build_blosc {
     # SSE2 support
     #   https://github.com/Blosc/c-blosc/issues/334
     DEACTIVATE_SSE2=OFF
-    if [[ "$CMAKE_OSX_ARCHITECTURES" == *"arm64"* ]]; then
+    if [[ "${CMAKE_OSX_ARCHITECTURES-}" == *"arm64"* ]]; then
       # error: SSE2 is not supported by the target architecture/platform and/or this compiler.
       DEACTIVATE_SSE2=ON
     fi
@@ -161,6 +161,7 @@ function build_blosc {
     CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/"
     PATH=${CMAKE_BIN}:${PATH} cmake          \
       -DDEACTIVATE_SNAPPY=ON                 \
+      -DDEACTIVATE_SSE2=${DEACTIVATE_SSE2}   \
       -DBUILD_SHARED=OFF                     \
       -DBUILD_TESTS=OFF                      \
       -DBUILD_BENCHMARKS=OFF                 \


### PR DESCRIPTION
We only built x64_64 targets so far for `arm64` builds for macOS.

Setting now `CMAKE_OSX_ARCHITECTURES` to change that.
https://cmake.org/cmake/help/latest/envvar/CMAKE_OSX_ARCHITECTURES.html

Disable macOS `universal2` builds because it's too cumbersome to build ADIOS1 and HDF5 twice and then combine them via `lipo` if we have two individual wheels anyway for now.

Fix macOS `arm64` builds, we can cross-compile HDF5 from macOS `x86-64`:
- https://github.com/HDFGroup/hdf5/issues/1516
- https://github.com/h5py/h5py/pull/2099

Disable ADIOS1 on macOS `arm64`, due to missing autotools support.

Fix #1232 

- [x] pypi: mark previous universal2 and arm64 macOS binaries as broken