### PR TITLE
Add memory leak suppression: ps_make_timer_name_

### DIFF
--- a/.github/ci/sanitizer/clang/Leak.supp
+++ b/.github/ci/sanitizer/clang/Leak.supp
@@ -15,3 +15,4 @@ leak:adios_inq_var
 # ADIOS2
 leak:adios2::core::engine::SstReader::*
 leak:adios2::core::engine::SstWriter::*
+leak:ps_make_timer_name_


### PR DESCRIPTION
Noticed in my offline Clang Sanitizer builds. Can theoretically also be fixed by the following: 

```
leak:adios2::format::BP3Serializer::AggregateCollectiveMetadataIndices
leak:adios2::core::engine::BP5Writer::MarshalAttributes
```
But I guess, putting the offending function explicitly is better.

Might affect our CI once we upgrade to ADIOS 2.8.0.