### PR TITLE
Fix: Missing HDF5 Include

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -31,6 +31,8 @@
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Attribute.hpp"
+
+#include <hdf5.h>
 #endif
 
 #include <complex>


### PR DESCRIPTION
This tries to fix a compile error on Maxwell (DESY).
```
/home/diederse/software/hipace_4GPU/hipace/build/_deps/fetchedopenpmd-src/src/IO/HDF5/HDF5IOHandler.cpp: In member function 'virtual void openPMD::HDF5IOHandlerImpl::readAttribute(openPMD::Writable*, openPMD::Parameter<openPMD::Operation::READ_ATT>&)':
/home/diederse/software/hipace_4GPU/hipace/build/_deps/fetchedopenpmd-src/src/IO/HDF5/HDF5IOHandler.cpp:1586:17: error: 'H5free_memory' was not declared in this scope
 1586 |                 H5free_memory(m1);
      |                 ^~~~~~~~~~~~~
/home/diederse/software/hipace_4GPU/hipace/build/_deps/fetchedopenpmd-src/src/IO/HDF5/HDF5IOHandler.cpp:1609:17: error: 'H5free_memory' was not declared in this scope
 1609 |                 H5free_memory(m1);
      |                 ^~~~~~~~~~~~~
/home/diederse/software/hipace_4GPU/hipace/build/_deps/fetchedopenpmd-src/src/IO/HDF5/HDF5IOHandler.cpp:1628:17: error: 'H5free_memory' was not declared in this scope
 1628 |                 H5free_memory(m2);
      |                 ^~~~~~~~~~~~~
```

X-ref: https://docs.hdfgroup.org/hdf5/v1_12/group___h5.html#title7

- [ ] wait for @SeverinDiederichs to test
```console
rm -rf build
cmake -S . -B build -DHiPACE_COMPUTE=CUDA -DHiPACE_openpmd_repo=https://github.com/ax3l/openPMD-api.git -DHiPACE_openpmd_branch=fix-compileIssueHDF5include
cmake --build build -j 4
```

## Software

- OpenMPI version: 3.0 (system) or 4.1.1 (module)
- HDF5: 1.12.1
- CUDA Toolkit version: 11.4.48
- Host compiler & version: GCC 9.3.0
- CMake version: 3.20.3

Note: System OpenMPI 4.1.1 module seems to be missing environment vars for `MPI_ROOT`, `PATH` and `LD_LIBRARY_PATH` (needs bug report).