### PR TITLE
Parsing logic: fail gracefully on unexpected input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,11 +540,17 @@ set(IO_SOURCE
         src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
         src/IO/InvalidatableFile.cpp)
 set(IO_ADIOS1_SEQUENTIAL_SOURCE
+        src/auxiliary/Filesystem.cpp
+        src/ChunkInfo.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
-        src/IO/ADIOS/ADIOS1IOHandler.cpp)
+        src/IO/ADIOS/ADIOS1IOHandler.cpp
+        src/IO/IOTask.cpp)
 set(IO_ADIOS1_SOURCE
+        src/auxiliary/Filesystem.cpp
+        src/ChunkInfo.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
-        src/IO/ADIOS/ParallelADIOS1IOHandler.cpp)
+        src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+        src/IO/IOTask.cpp)
 
 # library
 if(openPMD_BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -907,6 +907,7 @@ if(openPMD_USE_INVASIVE_TESTS)
         message(WARNING "Invasive tests that redefine class signatures are "
                         "known to fail on Windows!")
     endif()
+    target_compile_definitions(openPMD PRIVATE openPMD_USE_INVASIVE_TESTS=1)
 endif()
 
 if(openPMD_BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,19 +540,11 @@ set(IO_SOURCE
         src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
         src/IO/InvalidatableFile.cpp)
 set(IO_ADIOS1_SEQUENTIAL_SOURCE
-        src/Error.cpp
-        src/auxiliary/Filesystem.cpp
-        src/ChunkInfo.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
-        src/IO/ADIOS/ADIOS1IOHandler.cpp
-        src/IO/IOTask.cpp)
+        src/IO/ADIOS/ADIOS1IOHandler.cpp)
 set(IO_ADIOS1_SOURCE
-        src/Error.cpp
-        src/auxiliary/Filesystem.cpp
-        src/ChunkInfo.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
-        src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
-        src/IO/IOTask.cpp)
+        src/IO/ADIOS/ParallelADIOS1IOHandler.cpp)
 
 # library
 if(openPMD_BUILD_SHARED_LIBS)
@@ -674,6 +666,9 @@ if(openPMD_HAVE_ADIOS1)
     target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE openPMD_HAVE_ADIOS1=1)
     target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE openPMD_HAVE_MPI=0)
     target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE _NOMPI)  # ADIOS header
+    # This ensures that the ADIOS1 targets don't ever include Error.hpp
+    # To avoid incompatible error types in weird compile configurations
+    target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE OPENPMD_ADIOS1_IMPLEMENTATION)
 
     if(openPMD_HAVE_MPI)
         set_target_properties(openPMD.ADIOS1.Parallel PROPERTIES
@@ -711,6 +706,9 @@ if(openPMD_HAVE_ADIOS1)
         target_compile_definitions(openPMD.ADIOS1.Parallel PRIVATE openPMD_HAVE_MPI=0)
         target_compile_definitions(openPMD.ADIOS1.Parallel PRIVATE _NOMPI)  # ADIOS header
     endif()
+    # This ensures that the ADIOS1 targets don't ever include Error.hpp
+    # To avoid incompatible error types in weird compile configurations
+    target_compile_definitions(openPMD.ADIOS1.Parallel PRIVATE OPENPMD_ADIOS1_IMPLEMENTATION)
 
     # Runtime parameter and API status checks ("asserts")
     if(openPMD_USE_VERIFY)

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include "openPMD/ThrowError.hpp"
+
 #include <exception>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
+
+#if defined(OPENPMD_ADIOS1_IMPLEMENTATION)
+static_assert(false, "ADIOS1 implementation must not include Error.hpp");
+#endif
 
 namespace openPMD
 {
@@ -80,22 +86,6 @@ namespace error
     {
     public:
         Internal(std::string const &what);
-    };
-
-    enum class AffectedObject
-    {
-        Attribute,
-        Dataset,
-        Group,
-        Other
-    };
-
-    enum class Reason
-    {
-        NotFound,
-        CannotRead,
-        UnexpectedContent,
-        Other
     };
 
     /*

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -116,4 +116,10 @@ namespace error
         ParseError(std::string what);
     };
 } // namespace error
+
+/**
+ * @brief Backward-compatibility alias for no_such_file_error.
+ *
+ */
+using no_such_file_error = error::ReadError;
 } // namespace openPMD

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <exception>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -79,6 +80,50 @@ namespace error
     {
     public:
         Internal(std::string const &what);
+    };
+
+    enum class AffectedObject
+    {
+        Attribute,
+        Dataset,
+        Group,
+        Other
+    };
+
+    enum class Reason
+    {
+        NotFound,
+        CannotRead,
+        UnexpectedContent,
+        Other
+    };
+
+    /*
+     * Read error concerning a specific object.
+     */
+    class ReadError : public Error
+    {
+    public:
+        AffectedObject affectedObject;
+        Reason reason;
+        // If empty, then the error is thrown by the frontend
+        std::optional<std::string> backend;
+        std::string description; // object path, further details, ...
+
+        ReadError(
+            AffectedObject,
+            Reason,
+            std::optional<std::string> backend_in,
+            std::string description_in);
+    };
+
+    /*
+     * Inrecoverable parse error from the frontend.
+     */
+    class ParseError : public Error
+    {
+    public:
+        ParseError(std::string what);
     };
 } // namespace error
 } // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -1070,6 +1070,9 @@ namespace detail
         template <typename BA>
         void enqueue(BA &&ba, decltype(m_buffer) &);
 
+        template <typename... Args>
+        void flush(Args &&...args);
+
         struct ADIOS2FlushParams
         {
             /*
@@ -1103,7 +1106,7 @@ namespace detail
          *     deferred IO tasks had been queued.
          */
         template <typename F>
-        void flush(
+        void flush_impl(
             ADIOS2FlushParams flushParams,
             F &&performPutsGets,
             bool writeAttributes,
@@ -1114,7 +1117,7 @@ namespace detail
          * and does not flush unconditionally.
          *
          */
-        void flush(ADIOS2FlushParams, bool writeAttributes = false);
+        void flush_impl(ADIOS2FlushParams, bool writeAttributes = false);
 
         /**
          * @brief Begin or end an ADIOS step.

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -38,15 +38,6 @@
 
 namespace openPMD
 {
-class no_such_file_error : public std::runtime_error
-{
-public:
-    no_such_file_error(std::string const &what_arg)
-        : std::runtime_error(what_arg)
-    {}
-    virtual ~no_such_file_error()
-    {}
-};
 
 class unsupported_data_error : public std::runtime_error
 {

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -34,6 +34,7 @@
 #include <queue>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 namespace openPMD
 {
@@ -143,6 +144,48 @@ namespace internal
                 ///< Special state only active while internal routines are
                 ///< running.
     };
+
+    // @todo put this somewhere else
+    template <typename Functor, typename... Args>
+    auto withRWAccess(SeriesStatus &status, Functor &&functor, Args &&...args)
+        -> decltype(std::forward<Functor>(functor)(std::forward<Args>(args)...))
+    {
+        using Res = decltype(std::forward<Functor>(functor)(
+            std::forward<Args>(args)...));
+        if constexpr (std::is_void_v<Res>)
+        {
+            auto oldStatus = status;
+            status = internal::SeriesStatus::Parsing;
+            try
+            {
+                std::forward<decltype(functor)>(functor)();
+            }
+            catch (...)
+            {
+                status = oldStatus;
+                throw;
+            }
+            status = oldStatus;
+            return;
+        }
+        else
+        {
+            auto oldStatus = status;
+            status = internal::SeriesStatus::Parsing;
+            Res res;
+            try
+            {
+                res = std::forward<decltype(functor)>(functor)();
+            }
+            catch (...)
+            {
+                status = oldStatus;
+                throw;
+            }
+            status = oldStatus;
+            return res;
+        }
+    }
 } // namespace internal
 
 /** Interface for communicating between logical and physically persistent data.

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -208,10 +208,13 @@ public:
             {
                 std::cerr << "[AbstractIOHandlerImpl] IO Task "
                           << internal::operationAsString(i.operation)
-                          << " failed with exception. Removing task"
-                          << " from IO queue and passing on the exception."
+                          << " failed with exception. Clearing IO queue and "
+                             "passing on the exception."
                           << std::endl;
-                (*m_handler).m_work.pop();
+                while (!m_handler->m_work.empty())
+                {
+                    m_handler->m_work.pop();
+                }
                 throw;
             }
             (*m_handler).m_work.pop();

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -286,6 +286,8 @@ private:
         std::string filePath, std::string const &groupPath, bool beginStep);
     void readGorVBased(std::string const &groupPath, bool beginStep);
     void read_impl(std::string const &groupPath);
+    void readMeshes(std::string const &meshesPath);
+    void readParticles(std::string const &particlesPath);
 
     /**
      * Status after beginning an IO step. Currently includes:

--- a/include/openPMD/ReadIterations.hpp
+++ b/include/openPMD/ReadIterations.hpp
@@ -104,9 +104,21 @@ private:
 
     std::optional<SeriesIterator *> nextIterationInStep();
 
-    std::optional<SeriesIterator *> nextStep();
+    /*
+     * When a step cannot successfully be opened, the method nextStep() calls
+     * itself again recursively.
+     * (Recursion massively simplifies the logic here, and it only happens
+     * in case of error.)
+     * After successfully beginning a step, this methods needs to remember, how
+     * many broken steps have been skipped. In case the Series does not use
+     * the /data/snapshot attribute, this helps figuring out which iteration
+     * is now active. Hence, recursion_depth.
+     */
+    std::optional<SeriesIterator *> nextStep(size_t recursion_depth);
 
     std::optional<SeriesIterator *> loopBody();
+
+    void deactivateDeadIteration(iteration_index_t);
 };
 
 /**

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -611,9 +611,15 @@ OPENPMD_private
      * Iterations/Records/Record Components etc.
      * If series.iterations contains the attribute `snapshot`, returns its
      * value.
+     * If do_always_throw_errors is false, this method will try to handle errors
+     * and turn them into a warning (useful when parsing a Series, since parsing
+     * should succeed without issue).
+     * If true, the error will always be re-thrown (useful when using
+     * ReadIterations since those methods should be aware when the current step
+     * is broken).
      */
     std::optional<std::deque<IterationIndex_t> >
-    readGorVBased(bool init = true);
+    readGorVBased(bool do_always_throw_errors, bool init);
     void readBase();
     std::string iterationFilename(IterationIndex_t i);
 

--- a/include/openPMD/ThrowError.hpp
+++ b/include/openPMD/ThrowError.hpp
@@ -40,6 +40,7 @@ enum class AffectedObject
 {
     Attribute,
     Dataset,
+    File,
     Group,
     Other
 };

--- a/include/openPMD/ThrowError.hpp
+++ b/include/openPMD/ThrowError.hpp
@@ -1,0 +1,67 @@
+/* Copyright 2022 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * For objects that must not include Error.hpp but still need to throw errors.
+ * In some exotic compiler configurations (clang-6 with libc++),
+ * including Error.hpp into the ADIOS1 backend leads to incompatible error type
+ * symbols.
+ * So, use only the functions defined in here in the ADIOS1 backend.
+ * Definitions are in Error.cpp.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace openPMD::error
+{
+enum class AffectedObject
+{
+    Attribute,
+    Dataset,
+    Group,
+    Other
+};
+
+enum class Reason
+{
+    NotFound,
+    CannotRead,
+    UnexpectedContent,
+    Inaccessible,
+    Other
+};
+
+[[noreturn]] void
+throwBackendConfigSchema(std::vector<std::string> jsonPath, std::string what);
+
+[[noreturn]] void
+throwOperationUnsupportedInBackend(std::string backend, std::string what);
+
+[[noreturn]] void throwReadError(
+    AffectedObject affectedObject,
+    Reason reason_in,
+    std::optional<std::string> backend,
+    std::string description_in);
+} // namespace openPMD::error

--- a/include/openPMD/ThrowError.hpp
+++ b/include/openPMD/ThrowError.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "openPMD/auxiliary/Export.hpp"
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -54,13 +56,13 @@ enum class Reason
     Other
 };
 
-[[noreturn]] void
+[[noreturn]] OPENPMDAPI_EXPORT void
 throwBackendConfigSchema(std::vector<std::string> jsonPath, std::string what);
 
-[[noreturn]] void
+[[noreturn]] OPENPMDAPI_EXPORT void
 throwOperationUnsupportedInBackend(std::string backend, std::string what);
 
-[[noreturn]] void throwReadError(
+[[noreturn]] OPENPMDAPI_EXPORT void throwReadError(
     AffectedObject affectedObject,
     Reason reason_in,
     std::optional<std::string> backend,

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -23,8 +23,6 @@
 
 #include "openPMD/config.hpp"
 
-#include "openPMD/Error.hpp"
-
 #include <nlohmann/json.hpp>
 #include <toml.hpp>
 

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -141,6 +141,7 @@ class Container : public Attributable
     friend class Series;
     template <typename>
     friend class internal::EraseStaleEntries;
+    friend class SeriesIterator;
 
 protected:
     using ContainerData = internal::ContainerData<T, T_key, T_container>;

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -17,6 +17,13 @@ namespace error
         , backend{std::move(backend_in)}
     {}
 
+    void
+    throwOperationUnsupportedInBackend(std::string backend, std::string what)
+    {
+        throw OperationUnsupportedInBackend(
+            std::move(backend), std::move(what));
+    }
+
     WrongAPIUsage::WrongAPIUsage(std::string what)
         : Error("Wrong API usage: " + what)
     {}
@@ -45,6 +52,12 @@ namespace error
               concatVector(errorLocation_in) + "': " + std::move(what))
         , errorLocation(std::move(errorLocation_in))
     {}
+
+    void throwBackendConfigSchema(
+        std::vector<std::string> jsonPath, std::string what)
+    {
+        throw BackendConfigSchema(std::move(jsonPath), std::move(what));
+    }
 
     Internal::Internal(std::string const &what)
         : Error(
@@ -82,6 +95,8 @@ namespace error
                 return "CannotRead";
             case Re::UnexpectedContent:
                 return "UnexpectedContent";
+            case Re::Inaccessible:
+                return "Inaccessible";
             case Re::Other:
                 return "Other";
             }
@@ -105,6 +120,16 @@ namespace error
         , backend(std::move(backend_in))
         , description(std::move(description_in))
     {}
+
+    void throwReadError(
+        AffectedObject affectedObject,
+        Reason reason,
+        std::optional<std::string> backend,
+        std::string description)
+    {
+        throw ReadError(
+            affectedObject, reason, std::move(backend), std::move(description));
+    }
 
     ParseError::ParseError(std::string what) : Error("Parse Error: " + what)
     {}

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -77,6 +77,8 @@ namespace error
                 return "Attribute";
             case AO::Dataset:
                 return "Dataset";
+            case AO::File:
+                return "File";
             case AO::Group:
                 return "Group";
             case AO::Other:

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -52,5 +52,61 @@ namespace error
               "\nThis is a bug. Please report at ' "
               "https://github.com/openPMD/openPMD-api/issues'.")
     {}
+
+    namespace
+    {
+        std::string asString(AffectedObject obj)
+        {
+            switch (obj)
+            {
+                using AO = AffectedObject;
+            case AO::Attribute:
+                return "Attribute";
+            case AO::Dataset:
+                return "Dataset";
+            case AO::Group:
+                return "Group";
+            case AO::Other:
+                return "Other";
+            }
+            return "Unreachable";
+        }
+        std::string asString(Reason obj)
+        {
+            switch (obj)
+            {
+                using Re = Reason;
+            case Re::NotFound:
+                return "NotFound";
+            case Re::CannotRead:
+                return "CannotRead";
+            case Re::UnexpectedContent:
+                return "UnexpectedContent";
+            case Re::Other:
+                return "Other";
+            }
+            return "Unreachable";
+        }
+    } // namespace
+
+    ReadError::ReadError(
+        AffectedObject affectedObject_in,
+        Reason reason_in,
+        std::optional<std::string> backend_in,
+        std::string description_in)
+        : Error(
+              (backend_in ? ("Read Error in backend " + *backend_in)
+                          : "Read Error in frontend ") +
+              "\nObject type:\t" + asString(affectedObject_in) +
+              "\nError type:\t" + asString(reason_in) +
+              "\nFurther description:\t" + description_in)
+        , affectedObject(affectedObject_in)
+        , reason(reason_in)
+        , backend(std::move(backend_in))
+        , description(std::move(description_in))
+    {}
+
+    ParseError::ParseError(std::string what) : Error("Parse Error: " + what)
+    {}
 } // namespace error
 } // namespace openPMD

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -18,6 +18,7 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "openPMD/IO/ADIOS/ADIOS1IOHandler.hpp"
 #include "openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp"
 
@@ -157,10 +158,13 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
         {
             std::cerr << "[AbstractIOHandlerImpl] IO Task "
                       << internal::operationAsString(i.operation)
-                      << " failed with exception. Removing task"
-                      << " from IO queue and passing on the exception."
+                      << " failed with exception. Clearing IO queue and "
+                         "passing on the exception."
                       << std::endl;
-            handler->m_setup.pop();
+            while (!m_handler->m_work.empty())
+            {
+                m_handler->m_work.pop();
+            }
             throw;
         }
         handler->m_setup.pop();
@@ -289,10 +293,13 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
         {
             std::cerr << "[AbstractIOHandlerImpl] IO Task "
                       << internal::operationAsString(i.operation)
-                      << " failed with exception. Removing task"
-                      << " from IO queue and passing on the exception."
+                      << " failed with exception. Clearing IO queue and "
+                         "passing on the exception."
                       << std::endl;
-            m_handler->m_work.pop();
+            while (!m_handler->m_work.empty())
+            {
+                m_handler->m_work.pop();
+            }
             throw;
         }
         handler->m_work.pop();

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -685,9 +685,11 @@ void ADIOS2IOHandlerImpl::openFile(
 {
     if (!auxiliary::directory_exists(m_handler->directory))
     {
-        throw no_such_file_error(
-            "[ADIOS2] Supplied directory is not valid: " +
-            m_handler->directory);
+        throw error::ReadError(
+            error::AffectedObject::File,
+            error::Reason::Inaccessible,
+            "ADIOS2",
+            "Supplied directory is not valid: " + m_handler->directory);
     }
 
     std::string name = parameters.name + fileSuffix();

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -116,7 +116,7 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
      * Technically, std::sort() is sufficient here, since file names are unique.
      * Use std::stable_sort() for two reasons:
      * 1) On some systems (clang 13.0.1, libc++ 13.0.1), std::sort() leads to
-     *    weird inconsisten segfaults here.
+     *    weird inconsistent segfaults here.
      * 2) Robustness against future changes. stable_sort() might become needed
      *    in future, and debugging this can be hard.
      * 3) It does not really matter, this is just the destructor, so we can take

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -112,7 +112,17 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
         sorted.push_back(std::move(pair.second));
     }
     m_fileData.clear();
-    std::sort(
+    /*
+     * Technically, std::sort() is sufficient here, since file names are unique.
+     * Use std::stable_sort() for two reasons:
+     * 1) On some systems (clang 13.0.1, libc++ 13.0.1), std::sort() leads to
+     *    weird inconsisten segfaults here.
+     * 2) Robustness against future changes. stable_sort() might become needed
+     *    in future, and debugging this can be hard.
+     * 3) It does not really matter, this is just the destructor, so we can take
+     *    the extra time.
+     */
+    std::stable_sort(
         sorted.begin(), sorted.end(), [](auto const &left, auto const &right) {
             return left->m_file <= right->m_file;
         });

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -657,9 +657,11 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openFile(
     Writable *writable, Parameter<Operation::OPEN_FILE> const &parameters)
 {
     if (!auxiliary::directory_exists(m_handler->directory))
-        throw no_such_file_error(
-            "[ADIOS1] Supplied directory is not valid: " +
-            m_handler->directory);
+        error::throwReadError(
+            error::AffectedObject::File,
+            error::Reason::Inaccessible,
+            "ADIOS1",
+            "Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.name;
     if (!auxiliary::ends_with(name, ".bp"))

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -20,11 +20,10 @@
  */
 
 #include "openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp"
-#include "openPMD/Error.hpp"
+#include "openPMD/ThrowError.hpp"
 
 #if openPMD_HAVE_ADIOS1
 
-#include "openPMD/Error.hpp"
 #include "openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp"
 #include "openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
@@ -425,7 +424,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::createFile(
         if (m_handler->m_backendAccess == Access::APPEND &&
             auxiliary::file_exists(name))
         {
-            throw error::OperationUnsupportedInBackend(
+            error::throwOperationUnsupportedInBackend(
                 "ADIOS1",
                 "Appending to existing file on disk (use Access::CREATE to "
                 "overwrite)");
@@ -515,7 +514,7 @@ static std::optional<std::string> datasetTransform(json::TracingJSON config)
     }
     else
     {
-        throw error::BackendConfigSchema(
+        error::throwBackendConfigSchema(
             {"adios1", "dataset", "transform"},
             "Key must convertible to type string.");
     }
@@ -1248,15 +1247,22 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
 
     int status;
     status = adios_get_attr(f, attrname.c_str(), &datatype, &size, &data);
-    VERIFY(
-        status == 0,
-        "[ADIOS1] Internal error: Failed to get ADIOS1 attribute during "
-        "attribute read");
-    VERIFY(
-        datatype != adios_unknown,
-        "[ADIOS1] Internal error: Read unknown ADIOS1 datatype during "
-        "attribute read");
-    VERIFY(size != 0, "[ADIOS1] Internal error: ADIOS1 read 0-size attribute");
+    if (status != 0)
+    {
+        error::throwReadError(
+            error::AffectedObject::Attribute,
+            error::Reason::NotFound,
+            "ADIOS1",
+            attrname);
+    }
+    if (datatype == adios_unknown)
+    {
+        error::throwReadError(
+            error::AffectedObject::Attribute,
+            error::Reason::UnexpectedContent,
+            "ADIOS1",
+            "Unknown datatype: " + attrname);
+    }
 
     // size is returned in number of allocated bytes
     // note the ill-named fixed-byte adios_... types
@@ -1307,9 +1313,11 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
         break;
 
     default:
-        throw unsupported_data_error(
-            "[ADIOS1] readAttribute: Unsupported ADIOS1 attribute datatype '" +
-            std::to_string(datatype) + "' in size check");
+        error::throwReadError(
+            error::AffectedObject::Attribute,
+            error::Reason::UnexpectedContent,
+            "ADIOS1",
+            "Unsupported datatype: " + attrname);
     }
 
     Datatype dtype;
@@ -1345,9 +1353,12 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                 a = Attribute(*reinterpret_cast<long long *>(data));
             }
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype adios_short "
-                    "found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type adios_short: " +
+                        attrname);
             break;
         case adios_integer:
             if (sizeof(short) == 4u)
@@ -1371,9 +1382,12 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                 a = Attribute(*reinterpret_cast<long long *>(data));
             }
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype adios_integer "
-                    "found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type adios_integer: " +
+                        attrname);
             break;
         case adios_long:
             if (sizeof(short) == 8u)
@@ -1397,9 +1411,12 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                 a = Attribute(*reinterpret_cast<long long *>(data));
             }
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype adios_long "
-                    "found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type adios_long: " +
+                        attrname);
             break;
         case adios_unsigned_byte:
             dtype = DT::UCHAR;
@@ -1427,9 +1444,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                 a = Attribute(*reinterpret_cast<unsigned long long *>(data));
             }
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype "
-                    "adios_unsigned_short found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type "
+                    "adios_unsigned_short: " +
+                        attrname);
             break;
         case adios_unsigned_integer:
             if (sizeof(unsigned short) == 4u)
@@ -1453,9 +1474,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                 a = Attribute(*reinterpret_cast<unsigned long long *>(data));
             }
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype "
-                    "adios_unsigned_integer found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type "
+                    "adios_unsigned_integer: " +
+                        attrname);
             break;
         case adios_unsigned_long:
             if (sizeof(unsigned short) == 8u)
@@ -1479,9 +1504,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                 a = Attribute(*reinterpret_cast<unsigned long long *>(data));
             }
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype "
-                    "adios_unsigned_long found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type "
+                    "adios_unsigned_long: " +
+                        attrname);
             break;
         case adios_real:
             dtype = DT::FLOAT;
@@ -1527,10 +1556,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
             break;
         }
         default:
-            throw unsupported_data_error(
-                "[ADIOS1] readAttribute: Unsupported ADIOS1 attribute datatype "
-                "'" +
-                std::to_string(datatype) + "' in scalar branch");
+            error::throwReadError(
+                error::AffectedObject::Attribute,
+                error::Reason::Other,
+                "ADIOS1",
+                "Unsupported ADIOS1 attribute datatype '" +
+                    std::to_string(datatype) +
+                    "' in scalar branch: " + attrname);
         }
     }
     else
@@ -1565,9 +1597,12 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                     readVectorAttributeInternal<long long>(data, size),
                     DT::VEC_LONGLONG);
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype adios_short "
-                    "found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type adios_short: " +
+                        attrname);
             break;
         }
         case adios_integer: {
@@ -1587,9 +1622,12 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                     readVectorAttributeInternal<long long>(data, size),
                     DT::VEC_LONGLONG);
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype adios_integer "
-                    "found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type adios_integer: " +
+                        attrname);
             break;
         }
         case adios_long: {
@@ -1609,9 +1647,12 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                     readVectorAttributeInternal<long long>(data, size),
                     DT::VEC_LONGLONG);
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype adios_long "
-                    "found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type adios_long: " +
+                        attrname);
             break;
         }
         case adios_unsigned_byte: {
@@ -1642,9 +1683,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                     readVectorAttributeInternal<unsigned long long>(data, size),
                     DT::VEC_ULONGLONG);
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype "
-                    "adios_unsigned_short found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type "
+                    "adios_unsigned_short: " +
+                        attrname);
             break;
         }
         case adios_unsigned_integer: {
@@ -1665,9 +1710,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                     readVectorAttributeInternal<unsigned long long>(data, size),
                     DT::VEC_ULONGLONG);
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype "
-                    "adios_unsigned_integer found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type "
+                    "adios_unsigned_integer: " +
+                        attrname);
             break;
         }
         case adios_unsigned_long: {
@@ -1688,9 +1737,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
                     readVectorAttributeInternal<unsigned long long>(data, size),
                     DT::VEC_ULONGLONG);
             else
-                throw unsupported_data_error(
-                    "[ADIOS1] No native equivalent for Datatype "
-                    "adios_unsigned_long found.");
+                error::throwReadError(
+                    error::AffectedObject::Attribute,
+                    error::Reason::Other,
+                    "ADIOS1",
+                    "No native equivalent found for type "
+                    "adios_unsigned_long: " +
+                        attrname);
             break;
         }
         case adios_real: {
@@ -1750,10 +1803,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readAttribute(
         }
 
         default:
-            throw unsupported_data_error(
-                "[ADIOS1] readAttribute: Unsupported ADIOS1 attribute datatype "
-                "'" +
-                std::to_string(datatype) + "' in vector branch");
+            error::throwReadError(
+                error::AffectedObject::Attribute,
+                error::Reason::Other,
+                "ADIOS1",
+                "Unsupported ADIOS1 attribute datatype '" +
+                    std::to_string(datatype) +
+                    "' in vector branch: " + attrname);
         }
     }
 

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -179,10 +179,13 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
         {
             std::cerr << "[AbstractIOHandlerImpl] IO Task "
                       << internal::operationAsString(i.operation)
-                      << " failed with exception. Removing task"
-                      << " from IO queue and passing on the exception."
+                      << " failed with exception. Clearing IO queue and "
+                         "passing on the exception."
                       << std::endl;
-            handler->m_setup.pop();
+            while (!m_handler->m_work.empty())
+            {
+                m_handler->m_work.pop();
+            }
             throw;
         }
         handler->m_setup.pop();
@@ -309,10 +312,13 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
         {
             std::cerr << "[AbstractIOHandlerImpl] IO Task "
                       << internal::operationAsString(i.operation)
-                      << " failed with exception. Removing task"
-                      << " from IO queue and passing on the exception."
+                      << " failed with exception. Clearing IO queue and "
+                         "passing on the exception."
                       << std::endl;
-            m_handler->m_work.pop();
+            while (!m_handler->m_work.empty())
+            {
+                m_handler->m_work.pop();
+            }
             throw;
         }
         handler->m_work.pop();

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -774,8 +774,11 @@ void HDF5IOHandlerImpl::openFile(
     Writable *writable, Parameter<Operation::OPEN_FILE> const &parameters)
 {
     if (!auxiliary::directory_exists(m_handler->directory))
-        throw no_such_file_error(
-            "[HDF5] Supplied directory is not valid: " + m_handler->directory);
+        throw error::ReadError(
+            error::AffectedObject::File,
+            error::Reason::Inaccessible,
+            "HDF5",
+            "Supplied directory is not valid: " + m_handler->directory);
 
     std::string name = m_handler->directory + parameters.name;
     if (!auxiliary::ends_with(name, ".h5"))
@@ -809,7 +812,11 @@ void HDF5IOHandlerImpl::openFile(
     hid_t file_id;
     file_id = H5Fopen(name.c_str(), flags, m_fileAccessProperty);
     if (file_id < 0)
-        throw no_such_file_error("[HDF5] Failed to open HDF5 file " + name);
+        throw error::ReadError(
+            error::AffectedObject::File,
+            error::Reason::Inaccessible,
+            "HDF5",
+            "Failed to open HDF5 file " + name);
 
     writable->written = true;
     writable->abstractFilePosition = std::make_shared<HDF5FilePosition>("/");

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -530,8 +530,11 @@ void JSONIOHandlerImpl::openFile(
 {
     if (!auxiliary::directory_exists(m_handler->directory))
     {
-        throw no_such_file_error(
-            "[JSON] Supplied directory is not valid: " + m_handler->directory);
+        throw error::ReadError(
+            error::AffectedObject::File,
+            error::Reason::Inaccessible,
+            "JSON",
+            "Supplied directory is not valid: " + m_handler->directory);
     }
 
     std::string name = parameter.name;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -660,7 +660,8 @@ auto Iteration::beginStep(
             IOHandl->m_seriesStatus = internal::SeriesStatus::Parsing;
             try
             {
-                res.iterationsInOpenedStep = series.readGorVBased(false);
+                res.iterationsInOpenedStep = series.readGorVBased(
+                    /* do_always_throw_errors = */ true, /* init = */ false);
             }
             catch (...)
             {

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -434,7 +434,8 @@ void Iteration::read_impl(std::string const &groupPath)
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'dt'");
+            "Unexpected Attribute datatype for 'dt' (expected double, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "time";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -454,7 +455,9 @@ void Iteration::read_impl(std::string const &groupPath)
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'time'");
+            "Unexpected Attribute datatype for 'time' (expected double, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "timeUnitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -467,7 +470,9 @@ void Iteration::read_impl(std::string const &groupPath)
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'timeUnitSI'");
+            "Unexpected Attribute datatype for 'timeUnitSI' (expected double, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     /* Find the root point [Series] of this file,
      * meshesPath and particlesPath are stored there */

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -302,7 +302,9 @@ void Mesh::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'geometry'");
+            "Unexpected Attribute datatype for 'geometry' (expected a string, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "dataOrder";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -328,7 +330,9 @@ void Mesh::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'dataOrder'");
+            "Unexpected Attribute datatype for 'dataOrder' (expected char or "
+            "string, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "axisLabels";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -341,7 +345,9 @@ void Mesh::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'axisLabels'");
+            "Unexpected Attribute datatype for 'axisLabels' (expected a vector "
+            "of string, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "gridSpacing";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -362,7 +368,9 @@ void Mesh::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'gridSpacing'");
+            "Unexpected Attribute datatype for 'gridSpacing' (expected a "
+            "vector of double, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "gridGlobalOffset";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -376,7 +384,9 @@ void Mesh::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'gridGlobalOffset'");
+            "Unexpected Attribute datatype for 'gridGlobalOffset' (expected a "
+            "vector of double, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "gridUnitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -389,7 +399,9 @@ void Mesh::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'gridUnitSI'");
+            "Unexpected Attribute datatype for 'gridUnitSI' (expected double, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     if (scalar())
     {

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -90,7 +90,9 @@ void ParticlePatches::read()
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 {},
-                "Unexpected datatype for " + component_name);
+                "Unexpected datatype for " + component_name +
+                    "(expected uint64, found " +
+                    datatypeToString(*dOpen.dtype) + ")");
 
         /* allow all attributes to be set */
         prc.written() = false;

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -97,8 +97,6 @@ void ParticleSpecies::read()
                           << err.what() << std::endl;
 
                 map.forget(record_name);
-                //(*this)[record_name].erase(RecordComponent::SCALAR);
-                // this->erase(record_name);
             }
         }
     }

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -23,6 +23,8 @@
 
 #include "openPMD/Series.hpp"
 
+#include <iostream>
+
 namespace openPMD
 {
 
@@ -167,25 +169,66 @@ std::optional<SeriesIterator *> SeriesIterator::nextIterationInStep()
             {FlushLevel::UserFlush},
             /* flushIOHandler = */ true);
 
-        series.iterations[m_currentIteration].open();
+        try
+        {
+            series.iterations[m_currentIteration].open();
+        }
+        catch (error::ReadError const &err)
+        {
+            std::cerr << "Cannot read iteration '" << m_currentIteration
+                      << "' and will skip it due to read error:\n"
+                      << err.what() << std::endl;
+            return nextIterationInStep();
+        }
+
         return {this};
     }
     case IterationEncoding::fileBased:
-        series.iterations[m_currentIteration].open();
-        series.iterations[m_currentIteration].beginStep(/* reread = */ true);
+        try
+        {
+            /*
+             * Errors in here might appear due to deferred iteration parsing.
+             */
+            series.iterations[m_currentIteration].open();
+            /*
+             * Errors in here might appear due to reparsing after opening a
+             * new step.
+             */
+            series.iterations[m_currentIteration].beginStep(
+                /* reread = */ true);
+        }
+        catch (error::ReadError const &err)
+        {
+            std::cerr << "[SeriesIterator] Cannot read iteration due to error "
+                         "below, will skip it.\n"
+                      << err.what() << std::endl;
+            return nextIterationInStep();
+        }
+
         return {this};
     }
     throw std::runtime_error("Unreachable!");
 }
 
-std::optional<SeriesIterator *> SeriesIterator::nextStep()
+std::optional<SeriesIterator *> SeriesIterator::nextStep(size_t recursion_depth)
 {
     // since we are in group-based iteration layout, it does not
     // matter which iteration we begin a step upon
-    AdvanceStatus status;
+    AdvanceStatus status{};
     Iteration::BeginStepStatus::AvailableIterations_t availableIterations;
-    std::tie(status, availableIterations) =
-        Iteration::beginStep({}, *m_series, /* reread = */ true);
+    try
+    {
+        std::tie(status, availableIterations) =
+            Iteration::beginStep({}, *m_series, /* reread = */ true);
+    }
+    catch (error::ReadError const &err)
+    {
+        std::cerr << "[SeriesIterator] Cannot read iteration due to error "
+                     "below, will skip it.\n"
+                  << err.what() << std::endl;
+        m_series->advance(AdvanceMode::ENDSTEP);
+        return nextStep(recursion_depth + 1);
+    }
 
     if (availableIterations.has_value() &&
         status != AdvanceStatus::RANDOMACCESS)
@@ -224,7 +267,10 @@ std::optional<SeriesIterator *> SeriesIterator::nextStep()
         }
         else
         {
-            ++it;
+            for (size_t i = 0; i < recursion_depth && it != itEnd; ++i)
+            {
+                ++it;
+            }
 
             if (it == itEnd)
             {
@@ -295,9 +341,22 @@ std::optional<SeriesIterator *> SeriesIterator::loopBody()
         auto iteration = iterations.at(currentIterationIndex.value());
         if (iteration.get().m_closed != internal::CloseStatus::ClosedInBackend)
         {
-            iteration.open();
-            option.value()->setCurrentIteration();
-            return option;
+            try
+            {
+                iteration.open();
+                option.value()->setCurrentIteration();
+                return option;
+            }
+            catch (error::ReadError const &err)
+            {
+                std::cerr << "Cannot read iteration '"
+                          << currentIterationIndex.value()
+                          << "' and will skip it due to read error:\n"
+                          << err.what() << std::endl;
+                option.value()->deactivateDeadIteration(
+                    currentIterationIndex.value());
+                return std::nullopt;
+            }
         }
         else
         {
@@ -325,8 +384,32 @@ std::optional<SeriesIterator *> SeriesIterator::loopBody()
         return {this};
     }
 
-    auto option = nextStep();
+    auto option = nextStep(/*recursion_depth = */ 1);
     return guardReturn(option);
+}
+
+void SeriesIterator::deactivateDeadIteration(iteration_index_t index)
+{
+    switch (m_series->iterationEncoding())
+    {
+    case IterationEncoding::fileBased: {
+        Parameter<Operation::CLOSE_FILE> param;
+        m_series->IOHandler()->enqueue(
+            IOTask(&m_series->iterations[index], std::move(param)));
+        m_series->IOHandler()->flush({FlushLevel::UserFlush});
+    }
+    break;
+    case IterationEncoding::variableBased:
+    case IterationEncoding::groupBased: {
+        Parameter<Operation::ADVANCE> param;
+        param.mode = AdvanceMode::ENDSTEP;
+        m_series->IOHandler()->enqueue(
+            IOTask(&m_series->iterations[index], std::move(param)));
+        m_series->IOHandler()->flush({FlushLevel::UserFlush});
+    }
+    break;
+    }
+    m_series->iterations.container().erase(index);
 }
 
 SeriesIterator &SeriesIterator::operator++()
@@ -340,6 +423,9 @@ SeriesIterator &SeriesIterator::operator++()
     /*
      * loopBody() might return an empty option to indicate a skipped iteration.
      * Loop until it returns something real for us.
+     * Note that this is not an infinite loop:
+     * Upon end of the Series, loopBody() does not return an empty option,
+     * but the end iterator.
      */
     do
     {

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -109,7 +109,18 @@ void Record::read()
     if (scalar())
     {
         /* using operator[] will incorrectly update parent */
-        this->at(RecordComponent::SCALAR).read();
+        auto &scalarComponent = this->at(RecordComponent::SCALAR);
+        try
+        {
+            scalarComponent.read();
+        }
+        catch (error::ReadError const &err)
+        {
+            std::cerr << "Cannot read scalar record component and will skip it "
+                         "due to read error:\n"
+                      << err.what() << std::endl;
+            this->container().erase(RecordComponent::SCALAR);
+        }
     }
     else
     {
@@ -124,7 +135,17 @@ void Record::read()
             pOpen.path = component;
             IOHandler()->enqueue(IOTask(&rc, pOpen));
             rc.get().m_isConstant = true;
-            rc.read();
+            try
+            {
+                rc.read();
+            }
+            catch (error::ReadError const &err)
+            {
+                std::cerr << "Cannot read record component '" << component
+                          << "' and will skip it due to read error:\n"
+                          << err.what() << std::endl;
+                this->container().erase(component);
+            }
         }
 
         Parameter<Operation::LIST_DATASETS> dList;
@@ -141,7 +162,17 @@ void Record::read()
             rc.written() = false;
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
             rc.written() = true;
-            rc.read();
+            try
+            {
+                rc.read();
+            }
+            catch (error::ReadError const &err)
+            {
+                std::cerr << "Cannot read record component '" << component
+                          << "' and will skip it due to read error:\n"
+                          << err.what() << std::endl;
+                this->container().erase(component);
+            }
         }
     }
 

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -297,7 +297,15 @@ namespace
             rc.makeConstant(attr.get<T>());
         }
 
-        static constexpr char const *errorMsg = "Unexpected constant datatype";
+        template <unsigned n, typename... Args>
+        static void call(Args &&...)
+        {
+            throw error::ReadError(
+                error::AffectedObject::Attribute,
+                error::Reason::UnexpectedContent,
+                {},
+                "Unexpected constant datatype");
+        }
     };
 } // namespace
 
@@ -335,7 +343,11 @@ void RecordComponent::readBase()
             oss << "Unexpected datatype (" << *aRead.dtype
                 << ") for attribute 'shape' (" << determineDatatype<uint64_t>()
                 << " aka uint64_t)";
-            throw std::runtime_error(oss.str());
+            throw error::ReadError(
+                error::AffectedObject::Attribute,
+                error::Reason::UnexpectedContent,
+                {},
+                oss.str());
         }
 
         written() = false;
@@ -350,7 +362,11 @@ void RecordComponent::readBase()
         val.has_value())
         setUnitSI(val.value());
     else
-        throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
+        throw error::ReadError(
+            error::AffectedObject::Attribute,
+            error::Reason::UnexpectedContent,
+            {},
+            "Unexpected Attribute datatype for 'unitSI'");
 
     readAttributes(ReadMode::FullyReread);
 }

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -304,7 +304,7 @@ namespace
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 {},
-                "Unexpected constant datatype");
+                "Undefined constant datatype.");
         }
     };
 } // namespace
@@ -366,7 +366,9 @@ void RecordComponent::readBase()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'unitSI'");
+            "Unexpected Attribute datatype for 'unitSI' (expected double, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     readAttributes(ReadMode::FullyReread);
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -991,7 +991,7 @@ void Series::readFileBased()
 
     if (!auxiliary::directory_exists(IOHandler()->directory))
         throw error::ReadError(
-            error::AffectedObject::Other,
+            error::AffectedObject::File,
             error::Reason::Inaccessible,
             {},
             "Supplied directory is not valid: " + IOHandler()->directory);
@@ -1022,7 +1022,7 @@ void Series::readFileBased()
          * lifetime of a Series. */
         if (IOHandler()->m_backendAccess == Access::READ_ONLY)
             throw error::ReadError(
-                error::AffectedObject::Other,
+                error::AffectedObject::File,
                 error::Reason::Inaccessible,
                 {},
                 "No matching iterations found: " + name());

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1087,12 +1087,10 @@ void Series::readFileBased()
                 auto &firstError = forwardFirstError.value();
                 firstError.description.append(
                     "\n[Note] Not a single iteration can be successfully "
-                    "parsed (see above "
-                    "errors). Returning the first observed error, for better "
-                    "recoverability in user code. Need to access at least one "
-                    "iteration even in "
-                    "deferred parsing mode in order to read global Series "
-                    "attributes.");
+                    "parsed (see above errors). Returning the first observed "
+                    "error, for better recoverability in user code. Need to "
+                    "access at least one iteration even in deferred parsing "
+                    "mode in order to read global Series attributes.");
                 throw firstError;
             }
             else
@@ -1102,9 +1100,8 @@ void Series::readFileBased()
                     error::Reason::Other,
                     {},
                     "Not a single iteration can be successfully parsed (see "
-                    "above "
-                    "errors). Need to access at least one iteration even in "
-                    "deferred parsing mode in order to read global Series "
+                    "above errors). Need to access at least one iteration even "
+                    "in deferred parsing mode in order to read global Series "
                     "attributes.");
             }
         }
@@ -1138,9 +1135,8 @@ void Series::readFileBased()
                 auto &firstError = forwardFirstError.value();
                 firstError.description.append(
                     "\n[Note] Not a single iteration can be successfully "
-                    "parsed (see above "
-                    "errors). Returning the first observed error, for better "
-                    "recoverability in user code.");
+                    "parsed (see above errors). Returning the first observed "
+                    "error, for better recoverability in user code.");
                 throw firstError;
             }
             else
@@ -1150,8 +1146,7 @@ void Series::readFileBased()
                     error::Reason::Other,
                     {},
                     "Not a single iteration can be successfully parsed (see "
-                    "above "
-                    "warnings).");
+                    "above warnings).");
             }
         }
     }
@@ -1231,8 +1226,9 @@ void Series::readOneIterationFileBased(std::string const &filePath)
     }
     else
         throw std::runtime_error(
-            "Unexpected Attribute datatype "
-            "for 'iterationEncoding'");
+            "Unexpected Attribute datatype for 'iterationEncoding' (expected "
+            "string, found " +
+            datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "iterationFormat";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -1248,7 +1244,9 @@ void Series::readOneIterationFileBased(std::string const &filePath)
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'iterationFormat'");
+            "Unexpected Attribute datatype for 'iterationFormat' (expected "
+            "string, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     Parameter<Operation::OPEN_PATH> pOpen;
     std::string version = openPMD();
@@ -1341,7 +1339,9 @@ auto Series::readGorVBased(bool do_always_throw_errors, bool do_init)
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 {},
-                "Unexpected Attribute datatype for 'iterationEncoding'");
+                "Unexpected Attribute datatype for 'iterationEncoding' "
+                "(expected string, found " +
+                    datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
         aRead.name = "iterationFormat";
         IOHandler()->enqueue(IOTask(this, aRead));
@@ -1357,7 +1357,9 @@ auto Series::readGorVBased(bool do_always_throw_errors, bool do_init)
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 {},
-                "Unexpected Attribute datatype for 'iterationFormat'");
+                "Unexpected Attribute datatype for 'iterationFormat' (expected "
+                "string, found " +
+                    datatypeToString(Attribute(*aRead.resource).dtype) + ")");
     }
 
     Parameter<Operation::OPEN_PATH> pOpen;
@@ -1538,7 +1540,9 @@ void Series::readBase()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'openPMD'");
+            "Unexpected Attribute datatype for 'openPMD' (expected string, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "openPMDextension";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -1551,7 +1555,9 @@ void Series::readBase()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'openPMDextension'");
+            "Unexpected Attribute datatype for 'openPMDextension' (expected "
+            "uint32, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     aRead.name = "basePath";
     IOHandler()->enqueue(IOTask(this, aRead));
@@ -1564,7 +1570,9 @@ void Series::readBase()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'basePath'");
+            "Unexpected Attribute datatype for 'basePath' (expected string, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     Parameter<Operation::LIST_ATTS> aList;
     IOHandler()->enqueue(IOTask(this, aList));
@@ -1593,7 +1601,9 @@ void Series::readBase()
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 {},
-                "Unexpected Attribute datatype for 'meshesPath'");
+                "Unexpected Attribute datatype for 'meshesPath' (expected "
+                "string, found " +
+                    datatypeToString(Attribute(*aRead.resource).dtype) + ")");
     }
 
     if (std::count(
@@ -1621,7 +1631,9 @@ void Series::readBase()
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 {},
-                "Unexpected Attribute datatype for 'particlesPath'");
+                "Unexpected Attribute datatype for 'particlesPath' (expected "
+                "string, found " +
+                    datatypeToString(Attribute(*aRead.resource).dtype) + ")");
     }
 }
 
@@ -2303,6 +2315,8 @@ auto Series::currentSnapshot() const
         default: {
             std::stringstream s;
             s << "Unexpected datatype for '/data/snapshot': " << attribute.dtype
+              << " (expected a vector of integer, found " +
+                    datatypeToString(attribute.dtype) + ")"
               << std::endl;
             throw error::ReadError(
                 error::AffectedObject::Attribute,

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -22,6 +22,7 @@
 #include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
 
+#include "openPMD/Error.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -299,7 +299,10 @@ void Attributable::readAttributes(ReadMode mode)
                 // Some backends may report the wrong type when reading
                 if (vector.size() != 7)
                 {
-                    throw std::runtime_error(
+                    throw error::ReadError(
+                        error::AffectedObject::Attribute,
+                        error::Reason::UnexpectedContent,
+                        {},
                         "[Attributable] "
                         "Unexpected datatype for unitDimension.");
                 }
@@ -541,7 +544,11 @@ void Attributable::readAttributes(ReadMode mode)
                 internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::UNDEFINED:
-            throw std::runtime_error("Invalid Attribute datatype during read");
+            throw error::ReadError(
+                error::AffectedObject::Attribute,
+                error::Reason::UnexpectedContent,
+                {},
+                "Invalid Attribute datatype during read");
         }
     }
 

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -303,8 +303,10 @@ void Attributable::readAttributes(ReadMode mode)
                         error::AffectedObject::Attribute,
                         error::Reason::UnexpectedContent,
                         {},
-                        "[Attributable] "
-                        "Unexpected datatype for unitDimension.");
+                        "[Attributable] Unexpected datatype for unitDimension "
+                        "(supplied vector has " +
+                            std::to_string(vector.size()) +
+                            " entries, but 7 are expected).");
                 }
                 std::array<double, 7> arr;
                 std::copy_n(vector.begin(), 7, arr.begin());
@@ -548,7 +550,7 @@ void Attributable::readAttributes(ReadMode mode)
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 {},
-                "Invalid Attribute datatype during read");
+                "Undefined Attribute datatype during read");
         }
     }
 

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -47,7 +47,10 @@ void MeshRecordComponent::read()
     else if (auto val = a.getOptional<std::vector<double> >(); val.has_value())
         setPosition(val.value());
     else
-        throw std::runtime_error(
+        throw error::ReadError(
+            error::AffectedObject::Attribute,
+            error::Reason::UnexpectedContent,
+            {},
             "Unexpected Attribute datatype for 'position'");
 
     readBase();

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -51,7 +51,9 @@ void MeshRecordComponent::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'position'");
+            "Unexpected Attribute datatype for 'position' (expected a vector "
+            "of any floating point type, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     readBase();
 }

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -74,7 +74,9 @@ void PatchRecord::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'unitDimension'");
+            "Unexpected Attribute datatype for 'unitDimension' (expected an "
+            "array of seven floating point numbers, found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     Parameter<Operation::LIST_DATASETS> dList;
     IOHandler()->enqueue(IOTask(this, dList));

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -130,7 +130,11 @@ void PatchRecordComponent::read()
         val.has_value())
         setUnitSI(val.value());
     else
-        throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
+        throw error::ReadError(
+            error::AffectedObject::Attribute,
+            error::Reason::UnexpectedContent,
+            {},
+            "Unexpected Attribute datatype for 'unitSI'");
 
     readAttributes(ReadMode::FullyReread); // this will set dirty() = false
 }

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -134,7 +134,9 @@ void PatchRecordComponent::read()
             error::AffectedObject::Attribute,
             error::Reason::UnexpectedContent,
             {},
-            "Unexpected Attribute datatype for 'unitSI'");
+            "Unexpected Attribute datatype for 'unitSI' (expected double, "
+            "found " +
+                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
 
     readAttributes(ReadMode::FullyReread); // this will set dirty() = false
 }

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -1,4 +1,5 @@
 #include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/Error.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/openPMD.hpp"
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -283,10 +283,14 @@ TEST_CASE("git_hdf5_sample_content_test", "[parallel][hdf5]")
                 REQUIRE(raw_ptr[i] == constant_value);
         }
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 }
 
@@ -619,10 +623,14 @@ TEST_CASE("hzdr_adios_sample_content_test", "[parallel][adios1]")
                     REQUIRE(raw_ptr[j * 3 + k] == actual[rank][j][k]);
         }
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 }
 #endif

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3066,7 +3066,8 @@ TEST_CASE("git_hdf5_sample_fileBased_read_test", "[serial][hdf5]")
     }
     catch (error::ReadError &e)
     {
-        if (e.reason == error::Reason::Inaccessible)
+        if (e.reason == error::Reason::Inaccessible &&
+            e.affectedObject == error::AffectedObject::File)
         {
             std::cerr << "git sample not accessible. (" << e.what() << ")\n";
             return;

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3139,7 +3139,9 @@ TEST_CASE("git_hdf5_sample_fileBased_read_test", "[serial][hdf5]")
             auxiliary::remove_file(file);
         }
     }
-    catch (error::ReadError &e)
+    // use no_such_file_error here to check that the backward-compatibility
+    // alias works
+    catch (no_such_file_error &e)
     {
         if (e.reason == error::Reason::Inaccessible)
         {
@@ -3147,12 +3149,6 @@ TEST_CASE("git_hdf5_sample_fileBased_read_test", "[serial][hdf5]")
             return;
         }
         throw;
-    }
-    // @todo maybe unify error types
-    catch (no_such_file_error &e)
-    {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
     }
 }
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2379,9 +2379,16 @@ inline void optional_paths_110_test(const std::string &backend)
             REQUIRE(s.iterations[400].particles.empty());
         }
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "issue sample not accessible. (" << e.what() << ")\n";
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "issue sample not accessible. (" << e.what() << ")\n";
+        }
+        else
+        {
+            throw;
+        }
     }
 
     {
@@ -2450,10 +2457,14 @@ void git_early_chunk_query(
             }
         }
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 }
 
@@ -2490,9 +2501,16 @@ TEST_CASE("empty_alternate_fbpic", "[serial][hdf5]")
             helper::listSeries(list);
         }
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "issue sample not accessible. (" << e.what() << ")\n";
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "issue sample not accessible. (" << e.what() << ")\n";
+        }
+        else
+        {
+            throw;
+        }
     }
 }
 
@@ -2679,10 +2697,14 @@ TEST_CASE("git_hdf5_sample_structure_test", "[serial][hdf5]")
         int32_t i32 = 32;
         REQUIRE_THROWS(o.setAttribute("setAttributeFail", i32));
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 #else
     std::cerr << "Invasive tests not enabled. Hierarchy is not visible.\n";
@@ -2936,10 +2958,14 @@ TEST_CASE("git_hdf5_sample_attribute_test", "[serial][hdf5]")
         REQUIRE(weighting_scalar.getDimensionality() == 1);
         REQUIRE(weighting_scalar.getExtent() == e);
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 }
 
@@ -3010,10 +3036,14 @@ TEST_CASE("git_hdf5_sample_content_test", "[serial][hdf5]")
                 REQUIRE(raw_ptr[i] == constant_value);
         }
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 }
 
@@ -3034,10 +3064,14 @@ TEST_CASE("git_hdf5_sample_fileBased_read_test", "[serial][hdf5]")
         REQUIRE(o.get().m_filenamePadding == 8);
 #endif
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 
     try
@@ -3056,15 +3090,19 @@ TEST_CASE("git_hdf5_sample_fileBased_read_test", "[serial][hdf5]")
         REQUIRE(o.get().m_filenamePadding == 8);
 #endif
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 
-    REQUIRE_THROWS_WITH(
+    REQUIRE_THROWS_AS(
         Series("../samples/git-sample/data%07T.h5", Access::READ_ONLY),
-        Catch::Equals("No matching iterations found: data%07T"));
+        error::ReadError);
 
     try
     {
@@ -3101,6 +3139,16 @@ TEST_CASE("git_hdf5_sample_fileBased_read_test", "[serial][hdf5]")
             auxiliary::remove_file(file);
         }
     }
+    catch (error::ReadError &e)
+    {
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
+    }
+    // @todo maybe unify error types
     catch (no_such_file_error &e)
     {
         std::cerr << "git sample not accessible. (" << e.what() << ")\n";
@@ -3181,10 +3229,14 @@ TEST_CASE("git_hdf5_sample_read_thetaMode", "[serial][hdf5][thetaMode]")
         auto data = B_z.loadChunk<double>(offset, extent);
         o.flush();
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "git sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
     }
 }
 
@@ -3654,10 +3706,13 @@ TEST_CASE("hzdr_hdf5_sample_content_test", "[serial][hdf5]")
         REQUIRE(
             isSame(e_offset_z.getDatatype(), determineDatatype<uint64_t>()));
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "HZDR sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "HZDR sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
     }
 }
 
@@ -3848,10 +3903,13 @@ TEST_CASE("hzdr_adios1_sample_content_test", "[serial][adios1]")
                 for (int c = 0; c < 3; ++c)
                     REQUIRE(raw_ptr[((a * 3) + b) * 3 + c] == actual[a][b][c]);
     }
-    catch (no_such_file_error &e)
+    catch (error::ReadError &e)
     {
-        std::cerr << "HZDR sample not accessible. (" << e.what() << ")\n";
-        return;
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "HZDR sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
     }
 }
 
@@ -6052,7 +6110,7 @@ void deferred_parsing(std::string const &extension)
         Series series(basename + "%06T." + extension, Access::CREATE);
         std::vector<float> buffer(20);
         std::iota(buffer.begin(), buffer.end(), 0.f);
-        auto dataset = series.iterations[1000].meshes["E"]["x"];
+        auto dataset = series.iterations[0].meshes["E"]["x"];
         dataset.resetDataset({Datatype::FLOAT, {20}});
         dataset.storeChunk(buffer, {0}, {20});
         series.flush();
@@ -6060,7 +6118,7 @@ void deferred_parsing(std::string const &extension)
     // create some empty pseudo files
     // if the reader tries accessing them it's game over
     {
-        for (size_t i = 0; i < 1000; i += 100)
+        for (size_t i = 1; i < 1000; i += 100)
         {
             std::string infix = std::to_string(i);
             std::string padding;
@@ -6080,7 +6138,7 @@ void deferred_parsing(std::string const &extension)
             Access::READ_ONLY,
             "{\"defer_iteration_parsing\": true}");
         auto dataset =
-            series.iterations[1000].open().meshes["E"]["x"].loadChunk<float>(
+            series.iterations[0].open().meshes["E"]["x"].loadChunk<float>(
                 {0}, {20});
         series.flush();
         for (size_t i = 0; i < 20; ++i)
@@ -6096,7 +6154,7 @@ void deferred_parsing(std::string const &extension)
             Access::READ_WRITE,
             "{\"defer_iteration_parsing\": true}");
         auto dataset =
-            series.iterations[1000].open().meshes["E"]["x"].loadChunk<float>(
+            series.iterations[0].open().meshes["E"]["x"].loadChunk<float>(
                 {0}, {20});
         series.flush();
         for (size_t i = 0; i < 20; ++i)
@@ -6252,6 +6310,94 @@ TEST_CASE("chaotic_stream", "[serial]")
         chaotic_stream("../samples/chaotic_stream_vbased." + t, true);
     }
 }
+
+#ifdef openPMD_USE_INVASIVE_TESTS
+void unfinished_iteration_test(
+    std::string const &ext, bool filebased, std::string const &config = "{}")
+{
+    std::cout << "\n\nTESTING " << ext << "\n\n" << std::endl;
+    std::string file = std::string("../samples/unfinished_iteration") +
+        (filebased ? "_%T." : ".") + ext;
+    {
+        Series write(file, Access::CREATE, config);
+        auto it0 = write.writeIterations()[0];
+        auto it5 = write.writeIterations()[5];
+        /*
+         * With enabled invasive tests, this attribute will let the Iteration
+         * fail parsing.
+         */
+        it5.setAttribute("__openPMD_internal_fail", "asking for trouble");
+        auto it10 = write.writeIterations()[10];
+        auto E_x = it10.meshes["E"]["x"];
+        auto e_density = it10.meshes["e_density"][RecordComponent::SCALAR];
+        auto electron_x = it10.particles["e"]["position"]["x"];
+        auto electron_mass =
+            it10.particles["e"]["mass"][RecordComponent::SCALAR];
+    }
+    auto tryReading = [&config,
+                       file](std::string const &additionalConfig = "{}") {
+        Series read(
+            file, Access::READ_ONLY, json::merge(config, additionalConfig));
+
+        std::vector<decltype(Series::iterations)::key_type> iterations;
+        std::cout << "Going to list iterations in " << file << ":" << std::endl;
+        for (auto iteration : read.readIterations())
+        {
+            std::cout << "Seeing iteration " << iteration.iterationIndex
+                      << std::endl;
+            iterations.push_back(iteration.iterationIndex);
+
+            Parameter<Operation::READ_ATT> readAttribute;
+            readAttribute.name = "this_does_definitely_not_exist";
+            read.IOHandler()->enqueue(IOTask(&iteration, readAttribute));
+            // enqueue a second time to check that the queue is cleared upon
+            // exception
+            read.IOHandler()->enqueue(IOTask(&iteration, readAttribute));
+
+            REQUIRE_THROWS_AS(
+                read.IOHandler()->flush({FlushLevel::InternalFlush}),
+                error::ReadError);
+            REQUIRE(read.IOHandler()->m_work.empty());
+        }
+        REQUIRE(
+            (iterations ==
+             std::vector<decltype(Series::iterations)::key_type>{0, 10}));
+    };
+
+    tryReading();
+    tryReading(R"({"defer_iteration_parsing": true})");
+}
+
+TEST_CASE("unfinished_iteration_test", "[serial]")
+{
+#if openPMD_HAVE_ADIOS2
+    unfinished_iteration_test("bp", false, R"({"backend": "adios2"})");
+    unfinished_iteration_test(
+        "bp",
+        false,
+        R"(
+{
+  "backend": "adios2",
+  "iteration_encoding": "variable_based",
+  "adios2": {
+    "schema": 20210209
+  }
+}
+)");
+    unfinished_iteration_test("bp", true, R"({"backend": "adios2"})");
+#endif
+#if openPMD_HAVE_ADIOS1
+    unfinished_iteration_test("adios1.bp", false, R"({"backend": "adios1"})");
+    unfinished_iteration_test("adios1.bp", true, R"({"backend": "adios1"})");
+#endif
+#if openPMD_HAVE_HDF5
+    unfinished_iteration_test("h5", false);
+    unfinished_iteration_test("h5", true);
+#endif
+    unfinished_iteration_test("json", false);
+    unfinished_iteration_test("json", true);
+}
+#endif
 
 TEST_CASE("late_setting_of_iterationencoding", "[serial]")
 {


### PR DESCRIPTION
Reading failures should ideally affect only the innermost scope possible. When one record component fails parsing due to whatever error, the neighboring record components should remain readable. When one iteration fails parsing, skip it and go on to the next.
Current behavior: Parsing fails and the Series cannot be opened

Close #983 

TODO
- [x] Introduce `ReadError` error type that backends can throw to tell the frontend about recoverable failures
- [x] Throw `ReadError` inside ADIOS1 and ADIOS2 attribute reading routines
- [x] Frontend: Recover from `ReadError`s ~~(partially implemented so far)~~
- [x] ~~Other backends,~~ also consider dataset reading, ... UPDATE: Catching wrong attribute reads now possible in all backends, dataset reading and further things can come in a later update
- [x] Testing: ~~file-based, group-based, varialbe-based, deferred/eager~~, opening single iterations of a file-based series, ~~streaming API, skipping iteration~~
- [x] Merge #949 first to avoid merge conflicts
- [x] Correctly recover from deferred actions in ADIOS2
- [x] ADIOS2 / variable-based encoding: Backend reports wrong value for snapshot in iteration 10
- [x] ~~bp4_steps test seems to not write snapshot attribute~~ only written in new ADIOS2 schema as it should be
- [x] Avoid const_cast by using the parsing state

This whole PR is a bit of a stretch-goal as there are many different types and sources of errors to be recovered from.
@ax3l Can you name some specific error pattern (or even give me a test file) that the openPMD-api should handle more robustly?

I think that a backend failure should mean that the entire call to `AbstractIOHandler::flush()` has failed and the queue is cleared. For finer granularity error handling, the frontend must issue single `flush()` calls. So, I've changed error recovery procedures to clear the entire IO queue upon failure.