### PR TITLE
Fixes for opening an iteration

### DIFF
--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -84,7 +84,11 @@ enum class FlushLevel : unsigned char
      * CREATE_DATASET tasks.
      * Attributes may or may not be flushed yet.
      */
-    SkeletonOnly
+    SkeletonOnly,
+    /**
+     * Only creates/opens files, nothing more
+     */
+    CreateOrOpenFiles
 };
 
 namespace internal

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -61,11 +61,9 @@ public:
  * @brief Determine what items should be flushed upon Series::flush()
  *
  */
-#ifdef __NVCOMPILER_MAJOR__
+// do not write `enum class FlushLevel : unsigned char` here since NVHPC
+// does not compile it correctly
 enum class FlushLevel
-#else
-enum class FlushLevel : unsigned char
-#endif
 {
     /**
      * Flush operation that was triggered by user code.

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -61,7 +61,11 @@ public:
  * @brief Determine what items should be flushed upon Series::flush()
  *
  */
+#ifdef __NVCOMPILER_MAJOR__
+enum class FlushLevel
+#else
 enum class FlushLevel : unsigned char
+#endif
 {
     /**
      * Flush operation that was triggered by user code.

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -72,6 +72,7 @@ namespace internal
          * containing this iteration.
          */
         std::string filename;
+        bool beginStep = false;
     };
 
     class IterationData : public AttributableData
@@ -249,14 +250,16 @@ private:
     void flush(internal::FlushParams const &);
     void deferParseAccess(internal::DeferredParseAccess);
     /*
-     * Control flow for read(), readFileBased(), readGroupBased() and
-     * read_impl():
-     * read() is called as the entry point. File-based and group-based
+     * Control flow for runDeferredParseAccess(), readFileBased(),
+     * readGroupBased() and read_impl():
+     * runDeferredParseAccess() is called as the entry point.
+     * File-based and group-based
      * iteration layouts need to be parsed slightly differently:
      * In file-based iteration layout, each iteration's file also contains
      * attributes for the /data group. In group-based layout, those have
      * already been parsed during opening of the Series.
-     * Hence, read() will call either readFileBased() or readGroupBased() to
+     * Hence, runDeferredParseAccess() will call either readFileBased() or
+     * readGroupBased() to
      * allow for those different control flows.
      * Finally, read_impl() is called which contains the common parsing
      * logic for an iteration.
@@ -265,10 +268,10 @@ private:
      * Calling it on an Iteration not yet parsed is an error.
      *
      */
-    void read();
     void reread(std::string const &path);
-    void readFileBased(std::string filePath, std::string const &groupPath);
-    void readGorVBased(std::string const &groupPath);
+    void readFileBased(
+        std::string filePath, std::string const &groupPath, bool beginStep);
+    void readGorVBased(std::string const &groupPath, bool beginStep);
     void read_impl(std::string const &groupPath);
 
     /**
@@ -278,7 +281,7 @@ private:
      *
      * @return AdvanceStatus
      */
-    AdvanceStatus beginStep();
+    AdvanceStatus beginStep(bool reread);
 
     /**
      * @brief End an IO step on the IO file (or file-like object)

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -121,9 +121,9 @@ OPENPMD_private
      */
     std::shared_ptr<AbstractFilePosition> abstractFilePosition;
     std::shared_ptr<AbstractIOHandler> IOHandler;
-    internal::AttributableData *attributable;
-    Writable *parent;
-    bool dirty;
+    internal::AttributableData *attributable = nullptr;
+    Writable *parent = nullptr;
+    bool dirty = false;
     /**
      * If parent is not null, then this is a vector of keys such that:
      * &(*parent)[key_1]...[key_n] == this
@@ -146,6 +146,6 @@ OPENPMD_private
      * Writable and its meaning within the current dataset.
      *
      */
-    bool written;
+    bool written = false;
 };
 } // namespace openPMD

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -119,11 +119,11 @@ OPENPMD_private
      * These members need to be shared pointers since distinct instances of
      * Writable may share them.
      */
-    std::shared_ptr<AbstractFilePosition> abstractFilePosition;
-    std::shared_ptr<AbstractIOHandler> IOHandler;
+    std::shared_ptr<AbstractFilePosition> abstractFilePosition = nullptr;
+    std::shared_ptr<AbstractIOHandler> IOHandler = nullptr;
     internal::AttributableData *attributable = nullptr;
     Writable *parent = nullptr;
-    bool dirty = false;
+    bool dirty = true;
     /**
      * If parent is not null, then this is a vector of keys such that:
      * &(*parent)[key_1]...[key_n] == this

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2652,6 +2652,7 @@ namespace detail
 
         case FlushLevel::InternalFlush:
         case FlushLevel::SkeletonOnly:
+        case FlushLevel::CreateOrOpenFiles:
             /*
              * Tasks have been given to ADIOS2, but we don't flush them
              * yet. So, move everything to m_alreadyEnqueued to avoid

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -237,9 +237,15 @@ void Iteration::flushFileBased(
         s.openIteration(i, *this);
     }
 
-    if (flushParams.flushLevel != FlushLevel::CreateOrOpenFiles)
+    switch (flushParams.flushLevel)
     {
+    case FlushLevel::CreateOrOpenFiles:
+        break;
+    case FlushLevel::SkeletonOnly:
+    case FlushLevel::InternalFlush:
+    case FlushLevel::UserFlush:
         flush(flushParams);
+        break;
     }
 }
 
@@ -254,9 +260,15 @@ void Iteration::flushGroupBased(
         IOHandler()->enqueue(IOTask(this, pCreate));
     }
 
-    if (flushParams.flushLevel != FlushLevel::CreateOrOpenFiles)
+    switch (flushParams.flushLevel)
     {
+    case FlushLevel::CreateOrOpenFiles:
+        break;
+    case FlushLevel::SkeletonOnly:
+    case FlushLevel::InternalFlush:
+    case FlushLevel::UserFlush:
         flush(flushParams);
+        break;
     }
 }
 
@@ -272,9 +284,15 @@ void Iteration::flushVariableBased(
         this->setAttribute("snapshot", i);
     }
 
-    if (flushParams.flushLevel != FlushLevel::CreateOrOpenFiles)
+    switch (flushParams.flushLevel)
     {
+    case FlushLevel::CreateOrOpenFiles:
+        break;
+    case FlushLevel::SkeletonOnly:
+    case FlushLevel::InternalFlush:
+    case FlushLevel::UserFlush:
         flush(flushParams);
+        break;
     }
 }
 

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -63,7 +63,7 @@ SeriesIterator::SeriesIterator(Series series) : m_series(std::move(series))
              * the step after parsing the file is ok.
              */
             openIteration();
-            status = it->second.beginStep();
+            status = it->second.beginStep(/* reread = */ true);
             break;
         case IterationEncoding::groupBased:
         case IterationEncoding::variableBased:
@@ -72,7 +72,7 @@ SeriesIterator::SeriesIterator(Series series) : m_series(std::move(series))
              * access to the file until now. Better to begin a step right away,
              * otherwise we might get another step's data.
              */
-            status = it->second.beginStep();
+            status = it->second.beginStep(/* reread = */ true);
             openIteration();
             break;
         }
@@ -107,7 +107,8 @@ SeriesIterator &SeriesIterator::operator++()
     case IE::variableBased: {
         // since we are in group-based iteration layout, it does not
         // matter which iteration we begin a step upon
-        AdvanceStatus status = currentIteration.beginStep();
+        AdvanceStatus status{};
+        status = currentIteration.beginStep(/* reread = */ true);
         if (status == AdvanceStatus::OVER)
         {
             *this = end();
@@ -142,7 +143,8 @@ SeriesIterator &SeriesIterator::operator++()
         using IE = IterationEncoding;
     case IE::fileBased: {
         auto &iteration = series.iterations[m_currentIteration];
-        AdvanceStatus status = iteration.beginStep();
+        AdvanceStatus status{};
+        status = iteration.beginStep(/* reread = */ true);
         if (status == AdvanceStatus::OVER)
         {
             *this = end();

--- a/src/WriteIterations.cpp
+++ b/src/WriteIterations.cpp
@@ -68,7 +68,7 @@ WriteIterations::mapped_type &WriteIterations::operator[](key_type &&key)
     auto &res = shared->iterations[std::move(key)];
     if (res.getStepStatus() == StepStatus::NoStep)
     {
-        res.beginStep();
+        res.beginStep(/* reread = */ false);
         res.setStepStatus(StepStatus::DuringStep);
     }
     return res;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -213,9 +213,15 @@ void Attributable::seriesFlush(internal::FlushParams flushParams)
 
 void Attributable::flushAttributes(internal::FlushParams const &flushParams)
 {
-    if (flushParams.flushLevel == FlushLevel::SkeletonOnly)
+    switch (flushParams.flushLevel)
     {
+    case FlushLevel::SkeletonOnly:
+    case FlushLevel::CreateOrOpenFiles:
         return;
+    case FlushLevel::InternalFlush:
+    case FlushLevel::UserFlush:
+        // pass
+        break;
     }
     if (dirty())
     {

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -24,13 +24,7 @@
 
 namespace openPMD
 {
-Writable::Writable(internal::AttributableData *a)
-    : abstractFilePosition{nullptr}
-    , IOHandler{nullptr}
-    , attributable{a}
-    , parent{nullptr}
-    , dirty{true}
-    , written{false}
+Writable::Writable(internal::AttributableData *a) : attributable{a}
 {}
 
 void Writable::seriesFlush()

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4687,6 +4687,12 @@ void variableBasedSeries(std::string const &file)
             std::vector<int> data(1000, i);
             E_x.storeChunk(data, {0}, {1000});
 
+            if (i > 2)
+            {
+                iteration.setAttribute(
+                    "iteration_is_larger_than_two", "it truly is");
+            }
+
             // this tests changing extents and dimensionalities
             // across iterations
             auto E_y = iteration.meshes["E"]["y"];
@@ -4722,6 +4728,18 @@ void variableBasedSeries(std::string const &file)
         size_t last_iteration_index = 0;
         for (auto iteration : readSeries.readIterations())
         {
+            if (iteration.iterationIndex > 2)
+            {
+                REQUIRE(
+                    iteration.getAttribute("iteration_is_larger_than_two")
+                        .get<std::string>() == "it truly is");
+            }
+            else
+            {
+                REQUIRE_FALSE(iteration.containsAttribute(
+                    "iteration_is_larger_than_two"));
+            }
+
             auto E_x = iteration.meshes["E"]["x"];
             REQUIRE(E_x.getDimensionality() == 1);
             REQUIRE(E_x.getExtent()[0] == extent);


### PR DESCRIPTION
Commit isolated from #1237

1. When opening a new step in the Streaming API, don't flush the Series before doing that. It seems that flushing at this stage seems to confuse HDF5 and lead to rare deadlocks in parallel contexts, seen in PIConGPU. This PR is able to fix that behavior in the observed instance.
2. When reading a variable-based Series, make sure to open an IO step before doing anything. Otherwise, attributes from later iterations might leak into the early iteration (RandomAccess mode in BP4).

TODO:
- [x] Testing