### PR TITLE
CI: NVHPC New Apt Repo

### DIFF
--- a/.github/workflows/dependencies/install_nvhpc21-11.sh
+++ b/.github/workflows/dependencies/install_nvhpc21-11.sh
@@ -14,14 +14,13 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-wget -q https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc-21-5_21.5_amd64.deb \
-        https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc-2021_21.5_amd64.deb
-sudo apt-get update
-sudo apt-get install -y ./nvhpc-21-5_21.5_amd64.deb ./nvhpc-2021_21.5_amd64.deb
-rm -rf ./nvhpc-21-5_21.5_amd64.deb ./nvhpc-2021_21.5_amd64.deb
+echo 'deb [trusted=yes] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | \
+  sudo tee /etc/apt/sources.list.d/nvhpc.list
+sudo apt-get update -y
+sudo apt-get install -y --no-install-recommends nvhpc-21-11
 
 # things should reside in /opt/nvidia/hpc_sdk now
 
 # activation via:
 #   source /etc/profile.d/modules.sh
-#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/20.7
+#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.11

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -32,8 +32,8 @@ jobs:
         cmake --build build --parallel 2
         ctest --test-dir build --output-on-failure
 
-  tests-nvhpc21-5-nvcc:
-    name: NVHPC@21.5
+  tests-nvhpc21-11-nvcc:
+    name: NVHPC@21.11
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
     # Catch warnings:
@@ -42,11 +42,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
-      run: .github/workflows/dependencies/install_nvhpc21-5.sh
+      run: .github/workflows/dependencies/install_nvhpc21-11.sh
     - name: Build & Install
       run: |
         source /etc/profile.d/modules.sh
-        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.5
+        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.11
 
         which nvcc || echo "nvcc not in PATH!"
         which nvc++ || echo "nvc++ not in PATH!"


### PR DESCRIPTION
Update the NVHPC install instructions to the latest and greatest.
Fix failing CI (dependency install).

Also upgrade to 21.11 as on Perlmutter.