### PR TITLE
Python Iteration: Fix __repr__ (time)

### DIFF
--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -23,6 +23,8 @@
 
 #include "openPMD/Iteration.hpp"
 
+#include <ios>
+#include <sstream>
 #include <string>
 
 namespace py = pybind11;
@@ -36,10 +38,10 @@ void init_Iteration(py::module &m)
         .def(
             "__repr__",
             [](Iteration const &it) {
-                return "<openPMD.Iteration at t = '" +
-                    std::to_string(
-                           it.template time<double>() * it.timeUnitSI()) +
-                    " s'>";
+                std::stringstream ss;
+                ss << "<openPMD.Iteration at t = '" << std::scientific
+                   << it.template time<double>() * it.timeUnitSI() << " s'>";
+                return ss.str();
             })
 
         .def_property(


### PR DESCRIPTION
Small numbers, as common for iterations, were flushed to zero in `std::to_string(double)` of the representation of `Iteration` variables:
```
step    __repr__
100     <openPMD.Iteration at t = '0.000000 s'>
was:    8.687655225973454e-14 * 1.0
```