### PR TITLE
Doc: Update HDF5 Coll. Metadata Versions

### DIFF
--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -97,10 +97,11 @@ Known Issues
 .. warning::
 
    Jul 23th, 2021 (`HDFFV-11260 <https://jira.hdfgroup.org/browse/HDFFV-11260>`__):
-   Collective HDF5 metadata reads became broken in 1.10.5.
-   Consider using 1.10.4 if you plan to enable the collective HDF5 metadata operations optimization in openPMD (``OPENPMD_HDF5_COLLECTIVE_METADATA=ON``).
-   Enabling this feature with a newer version will make HDF5 fall back to the individual metadata operations.
-   HDF5 plans to fix the issue in the upcoming 1.10.8+ and 1.12.2+ releases, but visit the issue tracker above to see the status of the bug fix.
+   Collective HDF5 metadata reads broke in 1.10.5.
+   Enabling collective HDF5 metadata operations (``OPENPMD_HDF5_COLLECTIVE_METADATA=ON``) with a newer version will make HDF5 fall back to the individual metadata operations.
+
+   HDF5 releases 1.10.4 and earlier are not affected; versions 1.10.9+, 1.12.2+ and 1.13.1 fixed the issue.
+   Consider using these latest fixed HDF5 versions for MPI-parallel HDF5.
 
 Selected References
 -------------------

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -97,8 +97,8 @@ Known Issues
 .. warning::
 
    Jul 23th, 2021 (`HDFFV-11260 <https://jira.hdfgroup.org/browse/HDFFV-11260>`__):
-   Collective HDF5 metadata reads (``OPENPMD_HDF5_COLLECTIVE_METADATA=ON``) broke in 1.10.5, falling back to the individual metadata operations.
-   HDF5 releases 1.10.4 and earlier are not affected; versions 1.10.9+, 1.12.2+ and 1.13.1 fixed the issue.
+   Collective HDF5 metadata reads (``OPENPMD_HDF5_COLLECTIVE_METADATA=ON``) broke in 1.10.5, falling back to individual metadata operations.
+   HDF5 releases 1.10.4 and earlier are not affected; versions 1.10.9+, 1.12.2+ and 1.13.1+ fixed the issue.
 
 
 Selected References

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -97,11 +97,9 @@ Known Issues
 .. warning::
 
    Jul 23th, 2021 (`HDFFV-11260 <https://jira.hdfgroup.org/browse/HDFFV-11260>`__):
-   Collective HDF5 metadata reads broke in 1.10.5.
-   Enabling collective HDF5 metadata operations (``OPENPMD_HDF5_COLLECTIVE_METADATA=ON``) with a newer version will make HDF5 fall back to the individual metadata operations.
-
+   Collective HDF5 metadata reads (``OPENPMD_HDF5_COLLECTIVE_METADATA=ON``) broke in 1.10.5, falling back to the individual metadata operations.
    HDF5 releases 1.10.4 and earlier are not affected; versions 1.10.9+, 1.12.2+ and 1.13.1 fixed the issue.
-   Consider using these latest fixed HDF5 versions for MPI-parallel HDF5.
+
 
 Selected References
 -------------------


### PR DESCRIPTION
Update the documentation about HDFFV-11260 and the newly released fixes in release lines.

Thx @jeanbez et al. for finding, triaging and following up on this :rocket: :sparkles: 