### PR TITLE
SerialIOTest: Fix GCC Pragma Check

### DIFF
--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -417,7 +417,7 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
     /*
      * clang also understands these pragmas.
      */
-#if defined(__GNUC__MINOR__) || defined(__clang__)
+#if defined(__GNUC_MINOR__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif


### PR DESCRIPTION
There was a typo in `__GNUC_MINOR__`, causing the test not to work on all GCC versions.

Follow-up to #1213

update: upsi, also needs 51810387027af3ec89fad7e29d822685f87d9763