### PR TITLE
CI: Fix to ADIOS 2.7.1 on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -88,7 +88,7 @@ install:
   # Configure the VM.
   - cmd: conda install -n root --quiet --yes numpy cmake hdf5 python=%CONDA_PY%
   # ADIOS2 build only for 64bit Windows
-  - cmd: if "%TARGET_ARCH%"=="x64" conda install -n root --quiet --yes adios2 python=%CONDA_PY%
+  - cmd: if "%TARGET_ARCH%"=="x64" conda install -n root --quiet --yes adios2==2.7.1 python=%CONDA_PY%
 
 before_build:
   - cmd: cd C:\projects\openpmd-api


### PR DESCRIPTION
AppVeyor Windows CI build: Fix ADIOS version to 2.7.1, because BP5 is a conditional compile variant in ADIOS 2.8.0

Work-around for #1257 / https://github.com/ornladios/ADIOS2/issues/3182 to unbreak CI.