### PR TITLE
SerialIOTest: Fix GCC Pragma Check

### DIFF
--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -417,9 +417,11 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
     /*
      * clang also understands these pragmas.
      */
-#if defined(__GNUC__MINOR__) || defined(__clang__)
+#if defined(__GNUC_MINOR__) && !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__clang__)
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
     /*
      * First test: No premature flushes through destructor when another copy
@@ -463,11 +465,10 @@ TEST_CASE("multiple_series_handles_test", "[serial]")
          */
         series_ptr->flush();
     }
-#if defined(__INTEL_COMPILER)
-#pragma warning(disable : 2282)
-#endif
-#if defined(__GNUC__MINOR__) || defined(__clang__)
+#if defined(__GNUC_MINOR__) && !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic pop
+#elif defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 }
 


### PR DESCRIPTION
There was a typo in `__GNUC_MINOR__`, causing the test not to work on all GCC versions.

Follow-up to #1213

Redo of #1255