### PR TITLE
CI: Fix Conda Build - <3 Mamba

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -303,12 +303,13 @@ jobs:
     - name: Install
       shell: bash -eo pipefail -l {0}
       run: |
-        conda env create --file conda.yml
+        conda install -c conda-forge -y mamba
+        mamba env create --file conda.yml
     - name: Build
       shell: bash -eo pipefail -l {0}
       env: {CXXFLAGS: -Werror -Wno-deprecated-declarations}
       run: |
-        conda activate openpmd-api-dev
+        source activate openpmd-api-dev
 
         share/openPMD/download_samples.sh build
         chmod u-w build/samples/git-sample/*.h5


### PR DESCRIPTION
Fix the Conda-Build
```
-- The C compiler identification is GNU 10.3.0
-- The CXX compiler identification is GNU 10.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/share/miniconda/envs/openpmd-api-dev/bin/x86_64-conda-linux-gnu-cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/share/miniconda/envs/openpmd-api-dev/bin/x86_64-conda-linux-gnu-c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Checking for module 'mpi-cxx'
--   No package 'mpi-cxx' found
-- Could NOT find MPI_CXX (missing: MPI_CXX_LIB_NAMES MPI_CXX_HEADER_DIR MPI_CXX_WORKS)
CMake Error at /usr/share/miniconda/envs/openpmd-api-dev/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find MPI (missing: MPI_CXX_FOUND CXX)
Call Stack (most recent call first):
  /usr/share/miniconda/envs/openpmd-api-dev/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/miniconda/envs/openpmd-api-dev/share/cmake-3.23/Modules/FindMPI.cmake:1830 (find_package_handle_standard_args)
  CMakeLists.txt:201 (find_package)

-- Configuring incomplete, errors occurred!
See also "/home/runner/work/openPMD-api/openPMD-api/build/CMakeFiles/CMakeOutput.log".
See also "/home/runner/work/openPMD-api/openPMD-api/build/CMakeFiles/CMakeError.log".
```

by switching to `mamba`.

Also solves & downloads that ~800 MB environment significantly faster.