### PR TITLE
CI: ADIOS 2.7.1

### DIFF
--- a/.github/ci/spack-envs/clang8_py38_mpich_h5_ad1_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clang8_py38_mpich_h5_ad1_ad2/spack.yaml
@@ -7,7 +7,7 @@
 spack:
   specs:
   - adios
-  - adios2
+  - adios2@2.7.1
   - hdf5
   - mpich
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -151,6 +151,7 @@ jobs:
         cmake --build build --parallel 2
         ctest --test-dir build --output-on-failure
 
+  # ADIOS2 v2.7.1
   clang8_py38_mpich_h5_ad1_ad2_newLayout:
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Make sure we continue to build a ADIOS 2.7.1 variant in CI as long as we support it. Package managers otherwise will over time all transition to pick the latest ADIOS2 release.