### PR TITLE
Distinguish all char types in ADIOS2 backend 

### DIFF
--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -42,7 +42,8 @@ namespace openPMD
 enum class Datatype : int
 {
     CHAR,
-    UCHAR, // SCHAR,
+    UCHAR,
+    SCHAR,
     SHORT,
     INT,
     LONG,
@@ -74,6 +75,7 @@ enum class Datatype : int
     VEC_CFLOAT,
     VEC_CDOUBLE,
     VEC_CLONG_DOUBLE,
+    VEC_SCHAR,
     VEC_STRING,
     ARR_DBL_7,
 
@@ -123,6 +125,10 @@ inline constexpr Datatype determineDatatype()
     else if (decay_equiv<T, unsigned char>::value)
     {
         return DT::UCHAR;
+    }
+    else if (decay_equiv<T, signed char>::value)
+    {
+        return DT::SCHAR;
     }
     else if (decay_equiv<T, short>::value)
     {
@@ -207,6 +213,10 @@ inline constexpr Datatype determineDatatype()
     else if (decay_equiv<T, std::vector<unsigned char>>::value)
     {
         return DT::VEC_UCHAR;
+    }
+    else if (decay_equiv<T, std::vector<signed char>>::value)
+    {
+        return DT::VEC_SCHAR;
     }
     else if (decay_equiv<T, std::vector<unsigned short>>::value)
     {
@@ -276,6 +286,10 @@ inline constexpr Datatype determineDatatype(std::shared_ptr<T>)
     {
         return DT::UCHAR;
     }
+    else if (decay_equiv<T, signed char>::value)
+    {
+        return DT::SCHAR;
+    }
     else if (decay_equiv<T, short>::value)
     {
         return DT::SHORT;
@@ -359,6 +373,10 @@ inline constexpr Datatype determineDatatype(std::shared_ptr<T>)
     else if (decay_equiv<T, std::vector<unsigned char>>::value)
     {
         return DT::VEC_UCHAR;
+    }
+    else if (decay_equiv<T, std::vector<signed char>>::value)
+    {
+        return DT::VEC_SCHAR;
     }
     else if (decay_equiv<T, std::vector<unsigned short>>::value)
     {
@@ -434,9 +452,9 @@ inline size_t toBytes(Datatype d)
     case DT::UCHAR:
     case DT::VEC_UCHAR:
         return sizeof(unsigned char);
-    // case DT::SCHAR:
-    // case DT::VEC_SCHAR:
-    //     return sizeof(signed char);
+    case DT::SCHAR:
+    case DT::VEC_SCHAR:
+        return sizeof(signed char);
     case DT::SHORT:
     case DT::VEC_SHORT:
         return sizeof(short);

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -776,36 +776,6 @@ inline bool isSame(openPMD::Datatype const d, openPMD::Datatype const e)
     return false;
 }
 
-namespace detail
-{
-    template <typename T>
-    struct BasicDatatypeHelper
-    {
-        Datatype m_dt = determineDatatype<T>();
-    };
-
-    template <typename T>
-    struct BasicDatatypeHelper<std::vector<T>>
-    {
-        Datatype m_dt = BasicDatatypeHelper<T>{}.m_dt;
-    };
-
-    template <typename T, std::size_t n>
-    struct BasicDatatypeHelper<std::array<T, n>>
-    {
-        Datatype m_dt = BasicDatatypeHelper<T>{}.m_dt;
-    };
-
-    struct BasicDatatype
-    {
-        template <typename T>
-        static Datatype call();
-
-        template <int n>
-        static Datatype call();
-    };
-} // namespace detail
-
 /**
  * @brief basicDatatype Strip openPMD Datatype of std::vector, std::array et.
  * al.

--- a/include/openPMD/DatatypeHelpers.hpp
+++ b/include/openPMD/DatatypeHelpers.hpp
@@ -110,6 +110,8 @@ auto switchType(Datatype dt, Args &&...args)
     case Datatype::UCHAR:
         return Action::template call<unsigned char>(
             std::forward<Args>(args)...);
+    case Datatype::SCHAR:
+        return Action::template call<signed char>(std::forward<Args>(args)...);
     case Datatype::SHORT:
         return Action::template call<short>(std::forward<Args>(args)...);
     case Datatype::INT:
@@ -163,6 +165,9 @@ auto switchType(Datatype dt, Args &&...args)
             std::forward<Args>(args)...);
     case Datatype::VEC_UCHAR:
         return Action::template call<std::vector<unsigned char> >(
+            std::forward<Args>(args)...);
+    case Datatype::VEC_SCHAR:
+        return Action::template call<std::vector<signed char> >(
             std::forward<Args>(args)...);
     case Datatype::VEC_USHORT:
         return Action::template call<std::vector<unsigned short> >(
@@ -241,6 +246,8 @@ auto switchNonVectorType(Datatype dt, Args &&...args)
     case Datatype::UCHAR:
         return Action::template call<unsigned char>(
             std::forward<Args>(args)...);
+    case Datatype::SCHAR:
+        return Action::template call<signed char>(std::forward<Args>(args)...);
     case Datatype::SHORT:
         return Action::template call<short>(std::forward<Args>(args)...);
     case Datatype::INT:

--- a/include/openPMD/Datatype_internal.hpp
+++ b/include/openPMD/Datatype_internal.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2022 Franz Poeschel, Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #include "openPMD/auxiliary/TypeTraits.hpp"

--- a/include/openPMD/Datatype_internal.hpp
+++ b/include/openPMD/Datatype_internal.hpp
@@ -32,7 +32,20 @@ namespace detail
             {
                 return DoDetermineDatatype::template call<T>();
             }
+#if defined(__INTEL_COMPILER)
+/*
+ * ICPC has trouble with if constexpr, thinking that return statements are
+ * missing afterwards. Deactivate the warning.
+ * Note that putting a statement here will not help to fix this since it will
+ * then complain about unreachable code.
+ * https://community.intel.com/t5/Intel-C-Compiler/quot-if-constexpr-quot-and-quot-missing-return-statement-quot-in/td-p/1154551
+ */
+#pragma warning(disable : 1011)
         }
+#pragma warning(default : 1011)
+#else
+        }
+#endif
 
         constexpr static char const *errorMsg =
             "basicDatatype: received unknown datatype.";
@@ -59,7 +72,20 @@ namespace detail
             {
                 return DoDetermineDatatype::template call<std::vector<T>>();
             }
+#if defined(__INTEL_COMPILER)
+/*
+ * ICPC has trouble with if constexpr, thinking that return statements are
+ * missing afterwards. Deactivate the warning.
+ * Note that putting a statement here will not help to fix this since it will
+ * then complain about unreachable code.
+ * https://community.intel.com/t5/Intel-C-Compiler/quot-if-constexpr-quot-and-quot-missing-return-statement-quot-in/td-p/1154551
+ */
+#pragma warning(disable : 1011)
         }
+#pragma warning(default : 1011)
+#else
+        }
+#endif
 
         constexpr static char const *errorMsg =
             "toVectorType: received unknown datatype.";

--- a/include/openPMD/Datatype_internal.hpp
+++ b/include/openPMD/Datatype_internal.hpp
@@ -10,70 +10,54 @@ namespace openPMD
 {
 namespace detail
 {
-    template <typename DT, typename T>
-    constexpr DT determineDatatypeGeneric()
-    {
-        if constexpr (std::is_same_v<DT, Datatype>)
-        {
-            return determineDatatype<T>();
-        }
-        else
-        {
-            return DT{}; // @todo compile time error
-        }
-    }
-
-    template <typename DT, typename T>
-    struct BasicDatatypeHelper
-    {
-        constexpr static DT m_dt = determineDatatypeGeneric<DT, T>();
-    };
-
-    template <typename DT, typename T>
-    struct BasicDatatypeHelper<DT, std::vector<T>>
-    {
-        constexpr static DT m_dt = BasicDatatypeHelper<DT, T>{}.m_dt;
-    };
-
-    template <typename DT, typename T, std::size_t n>
-    struct BasicDatatypeHelper<DT, std::array<T, n>>
-    {
-        constexpr static DT m_dt = BasicDatatypeHelper<DT, T>{}.m_dt;
-    };
-
-    template <typename DT>
+    template <typename DoDetermineDatatype>
     struct BasicDatatype
     {
+        using DT = typename DoDetermineDatatype::DT_enum;
+
         template <typename T>
         constexpr static DT call()
         {
-            constexpr auto res = BasicDatatypeHelper<DT, T>::m_dt;
-            return res;
+            if constexpr (auxiliary::IsVector_v<T>)
+            {
+                return DoDetermineDatatype::template call<
+                    typename T::value_type>();
+            }
+            else if constexpr (auxiliary::IsArray_v<T>)
+            {
+                return DoDetermineDatatype::template call<
+                    typename T::value_type>();
+            }
+            else
+            {
+                return DoDetermineDatatype::template call<T>();
+            }
         }
 
         constexpr static char const *errorMsg =
             "basicDatatype: received unknown datatype.";
     };
 
-    template <typename DT>
+    template <typename DoDetermineDatatype>
     struct ToVectorType
     {
+        using DT = typename DoDetermineDatatype::DT_enum;
+
         template <typename T>
         constexpr static DT call()
         {
             if constexpr (auxiliary::IsVector_v<T>)
             {
-                return determineDatatypeGeneric<DT, T>();
+                return DoDetermineDatatype::template call<T>();
             }
             else if constexpr (auxiliary::IsArray_v<T>)
             {
-                return determineDatatypeGeneric<
-                    DT,
+                return DoDetermineDatatype::template call<
                     std::vector<typename T::value_type>>();
             }
             else
             {
-                return determineDatatypeGeneric<DT, std::vector<T>>();
+                return DoDetermineDatatype::template call<std::vector<T>>();
             }
         }
 

--- a/include/openPMD/Datatype_internal.hpp
+++ b/include/openPMD/Datatype_internal.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "openPMD/auxiliary/TypeTraits.hpp"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+namespace openPMD
+{
+namespace detail
+{
+    template <typename DT, typename T>
+    constexpr DT determineDatatypeGeneric()
+    {
+        if constexpr (std::is_same_v<DT, Datatype>)
+        {
+            return determineDatatype<T>();
+        }
+        else
+        {
+            return DT{}; // @todo compile time error
+        }
+    }
+
+    template <typename DT, typename T>
+    struct BasicDatatypeHelper
+    {
+        constexpr static DT m_dt = determineDatatypeGeneric<DT, T>();
+    };
+
+    template <typename DT, typename T>
+    struct BasicDatatypeHelper<DT, std::vector<T>>
+    {
+        constexpr static DT m_dt = BasicDatatypeHelper<DT, T>{}.m_dt;
+    };
+
+    template <typename DT, typename T, std::size_t n>
+    struct BasicDatatypeHelper<DT, std::array<T, n>>
+    {
+        constexpr static DT m_dt = BasicDatatypeHelper<DT, T>{}.m_dt;
+    };
+
+    template <typename DT>
+    struct BasicDatatype
+    {
+        template <typename T>
+        constexpr static DT call()
+        {
+            constexpr auto res = BasicDatatypeHelper<DT, T>::m_dt;
+            return res;
+        }
+
+        constexpr static char const *errorMsg =
+            "basicDatatype: received unknown datatype.";
+    };
+
+    template <typename DT>
+    struct ToVectorType
+    {
+        template <typename T>
+        constexpr static DT call()
+        {
+            if constexpr (auxiliary::IsVector_v<T>)
+            {
+                return determineDatatypeGeneric<DT, T>();
+            }
+            else if constexpr (auxiliary::IsArray_v<T>)
+            {
+                return determineDatatypeGeneric<
+                    DT,
+                    std::vector<typename T::value_type>>();
+            }
+            else
+            {
+                return determineDatatypeGeneric<DT, std::vector<T>>();
+            }
+        }
+
+        constexpr static char const *errorMsg =
+            "toVectorType: received unknown datatype.";
+    };
+} // namespace detail
+} // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -86,6 +86,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
     {
     case DT::CHAR:
     case DT::VEC_CHAR:
+    case DT::SCHAR:
+    case DT::VEC_SCHAR:
         return adios_byte;
     case DT::UCHAR:
     case DT::VEC_UCHAR:

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -36,6 +36,219 @@
 
 namespace openPMD
 {
+/** Concrete datatype of an object available at runtime.
+ * Since ADIOS2 distinguishes unsigned char, signed char and char, this enum
+ * has all three of them (unlike the public Datatype enum)
+ */
+enum class ADIOS2Datatype : int
+{
+    CHAR,
+    UCHAR,
+    SCHAR,
+    SHORT,
+    INT,
+    LONG,
+    LONGLONG,
+    USHORT,
+    UINT,
+    ULONG,
+    ULONGLONG,
+    FLOAT,
+    DOUBLE,
+    LONG_DOUBLE,
+    CFLOAT,
+    CDOUBLE,
+    CLONG_DOUBLE,
+    STRING,
+    VEC_CHAR,
+    VEC_UCHAR,
+    VEC_SCHAR,
+    VEC_SHORT,
+    VEC_INT,
+    VEC_LONG,
+    VEC_LONGLONG,
+    VEC_USHORT,
+    VEC_UINT,
+    VEC_ULONG,
+    VEC_ULONGLONG,
+    VEC_FLOAT,
+    VEC_DOUBLE,
+    VEC_LONG_DOUBLE,
+    VEC_CFLOAT,
+    VEC_CDOUBLE,
+    VEC_CLONG_DOUBLE,
+    VEC_STRING,
+    ARR_DBL_7,
+
+    BOOL,
+
+    UNDEFINED
+}; // Datatype
+
+template <typename T>
+inline constexpr ADIOS2Datatype determineAdios2Datatype()
+{
+    using DT = ADIOS2Datatype;
+    if (decay_equiv<T, char>::value)
+    {
+        return DT::CHAR;
+    }
+    else if (decay_equiv<T, signed char>::value)
+    {
+        return DT::SCHAR;
+    }
+    else if (decay_equiv<T, unsigned char>::value)
+    {
+        return DT::UCHAR;
+    }
+    else if (decay_equiv<T, short>::value)
+    {
+        return DT::SHORT;
+    }
+    else if (decay_equiv<T, int>::value)
+    {
+        return DT::INT;
+    }
+    else if (decay_equiv<T, long>::value)
+    {
+        return DT::LONG;
+    }
+    else if (decay_equiv<T, long long>::value)
+    {
+        return DT::LONGLONG;
+    }
+    else if (decay_equiv<T, unsigned short>::value)
+    {
+        return DT::USHORT;
+    }
+    else if (decay_equiv<T, unsigned int>::value)
+    {
+        return DT::UINT;
+    }
+    else if (decay_equiv<T, unsigned long>::value)
+    {
+        return DT::ULONG;
+    }
+    else if (decay_equiv<T, unsigned long long>::value)
+    {
+        return DT::ULONGLONG;
+    }
+    else if (decay_equiv<T, float>::value)
+    {
+        return DT::FLOAT;
+    }
+    else if (decay_equiv<T, double>::value)
+    {
+        return DT::DOUBLE;
+    }
+    else if (decay_equiv<T, long double>::value)
+    {
+        return DT::LONG_DOUBLE;
+    }
+    else if (decay_equiv<T, std::complex<float>>::value)
+    {
+        return DT::CFLOAT;
+    }
+    else if (decay_equiv<T, std::complex<double>>::value)
+    {
+        return DT::CDOUBLE;
+    }
+    else if (decay_equiv<T, std::complex<long double>>::value)
+    {
+        return DT::CLONG_DOUBLE;
+    }
+    else if (decay_equiv<T, std::string>::value)
+    {
+        return DT::STRING;
+    }
+    else if (decay_equiv<T, std::vector<char>>::value)
+    {
+        return DT::VEC_CHAR;
+    }
+    else if (decay_equiv<T, std::vector<signed char>>::value)
+    {
+        return DT::VEC_SCHAR;
+    }
+    else if (decay_equiv<T, std::vector<unsigned char>>::value)
+    {
+        return DT::VEC_UCHAR;
+    }
+    else if (decay_equiv<T, std::vector<short>>::value)
+    {
+        return DT::VEC_SHORT;
+    }
+    else if (decay_equiv<T, std::vector<int>>::value)
+    {
+        return DT::VEC_INT;
+    }
+    else if (decay_equiv<T, std::vector<long>>::value)
+    {
+        return DT::VEC_LONG;
+    }
+    else if (decay_equiv<T, std::vector<long long>>::value)
+    {
+        return DT::VEC_LONGLONG;
+    }
+    else if (decay_equiv<T, std::vector<unsigned char>>::value)
+    {
+        return DT::VEC_UCHAR;
+    }
+    else if (decay_equiv<T, std::vector<unsigned short>>::value)
+    {
+        return DT::VEC_USHORT;
+    }
+    else if (decay_equiv<T, std::vector<unsigned int>>::value)
+    {
+        return DT::VEC_UINT;
+    }
+    else if (decay_equiv<T, std::vector<unsigned long>>::value)
+    {
+        return DT::VEC_ULONG;
+    }
+    else if (decay_equiv<T, std::vector<unsigned long long>>::value)
+    {
+        return DT::VEC_ULONGLONG;
+    }
+    else if (decay_equiv<T, std::vector<float>>::value)
+    {
+        return DT::VEC_FLOAT;
+    }
+    else if (decay_equiv<T, std::vector<double>>::value)
+    {
+        return DT::VEC_DOUBLE;
+    }
+    else if (decay_equiv<T, std::vector<long double>>::value)
+    {
+        return DT::VEC_LONG_DOUBLE;
+    }
+    else if (decay_equiv<T, std::vector<std::complex<float>>>::value)
+    {
+        return DT::VEC_CFLOAT;
+    }
+    else if (decay_equiv<T, std::vector<std::complex<double>>>::value)
+    {
+        return DT::VEC_CDOUBLE;
+    }
+    else if (decay_equiv<T, std::vector<std::complex<long double>>>::value)
+    {
+        return DT::VEC_CLONG_DOUBLE;
+    }
+    else if (decay_equiv<T, std::vector<std::string>>::value)
+    {
+        return DT::VEC_STRING;
+    }
+    else if (decay_equiv<T, std::array<double, 7>>::value)
+    {
+        return DT::ARR_DBL_7;
+    }
+    else if (decay_equiv<T, bool>::value)
+    {
+        return DT::BOOL;
+    }
+    else
+        return ADIOS2Datatype::UNDEFINED;
+}
+
 namespace detail
 {
     // ADIOS2 does not natively support boolean values
@@ -50,13 +263,13 @@ namespace detail
     };
 
     template <typename T>
-    struct ToDatatypeHelper<std::vector<T> >
+    struct ToDatatypeHelper<std::vector<T>>
     {
         static std::string type();
     };
 
     template <typename T, size_t n>
-    struct ToDatatypeHelper<std::array<T, n> >
+    struct ToDatatypeHelper<std::array<T, n>>
     {
         static std::string type();
     };
@@ -82,7 +295,7 @@ namespace detail
      * @param verbose If false, don't print warnings.
      * @return
      */
-    Datatype fromADIOS2Type(std::string const &dt, bool verbose = true);
+    ADIOS2Datatype fromADIOS2Type(std::string const &dt, bool verbose = true);
 
     enum class VariableOrAttribute : unsigned char
     {
@@ -114,11 +327,14 @@ namespace detail
      * @return The openPMD datatype corresponding to the type of the attribute.
      *         UNDEFINED if attribute is not found.
      */
-    Datatype attributeInfo(
+    ADIOS2Datatype attributeInfo(
         adios2::IO &IO,
         std::string const &attributeName,
         bool verbose,
         VariableOrAttribute voa = VariableOrAttribute::Attribute);
+
+    ADIOS2Datatype fromPublicType(Datatype);
+    Datatype toPublicType(ADIOS2Datatype);
 } // namespace detail
 
 /**
@@ -137,57 +353,194 @@ namespace detail
  *     arguments and with the template parameter specified by dt.
  */
 template <typename Action, typename... Args>
-auto switchAdios2AttributeType(Datatype dt, Args &&...args)
+auto switchAdios2Datatype(ADIOS2Datatype dt, Args &&...args)
     -> decltype(Action::template call<char>(std::forward<Args>(args)...))
 {
     using ReturnType =
         decltype(Action::template call<char>(std::forward<Args>(args)...));
     switch (dt)
     {
-    case Datatype::CHAR:
+    case ADIOS2Datatype::CHAR:
         return Action::template call<char>(std::forward<Args>(args)...);
-    case Datatype::UCHAR:
+    case ADIOS2Datatype::UCHAR:
         return Action::template call<unsigned char>(
             std::forward<Args>(args)...);
-    case Datatype::SHORT:
+    case ADIOS2Datatype::SCHAR:
+        return Action::template call<signed char>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::SHORT:
         return Action::template call<short>(std::forward<Args>(args)...);
-    case Datatype::INT:
+    case ADIOS2Datatype::INT:
         return Action::template call<int>(std::forward<Args>(args)...);
-    case Datatype::LONG:
+    case ADIOS2Datatype::LONG:
         return Action::template call<long>(std::forward<Args>(args)...);
-    case Datatype::LONGLONG:
+    case ADIOS2Datatype::LONGLONG:
         return Action::template call<long long>(std::forward<Args>(args)...);
-    case Datatype::USHORT:
+    case ADIOS2Datatype::USHORT:
         return Action::template call<unsigned short>(
             std::forward<Args>(args)...);
-    case Datatype::UINT:
+    case ADIOS2Datatype::UINT:
         return Action::template call<unsigned int>(std::forward<Args>(args)...);
-    case Datatype::ULONG:
+    case ADIOS2Datatype::ULONG:
         return Action::template call<unsigned long>(
             std::forward<Args>(args)...);
-    case Datatype::ULONGLONG:
+    case ADIOS2Datatype::ULONGLONG:
         return Action::template call<unsigned long long>(
             std::forward<Args>(args)...);
-    case Datatype::FLOAT:
+    case ADIOS2Datatype::FLOAT:
         return Action::template call<float>(std::forward<Args>(args)...);
-    case Datatype::DOUBLE:
+    case ADIOS2Datatype::DOUBLE:
         return Action::template call<double>(std::forward<Args>(args)...);
-    case Datatype::LONG_DOUBLE:
+    case ADIOS2Datatype::LONG_DOUBLE:
         return Action::template call<long double>(std::forward<Args>(args)...);
-    case Datatype::CFLOAT:
-        return Action::template call<std::complex<float> >(
+    case ADIOS2Datatype::CFLOAT:
+        return Action::template call<std::complex<float>>(
             std::forward<Args>(args)...);
-    case Datatype::CDOUBLE:
-        return Action::template call<std::complex<double> >(
+    case ADIOS2Datatype::CDOUBLE:
+        return Action::template call<std::complex<double>>(
             std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_CHAR:
+        return Action::template call<std::vector<char>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_UCHAR:
+        return Action::template call<std::vector<unsigned char>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_SCHAR:
+        return Action::template call<std::vector<signed char>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_SHORT:
+        return Action::template call<std::vector<short>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_INT:
+        return Action::template call<std::vector<int>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_LONG:
+        return Action::template call<std::vector<long>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_LONGLONG:
+        return Action::template call<std::vector<long long>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_USHORT:
+        return Action::template call<std::vector<unsigned short>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_UINT:
+        return Action::template call<std::vector<unsigned int>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_ULONG:
+        return Action::template call<std::vector<unsigned long>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_ULONGLONG:
+        return Action::template call<std::vector<unsigned long long>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_FLOAT:
+        return Action::template call<std::vector<float>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_DOUBLE:
+        return Action::template call<std::vector<double>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_LONG_DOUBLE:
+        return Action::template call<std::vector<long double>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_CFLOAT:
+        return Action::template call<std::vector<std::complex<float>>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_CDOUBLE:
+        return Action::template call<std::vector<std::complex<double>>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::VEC_STRING:
+        return Action::template call<std::vector<std::string>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::ARR_DBL_7:
+        return Action::template call<std::array<double, 7>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::BOOL:
+        return Action::template call<bool>(std::forward<Args>(args)...);
     // missing std::complex< long double > type in ADIOS2 v2.6.0
-    // case Datatype::CLONG_DOUBLE:
+    // case ADIOS2Datatype::CLONG_DOUBLE:
     //     return action
     //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
     //             std::forward< Args >( args )... );
-    case Datatype::STRING:
+    case ADIOS2Datatype::STRING:
         return Action::template call<std::string>(std::forward<Args>(args)...);
-    case Datatype::UNDEFINED:
+    case ADIOS2Datatype::UNDEFINED:
+        return detail::
+            CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
+                std::forward<Args>(args)...);
+    default:
+        throw std::runtime_error(
+            "Internal error: Encountered unknown datatype (switchType) ->" +
+            std::to_string(static_cast<int>(dt)));
+    }
+}
+
+/**
+ * Generalizes switching over an openPMD datatype.
+ *
+ * Will call the function template found at Action::call< T >(), instantiating T
+ * with the C++ internal datatype corresponding to the openPMD datatype.
+ * Considers only types that are eligible for an ADIOS2 attribute.
+ *
+ * @tparam ReturnType The function template's return type.
+ * @tparam Action The struct containing the function template.
+ * @tparam Args The function template's argument types.
+ * @param dt The openPMD datatype.
+ * @param args The function template's arguments.
+ * @return Passes on the result of invoking the function template with the given
+ *     arguments and with the template parameter specified by dt.
+ */
+template <typename Action, typename... Args>
+auto switchAdios2AttributeType(ADIOS2Datatype dt, Args &&...args)
+    -> decltype(Action::template call<char>(std::forward<Args>(args)...))
+{
+    using ReturnType =
+        decltype(Action::template call<char>(std::forward<Args>(args)...));
+    switch (dt)
+    {
+    case ADIOS2Datatype::CHAR:
+        return Action::template call<char>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::UCHAR:
+        return Action::template call<unsigned char>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::SCHAR:
+        return Action::template call<signed char>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::SHORT:
+        return Action::template call<short>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::INT:
+        return Action::template call<int>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::LONG:
+        return Action::template call<long>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::LONGLONG:
+        return Action::template call<long long>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::USHORT:
+        return Action::template call<unsigned short>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::UINT:
+        return Action::template call<unsigned int>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::ULONG:
+        return Action::template call<unsigned long>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::ULONGLONG:
+        return Action::template call<unsigned long long>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::FLOAT:
+        return Action::template call<float>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::DOUBLE:
+        return Action::template call<double>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::LONG_DOUBLE:
+        return Action::template call<long double>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::CFLOAT:
+        return Action::template call<std::complex<float>>(
+            std::forward<Args>(args)...);
+    case ADIOS2Datatype::CDOUBLE:
+        return Action::template call<std::complex<double>>(
+            std::forward<Args>(args)...);
+    // missing std::complex< long double > type in ADIOS2 v2.6.0
+    // case ADIOS2Datatype::CLONG_DOUBLE:
+    //     return action
+    //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
+    //             std::forward< Args >( args )... );
+    case ADIOS2Datatype::STRING:
+        return Action::template call<std::string>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::UNDEFINED:
         return detail::
             CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
                 std::forward<Args>(args)...);
@@ -215,55 +568,57 @@ auto switchAdios2AttributeType(Datatype dt, Args &&...args)
  *     arguments and with the template parameter specified by dt.
  */
 template <typename Action, typename... Args>
-auto switchAdios2VariableType(Datatype dt, Args &&...args)
+auto switchAdios2VariableType(ADIOS2Datatype dt, Args &&...args)
     -> decltype(Action::template call<char>(std::forward<Args>(args)...))
 {
     using ReturnType =
         decltype(Action::template call<char>(std::forward<Args>(args)...));
     switch (dt)
     {
-    case Datatype::CHAR:
+    case ADIOS2Datatype::CHAR:
         return Action::template call<char>(std::forward<Args>(args)...);
-    case Datatype::UCHAR:
+    case ADIOS2Datatype::UCHAR:
         return Action::template call<unsigned char>(
             std::forward<Args>(args)...);
-    case Datatype::SHORT:
+    case ADIOS2Datatype::SCHAR:
+        return Action::template call<signed char>(std::forward<Args>(args)...);
+    case ADIOS2Datatype::SHORT:
         return Action::template call<short>(std::forward<Args>(args)...);
-    case Datatype::INT:
+    case ADIOS2Datatype::INT:
         return Action::template call<int>(std::forward<Args>(args)...);
-    case Datatype::LONG:
+    case ADIOS2Datatype::LONG:
         return Action::template call<long>(std::forward<Args>(args)...);
-    case Datatype::LONGLONG:
+    case ADIOS2Datatype::LONGLONG:
         return Action::template call<long long>(std::forward<Args>(args)...);
-    case Datatype::USHORT:
+    case ADIOS2Datatype::USHORT:
         return Action::template call<unsigned short>(
             std::forward<Args>(args)...);
-    case Datatype::UINT:
+    case ADIOS2Datatype::UINT:
         return Action::template call<unsigned int>(std::forward<Args>(args)...);
-    case Datatype::ULONG:
+    case ADIOS2Datatype::ULONG:
         return Action::template call<unsigned long>(
             std::forward<Args>(args)...);
-    case Datatype::ULONGLONG:
+    case ADIOS2Datatype::ULONGLONG:
         return Action::template call<unsigned long long>(
             std::forward<Args>(args)...);
-    case Datatype::FLOAT:
+    case ADIOS2Datatype::FLOAT:
         return Action::template call<float>(std::forward<Args>(args)...);
-    case Datatype::DOUBLE:
+    case ADIOS2Datatype::DOUBLE:
         return Action::template call<double>(std::forward<Args>(args)...);
-    case Datatype::LONG_DOUBLE:
+    case ADIOS2Datatype::LONG_DOUBLE:
         return Action::template call<long double>(std::forward<Args>(args)...);
-    case Datatype::CFLOAT:
-        return Action::template call<std::complex<float> >(
+    case ADIOS2Datatype::CFLOAT:
+        return Action::template call<std::complex<float>>(
             std::forward<Args>(args)...);
-    case Datatype::CDOUBLE:
-        return Action::template call<std::complex<double> >(
+    case ADIOS2Datatype::CDOUBLE:
+        return Action::template call<std::complex<double>>(
             std::forward<Args>(args)...);
     // missing std::complex< long double > type in ADIOS2 v2.6.0
-    // case Datatype::CLONG_DOUBLE:
+    // case ADIOS2Datatype::CLONG_DOUBLE:
     //     return action
     //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
     //             std::forward< Args >( args )... );
-    case Datatype::UNDEFINED:
+    case ADIOS2Datatype::UNDEFINED:
         return detail::
             CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
                 std::forward<Args>(args)...);

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -36,221 +36,6 @@
 
 namespace openPMD
 {
-/** Concrete datatype of an object available at runtime.
- * Since ADIOS2 distinguishes unsigned char, signed char and char, this enum
- * has all three of them (unlike the public Datatype enum)
- */
-enum class ADIOS2Datatype : int
-{
-    CHAR,
-    UCHAR,
-    SCHAR,
-    SHORT,
-    INT,
-    LONG,
-    LONGLONG,
-    USHORT,
-    UINT,
-    ULONG,
-    ULONGLONG,
-    FLOAT,
-    DOUBLE,
-    LONG_DOUBLE,
-    CFLOAT,
-    CDOUBLE,
-    // unsupported by ADIOS2
-    // CLONG_DOUBLE,
-    STRING,
-    VEC_CHAR,
-    VEC_UCHAR,
-    VEC_SCHAR,
-    VEC_SHORT,
-    VEC_INT,
-    VEC_LONG,
-    VEC_LONGLONG,
-    VEC_USHORT,
-    VEC_UINT,
-    VEC_ULONG,
-    VEC_ULONGLONG,
-    VEC_FLOAT,
-    VEC_DOUBLE,
-    VEC_LONG_DOUBLE,
-    VEC_CFLOAT,
-    VEC_CDOUBLE,
-    // unsupported by ADIOS2
-    // VEC_CLONG_DOUBLE,
-    VEC_STRING,
-    ARR_DBL_7,
-
-    BOOL,
-
-    UNDEFINED
-}; // Datatype
-
-template <typename T>
-inline constexpr ADIOS2Datatype determineAdios2Datatype()
-{
-    using DT = ADIOS2Datatype;
-    if (decay_equiv<T, char>::value)
-    {
-        return DT::CHAR;
-    }
-    else if (decay_equiv<T, signed char>::value)
-    {
-        return DT::SCHAR;
-    }
-    else if (decay_equiv<T, unsigned char>::value)
-    {
-        return DT::UCHAR;
-    }
-    else if (decay_equiv<T, short>::value)
-    {
-        return DT::SHORT;
-    }
-    else if (decay_equiv<T, int>::value)
-    {
-        return DT::INT;
-    }
-    else if (decay_equiv<T, long>::value)
-    {
-        return DT::LONG;
-    }
-    else if (decay_equiv<T, long long>::value)
-    {
-        return DT::LONGLONG;
-    }
-    else if (decay_equiv<T, unsigned short>::value)
-    {
-        return DT::USHORT;
-    }
-    else if (decay_equiv<T, unsigned int>::value)
-    {
-        return DT::UINT;
-    }
-    else if (decay_equiv<T, unsigned long>::value)
-    {
-        return DT::ULONG;
-    }
-    else if (decay_equiv<T, unsigned long long>::value)
-    {
-        return DT::ULONGLONG;
-    }
-    else if (decay_equiv<T, float>::value)
-    {
-        return DT::FLOAT;
-    }
-    else if (decay_equiv<T, double>::value)
-    {
-        return DT::DOUBLE;
-    }
-    else if (decay_equiv<T, long double>::value)
-    {
-        return DT::LONG_DOUBLE;
-    }
-    else if (decay_equiv<T, std::complex<float>>::value)
-    {
-        return DT::CFLOAT;
-    }
-    else if (decay_equiv<T, std::complex<double>>::value)
-    {
-        return DT::CDOUBLE;
-    }
-    // else if (decay_equiv<T, std::complex<long double>>::value)
-    // {
-    //     return DT::CLONG_DOUBLE;
-    // }
-    else if (decay_equiv<T, std::string>::value)
-    {
-        return DT::STRING;
-    }
-    else if (decay_equiv<T, std::vector<char>>::value)
-    {
-        return DT::VEC_CHAR;
-    }
-    else if (decay_equiv<T, std::vector<signed char>>::value)
-    {
-        return DT::VEC_SCHAR;
-    }
-    else if (decay_equiv<T, std::vector<unsigned char>>::value)
-    {
-        return DT::VEC_UCHAR;
-    }
-    else if (decay_equiv<T, std::vector<short>>::value)
-    {
-        return DT::VEC_SHORT;
-    }
-    else if (decay_equiv<T, std::vector<int>>::value)
-    {
-        return DT::VEC_INT;
-    }
-    else if (decay_equiv<T, std::vector<long>>::value)
-    {
-        return DT::VEC_LONG;
-    }
-    else if (decay_equiv<T, std::vector<long long>>::value)
-    {
-        return DT::VEC_LONGLONG;
-    }
-    else if (decay_equiv<T, std::vector<unsigned char>>::value)
-    {
-        return DT::VEC_UCHAR;
-    }
-    else if (decay_equiv<T, std::vector<unsigned short>>::value)
-    {
-        return DT::VEC_USHORT;
-    }
-    else if (decay_equiv<T, std::vector<unsigned int>>::value)
-    {
-        return DT::VEC_UINT;
-    }
-    else if (decay_equiv<T, std::vector<unsigned long>>::value)
-    {
-        return DT::VEC_ULONG;
-    }
-    else if (decay_equiv<T, std::vector<unsigned long long>>::value)
-    {
-        return DT::VEC_ULONGLONG;
-    }
-    else if (decay_equiv<T, std::vector<float>>::value)
-    {
-        return DT::VEC_FLOAT;
-    }
-    else if (decay_equiv<T, std::vector<double>>::value)
-    {
-        return DT::VEC_DOUBLE;
-    }
-    else if (decay_equiv<T, std::vector<long double>>::value)
-    {
-        return DT::VEC_LONG_DOUBLE;
-    }
-    else if (decay_equiv<T, std::vector<std::complex<float>>>::value)
-    {
-        return DT::VEC_CFLOAT;
-    }
-    else if (decay_equiv<T, std::vector<std::complex<double>>>::value)
-    {
-        return DT::VEC_CDOUBLE;
-    }
-    // else if (decay_equiv<T, std::vector<std::complex<long double>>>::value)
-    // {
-    //     return DT::VEC_CLONG_DOUBLE;
-    // }
-    else if (decay_equiv<T, std::vector<std::string>>::value)
-    {
-        return DT::VEC_STRING;
-    }
-    else if (decay_equiv<T, std::array<double, 7>>::value)
-    {
-        return DT::ARR_DBL_7;
-    }
-    else if (decay_equiv<T, bool>::value)
-    {
-        return DT::BOOL;
-    }
-    else
-        return ADIOS2Datatype::UNDEFINED;
-}
-
 namespace detail
 {
     // ADIOS2 does not natively support boolean values
@@ -297,7 +82,7 @@ namespace detail
      * @param verbose If false, don't print warnings.
      * @return
      */
-    ADIOS2Datatype fromADIOS2Type(std::string const &dt, bool verbose = true);
+    Datatype fromADIOS2Type(std::string const &dt, bool verbose = true);
 
     enum class VariableOrAttribute : unsigned char
     {
@@ -329,14 +114,11 @@ namespace detail
      * @return The openPMD datatype corresponding to the type of the attribute.
      *         UNDEFINED if attribute is not found.
      */
-    ADIOS2Datatype attributeInfo(
+    Datatype attributeInfo(
         adios2::IO &IO,
         std::string const &attributeName,
         bool verbose,
         VariableOrAttribute voa = VariableOrAttribute::Attribute);
-
-    ADIOS2Datatype fromPublicType(Datatype);
-    Datatype toPublicType(ADIOS2Datatype);
 } // namespace detail
 
 /**
@@ -355,194 +137,59 @@ namespace detail
  *     arguments and with the template parameter specified by dt.
  */
 template <typename Action, typename... Args>
-auto switchAdios2Datatype(ADIOS2Datatype dt, Args &&...args)
+auto switchAdios2AttributeType(Datatype dt, Args &&...args)
     -> decltype(Action::template call<char>(std::forward<Args>(args)...))
 {
     using ReturnType =
         decltype(Action::template call<char>(std::forward<Args>(args)...));
     switch (dt)
     {
-    case ADIOS2Datatype::CHAR:
+    case Datatype::CHAR:
         return Action::template call<char>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::UCHAR:
+    case Datatype::UCHAR:
         return Action::template call<unsigned char>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::SCHAR:
+    case Datatype::SCHAR:
         return Action::template call<signed char>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::SHORT:
+    case Datatype::SHORT:
         return Action::template call<short>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::INT:
+    case Datatype::INT:
         return Action::template call<int>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONG:
+    case Datatype::LONG:
         return Action::template call<long>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONGLONG:
+    case Datatype::LONGLONG:
         return Action::template call<long long>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::USHORT:
+    case Datatype::USHORT:
         return Action::template call<unsigned short>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::UINT:
+    case Datatype::UINT:
         return Action::template call<unsigned int>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::ULONG:
+    case Datatype::ULONG:
         return Action::template call<unsigned long>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::ULONGLONG:
+    case Datatype::ULONGLONG:
         return Action::template call<unsigned long long>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::FLOAT:
+    case Datatype::FLOAT:
         return Action::template call<float>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::DOUBLE:
+    case Datatype::DOUBLE:
         return Action::template call<double>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONG_DOUBLE:
+    case Datatype::LONG_DOUBLE:
         return Action::template call<long double>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::CFLOAT:
+    case Datatype::CFLOAT:
         return Action::template call<std::complex<float>>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::CDOUBLE:
-        return Action::template call<std::complex<double>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_CHAR:
-        return Action::template call<std::vector<char>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_UCHAR:
-        return Action::template call<std::vector<unsigned char>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_SCHAR:
-        return Action::template call<std::vector<signed char>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_SHORT:
-        return Action::template call<std::vector<short>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_INT:
-        return Action::template call<std::vector<int>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_LONG:
-        return Action::template call<std::vector<long>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_LONGLONG:
-        return Action::template call<std::vector<long long>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_USHORT:
-        return Action::template call<std::vector<unsigned short>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_UINT:
-        return Action::template call<std::vector<unsigned int>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_ULONG:
-        return Action::template call<std::vector<unsigned long>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_ULONGLONG:
-        return Action::template call<std::vector<unsigned long long>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_FLOAT:
-        return Action::template call<std::vector<float>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_DOUBLE:
-        return Action::template call<std::vector<double>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_LONG_DOUBLE:
-        return Action::template call<std::vector<long double>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_CFLOAT:
-        return Action::template call<std::vector<std::complex<float>>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_CDOUBLE:
-        return Action::template call<std::vector<std::complex<double>>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::VEC_STRING:
-        return Action::template call<std::vector<std::string>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::ARR_DBL_7:
-        return Action::template call<std::array<double, 7>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::BOOL:
-        return Action::template call<bool>(std::forward<Args>(args)...);
-    // missing std::complex< long double > type in ADIOS2 v2.6.0
-    // case ADIOS2Datatype::CLONG_DOUBLE:
-    //     return action
-    //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
-    //             std::forward< Args >( args )... );
-    case ADIOS2Datatype::STRING:
-        return Action::template call<std::string>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::UNDEFINED:
-        return detail::
-            CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
-                std::forward<Args>(args)...);
-    default:
-        throw std::runtime_error(
-            "Internal error: Encountered unknown datatype (switchType) ->" +
-            std::to_string(static_cast<int>(dt)));
-    }
-}
-
-/**
- * Generalizes switching over an openPMD datatype.
- *
- * Will call the function template found at Action::call< T >(), instantiating T
- * with the C++ internal datatype corresponding to the openPMD datatype.
- * Considers only types that are eligible for an ADIOS2 attribute.
- *
- * @tparam ReturnType The function template's return type.
- * @tparam Action The struct containing the function template.
- * @tparam Args The function template's argument types.
- * @param dt The openPMD datatype.
- * @param args The function template's arguments.
- * @return Passes on the result of invoking the function template with the given
- *     arguments and with the template parameter specified by dt.
- */
-template <typename Action, typename... Args>
-auto switchAdios2AttributeType(ADIOS2Datatype dt, Args &&...args)
-    -> decltype(Action::template call<char>(std::forward<Args>(args)...))
-{
-    using ReturnType =
-        decltype(Action::template call<char>(std::forward<Args>(args)...));
-    switch (dt)
-    {
-    case ADIOS2Datatype::CHAR:
-        return Action::template call<char>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::UCHAR:
-        return Action::template call<unsigned char>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::SCHAR:
-        return Action::template call<signed char>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::SHORT:
-        return Action::template call<short>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::INT:
-        return Action::template call<int>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONG:
-        return Action::template call<long>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONGLONG:
-        return Action::template call<long long>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::USHORT:
-        return Action::template call<unsigned short>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::UINT:
-        return Action::template call<unsigned int>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::ULONG:
-        return Action::template call<unsigned long>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::ULONGLONG:
-        return Action::template call<unsigned long long>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::FLOAT:
-        return Action::template call<float>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::DOUBLE:
-        return Action::template call<double>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONG_DOUBLE:
-        return Action::template call<long double>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::CFLOAT:
-        return Action::template call<std::complex<float>>(
-            std::forward<Args>(args)...);
-    case ADIOS2Datatype::CDOUBLE:
+    case Datatype::CDOUBLE:
         return Action::template call<std::complex<double>>(
             std::forward<Args>(args)...);
     // missing std::complex< long double > type in ADIOS2 v2.6.0
-    // case ADIOS2Datatype::CLONG_DOUBLE:
+    // case Datatype::CLONG_DOUBLE:
     //     return action
     //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
     //             std::forward< Args >( args )... );
-    case ADIOS2Datatype::STRING:
+    case Datatype::STRING:
         return Action::template call<std::string>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::UNDEFINED:
+    case Datatype::UNDEFINED:
         return detail::
             CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
                 std::forward<Args>(args)...);
@@ -570,57 +217,57 @@ auto switchAdios2AttributeType(ADIOS2Datatype dt, Args &&...args)
  *     arguments and with the template parameter specified by dt.
  */
 template <typename Action, typename... Args>
-auto switchAdios2VariableType(ADIOS2Datatype dt, Args &&...args)
+auto switchAdios2VariableType(Datatype dt, Args &&...args)
     -> decltype(Action::template call<char>(std::forward<Args>(args)...))
 {
     using ReturnType =
         decltype(Action::template call<char>(std::forward<Args>(args)...));
     switch (dt)
     {
-    case ADIOS2Datatype::CHAR:
+    case Datatype::CHAR:
         return Action::template call<char>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::UCHAR:
+    case Datatype::UCHAR:
         return Action::template call<unsigned char>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::SCHAR:
+    case Datatype::SCHAR:
         return Action::template call<signed char>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::SHORT:
+    case Datatype::SHORT:
         return Action::template call<short>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::INT:
+    case Datatype::INT:
         return Action::template call<int>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONG:
+    case Datatype::LONG:
         return Action::template call<long>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONGLONG:
+    case Datatype::LONGLONG:
         return Action::template call<long long>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::USHORT:
+    case Datatype::USHORT:
         return Action::template call<unsigned short>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::UINT:
+    case Datatype::UINT:
         return Action::template call<unsigned int>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::ULONG:
+    case Datatype::ULONG:
         return Action::template call<unsigned long>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::ULONGLONG:
+    case Datatype::ULONGLONG:
         return Action::template call<unsigned long long>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::FLOAT:
+    case Datatype::FLOAT:
         return Action::template call<float>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::DOUBLE:
+    case Datatype::DOUBLE:
         return Action::template call<double>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::LONG_DOUBLE:
+    case Datatype::LONG_DOUBLE:
         return Action::template call<long double>(std::forward<Args>(args)...);
-    case ADIOS2Datatype::CFLOAT:
+    case Datatype::CFLOAT:
         return Action::template call<std::complex<float>>(
             std::forward<Args>(args)...);
-    case ADIOS2Datatype::CDOUBLE:
+    case Datatype::CDOUBLE:
         return Action::template call<std::complex<double>>(
             std::forward<Args>(args)...);
     // missing std::complex< long double > type in ADIOS2 v2.6.0
-    // case ADIOS2Datatype::CLONG_DOUBLE:
+    // case Datatype::CLONG_DOUBLE:
     //     return action
     //         .OPENPMD_TEMPLATE_OPERATOR()< std::complex< long double > >(
     //             std::forward< Args >( args )... );
-    case ADIOS2Datatype::UNDEFINED:
+    case Datatype::UNDEFINED:
         return detail::
             CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
                 std::forward<Args>(args)...);

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -58,7 +58,8 @@ enum class ADIOS2Datatype : int
     LONG_DOUBLE,
     CFLOAT,
     CDOUBLE,
-    CLONG_DOUBLE,
+    // unsupported by ADIOS2
+    // CLONG_DOUBLE,
     STRING,
     VEC_CHAR,
     VEC_UCHAR,
@@ -76,7 +77,8 @@ enum class ADIOS2Datatype : int
     VEC_LONG_DOUBLE,
     VEC_CFLOAT,
     VEC_CDOUBLE,
-    VEC_CLONG_DOUBLE,
+    // unsupported by ADIOS2
+    // VEC_CLONG_DOUBLE,
     VEC_STRING,
     ARR_DBL_7,
 
@@ -153,10 +155,10 @@ inline constexpr ADIOS2Datatype determineAdios2Datatype()
     {
         return DT::CDOUBLE;
     }
-    else if (decay_equiv<T, std::complex<long double>>::value)
-    {
-        return DT::CLONG_DOUBLE;
-    }
+    // else if (decay_equiv<T, std::complex<long double>>::value)
+    // {
+    //     return DT::CLONG_DOUBLE;
+    // }
     else if (decay_equiv<T, std::string>::value)
     {
         return DT::STRING;
@@ -229,10 +231,10 @@ inline constexpr ADIOS2Datatype determineAdios2Datatype()
     {
         return DT::VEC_CDOUBLE;
     }
-    else if (decay_equiv<T, std::vector<std::complex<long double>>>::value)
-    {
-        return DT::VEC_CLONG_DOUBLE;
-    }
+    // else if (decay_equiv<T, std::vector<std::complex<long double>>>::value)
+    // {
+    //     return DT::VEC_CLONG_DOUBLE;
+    // }
     else if (decay_equiv<T, std::vector<std::string>>::value)
     {
         return DT::VEC_STRING;

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -575,7 +575,7 @@ namespace detail
             detail::BufferedAttributeWrite &params,
             T value);
 
-        static void readAttribute(
+        static Datatype readAttribute(
             detail::PreloadAdiosAttributes const &,
             std::string name,
             std::shared_ptr<Attribute::resource> resource);
@@ -614,7 +614,7 @@ namespace detail
                 "attribute types");
         }
 
-        static void readAttribute(
+        static Datatype readAttribute(
             detail::PreloadAdiosAttributes const &,
             std::string,
             std::shared_ptr<Attribute::resource>)
@@ -647,7 +647,7 @@ namespace detail
                 "vector attribute types");
         }
 
-        static void readAttribute(
+        static Datatype readAttribute(
             detail::PreloadAdiosAttributes const &,
             std::string,
             std::shared_ptr<Attribute::resource>)
@@ -675,7 +675,7 @@ namespace detail
             detail::BufferedAttributeWrite &params,
             const std::vector<T> &value);
 
-        static void readAttribute(
+        static Datatype readAttribute(
             detail::PreloadAdiosAttributes const &,
             std::string name,
             std::shared_ptr<Attribute::resource> resource);
@@ -713,7 +713,7 @@ namespace detail
             detail::BufferedAttributeWrite &params,
             const std::vector<std::string> &vec);
 
-        static void readAttribute(
+        static Datatype readAttribute(
             detail::PreloadAdiosAttributes const &,
             std::string name,
             std::shared_ptr<Attribute::resource> resource);
@@ -751,7 +751,7 @@ namespace detail
             detail::BufferedAttributeWrite &params,
             const std::array<T, n> &value);
 
-        static void readAttribute(
+        static Datatype readAttribute(
             detail::PreloadAdiosAttributes const &,
             std::string name,
             std::shared_ptr<Attribute::resource> resource);
@@ -816,7 +816,7 @@ namespace detail
             detail::BufferedAttributeWrite &params,
             bool value);
 
-        static void readAttribute(
+        static Datatype readAttribute(
             detail::PreloadAdiosAttributes const &,
             std::string name,
             std::shared_ptr<Attribute::resource> resource);

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -73,12 +73,11 @@ namespace detail
         {
             adios2::Dims shape;
             size_t offset;
-            ADIOS2Datatype dt;
+            Datatype dt;
             char *destroy = nullptr;
 
             AttributeLocation() = delete;
-            AttributeLocation(
-                adios2::Dims shape, size_t offset, ADIOS2Datatype dt);
+            AttributeLocation(adios2::Dims shape, size_t offset, Datatype dt);
 
             AttributeLocation(AttributeLocation const &other) = delete;
             AttributeLocation &
@@ -137,7 +136,7 @@ namespace detail
         template <typename T>
         AttributeWithShape<T> getAttribute(std::string const &name) const;
 
-        ADIOS2Datatype attributeType(std::string const &name) const;
+        Datatype attributeType(std::string const &name) const;
     };
 
     template <typename T>
@@ -151,12 +150,12 @@ namespace detail
                 "[ADIOS2] Requested attribute not found: " + name);
         }
         AttributeLocation const &location = it->second;
-        ADIOS2Datatype determinedDatatype = determineAdios2Datatype<T>();
+        Datatype determinedDatatype = determineDatatype<T>();
         if (location.dt != determinedDatatype)
         {
             std::stringstream errorMsg;
             errorMsg << "[ADIOS2] Wrong datatype for attribute: " << name
-                     << "(location.dt=" << detail::toPublicType(location.dt)
+                     << "(location.dt=" << location.dt
                      << ", T=" << determineDatatype<T>() << ")";
             throw std::runtime_error(errorMsg.str());
         }

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -295,8 +295,6 @@ private:
      * @brief End an IO step on the IO file (or file-like object)
      *        containing this iteration. In case of group-based iteration
      *        layout, this will be the complete Series.
-     *
-     * @return AdvanceStatus
      */
     void endStep();
 

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -133,6 +133,11 @@ namespace auxiliary
             data = new unsigned char[numPoints];
             del = [](void *p) { delete[] static_cast<unsigned char *>(p); };
             break;
+        case DT::VEC_SCHAR:
+        case DT::SCHAR:
+            data = new signed char[numPoints];
+            del = [](void *p) { delete[] static_cast<signed char *>(p); };
+            break;
         case DT::BOOL:
             data = new bool[numPoints];
             del = [](void *p) { delete[] static_cast<bool *>(p); };

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -53,7 +53,8 @@ class Attribute
     : public auxiliary::Variant<
           Datatype,
           char,
-          unsigned char, // signed char,
+          unsigned char,
+          signed char,
           short,
           int,
           long,
@@ -85,6 +86,7 @@ class Attribute
           std::vector<std::complex<float> >,
           std::vector<std::complex<double> >,
           std::vector<std::complex<long double> >,
+          std::vector<signed char>,
           std::vector<std::string>,
           std::array<double, 7>,
           bool>

--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -136,6 +136,8 @@ inline pybind11::dtype dtype_to_numpy(Datatype const dt)
     {
     case DT::CHAR:
     case DT::VEC_CHAR:
+    case DT::SCHAR:
+    case DT::VEC_SCHAR:
     case DT::STRING:
     case DT::VEC_STRING:
         return pybind11::dtype("b");

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -47,6 +47,9 @@ std::ostream &operator<<(std::ostream &os, openPMD::Datatype const &d)
     case DT::UCHAR:
         os << "UCHAR";
         break;
+    case DT::SCHAR:
+        os << "SCHAR";
+        break;
     case DT::SHORT:
         os << "SHORT";
         break;
@@ -140,6 +143,9 @@ std::ostream &operator<<(std::ostream &os, openPMD::Datatype const &d)
     case DT::VEC_CLONG_DOUBLE:
         os << "VEC_CLONG_DOUBLE";
         break;
+    case DT::VEC_SCHAR:
+        os << "VEC_SCHAR";
+        break;
     case DT::VEC_STRING:
         os << "VEC_STRING";
         break;
@@ -162,6 +168,7 @@ Datatype stringToDatatype(std::string s)
     static std::unordered_map<std::string, Datatype> m{
         {"CHAR", Datatype::CHAR},
         {"UCHAR", Datatype::UCHAR},
+        {"SCHAR", Datatype::SCHAR},
         {"SHORT", Datatype::SHORT},
         {"INT", Datatype::INT},
         {"LONG", Datatype::LONG},
@@ -193,6 +200,7 @@ Datatype stringToDatatype(std::string s)
         {"VEC_CFLOAT", Datatype::VEC_CFLOAT},
         {"VEC_CDOUBLE", Datatype::VEC_CDOUBLE},
         {"VEC_CLONG_DOUBLE", Datatype::VEC_CLONG_DOUBLE},
+        {"VEC_SCHAR", Datatype::VEC_SCHAR},
         {"VEC_STRING", Datatype::VEC_STRING},
         {"ARR_DBL_7", Datatype::ARR_DBL_7},
         {"BOOL", Datatype::BOOL},
@@ -217,18 +225,44 @@ std::string datatypeToString(openPMD::Datatype dt)
 }
 
 std::vector<Datatype> openPMD_Datatypes{
-    Datatype::CHAR,         Datatype::UCHAR,       Datatype::SHORT,
-    Datatype::INT,          Datatype::LONG,        Datatype::LONGLONG,
-    Datatype::USHORT,       Datatype::UINT,        Datatype::ULONG,
-    Datatype::ULONGLONG,    Datatype::FLOAT,       Datatype::DOUBLE,
-    Datatype::LONG_DOUBLE,  Datatype::CFLOAT,      Datatype::CDOUBLE,
-    Datatype::CLONG_DOUBLE, Datatype::STRING,      Datatype::VEC_CHAR,
-    Datatype::VEC_SHORT,    Datatype::VEC_INT,     Datatype::VEC_LONG,
-    Datatype::VEC_LONGLONG, Datatype::VEC_UCHAR,   Datatype::VEC_USHORT,
-    Datatype::VEC_UINT,     Datatype::VEC_ULONG,   Datatype::VEC_ULONGLONG,
-    Datatype::VEC_FLOAT,    Datatype::VEC_DOUBLE,  Datatype::VEC_LONG_DOUBLE,
-    Datatype::VEC_CFLOAT,   Datatype::VEC_CDOUBLE, Datatype::VEC_CLONG_DOUBLE,
-    Datatype::VEC_STRING,   Datatype::ARR_DBL_7,   Datatype::BOOL,
+    Datatype::CHAR,
+    Datatype::UCHAR,
+    Datatype::SCHAR,
+    Datatype::SHORT,
+    Datatype::INT,
+    Datatype::LONG,
+    Datatype::LONGLONG,
+    Datatype::USHORT,
+    Datatype::UINT,
+    Datatype::ULONG,
+    Datatype::ULONGLONG,
+    Datatype::FLOAT,
+    Datatype::DOUBLE,
+    Datatype::LONG_DOUBLE,
+    Datatype::CFLOAT,
+    Datatype::CDOUBLE,
+    Datatype::CLONG_DOUBLE,
+    Datatype::STRING,
+    Datatype::VEC_CHAR,
+    Datatype::VEC_SHORT,
+    Datatype::VEC_INT,
+    Datatype::VEC_LONG,
+    Datatype::VEC_LONGLONG,
+    Datatype::VEC_UCHAR,
+    Datatype::VEC_USHORT,
+    Datatype::VEC_UINT,
+    Datatype::VEC_ULONG,
+    Datatype::VEC_ULONGLONG,
+    Datatype::VEC_FLOAT,
+    Datatype::VEC_DOUBLE,
+    Datatype::VEC_LONG_DOUBLE,
+    Datatype::VEC_CFLOAT,
+    Datatype::VEC_CDOUBLE,
+    Datatype::VEC_CLONG_DOUBLE,
+    Datatype::VEC_SCHAR,
+    Datatype::VEC_STRING,
+    Datatype::ARR_DBL_7,
+    Datatype::BOOL,
     Datatype::UNDEFINED};
 
 namespace

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -231,13 +231,28 @@ std::vector<Datatype> openPMD_Datatypes{
     Datatype::VEC_STRING,   Datatype::ARR_DBL_7,   Datatype::BOOL,
     Datatype::UNDEFINED};
 
+namespace
+{
+    struct DoDetermineDatatype
+    {
+        using DT_enum = Datatype;
+
+        template <typename T>
+        static constexpr Datatype call()
+        {
+            return determineDatatype<T>();
+        }
+    };
+} // namespace
+
 Datatype basicDatatype(Datatype dt)
 {
-    return switchType<detail::BasicDatatype<Datatype>>(dt);
+    return switchType<detail::BasicDatatype<DoDetermineDatatype>>(dt);
 }
 
 Datatype toVectorType(Datatype dt)
 {
-    return switchType<detail::ToVectorType<Datatype>>(dt);
+    using DT_enum = Datatype;
+    return switchType<detail::ToVectorType<DoDetermineDatatype>>(dt);
 }
 } // namespace openPMD

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -235,7 +235,11 @@ namespace
 {
     struct DoDetermineDatatype
     {
-        using DT_enum = Datatype;
+        /*
+         * Suppress wrong compiler warnings.
+         * The typedef is needed in instantiation.
+         */
+        using DT_enum [[maybe_unused]] = Datatype;
 
         template <typename T>
         static constexpr Datatype call()
@@ -252,7 +256,6 @@ Datatype basicDatatype(Datatype dt)
 
 Datatype toVectorType(Datatype dt)
 {
-    using DT_enum = Datatype;
     return switchType<detail::ToVectorType<DoDetermineDatatype>>(dt);
 }
 } // namespace openPMD

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -107,9 +107,9 @@ ADIOS2Datatype fromADIOS2Type(std::string const &dt, bool verbose)
         {"long double", ADIOS2Datatype::LONG_DOUBLE},
         {"float complex", ADIOS2Datatype::CFLOAT},
         {"double complex", ADIOS2Datatype::CDOUBLE},
-        {"long double complex",
-         ADIOS2Datatype::CLONG_DOUBLE}, // does not exist as of 2.7.0 but might
-                                        // come later
+        // does not exist as of 2.7.0 but might come later
+        // {"long double complex",
+        //  ADIOS2Datatype::CLONG_DOUBLE},
         {"uint8_t", ADIOS2Datatype::UCHAR},
         {"int8_t", ADIOS2Datatype::SCHAR},
         {"uint16_t", determineAdios2Datatype<uint16_t>()},

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -34,7 +34,11 @@ namespace
 {
     struct DoDetermineDatatype
     {
-        using DT_enum = ADIOS2Datatype;
+        /*
+         * Suppress wrong compiler warnings.
+         * The typedef is needed in instantiation.
+         */
+        using DT_enum [[maybe_unused]] = ADIOS2Datatype;
 
         template <typename T>
         static constexpr ADIOS2Datatype call()

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -154,7 +154,7 @@ namespace
 using AttributeLocation = PreloadAdiosAttributes::AttributeLocation;
 
 AttributeLocation::AttributeLocation(
-    adios2::Dims shape_in, size_t offset_in, Datatype dt_in)
+    adios2::Dims shape_in, size_t offset_in, ADIOS2Datatype dt_in)
     : shape(std::move(shape_in)), offset(offset_in), dt(dt_in)
 {}
 
@@ -199,18 +199,19 @@ void PreloadAdiosAttributes::preloadAttributes(
     adios2::IO &IO, adios2::Engine &engine)
 {
     m_offsets.clear();
-    std::map<Datatype, std::vector<std::string> > attributesByType;
-    auto addAttribute = [&attributesByType](Datatype dt, std::string name) {
-        constexpr size_t reserve = 10;
-        auto it = attributesByType.find(dt);
-        if (it == attributesByType.end())
-        {
-            it = attributesByType.emplace_hint(
-                it, dt, std::vector<std::string>());
-            it->second.reserve(reserve);
-        }
-        it->second.push_back(std::move(name));
-    };
+    std::map<ADIOS2Datatype, std::vector<std::string> > attributesByType;
+    auto addAttribute =
+        [&attributesByType](ADIOS2Datatype dt, std::string name) {
+            constexpr size_t reserve = 10;
+            auto it = attributesByType.find(dt);
+            if (it == attributesByType.end())
+            {
+                it = attributesByType.emplace_hint(
+                    it, dt, std::vector<std::string>());
+                it->second.reserve(reserve);
+            }
+            it->second.push_back(std::move(name));
+        };
     // PHASE 1: collect names of available attributes by ADIOS datatype
     for (auto &variable : IO.AvailableVariables())
     {
@@ -219,7 +220,7 @@ void PreloadAdiosAttributes::preloadAttributes(
             continue;
         }
         // this will give us basic types only, no fancy vectors or similar
-        Datatype dt = fromADIOS2Type(IO.VariableType(variable.first));
+        ADIOS2Datatype dt = fromADIOS2Type(IO.VariableType(variable.first));
         addAttribute(dt, std::move(variable.first));
     }
 
@@ -268,12 +269,13 @@ void PreloadAdiosAttributes::preloadAttributes(
     }
 }
 
-Datatype PreloadAdiosAttributes::attributeType(std::string const &name) const
+ADIOS2Datatype
+PreloadAdiosAttributes::attributeType(std::string const &name) const
 {
     auto it = m_offsets.find(name);
     if (it == m_offsets.end())
     {
-        return Datatype::UNDEFINED;
+        return ADIOS2Datatype::UNDEFINED;
     }
     return it->second.dt;
 }

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -154,7 +154,7 @@ namespace
 using AttributeLocation = PreloadAdiosAttributes::AttributeLocation;
 
 AttributeLocation::AttributeLocation(
-    adios2::Dims shape_in, size_t offset_in, ADIOS2Datatype dt_in)
+    adios2::Dims shape_in, size_t offset_in, Datatype dt_in)
     : shape(std::move(shape_in)), offset(offset_in), dt(dt_in)
 {}
 
@@ -199,19 +199,18 @@ void PreloadAdiosAttributes::preloadAttributes(
     adios2::IO &IO, adios2::Engine &engine)
 {
     m_offsets.clear();
-    std::map<ADIOS2Datatype, std::vector<std::string> > attributesByType;
-    auto addAttribute =
-        [&attributesByType](ADIOS2Datatype dt, std::string name) {
-            constexpr size_t reserve = 10;
-            auto it = attributesByType.find(dt);
-            if (it == attributesByType.end())
-            {
-                it = attributesByType.emplace_hint(
-                    it, dt, std::vector<std::string>());
-                it->second.reserve(reserve);
-            }
-            it->second.push_back(std::move(name));
-        };
+    std::map<Datatype, std::vector<std::string> > attributesByType;
+    auto addAttribute = [&attributesByType](Datatype dt, std::string name) {
+        constexpr size_t reserve = 10;
+        auto it = attributesByType.find(dt);
+        if (it == attributesByType.end())
+        {
+            it = attributesByType.emplace_hint(
+                it, dt, std::vector<std::string>());
+            it->second.reserve(reserve);
+        }
+        it->second.push_back(std::move(name));
+    };
     // PHASE 1: collect names of available attributes by ADIOS datatype
     for (auto &variable : IO.AvailableVariables())
     {
@@ -220,7 +219,7 @@ void PreloadAdiosAttributes::preloadAttributes(
             continue;
         }
         // this will give us basic types only, no fancy vectors or similar
-        ADIOS2Datatype dt = fromADIOS2Type(IO.VariableType(variable.first));
+        Datatype dt = fromADIOS2Type(IO.VariableType(variable.first));
         addAttribute(dt, std::move(variable.first));
     }
 
@@ -269,13 +268,12 @@ void PreloadAdiosAttributes::preloadAttributes(
     }
 }
 
-ADIOS2Datatype
-PreloadAdiosAttributes::attributeType(std::string const &name) const
+Datatype PreloadAdiosAttributes::attributeType(std::string const &name) const
 {
     auto it = m_offsets.find(name);
     if (it == m_offsets.end())
     {
-        return ADIOS2Datatype::UNDEFINED;
+        return Datatype::UNDEFINED;
     }
     return it->second.dt;
 }

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -108,6 +108,9 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::flush_attribute(
     case DT::VEC_UCHAR:
         nelems = att.get<std::vector<unsigned char> >().size();
         break;
+    case DT::VEC_SCHAR:
+        nelems = att.get<std::vector<signed char> >().size();
+        break;
     case DT::VEC_USHORT:
         nelems = att.get<std::vector<unsigned short> >().size();
         break;
@@ -154,6 +157,11 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::flush_attribute(
     case DT::UCHAR: {
         auto ptr = reinterpret_cast<unsigned char *>(values.get());
         *ptr = att.get<unsigned char>();
+        break;
+    }
+    case DT::SCHAR: {
+        auto ptr = reinterpret_cast<signed char *>(values.get());
+        *ptr = att.get<signed char>();
         break;
     }
     case DT::SHORT: {
@@ -270,6 +278,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::flush_attribute(
     case DT::VEC_UCHAR: {
         auto ptr = reinterpret_cast<unsigned char *>(values.get());
         auto const &vec = att.get<std::vector<unsigned char> >();
+        for (size_t i = 0; i < vec.size(); ++i)
+            ptr[i] = vec[i];
+        break;
+    }
+    case DT::VEC_SCHAR: {
+        auto ptr = reinterpret_cast<signed char *>(values.get());
+        auto const &vec = att.get<std::vector<signed char> >();
         for (size_t i = 0; i < vec.size(); ++i)
             ptr[i] = vec[i];
         break;
@@ -1149,6 +1164,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::readDataset(
     case DT::ULONGLONG:
     case DT::CHAR:
     case DT::UCHAR:
+    case DT::SCHAR:
     case DT::BOOL:
         break;
     case DT::UNDEFINED:

--- a/src/IO/HDF5/HDF5Auxiliary.cpp
+++ b/src/IO/HDF5/HDF5Auxiliary.cpp
@@ -62,6 +62,9 @@ hid_t openPMD::GetH5DataType::operator()(Attribute const &att)
     case DT::UCHAR:
     case DT::VEC_UCHAR:
         return H5Tcopy(H5T_NATIVE_UCHAR);
+    case DT::SCHAR:
+    case DT::VEC_SCHAR:
+        return H5Tcopy(H5T_NATIVE_SCHAR);
     case DT::SHORT:
     case DT::VEC_SHORT:
         return H5Tcopy(H5T_NATIVE_SHORT);
@@ -145,6 +148,7 @@ hid_t openPMD::getH5DataSpace(Attribute const &att)
     {
     case DT::CHAR:
     case DT::UCHAR:
+    case DT::SCHAR:
     case DT::SHORT:
     case DT::INT:
     case DT::LONG:
@@ -195,6 +199,12 @@ hid_t openPMD::getH5DataSpace(Attribute const &att)
     case DT::VEC_UCHAR: {
         hid_t vec_t_id = H5Screate(H5S_SIMPLE);
         hsize_t dims[1] = {att.get<std::vector<unsigned char> >().size()};
+        H5Sset_extent_simple(vec_t_id, 1, dims, nullptr);
+        return vec_t_id;
+    }
+    case DT::VEC_SCHAR: {
+        hid_t vec_t_id = H5Screate(H5S_SIMPLE);
+        hsize_t dims[1] = {att.get<std::vector<signed char> >().size()};
         H5Sset_extent_simple(vec_t_id, 1, dims, nullptr);
         return vec_t_id;
     }

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1247,6 +1247,7 @@ void HDF5IOHandlerImpl::writeDataset(
     case DT::ULONGLONG:
     case DT::CHAR:
     case DT::UCHAR:
+    case DT::SCHAR:
     case DT::BOOL:
         status = H5Dwrite(
             dataset_id,
@@ -1376,6 +1377,11 @@ void HDF5IOHandlerImpl::writeAttribute(
         status = H5Awrite(attribute_id, dataType, &u);
         break;
     }
+    case DT::SCHAR: {
+        auto u = att.get<signed char>();
+        status = H5Awrite(attribute_id, dataType, &u);
+        break;
+    }
     case DT::SHORT: {
         auto i = att.get<short>();
         status = H5Awrite(attribute_id, dataType, &i);
@@ -1475,6 +1481,12 @@ void HDF5IOHandlerImpl::writeAttribute(
             attribute_id,
             dataType,
             att.get<std::vector<unsigned char> >().data());
+        break;
+    case DT::VEC_SCHAR:
+        status = H5Awrite(
+            attribute_id,
+            dataType,
+            att.get<std::vector<signed char> >().data());
         break;
     case DT::VEC_USHORT:
         status = H5Awrite(

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -287,6 +287,20 @@ void RecordComponent::read()
     readBase();
 }
 
+namespace
+{
+    struct MakeConstant
+    {
+        template <typename T>
+        static void call(RecordComponent rc, Attribute const &attr)
+        {
+            rc.makeConstant(attr.get<T>());
+        }
+
+        static constexpr char const *errorMsg = "Unexpected constant datatype";
+    };
+} // namespace
+
 void RecordComponent::readBase()
 {
     using DT = Datatype;
@@ -302,62 +316,7 @@ void RecordComponent::readBase()
         Attribute a(*aRead.resource);
         DT dtype = *aRead.dtype;
         written() = false;
-        switch (dtype)
-        {
-        case DT::LONG_DOUBLE:
-            makeConstant(a.get<long double>());
-            break;
-        case DT::DOUBLE:
-            makeConstant(a.get<double>());
-            break;
-        case DT::FLOAT:
-            makeConstant(a.get<float>());
-            break;
-        case DT::CLONG_DOUBLE:
-            makeConstant(a.get<std::complex<long double> >());
-            break;
-        case DT::CDOUBLE:
-            makeConstant(a.get<std::complex<double> >());
-            break;
-        case DT::CFLOAT:
-            makeConstant(a.get<std::complex<float> >());
-            break;
-        case DT::SHORT:
-            makeConstant(a.get<short>());
-            break;
-        case DT::INT:
-            makeConstant(a.get<int>());
-            break;
-        case DT::LONG:
-            makeConstant(a.get<long>());
-            break;
-        case DT::LONGLONG:
-            makeConstant(a.get<long long>());
-            break;
-        case DT::USHORT:
-            makeConstant(a.get<unsigned short>());
-            break;
-        case DT::UINT:
-            makeConstant(a.get<unsigned int>());
-            break;
-        case DT::ULONG:
-            makeConstant(a.get<unsigned long>());
-            break;
-        case DT::ULONGLONG:
-            makeConstant(a.get<unsigned long long>());
-            break;
-        case DT::CHAR:
-            makeConstant(a.get<char>());
-            break;
-        case DT::UCHAR:
-            makeConstant(a.get<unsigned char>());
-            break;
-        case DT::BOOL:
-            makeConstant(a.get<bool>());
-            break;
-        default:
-            throw std::runtime_error("Unexpected constant datatype");
-        }
+        switchNonVectorType<MakeConstant>(dtype, *this, a);
         written() = true;
 
         aRead.name = "shape";

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -333,6 +333,12 @@ void Attributable::readAttributes(ReadMode mode)
                 a.get<unsigned char>(),
                 internal::SetAttributeMode::WhileReadingAttributes);
             break;
+        case DT::SCHAR:
+            setAttributeImpl(
+                att,
+                a.get<signed char>(),
+                internal::SetAttributeMode::WhileReadingAttributes);
+            break;
         case DT::SHORT:
             setAttributeImpl(
                 att,
@@ -508,6 +514,12 @@ void Attributable::readAttributes(ReadMode mode)
             setAttributeImpl(
                 att,
                 a.get<std::vector<std::complex<long double> > >(),
+                internal::SetAttributeMode::WhileReadingAttributes);
+            break;
+        case DT::VEC_SCHAR:
+            setAttributeImpl(
+                att,
+                a.get<std::vector<signed char> >(),
                 internal::SetAttributeMode::WhileReadingAttributes);
             break;
         case DT::VEC_STRING:

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -558,6 +558,8 @@ void load_chunk(
         load_data((char)0);
     else if (r.getDatatype() == Datatype::UCHAR)
         load_data((unsigned char)0);
+    else if (r.getDatatype() == Datatype::SCHAR)
+        load_data((signed char)0);
     else if (r.getDatatype() == Datatype::SHORT)
         load_data((short)0);
     else if (r.getDatatype() == Datatype::INT)
@@ -664,6 +666,8 @@ inline void load_chunk(
         load_data(char());
     else if (r.getDatatype() == Datatype::UCHAR)
         load_data((unsigned char)0);
+    else if (r.getDatatype() == Datatype::SCHAR)
+        load_data((signed char)0);
     else if (r.getDatatype() == Datatype::SHORT)
         load_data(short());
     else if (r.getDatatype() == Datatype::INT)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1237,6 +1237,8 @@ inline void dtype_test(const std::string &backend)
         s.setAttribute("char", c);
         unsigned char uc = 'u';
         s.setAttribute("uchar", uc);
+        signed char sc = 's';
+        s.setAttribute("schar", sc);
         int16_t i16 = 16;
         s.setAttribute("int16", i16);
         int32_t i32 = 32;
@@ -1268,7 +1270,9 @@ inline void dtype_test(const std::string &backend)
             "vecInt64",
             std::vector<int64_t>({9223372036854775806, 9223372036854775807}));
         s.setAttribute(
-            "vecUchar", std::vector<char>({'u', 'c', 'h', 'a', 'r'}));
+            "vecUchar", std::vector<unsigned char>({'u', 'c', 'h', 'a', 'r'}));
+        s.setAttribute(
+            "vecSchar", std::vector<signed char>({'s', 'c', 'h', 'a', 'r'}));
         s.setAttribute("vecUint16", std::vector<uint16_t>({65534u, 65535u}));
         s.setAttribute(
             "vecUint32", std::vector<uint32_t>({4294967294u, 4294967295u}));
@@ -1349,6 +1353,7 @@ inline void dtype_test(const std::string &backend)
 
     REQUIRE(s.getAttribute("char").get<char>() == 'c');
     REQUIRE(s.getAttribute("uchar").get<unsigned char>() == 'u');
+    REQUIRE(s.getAttribute("schar").get<signed char>() == 's');
     REQUIRE(s.getAttribute("int16").get<int16_t>() == 16);
     REQUIRE(s.getAttribute("int32").get<int32_t>() == 32);
     REQUIRE(s.getAttribute("int64").get<int64_t>() == 64);
@@ -1375,8 +1380,11 @@ inline void dtype_test(const std::string &backend)
         s.getAttribute("vecInt64").get<std::vector<int64_t> >() ==
         std::vector<int64_t>({9223372036854775806, 9223372036854775807}));
     REQUIRE(
-        s.getAttribute("vecUchar").get<std::vector<char> >() ==
-        std::vector<char>({'u', 'c', 'h', 'a', 'r'}));
+        s.getAttribute("vecUchar").get<std::vector<unsigned char> >() ==
+        std::vector<unsigned char>({'u', 'c', 'h', 'a', 'r'}));
+    REQUIRE(
+        s.getAttribute("vecSchar").get<std::vector<signed char> >() ==
+        std::vector<signed char>({'s', 'c', 'h', 'a', 'r'}));
     REQUIRE(
         s.getAttribute("vecUint16").get<std::vector<uint16_t> >() ==
         std::vector<uint16_t>({65534u, 65535u}));

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2292,7 +2292,7 @@ TEST_CASE("deletion_test", "[serial]")
 {
     for (auto const &t : testedFileExtensions())
     {
-        if (t == "bp")
+        if (t == "bp" || t == "bp4" || t == "bp5")
         {
             continue; // deletion not implemented in ADIOS1 backend
         }
@@ -5794,7 +5794,7 @@ void append_mode(
     }
     {
         Series read(filename, Access::READ_ONLY);
-        if (variableBased)
+        if (variableBased || extension == "bp5")
         {
             // in variable-based encodings, iterations are not parsed ahead of
             // time but as they go
@@ -5825,7 +5825,7 @@ TEST_CASE("append_mode", "[serial]")
 {
     for (auto const &t : testedFileExtensions())
     {
-        if (t == "bp")
+        if (t == "bp" || t == "bp4" || t == "bp5")
         {
             std::string jsonConfigOld = R"END(
 {


### PR DESCRIPTION
ADIOS2 now distinguishes between `char`, `signed char` and `unsigned char`. Especially BP5 is unforgiving about this.

Until now, the ADIOS2 backend uses the public `openPMD::Datatype` enum, which has already caused some issues in the past. This PR introduces a new internal enum `ADIOS2Datatype` which is used to fully support ADIOS2 datatypes, especially char types. It is purely internal so we can change it as we please without breaking the API.

Close #1273

Tests will mainly come in #1218 where BP5 will be a default backend for tests