### PR TITLE
[WIP] Use JSON/TOML template for defining openPMD metadata in a config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,7 @@ set(CORE_SOURCE
         src/auxiliary/Mpi.cpp
         src/auxiliary/UniquePtr.cpp
         src/auxiliary/Variant.cpp
+        src/auxiliary/TemplateFile.cpp
         src/backend/Attributable.cpp
         src/backend/Attribute.cpp
         src/backend/BaseRecord.cpp

--- a/examples/14_toml_template.cpp
+++ b/examples/14_toml_template.cpp
@@ -108,7 +108,8 @@ void read()
 {
   "iteration_encoding": "variable_based",
   "json": {
-    "mode": "template"
+    "dataset": {"mode": "template"},
+    "attribute": {"mode": "short"}
   }
 }
 )";

--- a/examples/14_toml_template.cpp
+++ b/examples/14_toml_template.cpp
@@ -1,3 +1,5 @@
+#include "openPMD/Dataset.hpp"
+#include <openPMD/auxiliary/TemplateFile.hpp>
 #include <openPMD/openPMD.hpp>
 
 std::string backendEnding()
@@ -101,7 +103,23 @@ void read()
         "../samples/tomlTemplate." + backendEnding(),
         openPMD::Access::READ_LINEAR);
     read.parseBase();
-    openPMD::helper::listSeries(read);
+
+    std::string jsonConfig = R"(
+{
+  "iteration_encoding": "variable_based",
+  "json": {
+    "mode": "template"
+  }
+}
+)";
+    openPMD::Series cloned(
+        "../samples/jsonTemplate.json", openPMD::Access::CREATE, jsonConfig);
+    openPMD::auxiliary::initializeFromTemplate(cloned, read, 0);
+    // Have to define the dataset for E/z as it is not defined in the template
+    // @todo check that the dataset is defined only upon destruction, not at
+    // flushing already
+    cloned.writeIterations()[0].meshes["E"]["z"].resetDataset(
+        {openPMD::Datatype::INT, {openPMD::Dataset::UNDEFINED_EXTENT}});
 }
 
 int main()

--- a/examples/14_toml_template.cpp
+++ b/examples/14_toml_template.cpp
@@ -119,7 +119,7 @@ void read()
     // Have to define the dataset for E/z as it is not defined in the template
     // @todo check that the dataset is defined only upon destruction, not at
     // flushing already
-    cloned.writeIterations()[0].meshes["E"]["z"].resetDataset(
+    cloned.writeIterations()[0].meshes["E"].at("z").resetDataset(
         {openPMD::Datatype::INT, {openPMD::Dataset::UNDEFINED_EXTENT}});
 }
 

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -134,6 +134,15 @@ namespace internal
          * Otherwise empty.
          */
         std::optional<DeferredParseAccess> m_deferredParseAccess{};
+
+        enum TernaryBool
+        {
+            Undefined,
+            True,
+            False
+        };
+        TernaryBool hasMeshes = TernaryBool::Undefined;
+        TernaryBool hasParticles = TernaryBool::Undefined;
     };
 } // namespace internal
 /** @brief  Logical compilation of data from one snapshot (e.g. a single
@@ -270,6 +279,9 @@ public:
 
     Container<Mesh> meshes{};
     Container<ParticleSpecies> particles{}; // particleSpecies?
+
+    bool hasMeshes() const;
+    bool hasParticles() const;
 
     virtual ~Iteration() = default;
 

--- a/include/openPMD/auxiliary/TemplateFile.hpp
+++ b/include/openPMD/auxiliary/TemplateFile.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "openPMD/Series.hpp"
+
+namespace openPMD::auxiliary
+{
+// @todo replace uint64_t with proper type after merging #1285
+Series &initializeFromTemplate(
+    Series &initializeMe, Series const &fromTemplate, uint64_t iteration);
+} // namespace openPMD::auxiliary

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -48,6 +48,50 @@ namespace openPMD
 using internal::CloseStatus;
 using internal::DeferredParseAccess;
 
+bool Iteration::hasMeshes() const
+{
+    /*
+     * Currently defined at the Series level, but might be defined at the
+     * Iteration level in next standard iterations.
+     * Hence an Iteration:: method.
+     */
+
+    switch (get().hasMeshes)
+    {
+    case internal::IterationData::TernaryBool::True:
+        return true;
+    case internal::IterationData::TernaryBool::False:
+        return false;
+    case internal::IterationData::TernaryBool::Undefined: {
+        Series s = retrieveSeries();
+        return !meshes.empty() || s.containsAttribute("meshesPath");
+    };
+    }
+    throw std::runtime_error("Unreachable!");
+}
+
+bool Iteration::hasParticles() const
+{
+    /*
+     * Currently defined at the Series level, but might be defined at the
+     * Iteration level in next standard iterations.
+     * Hence an Iteration:: method.
+     */
+
+    switch (get().hasParticles)
+    {
+    case internal::IterationData::TernaryBool::True:
+        return true;
+    case internal::IterationData::TernaryBool::False:
+        return false;
+    case internal::IterationData::TernaryBool::Undefined: {
+        Series s = retrieveSeries();
+        return !particles.empty() || s.containsAttribute("particlesPath");
+    };
+    }
+    throw std::runtime_error("Unreachable!");
+}
+
 Iteration::Iteration() : Attributable(NoInit())
 {
     setData(std::make_shared<Data_t>());
@@ -364,7 +408,7 @@ void Iteration::flush(internal::FlushParams const &flushParams)
          * meshesPath and particlesPath are stored there */
         Series s = retrieveSeries();
 
-        if (!meshes.empty() || s.containsAttribute("meshesPath"))
+        if (hasMeshes())
         {
             if (!s.containsAttribute("meshesPath"))
             {
@@ -385,7 +429,7 @@ void Iteration::flush(internal::FlushParams const &flushParams)
             meshes.setDirty(false);
         }
 
-        if (!particles.empty() || s.containsAttribute("particlesPath"))
+        if (hasParticles())
         {
             if (!s.containsAttribute("particlesPath"))
             {
@@ -598,6 +642,12 @@ void Iteration::read_impl(std::string const &groupPath)
     {
         hasMeshes = s.containsAttribute("meshesPath");
         hasParticles = s.containsAttribute("particlesPath");
+    }
+    {
+        using TB = internal::IterationData::TernaryBool;
+        auto &data = get();
+        data.hasMeshes = hasMeshes ? TB::True : TB::False;
+        data.hasParticles = hasParticles ? TB::True : TB::False;
     }
 
     if (hasMeshes)

--- a/src/auxiliary/TemplateFile.cpp
+++ b/src/auxiliary/TemplateFile.cpp
@@ -1,0 +1,173 @@
+#include "openPMD/auxiliary/TemplateFile.hpp"
+#include "openPMD/DatatypeHelpers.hpp"
+
+#include <iostream>
+
+namespace openPMD::auxiliary
+{
+namespace
+{
+    // Some forward declarations
+    template <typename T>
+    void initializeFromTemplate(
+        Container<T> &initializeMe, Container<T> const &fromTemplate);
+
+    struct SetAttribute
+    {
+        template <typename T>
+        static void
+        call(Attributable &object, std::string const &name, Attribute attr)
+        {
+            object.setAttribute(name, attr.get<T>());
+        }
+
+        template <unsigned n>
+        static void call(Attributable &, std::string const &name, Attribute)
+        {
+            std::cerr << "Unknown datatype for template attribute '" << name
+                      << "'. Will skip it." << std::endl;
+        }
+    };
+
+    void copyAttributes(
+        Attributable &target,
+        Attributable const &source,
+        std::vector<std::string> ignore = {})
+    {
+        auto shouldBeIgnored = [&ignore](std::string const &attrName) {
+            // `ignore` is empty by default and normally has only a handful of
+            // entries otherwise.
+            // So just use linear search.
+            for (auto const &ignored : ignore)
+            {
+                if (attrName == ignored)
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        for (auto const &attrName : source.attributes())
+        {
+            if (shouldBeIgnored(attrName))
+            {
+                continue;
+            }
+            auto attr = source.getAttribute(attrName);
+            auto dtype = attr.dtype;
+            switchType<SetAttribute>(dtype, target, attrName, std::move(attr));
+        }
+    }
+
+    void initializeFromTemplate(
+        BaseRecordComponent &initializeMe,
+        BaseRecordComponent const &fromTemplate)
+    {
+        copyAttributes(initializeMe, fromTemplate);
+    }
+
+    void initializeFromTemplate(
+        RecordComponent &initializeMe, RecordComponent const &fromTemplate)
+    {
+        if (fromTemplate.getDatatype() != Datatype::UNDEFINED)
+        {
+            initializeMe.resetDataset(
+                Dataset{fromTemplate.getDatatype(), fromTemplate.getExtent()});
+        }
+        initializeFromTemplate(
+            static_cast<BaseRecordComponent &>(initializeMe),
+            static_cast<BaseRecordComponent const &>(fromTemplate));
+    }
+
+    void initializeFromTemplate(
+        PatchRecordComponent &initializeMe,
+        PatchRecordComponent const &fromTemplate)
+    {
+        if (fromTemplate.getDatatype() != Datatype::UNDEFINED)
+        {
+            initializeMe.resetDataset(
+                Dataset{fromTemplate.getDatatype(), fromTemplate.getExtent()});
+        }
+        initializeFromTemplate(
+            static_cast<BaseRecordComponent &>(initializeMe),
+            static_cast<BaseRecordComponent const &>(fromTemplate));
+    }
+
+    void initializeFromTemplate(
+        ParticleSpecies &initializeMe, ParticleSpecies const &fromTemplate)
+    {
+        if (!fromTemplate.particlePatches.empty())
+        {
+            initializeFromTemplate(
+                static_cast<Container<PatchRecord> &>(
+                    initializeMe.particlePatches),
+                static_cast<Container<PatchRecord> const &>(
+                    fromTemplate.particlePatches));
+        }
+        initializeFromTemplate(
+            static_cast<Container<Record> &>(initializeMe),
+            static_cast<Container<Record> const &>(fromTemplate));
+    }
+
+    template <typename T>
+    void initializeFromTemplate(
+        Container<T> &initializeMe, Container<T> const &fromTemplate)
+    {
+        copyAttributes(initializeMe, fromTemplate);
+        for (auto const &pair : fromTemplate)
+        {
+            initializeFromTemplate(initializeMe[pair.first], pair.second);
+        }
+    }
+
+    void initializeFromTemplate(
+        Iteration &initializeMe, Iteration const &fromTemplate)
+    {
+        copyAttributes(initializeMe, fromTemplate, {"snapshot"});
+        if (fromTemplate.hasMeshes())
+        {
+            initializeFromTemplate(initializeMe.meshes, fromTemplate.meshes);
+        }
+        if (fromTemplate.hasParticles())
+        {
+            initializeFromTemplate(
+                initializeMe.particles, fromTemplate.particles);
+        }
+    }
+} // namespace
+
+Series &initializeFromTemplate(
+    Series &initializeMe, Series const &fromTemplate, uint64_t iteration)
+{
+    if (!initializeMe.containsAttribute("from_template"))
+    {
+        copyAttributes(
+            initializeMe,
+            fromTemplate,
+            {"basePath", "iterationEncoding", "iterationFormat", "openPMD"});
+        initializeMe.setAttribute("from_template", fromTemplate.name());
+    }
+
+    uint64_t sourceIteration = iteration;
+    if (!fromTemplate.iterations.contains(sourceIteration))
+    {
+        if (fromTemplate.iterations.empty())
+        {
+            std::cerr << "Template file has no iterations, will only fill in "
+                         "global attributes."
+                      << std::endl;
+            return initializeMe;
+        }
+        else
+        {
+            sourceIteration = fromTemplate.iterations.begin()->first;
+        }
+    }
+
+    initializeFromTemplate(
+        initializeMe.iterations[iteration],
+        fromTemplate.iterations.at(sourceIteration));
+    return initializeMe;
+}
+} // namespace openPMD::auxiliary

--- a/src/auxiliary/TemplateFile.cpp
+++ b/src/auxiliary/TemplateFile.cpp
@@ -34,6 +34,25 @@ namespace
         Attributable const &source,
         std::vector<std::string> ignore = {})
     {
+#if 0 // leave this in for potential future debugging
+        std::cout << "COPYING ATTRIBUTES FROM '" << [&source]() -> std::string {
+            auto vec = source.myPath().group;
+            if (vec.empty())
+            {
+                return "[]";
+            }
+            std::stringstream sstream;
+            auto it = vec.begin();
+            sstream << "[" << *it++;
+            for (; it != vec.end(); ++it)
+            {
+                sstream << ", " << *it;
+            }
+            sstream << "]";
+            return sstream.str();
+        }() << "'"
+            << std::endl;
+#endif
         auto shouldBeIgnored = [&ignore](std::string const &attrName) {
             // `ignore` is empty by default and normally has only a handful of
             // entries otherwise.
@@ -92,6 +111,25 @@ namespace
         initializeFromTemplate(
             static_cast<BaseRecordComponent &>(initializeMe),
             static_cast<BaseRecordComponent const &>(fromTemplate));
+    }
+
+    template <typename T>
+    void initializeFromTemplate(
+        BaseRecord<T> &initializeMe, BaseRecord<T> const &fromTemplate)
+    {
+        if (fromTemplate.scalar())
+        {
+            initializeMe[RecordComponent::SCALAR];
+            initializeFromTemplate(
+                static_cast<T &>(initializeMe),
+                static_cast<T const &>(fromTemplate));
+        }
+        else
+        {
+            initializeFromTemplate(
+                static_cast<Container<T> &>(initializeMe),
+                static_cast<Container<T> const &>(fromTemplate));
+        }
     }
 
     void initializeFromTemplate(

--- a/src/auxiliary/TemplateFile.cpp
+++ b/src/auxiliary/TemplateFile.cpp
@@ -76,7 +76,7 @@ namespace
             }
             auto attr = source.getAttribute(attrName);
             auto dtype = attr.dtype;
-            switchType<SetAttribute>(dtype, target, attrName, std::move(attr));
+            switchType<SetAttribute>(dtype, target, attrName, attr);
         }
     }
 

--- a/src/auxiliary/TemplateFile.cpp
+++ b/src/auxiliary/TemplateFile.cpp
@@ -16,13 +16,14 @@ namespace
     {
         template <typename T>
         static void
-        call(Attributable &object, std::string const &name, Attribute attr)
+        call(Attributable &object, std::string const &name, Attribute &attr)
         {
             object.setAttribute(name, attr.get<T>());
         }
 
         template <unsigned n>
-        static void call(Attributable &, std::string const &name, Attribute)
+        static void
+        call(Attributable &, std::string const &name, Attribute const &)
         {
             std::cerr << "Unknown datatype for template attribute '" << name
                       << "'. Will skip it." << std::endl;

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1568,7 +1568,15 @@ TEST_CASE("dtype_test", "[serial]")
 {
     for (auto const &t : testedFileExtensions())
     {
-        dtype_test(t);
+        if (t == "json")
+        {
+            dtype_test(t);
+            dtype_test(t, R"(json.mode = "template")");
+        }
+        else
+        {
+            dtype_test(t);
+        }
     }
     dtype_test("json", R"(
 {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -14,6 +14,7 @@
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
+#include "openPMD/auxiliary/TemplateFile.hpp"
 #include "openPMD/openPMD.hpp"
 
 #include <catch2/catch.hpp>
@@ -1489,6 +1490,12 @@ inline void dtype_test(
 
     if (activateTemplateMode.has_value())
     {
+        Series out(
+            "../samples/dtype_test_from_template." + backend,
+            Access::CREATE,
+            activateTemplateMode.value());
+        auxiliary::initializeFromTemplate(out, s, 1000);
+        out.flush();
         return;
     }
     // same implementation types (not necessary aliases) detection

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3040,21 +3040,21 @@ TEST_CASE("git_hdf5_legacy_picongpu", "[serial][hdf5]")
 
 TEST_CASE("git_hdf5_sample_attribute_test", "[serial][hdf5]")
 {
-    try
-    {
-        Series o = Series("../samples/git-sample/data%T.h5", Access::READ_ONLY);
-
+    auto verifySeries = [](Series o, bool this_is_the_original_file) {
         REQUIRE(o.openPMD() == "1.1.0");
         REQUIRE(o.openPMDextension() == 1);
         REQUIRE(o.basePath() == "/data/%T/");
         REQUIRE(o.meshesPath() == "fields/");
         REQUIRE(o.particlesPath() == "particles/");
-        REQUIRE(o.iterationEncoding() == IterationEncoding::fileBased);
-        REQUIRE(o.iterationFormat() == "data%T.h5");
-        REQUIRE(o.name() == "data%T");
+        if (this_is_the_original_file)
+        {
+            REQUIRE(o.iterationEncoding() == IterationEncoding::fileBased);
+            REQUIRE(o.iterationFormat() == "data%T.h5");
+            REQUIRE(o.name() == "data%T");
 
-        REQUIRE(o.iterations.size() == 5);
-        REQUIRE(o.iterations.count(100) == 1);
+            REQUIRE(o.iterations.size() == 5);
+            REQUIRE(o.iterations.count(100) == 1);
+        }
 
         Iteration &iteration_100 = o.iterations[100];
         REQUIRE(iteration_100.time<double>() == 3.2847121452090077e-14);
@@ -3284,6 +3284,30 @@ TEST_CASE("git_hdf5_sample_attribute_test", "[serial][hdf5]")
         REQUIRE(weighting_scalar.getDatatype() == Datatype::DOUBLE);
         REQUIRE(weighting_scalar.getDimensionality() == 1);
         REQUIRE(weighting_scalar.getExtent() == e);
+    };
+
+    try
+    {
+        {
+            Series o =
+                Series("../samples/git-sample/data%T.h5", Access::READ_ONLY);
+            verifySeries(o, true);
+
+            Series fromTemplate(
+                "../samples/initialized_from_git_sample.json",
+                Access::CREATE,
+                R"(json.mode = "template")");
+            auxiliary::initializeFromTemplate(fromTemplate, o, 100);
+            fromTemplate.flush();
+        }
+
+        {
+            Series o(
+                "../samples/initialized_from_git_sample.json",
+                Access::READ_ONLY,
+                R"(json.mode = "template")");
+            verifySeries(o, false);
+        }
     }
     catch (error::ReadError &e)
     {


### PR DESCRIPTION
Not relevant for next release

* **Until now:** Simulations specify their metadata in-code via API calls
* **With this PR:** In some workflows (e.g. experiments) there is no omniscient simulation, but metadata is instead input by the experimentors via configuration files, using the API is not a good workflow for that

Idea: We already have a JSON backend, use an openPMD-conforming JSON dataset to define only metadata. With this, the configuration file will be just another openPMD dataset.
Then, add some functionality to initialize an empty Series from such a metadata file.

TODO:

- [x] Add a `template` mode to the JSON backend that (1) does not pre-fill datasets, (2) does not allow writing to datasets
- [x] Use TOML as an alternative target for the JSON backend (better because it allows comments)
- [x] Add a basic `intitializeFromTemplate()` functionality
- [ ] Check how this fits experiments workflows, adapt
- [x] Make JSON/TOML maybe a bit easier to write, e.g. make the `datatype` field optional
- [ ] Maybe find another way to distinguish groups from datasets, so that not even `dtype` and `extent` are required
- [ ] Maybe find a way to make default attributes optional
- [x] Merge #1218 first
- [x] Introduce a good workflow to use a variable-based single iteration Series such that the single iteration represents all iterations
- [ ] Check interplay with Read Mode changes
- [x] Maybe automatically detect template mode in reading
- [x] Merge https://github.com/openPMD/openPMD-api/pull/1278 first
- [ ] documentation
- [ ] Merge #1493 first
- [ ] Will probably need an update to work together with #1432

https://github.com/franzpoeschel/openPMD-api/compare/topic-json-short-modes..topic-json-template