### PR TITLE
Add Attribute::getOptional<T>() and use to add some more dynamic datatype conversions at read time

### DIFF
--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace openPMD
@@ -136,98 +137,101 @@ public:
     std::optional<U> getOptional() const;
 };
 
-template <typename T, typename U>
-auto doConvert(T *pv) -> U
+namespace detail
 {
-    (void)pv;
-    if constexpr (std::is_convertible_v<T, U>)
+    template <typename T, typename U>
+    auto doConvert(T *pv) -> std::variant<U, std::runtime_error>
     {
-        return static_cast<U>(*pv);
-    }
-    else if constexpr (auxiliary::IsVector_v<T> && auxiliary::IsVector_v<U>)
-    {
-        if constexpr (std::is_convertible_v<
-                          typename T::value_type,
-                          typename U::value_type>)
+        (void)pv;
+        if constexpr (std::is_convertible_v<T, U>)
         {
-            U res{};
-            res.reserve(pv->size());
-            std::copy(pv->begin(), pv->end(), std::back_inserter(res));
-            return res;
+            return static_cast<U>(*pv);
         }
-        else
+        else if constexpr (auxiliary::IsVector_v<T> && auxiliary::IsVector_v<U>)
         {
-            throw std::runtime_error("getCast: no vector cast possible.");
-        }
-    }
-    // conversion cast: array to vector
-    // if a backend reports a std::array<> for something where
-    // the frontend expects a vector
-    else if constexpr (auxiliary::IsArray_v<T> && auxiliary::IsVector_v<U>)
-    {
-        if constexpr (std::is_convertible_v<
-                          typename T::value_type,
-                          typename U::value_type>)
-        {
-            U res{};
-            res.reserve(pv->size());
-            std::copy(pv->begin(), pv->end(), std::back_inserter(res));
-            return res;
-        }
-        else
-        {
-            throw std::runtime_error(
-                "getCast: no array to vector conversion possible.");
-        }
-    }
-    // conversion cast: vector to array
-    // if a backend reports a std::vector<> for something where
-    // the frontend expects an array
-    else if constexpr (auxiliary::IsVector_v<T> && auxiliary::IsArray_v<U>)
-    {
-        if constexpr (std::is_convertible_v<
-                          typename T::value_type,
-                          typename U::value_type>)
-        {
-            U res{};
-            if (res.size() != pv->size())
+            if constexpr (std::is_convertible_v<
+                              typename T::value_type,
+                              typename U::value_type>)
             {
-                throw std::runtime_error(
-                    "getCast: no vector to array conversion possible (wrong "
-                    "requested array size).");
+                U res{};
+                res.reserve(pv->size());
+                std::copy(pv->begin(), pv->end(), std::back_inserter(res));
+                return res;
             }
-            for (size_t i = 0; i < res.size(); ++i)
+            else
             {
-                res[i] = static_cast<typename U::value_type>((*pv)[i]);
+                return std::runtime_error("getCast: no vector cast possible.");
             }
-            return res;
+        }
+        // conversion cast: array to vector
+        // if a backend reports a std::array<> for something where
+        // the frontend expects a vector
+        else if constexpr (auxiliary::IsArray_v<T> && auxiliary::IsVector_v<U>)
+        {
+            if constexpr (std::is_convertible_v<
+                              typename T::value_type,
+                              typename U::value_type>)
+            {
+                U res{};
+                res.reserve(pv->size());
+                std::copy(pv->begin(), pv->end(), std::back_inserter(res));
+                return res;
+            }
+            else
+            {
+                return std::runtime_error(
+                    "getCast: no array to vector conversion possible.");
+            }
+        }
+        // conversion cast: vector to array
+        // if a backend reports a std::vector<> for something where
+        // the frontend expects an array
+        else if constexpr (auxiliary::IsVector_v<T> && auxiliary::IsArray_v<U>)
+        {
+            if constexpr (std::is_convertible_v<
+                              typename T::value_type,
+                              typename U::value_type>)
+            {
+                U res{};
+                if (res.size() != pv->size())
+                {
+                    return std::runtime_error(
+                        "getCast: no vector to array conversion possible "
+                        "(wrong "
+                        "requested array size).");
+                }
+                for (size_t i = 0; i < res.size(); ++i)
+                {
+                    res[i] = static_cast<typename U::value_type>((*pv)[i]);
+                }
+                return res;
+            }
+            else
+            {
+                return std::runtime_error(
+                    "getCast: no vector to array conversion possible.");
+            }
+        }
+        // conversion cast: turn a single value into a 1-element vector
+        else if constexpr (auxiliary::IsVector_v<U>)
+        {
+            if constexpr (std::is_convertible_v<T, typename U::value_type>)
+            {
+                U res{};
+                res.reserve(1);
+                res.push_back(static_cast<typename U::value_type>(*pv));
+                return res;
+            }
+            else
+            {
+                return std::runtime_error(
+                    "getCast: no scalar to vector conversion possible.");
+            }
         }
         else
         {
-            throw std::runtime_error(
-                "getCast: no vector to array conversion possible.");
+            return std::runtime_error("getCast: no cast possible.");
         }
-    }
-    // conversion cast: turn a single value into a 1-element vector
-    else if constexpr (auxiliary::IsVector_v<U>)
-    {
-        if constexpr (std::is_convertible_v<T, typename U::value_type>)
-        {
-            U res{};
-            res.reserve(1);
-            res.push_back(static_cast<typename U::value_type>(*pv));
-            return res;
-        }
-        else
-        {
-            throw std::runtime_error(
-                "getCast: no scalar to vector conversion possible.");
-        }
-    }
-    else
-    {
-        throw std::runtime_error("getCast: no cast possible.");
-    }
 #if defined(__INTEL_COMPILER)
 /*
  * ICPC has trouble with if constexpr, thinking that return statements are
@@ -237,151 +241,58 @@ auto doConvert(T *pv) -> U
  * https://community.intel.com/t5/Intel-C-Compiler/quot-if-constexpr-quot-and-quot-missing-return-statement-quot-in/td-p/1154551
  */
 #pragma warning(disable : 1011)
-}
+    }
 #pragma warning(default : 1011)
 #else
-}
+    }
 #endif
-
-template <typename T, typename U>
-auto doConvertOptional(T *pv) -> std::optional<U>
-{
-    (void)pv;
-    if constexpr (std::is_convertible_v<T, U>)
-    {
-        return static_cast<U>(*pv);
-    }
-    else if constexpr (auxiliary::IsVector_v<T> && auxiliary::IsVector_v<U>)
-    {
-        if constexpr (std::is_convertible_v<
-                          typename T::value_type,
-                          typename U::value_type>)
-        {
-            U res{};
-            res.reserve(pv->size());
-            std::copy(pv->begin(), pv->end(), std::back_inserter(res));
-            return res;
-        }
-        else
-        {
-            return {};
-        }
-    }
-    // conversion cast: array to vector
-    // if a backend reports a std::array<> for something where
-    // the frontend expects a vector
-    else if constexpr (auxiliary::IsArray_v<T> && auxiliary::IsVector_v<U>)
-    {
-        if constexpr (std::is_convertible_v<
-                          typename T::value_type,
-                          typename U::value_type>)
-        {
-            U res{};
-            res.reserve(pv->size());
-            std::copy(pv->begin(), pv->end(), std::back_inserter(res));
-            return res;
-        }
-        else
-        {
-            return {};
-        }
-    }
-    // conversion cast: vector to array
-    // if a backend reports a std::vector<> for something where
-    // the frontend expects an array
-    else if constexpr (auxiliary::IsVector_v<T> && auxiliary::IsArray_v<U>)
-    {
-        if constexpr (std::is_convertible_v<
-                          typename T::value_type,
-                          typename U::value_type>)
-        {
-            U res{};
-            if (res.size() != pv->size())
-            {
-                throw std::runtime_error(
-                    "getCast: no vector to array conversion possible (wrong "
-                    "requested array size).");
-            }
-            for (size_t i = 0; i < res.size(); ++i)
-            {
-                res[i] = static_cast<typename U::value_type>((*pv)[i]);
-            }
-            return res;
-        }
-        else
-        {
-            return {};
-        }
-    }
-    // conversion cast: turn a single value into a 1-element vector
-    else if constexpr (auxiliary::IsVector_v<U>)
-    {
-        if constexpr (std::is_convertible_v<T, typename U::value_type>)
-        {
-            U res{};
-            res.reserve(1);
-            res.push_back(static_cast<typename U::value_type>(*pv));
-            return res;
-        }
-        else
-        {
-            return {};
-        }
-    }
-    else
-    {
-        return {};
-    }
-#if defined(__INTEL_COMPILER)
-/*
- * ICPC has trouble with if constexpr, thinking that return statements are
- * missing afterwards. Deactivate the warning.
- * Note that putting a statement here will not help to fix this since it will
- * then complain about unreachable code.
- * https://community.intel.com/t5/Intel-C-Compiler/quot-if-constexpr-quot-and-quot-missing-return-statement-quot-in/td-p/1154551
- */
-#pragma warning(disable : 1011)
-}
-#pragma warning(default : 1011)
-#else
-}
-#endif
-
-/** Retrieve a stored specific Attribute and cast if convertible.
- *
- * @throw   std::runtime_error if stored object is not static castable to U.
- * @tparam  U   Type of the object to be casted to.
- * @return  Copy of the retrieved object, casted to type U.
- */
-template <typename U>
-inline U getCast(Attribute const &a)
-{
-    auto v = a.getResource();
-
-    return std::visit(
-        [](auto &&containedValue) -> U {
-            using containedType = std::decay_t<decltype(containedValue)>;
-            return doConvert<containedType, U>(&containedValue);
-        },
-        v);
-}
+} // namespace detail
 
 template <typename U>
 U Attribute::get() const
 {
-    return getCast<U>(Variant::getResource());
+    auto eitherValueOrError = std::visit(
+        [](auto &&containedValue) -> std::variant<U, std::runtime_error> {
+            using containedType = std::decay_t<decltype(containedValue)>;
+            return detail::doConvert<containedType, U>(&containedValue);
+        },
+        Variant::getResource());
+    return std::visit(
+        [](auto &&containedValue) -> U {
+            using T = std::decay_t<decltype(containedValue)>;
+            if constexpr (std::is_same_v<T, std::runtime_error>)
+            {
+                throw std::move(containedValue);
+            }
+            else
+            {
+                return std::move(containedValue);
+            }
+        },
+        std::move(eitherValueOrError));
 }
 
 template <typename U>
 std::optional<U> Attribute::getOptional() const
 {
-    auto v = Variant::getResource();
-
-    return std::visit(
-        [](auto &&containedValue) -> U {
+    auto eitherValueOrError = std::visit(
+        [](auto &&containedValue) -> std::variant<U, std::runtime_error> {
             using containedType = std::decay_t<decltype(containedValue)>;
-            return doConvert<containedType, U>(&containedValue);
+            return detail::doConvert<containedType, U>(&containedValue);
         },
-        v);
+        Variant::getResource());
+    return std::visit(
+        [](auto &&containedValue) -> std::optional<U> {
+            using T = std::decay_t<decltype(containedValue)>;
+            if constexpr (std::is_same_v<T, std::runtime_error>)
+            {
+                return std::nullopt;
+            }
+            else
+            {
+                return {std::move(containedValue)};
+            }
+        },
+        std::move(eitherValueOrError));
 }
 } // namespace openPMD

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -425,6 +425,10 @@ void Iteration::read_impl(std::string const &groupPath)
         setDt(Attribute(*aRead.resource).get<double>());
     else if (*aRead.dtype == DT::LONG_DOUBLE)
         setDt(Attribute(*aRead.resource).get<long double>());
+    // conversion cast if a backend reports an integer type
+    else if (auto val = Attribute(*aRead.resource).getOptional<double>();
+             val.has_value())
+        setDt(val.value());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'dt'");
 
@@ -437,14 +441,19 @@ void Iteration::read_impl(std::string const &groupPath)
         setTime(Attribute(*aRead.resource).get<double>());
     else if (*aRead.dtype == DT::LONG_DOUBLE)
         setTime(Attribute(*aRead.resource).get<long double>());
+    // conversion cast if a backend reports an integer type
+    else if (auto val = Attribute(*aRead.resource).getOptional<double>();
+             val.has_value())
+        setTime(val.value());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'time'");
 
     aRead.name = "timeUnitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == DT::DOUBLE)
-        setTimeUnitSI(Attribute(*aRead.resource).get<double>());
+    if (auto val = Attribute(*aRead.resource).getOptional<double>();
+        val.has_value())
+        setTimeUnitSI(val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'timeUnitSI'");

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -341,6 +341,9 @@ void Mesh::read()
     else if (
         *aRead.dtype == DT::VEC_LONG_DOUBLE || *aRead.dtype == DT::LONG_DOUBLE)
         setGridSpacing(a.get<std::vector<long double> >());
+    // conversion cast if a backend reports an integer type
+    else if (auto val = a.getOptional<std::vector<double> >(); val.has_value())
+        setGridSpacing(val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'gridSpacing'");
@@ -348,9 +351,10 @@ void Mesh::read()
     aRead.name = "gridGlobalOffset";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == DT::VEC_DOUBLE || *aRead.dtype == DT::DOUBLE)
-        setGridGlobalOffset(
-            Attribute(*aRead.resource).get<std::vector<double> >());
+    if (auto val =
+            Attribute(*aRead.resource).getOptional<std::vector<double> >();
+        val.has_value())
+        setGridGlobalOffset(val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'gridGlobalOffset'");
@@ -358,8 +362,9 @@ void Mesh::read()
     aRead.name = "gridUnitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == DT::DOUBLE)
-        setGridUnitSI(Attribute(*aRead.resource).get<double>());
+    if (auto val = Attribute(*aRead.resource).getOptional<double>();
+        val.has_value())
+        setGridUnitSI(val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'gridUnitSI'");

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -326,11 +326,9 @@ void RecordComponent::readBase()
         Extent e;
 
         // uint64_t check
-        Datatype const attrDtype = *aRead.dtype;
-        if (isSame(attrDtype, determineDatatype<std::vector<uint64_t> >()) ||
-            isSame(attrDtype, determineDatatype<uint64_t>()))
-            for (auto const &val : a.get<std::vector<uint64_t> >())
-                e.push_back(val);
+        if (auto val = a.getOptional<std::vector<uint64_t> >(); val.has_value())
+            for (auto const &shape : val.value())
+                e.push_back(shape);
         else
         {
             std::ostringstream oss;
@@ -348,8 +346,9 @@ void RecordComponent::readBase()
     aRead.name = "unitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == DT::DOUBLE)
-        setUnitSI(Attribute(*aRead.resource).get<double>());
+    if (auto val = Attribute(*aRead.resource).getOptional<double>();
+        val.has_value())
+        setUnitSI(val.value());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1334,22 +1334,23 @@ std::optional<std::deque<uint64_t>> Series::readGorVBased(bool do_init)
 void Series::readBase()
 {
     auto &series = get();
-    using DT = Datatype;
     Parameter<Operation::READ_ATT> aRead;
 
     aRead.name = "openPMD";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == DT::STRING)
-        setOpenPMD(Attribute(*aRead.resource).get<std::string>());
+    if (auto val = Attribute(*aRead.resource).getOptional<std::string>();
+        val.has_value())
+        setOpenPMD(val.value());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'openPMD'");
 
     aRead.name = "openPMDextension";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == determineDatatype<uint32_t>())
-        setOpenPMDextension(Attribute(*aRead.resource).get<uint32_t>());
+    if (auto val = Attribute(*aRead.resource).getOptional<uint32_t>();
+        val.has_value())
+        setOpenPMDextension(val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'openPMDextension'");
@@ -1357,8 +1358,9 @@ void Series::readBase()
     aRead.name = "basePath";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == DT::STRING)
-        setAttribute("basePath", Attribute(*aRead.resource).get<std::string>());
+    if (auto val = Attribute(*aRead.resource).getOptional<std::string>();
+        val.has_value())
+        setAttribute("basePath", val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'basePath'");
@@ -1373,13 +1375,14 @@ void Series::readBase()
         aRead.name = "meshesPath";
         IOHandler()->enqueue(IOTask(this, aRead));
         IOHandler()->flush(internal::defaultFlushParams);
-        if (*aRead.dtype == DT::STRING)
+        if (auto val = Attribute(*aRead.resource).getOptional<std::string>();
+            val.has_value())
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
                 it.second.meshes.written() = false;
 
-            setMeshesPath(Attribute(*aRead.resource).get<std::string>());
+            setMeshesPath(val.value());
 
             for (auto &it : series.iterations)
                 it.second.meshes.written() = true;
@@ -1397,13 +1400,14 @@ void Series::readBase()
         aRead.name = "particlesPath";
         IOHandler()->enqueue(IOTask(this, aRead));
         IOHandler()->flush(internal::defaultFlushParams);
-        if (*aRead.dtype == DT::STRING)
+        if (auto val = Attribute(*aRead.resource).getOptional<std::string>();
+            val.has_value())
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
                 it.second.particles.written() = false;
 
-            setParticlesPath(Attribute(*aRead.resource).get<std::string>());
+            setParticlesPath(val.value());
 
             for (auto &it : series.iterations)
                 it.second.particles.written() = true;

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -43,6 +43,9 @@ void MeshRecordComponent::read()
     else if (
         *aRead.dtype == DT::VEC_LONG_DOUBLE || *aRead.dtype == DT::LONG_DOUBLE)
         setPosition(a.get<std::vector<long double> >());
+    // conversion cast if a backend reports an integer type
+    else if (auto val = a.getOptional<std::vector<double> >(); val.has_value())
+        setPosition(val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'position'");

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -63,11 +63,10 @@ void PatchRecord::read()
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
 
-    if (*aRead.dtype == Datatype::ARR_DBL_7 ||
-        *aRead.dtype == Datatype::VEC_DOUBLE)
-        this->setAttribute(
-            "unitDimension",
-            Attribute(*aRead.resource).template get<std::array<double, 7> >());
+    if (auto val =
+            Attribute(*aRead.resource).getOptional<std::array<double, 7> >();
+        val.has_value())
+        this->setAttribute("unitDimension", val.value());
     else
         throw std::runtime_error(
             "Unexpected Attribute datatype for 'unitDimension'");

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -126,8 +126,9 @@ void PatchRecordComponent::read()
     aRead.name = "unitSI";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == Datatype::DOUBLE)
-        setUnitSI(Attribute(*aRead.resource).get<double>());
+    if (auto val = Attribute(*aRead.resource).getOptional<double>();
+        val.has_value())
+        setUnitSI(val.value());
     else
         throw std::runtime_error("Unexpected Attribute datatype for 'unitSI'");
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6383,16 +6383,11 @@ enum class ParseMode
 };
 
 void append_mode(
-    std::string const &extension,
+    std::string const &filename,
     bool variableBased,
     ParseMode parseMode,
     std::string jsonConfig = "{}")
 {
-
-    std::string filename =
-        (variableBased ? "../samples/append/append_variablebased."
-                       : "../samples/append/append_groupbased.") +
-        extension;
     if (auxiliary::directory_exists("../samples/append"))
     {
         auxiliary::remove_directory("../samples/append");
@@ -6559,11 +6554,11 @@ void append_mode(
         break;
         }
     }
+    // AppendAfterSteps has a bug before that version
 #if 100000000 * ADIOS2_VERSION_MAJOR + 1000000 * ADIOS2_VERSION_MINOR +        \
         10000 * ADIOS2_VERSION_PATCH + 100 * ADIOS2_VERSION_TWEAK >=           \
     208002700
-    // AppendAfterSteps has a bug before that version
-    if (extension == "bp5")
+    if (auxiliary::ends_with(filename, ".bp5"))
     {
         {
             Series write(
@@ -6669,22 +6664,55 @@ TEST_CASE("append_mode", "[serial]")
         if (t == "bp5")
         {
             append_mode(
-                t, false, ParseMode::LinearWithoutSnapshot, jsonConfigOld);
-            append_mode(t, false, ParseMode::WithSnapshot, jsonConfigNew);
-            append_mode(t, true, ParseMode::WithSnapshot, jsonConfigOld);
-            append_mode(t, true, ParseMode::WithSnapshot, jsonConfigNew);
+                "../samples/append/groupbased." + t,
+                false,
+                ParseMode::LinearWithoutSnapshot,
+                jsonConfigOld);
+            append_mode(
+                "../samples/append/groupbased_newschema." + t,
+                false,
+                ParseMode::WithSnapshot,
+                jsonConfigNew);
+            append_mode(
+                "../samples/append/variablebased." + t,
+                true,
+                ParseMode::WithSnapshot,
+                jsonConfigOld);
+            append_mode(
+                "../samples/append/variablebased_newschema." + t,
+                true,
+                ParseMode::WithSnapshot,
+                jsonConfigNew);
         }
-        else if (t == "bp" || t == "bp4" || t == "bp5")
+        else if (t == "bp" || t == "bp4")
         {
             append_mode(
-                t, false, ParseMode::AheadOfTimeWithoutSnapshot, jsonConfigOld);
-            append_mode(t, false, ParseMode::WithSnapshot, jsonConfigNew);
-            append_mode(t, true, ParseMode::WithSnapshot, jsonConfigOld);
-            append_mode(t, true, ParseMode::WithSnapshot, jsonConfigNew);
+                "../samples/append/append_groupbased." + t,
+                false,
+                ParseMode::AheadOfTimeWithoutSnapshot,
+                jsonConfigOld);
+            append_mode(
+                "../samples/append/append_groupbased." + t,
+                false,
+                ParseMode::WithSnapshot,
+                jsonConfigNew);
+            append_mode(
+                "../samples/append/append_variablebased." + t,
+                true,
+                ParseMode::WithSnapshot,
+                jsonConfigOld);
+            append_mode(
+                "../samples/append/append_variablebased." + t,
+                true,
+                ParseMode::WithSnapshot,
+                jsonConfigNew);
         }
         else
         {
-            append_mode(t, false, ParseMode::NoSteps);
+            append_mode(
+                "../samples/append/append_groupbased." + t,
+                false,
+                ParseMode::NoSteps);
         }
     }
 }


### PR DESCRIPTION
Currently, we have `Attribute::get<T>()` that throws a `std::runtime_error()` if no conversion is possible.
Adding `Attribute::getOptional<T>()` is helpful to check if a conversion is possible without having to resort to catching exceptions.

This PR also uses that new API method while reading a Series in. This became necessary in #1277 from where I have extracted this PR (that PR adds a less verbose mode to the JSON backend that does not explicitly annotate datatypes and might hence report different numerical types at read times).