### PR TITLE
Add IterationIndex_t to replace hardcoded uint64_t to index iterations

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -134,6 +134,8 @@ public:
     Iteration(Iteration const &) = default;
     Iteration &operator=(Iteration const &) = default;
 
+    using IterationIndex_t = uint64_t;
+
     /**
      * @tparam  T   Floating point type of user-selected precision (e.g. float,
      * double).
@@ -255,9 +257,9 @@ private:
     }
 
     void flushFileBased(
-        std::string const &, uint64_t, internal::FlushParams const &);
-    void flushGroupBased(uint64_t, internal::FlushParams const &);
-    void flushVariableBased(uint64_t, internal::FlushParams const &);
+        std::string const &, IterationIndex_t, internal::FlushParams const &);
+    void flushGroupBased(IterationIndex_t, internal::FlushParams const &);
+    void flushVariableBased(IterationIndex_t, internal::FlushParams const &);
     void flush(internal::FlushParams const &);
     void deferParseAccess(internal::DeferredParseAccess);
     /*

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -37,7 +37,7 @@
 #include <mpi.h>
 #endif
 
-#include <cstdint>
+#include <cstdint> // uint64_t
 #include <deque>
 #include <map>
 #include <optional>
@@ -76,7 +76,8 @@ namespace internal
         SeriesData &operator=(SeriesData const &) = delete;
         SeriesData &operator=(SeriesData &&) = delete;
 
-        Container<Iteration, uint64_t> iterations{};
+        using IterationIndex_t = Iteration::IterationIndex_t;
+        Container<Iteration, IterationIndex_t> iterations{};
 
         /**
          * For each instance of Series, there is only one instance
@@ -90,7 +91,7 @@ namespace internal
          * currently active output step. Use this later when writing the
          * snapshot attribute.
          */
-        std::set<uint64_t> m_currentlyActiveIterations;
+        std::set<IterationIndex_t> m_currentlyActiveIterations;
         /**
          * Needed if reading a single iteration of a file-based series.
          * Users may specify the concrete filename of one iteration instead of
@@ -210,7 +211,11 @@ public:
 
     virtual ~Series() = default;
 
-    Container<Iteration, uint64_t> iterations;
+    /**
+     * An unsigned integer type, used to identify Iterations in a Series.
+     */
+    using IterationIndex_t = Iteration::IterationIndex_t;
+    Container<Iteration, IterationIndex_t> iterations;
 
     /**
      * @brief Is this a usable Series object?
@@ -588,9 +593,10 @@ OPENPMD_private
      * If series.iterations contains the attribute `snapshot`, returns its
      * value.
      */
-    std::optional<std::deque<uint64_t> > readGorVBased(bool init = true);
+    std::optional<std::deque<IterationIndex_t> >
+    readGorVBased(bool init = true);
     void readBase();
-    std::string iterationFilename(uint64_t i);
+    std::string iterationFilename(IterationIndex_t i);
 
     enum class IterationOpened : bool
     {
@@ -603,14 +609,15 @@ OPENPMD_private
      * Only open if the iteration is dirty and if it is not in deferred
      * parse state.
      */
-    IterationOpened openIterationIfDirty(uint64_t index, Iteration iteration);
+    IterationOpened
+    openIterationIfDirty(IterationIndex_t index, Iteration iteration);
     /*
      * Open an iteration. Ensures that the iteration's m_closed status
      * is set properly and that any files pertaining to the iteration
      * is opened.
      * Does not create files when called in CREATE mode.
      */
-    void openIteration(uint64_t index, Iteration iteration);
+    void openIteration(IterationIndex_t index, Iteration iteration);
 
     /**
      * Find the given iteration in Series::iterations and return an iterator
@@ -653,7 +660,7 @@ OPENPMD_private
      * Returns the current content of the /data/snapshot attribute.
      * (We could also add this to the public API some time)
      */
-    std::optional<std::vector<uint64_t> > currentSnapshot() const;
+    std::optional<std::vector<IterationIndex_t> > currentSnapshot() const;
 }; // Series
 } // namespace openPMD
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -77,7 +77,8 @@ namespace internal
         SeriesData &operator=(SeriesData &&) = delete;
 
         using IterationIndex_t = Iteration::IterationIndex_t;
-        Container<Iteration, IterationIndex_t> iterations{};
+        using IterationsContainer_t = Container<Iteration, IterationIndex_t>;
+        IterationsContainer_t iterations{};
 
         /**
          * For each instance of Series, there is only one instance
@@ -215,7 +216,11 @@ public:
      * An unsigned integer type, used to identify Iterations in a Series.
      */
     using IterationIndex_t = Iteration::IterationIndex_t;
-    Container<Iteration, IterationIndex_t> iterations;
+    /**
+     * Type for a container of Iterations indexed by IterationIndex_t.
+     */
+    using IterationsContainer_t = internal::SeriesData::IterationsContainer_t;
+    IterationsContainer_t iterations;
 
     /**
      * @brief Is this a usable Series object?

--- a/include/openPMD/WriteIterations.hpp
+++ b/include/openPMD/WriteIterations.hpp
@@ -49,25 +49,26 @@ class WriteIterations
     friend class Series;
 
 private:
-    using iterations_t = Container<Iteration, uint64_t>;
+    using IterationsContainer_t =
+        Container<Iteration, Iteration::IterationIndex_t>;
 
 public:
-    using key_type = typename iterations_t::key_type;
-    using mapped_type = typename iterations_t::mapped_type;
-    using value_type = typename iterations_t::value_type;
-    using reference = typename iterations_t::reference;
+    using key_type = IterationsContainer_t::key_type;
+    using mapped_type = IterationsContainer_t::mapped_type;
+    using value_type = IterationsContainer_t::value_type;
+    using reference = IterationsContainer_t::reference;
 
 private:
     struct SharedResources
     {
-        iterations_t iterations;
-        std::optional<uint64_t> currentlyOpen;
+        IterationsContainer_t iterations;
+        std::optional<Iteration::IterationIndex_t> currentlyOpen;
 
-        SharedResources(iterations_t);
+        SharedResources(IterationsContainer_t);
         ~SharedResources();
     };
 
-    WriteIterations(iterations_t);
+    WriteIterations(IterationsContainer_t);
     explicit WriteIterations() = default;
     //! Index of the last opened iteration
     std::shared_ptr<SharedResources> shared;

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -105,7 +105,7 @@ public:
         std::string jsonConfig,
         std::string backend,
         Datatype dt,
-        typename decltype(Series::iterations)::key_type iterations,
+        Series::IterationIndex_t iterations,
         int threadSize);
 
     /**
@@ -123,7 +123,7 @@ public:
         std::string jsonConfig,
         std::string backend,
         Datatype dt,
-        typename decltype(Series::iterations)::key_type iterations);
+        Series::IterationIndex_t iterations);
 
     void resetConfigurations();
 
@@ -146,7 +146,7 @@ private:
         std::string,
         int,
         Datatype,
-        typename decltype(Series::iterations)::key_type>>
+        Series::IterationIndex_t>>
         m_configurations;
 
     enum Config
@@ -194,7 +194,7 @@ private:
             Extent &extent,
             std::string const &extension,
             std::shared_ptr<DatasetFiller<T>> datasetFiller,
-            typename decltype(Series::iterations)::key_type iterations);
+            Series::IterationIndex_t iterations);
 
         /**
          * Execute a single read benchmark.
@@ -210,7 +210,7 @@ private:
             Offset &offset,
             Extent &extent,
             std::string extension,
-            typename decltype(Series::iterations)::key_type iterations);
+            Series::IterationIndex_t iterations);
 
         template <typename T>
         static void call(
@@ -278,7 +278,7 @@ void MPIBenchmark<DatasetFillerProvider>::addConfiguration(
     std::string jsonConfig,
     std::string backend,
     Datatype dt,
-    typename decltype(Series::iterations)::key_type iterations,
+    Series::IterationIndex_t iterations,
     int threadSize)
 {
     this->m_configurations.emplace_back(
@@ -290,7 +290,7 @@ void MPIBenchmark<DatasetFillerProvider>::addConfiguration(
     std::string jsonConfig,
     std::string backend,
     Datatype dt,
-    typename decltype(Series::iterations)::key_type iterations)
+    Series::IterationIndex_t iterations)
 {
     int size;
     MPI_Comm_size(communicator, &size);
@@ -313,7 +313,7 @@ MPIBenchmark<DatasetFillerProvider>::BenchmarkExecution<Clock>::writeBenchmark(
     Extent &extent,
     std::string const &extension,
     std::shared_ptr<DatasetFiller<T>> datasetFiller,
-    typename decltype(Series::iterations)::key_type iterations)
+    Series::IterationIndex_t iterations)
 {
     MPI_Barrier(m_benchmark->communicator);
     auto start = Clock::now();
@@ -325,8 +325,7 @@ MPIBenchmark<DatasetFillerProvider>::BenchmarkExecution<Clock>::writeBenchmark(
         m_benchmark->communicator,
         jsonConfig);
 
-    for (typename decltype(Series::iterations)::key_type i = 0; i < iterations;
-         i++)
+    for (Series::IterationIndex_t i = 0; i < iterations; i++)
     {
         auto writeData = datasetFiller->produceData();
 
@@ -348,8 +347,7 @@ MPIBenchmark<DatasetFillerProvider>::BenchmarkExecution<Clock>::writeBenchmark(
     auto end = Clock::now();
 
     // deduct the time needed for data generation
-    for (typename decltype(Series::iterations)::key_type i = 0; i < iterations;
-         i++)
+    for (Series::IterationIndex_t i = 0; i < iterations; i++)
     {
         datasetFiller->produceData();
     }
@@ -366,7 +364,7 @@ MPIBenchmark<DatasetFillerProvider>::BenchmarkExecution<Clock>::readBenchmark(
     Offset &offset,
     Extent &extent,
     std::string extension,
-    typename decltype(Series::iterations)::key_type iterations)
+    Series::IterationIndex_t iterations)
 {
     MPI_Barrier(m_benchmark->communicator);
     // let every thread measure time
@@ -377,8 +375,7 @@ MPIBenchmark<DatasetFillerProvider>::BenchmarkExecution<Clock>::readBenchmark(
         Access::READ_ONLY,
         m_benchmark->communicator);
 
-    for (typename decltype(Series::iterations)::key_type i = 0; i < iterations;
-         i++)
+    for (Series::IterationIndex_t i = 0; i < iterations; i++)
     {
         MeshRecordComponent id =
             series.iterations[i].meshes["id"][MeshRecordComponent::SCALAR];
@@ -409,7 +406,7 @@ void MPIBenchmark<DatasetFillerProvider>::BenchmarkExecution<Clock>::call(
         std::string backend;
         int size;
         Datatype dt2;
-        typename decltype(Series::iterations)::key_type iterations;
+        Series::IterationIndex_t iterations;
         std::tie(jsonConfig, backend, size, dt2, iterations) = config;
 
         if (dt != dt2)

--- a/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
@@ -57,7 +57,7 @@ struct MPIBenchmarkReport
             std::string, // extension
             int, // thread size
             Datatype,
-            typename decltype(Series::iterations)::key_type>,
+            Series::IterationIndex_t>,
         std::pair<Duration, Duration> >
         durations;
 
@@ -89,7 +89,7 @@ struct MPIBenchmarkReport
         std::string extension,
         int threadSize,
         Datatype dt,
-        typename decltype(Series::iterations)::key_type iterations,
+        Series::IterationIndex_t iterations,
         std::pair<Duration, Duration> const &report);
 
     /** Retrieve the time measured for a certain compression strategy.
@@ -108,7 +108,7 @@ struct MPIBenchmarkReport
         std::string extension,
         int threadSize,
         Datatype dt,
-        typename decltype(Series::iterations)::key_type iterations);
+        Series::IterationIndex_t iterations);
 
 private:
     template <typename D, typename Dummy = D>
@@ -189,7 +189,7 @@ void MPIBenchmarkReport<Duration>::addReport(
     std::string extension,
     int threadSize,
     Datatype dt,
-    typename decltype(Series::iterations)::key_type iterations,
+    Series::IterationIndex_t iterations,
     std::pair<Duration, Duration> const &report)
 {
     using rep = typename Duration::rep;
@@ -257,7 +257,7 @@ std::pair<Duration, Duration> MPIBenchmarkReport<Duration>::getReport(
     std::string extension,
     int threadSize,
     Datatype dt,
-    typename decltype(Series::iterations)::key_type iterations)
+    Series::IterationIndex_t iterations)
 {
     auto it = this->durations.find(std::make_tuple(
         rank, jsonConfig, extension, threadSize, dt, iterations));

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -79,7 +79,7 @@ Iteration &Iteration::setTimeUnitSI(double newTimeUnitSI)
     return *this;
 }
 
-using iterator_t = Container<Iteration, uint64_t>::iterator;
+using iterator_t = Container<Iteration, Iteration::IterationIndex_t>::iterator;
 
 Iteration &Iteration::close(bool _flush)
 {
@@ -194,7 +194,7 @@ bool Iteration::closedByWriter() const
 
 void Iteration::flushFileBased(
     std::string const &filename,
-    uint64_t i,
+    IterationIndex_t i,
     internal::FlushParams const &flushParams)
 {
     /* Find the root point [Series] of this file,
@@ -251,7 +251,7 @@ void Iteration::flushFileBased(
 }
 
 void Iteration::flushGroupBased(
-    uint64_t i, internal::FlushParams const &flushParams)
+    IterationIndex_t i, internal::FlushParams const &flushParams)
 {
     if (!written())
     {
@@ -274,7 +274,7 @@ void Iteration::flushGroupBased(
 }
 
 void Iteration::flushVariableBased(
-    uint64_t i, internal::FlushParams const &flushParams)
+    IterationIndex_t i, internal::FlushParams const &flushParams)
 {
     if (!written())
     {

--- a/src/WriteIterations.cpp
+++ b/src/WriteIterations.cpp
@@ -25,7 +25,8 @@
 
 namespace openPMD
 {
-WriteIterations::SharedResources::SharedResources(iterations_t _iterations)
+WriteIterations::SharedResources::SharedResources(
+    IterationsContainer_t _iterations)
     : iterations(std::move(_iterations))
 {}
 
@@ -43,7 +44,7 @@ WriteIterations::SharedResources::~SharedResources()
     }
 }
 
-WriteIterations::WriteIterations(iterations_t iterations)
+WriteIterations::WriteIterations(IterationsContainer_t iterations)
     : shared{std::make_shared<SharedResources>(std::move(iterations))}
 {}
 

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -33,6 +33,7 @@
 #include "openPMD/ParticlePatches.hpp"
 #include "openPMD/ParticleSpecies.hpp"
 #include "openPMD/Record.hpp"
+#include "openPMD/Series.hpp"
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/backend/Container.hpp"
@@ -135,7 +136,7 @@ bind_container(py::handle scope, std::string const &name, Args &&...args)
 }
 } // namespace detail
 
-using PyIterationContainer = Container<Iteration, uint64_t>;
+using PyIterationContainer = Series::IterationsContainer_t;
 using PyMeshContainer = Container<Mesh>;
 using PyPartContainer = Container<ParticleSpecies>;
 using PyPatchContainer = Container<ParticlePatches>;

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -54,12 +54,10 @@ using openPMD_PyMPIIntracommObject = openPMD_PyMPICommObject;
 
 void init_Series(py::module &m)
 {
-
-    using iterations_key_t = decltype(Series::iterations)::key_type;
     py::class_<WriteIterations>(m, "WriteIterations")
         .def(
             "__getitem__",
-            [](WriteIterations writeIterations, iterations_key_t key) {
+            [](WriteIterations writeIterations, Series::IterationIndex_t key) {
                 return writeIterations[key];
             },
             // keep container alive while iterator exists


### PR DESCRIPTION
We're currently hardcoding `Container<Iteration, uint64_t> iterations` in the `Series` class. Replace with a type alias.
Not really necessary in Python I think, because you just use an integer there without caring for the concrete type?

Todo:
- [x] Maybe also replace `Container<Iteration,IterationIndex_t>` with `Iterations_t` or sth
- [x] Search for instances of `decltype(Series::iterations)::key_type`