### PR TITLE
Wheels: 0.14.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'src'
-        ref: '0.14.4'
+        ref: '0.14.5'
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,18 +92,18 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install cibuildwheel==2.2.2
 
-#    - name: Download Patch 1/1
-#      uses: suisei-cn/actions-download-file@v1
-#      id: setupversion
-#      with:
-#        url: "https://gist.githubusercontent.com/ax3l/4db2f1744e0e28e6c013ee4e752b3cb7/raw/324bdb60894d51608a48890573654e10e1b1c3a0/setupversion.patch"
-#        target: src/.patch/
+    - name: Download Patch 1/1
+      uses: suisei-cn/actions-download-file@v1
+      id: setupversion
+      with:
+        url: "https://github.com/ax3l/openPMD-api/commit/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch"
+        target: src/.patch/
 
-#    - name: Apply Patch
-#      run: |
-#        python -m pip install "patch==1.*"
-#        cd src
-#        python -m patch .patch/setupversion.patch
+    - name: Apply Patch
+      run: |
+        python -m pip install "patch==1.*"
+        cd src
+        python -m patch .patch/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
 
     - name: Build wheel
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.14.4"
+    - OPENPMD_GIT_REF="0.14.5"
 
     - CIBW_PROJECT_REQUIRES_PYTHON=">=3.6"
     # Install dependencies on Linux and OSX

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,13 +134,13 @@ install:
   - python3 -m pip install "patch==1.*"
 
 # Download & Apply Patches
-#before_script:
-#  - mkdir -p src/.patch
-#  - cd src/.patch
-#  - curl -sOL https://gist.githubusercontent.com/ax3l/4db2f1744e0e28e6c013ee4e752b3cb7/raw/324bdb60894d51608a48890573654e10e1b1c3a0/setupversion.patch
-#  - cd ..
-#  - python3 -m patch .patch/setupversion.patch
-#  - cd ..
+before_script:
+  - mkdir -p src/.patch
+  - cd src/.patch
+  - curl -sOL https://github.com/ax3l/openPMD-api/commit/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
+  - cd ..
+  - python3 -m patch .patch/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
+  - cd ..
 
 script:
   - cd src


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.14.5 release.

Includes:
- fixed macOS aarch64/arm64 (Apple Silicon/M1) wheels #1233
  (old releases were broken and are removed now)
- win32 wheels (also published for 0.14.4 already)
- post-release patch #1288 to fix macOS `x86_64` builds #1287

Fix #1232