### PR TITLE
New Access type READ_LINEAR

### DIFF
--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -23,7 +23,7 @@ Therefore, enabling users to handle hierarchical, self-describing file formats w
 
 .. literalinclude:: IOTask.hpp
    :language: cpp
-   :lines: 44-62
+   :lines: 48-78
 
 Every task is designed to be a fully self-contained description of one such atomic operation. By describing a required minimal step of work (without any side-effect), these operations are the foundation of the unified handling mechanism across suitable file formats.
 The actual low-level exchange of data is implemented in ``IOHandlers``, one per file format (possibly two if handlingi MPI-parallel work is possible and requires different behaviour).

--- a/docs/source/usage/streaming.rst
+++ b/docs/source/usage/streaming.rst
@@ -22,6 +22,7 @@ C++
 ^^^
 
 The reading end of the streaming API is activated through use of ``Series::readIterations()`` instead of accessing the field ``Series::iterations`` directly.
+Use of ``Access::READ_LINEAR`` mode is recommended.
 The returned object of type ``ReadIterations`` can be used in a C++11 range-based for loop to iterate over objects of type ``IndexedIteration``.
 This class extends the ``Iteration`` class with a field ``IndexedIteration::iterationIndex``, denoting this iteration's index.
 
@@ -40,6 +41,7 @@ Python
 ^^^^^^
 
 The reading end of the streaming API is activated through use of ``Series.read_iterations()`` instead of accessing the field ``Series.iterations`` directly.
+Use of ``Access.read_linear`` mode is recommended.
 The returned object of type ``ReadIterations`` can be used in a Python range-based for loop to iterate over objects of type ``IndexedIteration``.
 This class extends the ``Iteration`` class with a field ``IndexedIteration.iteration_index``, denoting this iteration's index.
 

--- a/examples/10_streaming_read.cpp
+++ b/examples/10_streaming_read.cpp
@@ -19,7 +19,7 @@ int main()
         return 0;
     }
 
-    Series series = Series("electrons.sst", Access::READ_ONLY);
+    Series series = Series("electrons.sst", Access::READ_LINEAR);
 
     for (IndexedIteration iteration : series.readIterations())
     {

--- a/examples/10_streaming_read.py
+++ b/examples/10_streaming_read.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         print("SST engine not available in ADIOS2.")
         sys.exit(0)
 
-    series = io.Series("simData.sst", io.Access_Type.read_only,
+    series = io.Series("simData.sst", io.Access_Type.read_linear,
                        json.dumps(config))
 
     # Read all available iterations and print electron position data.

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -1285,6 +1285,11 @@ namespace detail
         std::optional<AttributeMap_t> m_availableVariables;
 
         /*
+         * Cannot write attributes right after opening the engine
+         * https://github.com/ornladios/ADIOS2/issues/3433
+         */
+        bool initializedDefaults = false;
+        /*
          * finalize() will set this true to avoid running twice.
          */
         bool finalized = false;

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -213,6 +213,10 @@ public:
 
     void availableChunks(
         Writable *, Parameter<Operation::AVAILABLE_CHUNKS> &) override;
+
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
+
     /**
      * @brief The ADIOS2 access type to chose for Engines opened
      * within this instance.

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -164,7 +164,7 @@ public:
     void extendDataset(
         Writable *, Parameter<Operation::EXTEND_DATASET> const &) override;
 
-    void openFile(Writable *, Parameter<Operation::OPEN_FILE> const &) override;
+    void openFile(Writable *, Parameter<Operation::OPEN_FILE> &) override;
 
     void
     closeFile(Writable *, Parameter<Operation::CLOSE_FILE> const &) override;

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -248,7 +248,10 @@ private:
      */
     std::string m_userSpecifiedExtension;
 
-    ADIOS2Schema::schema_t m_schema = ADIOS2Schema::schema_0000_00_00;
+    /*
+     * Empty option: No schema has been explicitly selected, use default.
+     */
+    std::optional<ADIOS2Schema::schema_t> m_schema;
 
     enum class UseSpan : char
     {
@@ -267,7 +270,11 @@ private:
 
     inline SupportedSchema schema() const
     {
-        switch (m_schema)
+        if (!m_schema.has_value())
+        {
+            return SupportedSchema::s_0000_00_00;
+        }
+        switch (m_schema.value())
         {
         case ADIOS2Schema::schema_0000_00_00:
             return SupportedSchema::s_0000_00_00;
@@ -276,7 +283,7 @@ private:
         default:
             throw std::runtime_error(
                 "[ADIOS2] Encountered unsupported schema version: " +
-                std::to_string(m_schema));
+                std::to_string(m_schema.value()));
         }
     }
 
@@ -331,11 +338,11 @@ private:
      * @return first parameter: the operators, second parameters: whether
      * operators have been configured
      */
-    std::optional<std::vector<ParameterizedOperator> >
+    std::optional<std::vector<ParameterizedOperator>>
     getOperators(json::TracingJSON config);
 
     // use m_config
-    std::optional<std::vector<ParameterizedOperator> > getOperators();
+    std::optional<std::vector<ParameterizedOperator>> getOperators();
 
     std::string fileSuffix(bool verbose = true) const;
 
@@ -361,7 +368,7 @@ private:
      */
     std::unordered_map<
         InvalidatableFile,
-        std::unique_ptr<detail::BufferedActions> >
+        std::unique_ptr<detail::BufferedActions>>
         m_fileData;
 
     std::map<std::string, adios2::Operator> m_operators;
@@ -455,8 +462,8 @@ namespace detail
 
     template <typename T>
     inline constexpr bool IsUnsupportedComplex_v =
-        std::is_same_v<T, std::complex<long double> > ||
-        std::is_same_v<T, std::vector<std::complex<long double> > >;
+        std::is_same_v<T, std::complex<long double>> ||
+        std::is_same_v<T, std::vector<std::complex<long double>>>;
 
     struct DatasetReader
     {
@@ -581,7 +588,8 @@ namespace detail
             Parameter<Operation::AVAILABLE_CHUNKS> &params,
             adios2::IO &IO,
             adios2::Engine &engine,
-            std::string const &varName);
+            std::string const &varName,
+            bool allSteps);
 
         template <int n, typename... Params>
         static void call(Params &&...);
@@ -630,7 +638,7 @@ namespace detail
     };
 
     template <>
-    struct AttributeTypes<std::complex<long double> >
+    struct AttributeTypes<std::complex<long double>>
     {
         static void createAttribute(
             adios2::IO &,
@@ -663,13 +671,13 @@ namespace detail
     };
 
     template <>
-    struct AttributeTypes<std::vector<std::complex<long double> > >
+    struct AttributeTypes<std::vector<std::complex<long double>>>
     {
         static void createAttribute(
             adios2::IO &,
             adios2::Engine &,
             detail::BufferedAttributeWrite &,
-            const std::vector<std::complex<long double> > &)
+            const std::vector<std::complex<long double>> &)
         {
             throw std::runtime_error(
                 "[ADIOS2] Internal error: no support for long double complex "
@@ -687,7 +695,7 @@ namespace detail
         }
 
         static bool attributeUnchanged(
-            adios2::IO &, std::string, std::vector<std::complex<long double> >)
+            adios2::IO &, std::string, std::vector<std::complex<long double>>)
         {
             throw std::runtime_error(
                 "[ADIOS2] Internal error: no support for long double complex "
@@ -696,7 +704,7 @@ namespace detail
     };
 
     template <typename T>
-    struct AttributeTypes<std::vector<T> >
+    struct AttributeTypes<std::vector<T>>
     {
         static void createAttribute(
             adios2::IO &IO,
@@ -734,7 +742,7 @@ namespace detail
     };
 
     template <>
-    struct AttributeTypes<std::vector<std::string> >
+    struct AttributeTypes<std::vector<std::string>>
     {
         static void createAttribute(
             adios2::IO &IO,
@@ -772,7 +780,7 @@ namespace detail
     };
 
     template <typename T, size_t n>
-    struct AttributeTypes<std::array<T, n> >
+    struct AttributeTypes<std::array<T, n>>
     {
         static void createAttribute(
             adios2::IO &IO,
@@ -986,14 +994,14 @@ namespace detail
          * Hence, next to the actual file name, also store the name for the
          * IO.
          */
-        std::string const m_IOName;
+        std::string m_IOName;
         adios2::ADIOS &m_ADIOS;
         adios2::IO m_IO;
         /**
          * The default queue for deferred actions.
          * Drained upon BufferedActions::flush().
          */
-        std::vector<std::unique_ptr<BufferedAction> > m_buffer;
+        std::vector<std::unique_ptr<BufferedAction>> m_buffer;
         /**
          * Buffer for attributes to be written in the new (variable-based)
          * attribute layout.
@@ -1017,7 +1025,7 @@ namespace detail
          * We must store them somewhere until the next PerformPuts/Gets, EndStep
          * or Close in ADIOS2 to avoid use after free conditions.
          */
-        std::vector<std::unique_ptr<BufferedAction> > m_alreadyEnqueued;
+        std::vector<std::unique_ptr<BufferedAction>> m_alreadyEnqueued;
         adios2::Mode m_mode;
         /**
          * The base pointer of an ADIOS2 span might change after reallocations.
@@ -1027,7 +1035,7 @@ namespace detail
          * retrieval of the updated base pointer.
          * This map is cleared upon flush points.
          */
-        std::map<unsigned, std::unique_ptr<I_UpdateSpan> > m_updateSpans;
+        std::map<unsigned, std::unique_ptr<I_UpdateSpan>> m_updateSpans;
         PreloadAdiosAttributes preloadAttributes;
 
         /*
@@ -1048,6 +1056,10 @@ namespace detail
          * on chosen ADIOS2 engine and can not be explicitly overridden by user.
          */
         bool optimizeAttributesStreaming = false;
+
+        using ParsePreference =
+            Parameter<Operation::OPEN_FILE>::ParsePreference;
+        ParsePreference parsePreference = ParsePreference::UpFront;
 
         using AttributeMap_t = std::map<std::string, adios2::Params>;
 
@@ -1257,13 +1269,6 @@ namespace detail
          */
         std::string m_engineType;
 
-        /**
-         * See documentation for StreamStatus::Parsing.
-         * Will be set true under the circumstance described there in order to
-         * indicate that the first step should only be opened after parsing.
-         */
-        bool delayOpeningTheFirstStep = false;
-
         /*
          * ADIOS2 does not give direct access to its internal attribute and
          * variable maps, but will instead give access to copies of them.
@@ -1289,7 +1294,11 @@ namespace detail
             return m_impl->schema();
         }
 
+        void create_IO();
+
         void configure_IO(ADIOS2IOHandlerImpl &impl);
+        void configure_IO_Read(std::optional<bool> userSpecifiedUsesteps);
+        void configure_IO_Write(std::optional<bool> userSpecifiedUsesteps);
 
         using AttributeLayout = ADIOS2IOHandlerImpl::AttributeLayout;
         inline AttributeLayout attributeLayout() const

--- a/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
@@ -84,6 +84,8 @@ public:
     void
     listDatasets(Writable *, Parameter<Operation::LIST_DATASETS> &) override;
     void listAttributes(Writable *, Parameter<Operation::LIST_ATTS> &) override;
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
 
     void close(int64_t);
     void close(ADIOS_FILE *);

--- a/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
@@ -59,7 +59,7 @@ public:
         Writable *, Parameter<Operation::CREATE_DATASET> const &) override;
     void extendDataset(
         Writable *, Parameter<Operation::EXTEND_DATASET> const &) override;
-    void openFile(Writable *, Parameter<Operation::OPEN_FILE> const &) override;
+    void openFile(Writable *, Parameter<Operation::OPEN_FILE> &) override;
     void
     closeFile(Writable *, Parameter<Operation::CLOSE_FILE> const &) override;
     void availableChunks(

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -202,6 +202,12 @@ public:
                         deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS> >(
                             i.parameter.get()));
                     break;
+                case O::DEREGISTER:
+                    deregister(
+                        i.writable,
+                        deref_dynamic_cast<Parameter<O::DEREGISTER> >(
+                            i.parameter.get()));
+                    break;
                 }
             }
             catch (...)
@@ -565,6 +571,16 @@ public:
      */
     void
     keepSynchronous(Writable *, Parameter<Operation::KEEP_SYNCHRONOUS> param);
+
+    /** Notify the backend that the Writable has been / will be deallocated.
+     *
+     * The backend should remove all references to this Writable from internal
+     * data structures. Subtle bugs might be possible if not doing this, since
+     * new objects might be allocated to the now-freed address.
+     * The Writable pointer must not be dereferenced.
+     */
+    virtual void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &param) = 0;
 
     AbstractIOHandler *m_handler;
 }; // AbstractIOHandlerImpl

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -354,8 +354,7 @@ public:
      * root group "/" of the hierarchy in the opened file. The Writable should
      * be marked written when the operation completes successfully.
      */
-    virtual void
-    openFile(Writable *, Parameter<Operation::OPEN_FILE> const &) = 0;
+    virtual void openFile(Writable *, Parameter<Operation::OPEN_FILE> &) = 0;
     /** Open all contained groups in a path, possibly recursively.
      *
      * The operation should overwrite existing file positions, even when the

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -27,10 +27,53 @@ namespace openPMD
 enum class Access
 {
     READ_ONLY, //!< open series as read-only, fails if series is not found
+    READ_RANDOM_ACCESS = READ_ONLY,
+    READ_LINEAR,
     READ_WRITE, //!< open existing series as writable
     CREATE, //!< create new series and truncate existing (files)
     APPEND //!< write new iterations to an existing series without reading
 }; // Access
+
+namespace access
+{
+    inline bool readOnly(Access access)
+    {
+        switch (access)
+        {
+        case Access::READ_LINEAR:
+        case Access::READ_ONLY:
+            return true;
+        case Access::READ_WRITE:
+        case Access::CREATE:
+        case Access::APPEND:
+            return false;
+        }
+    }
+
+    inline bool write(Access access)
+    {
+        return !readOnly(access);
+    }
+
+    inline bool writeOnly(Access access)
+    {
+        switch (access)
+        {
+        case Access::READ_LINEAR:
+        case Access::READ_ONLY:
+        case Access::READ_WRITE:
+            return false;
+        case Access::CREATE:
+        case Access::APPEND:
+            return true;
+        }
+    }
+
+    inline bool read(Access access)
+    {
+        return !writeOnly(access);
+    }
+} // namespace access
 
 // deprecated name (used prior to 0.12.0)
 // note: "using old [[deprecated(msg)]] = new;" is still badly supported, thus

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -20,6 +20,8 @@
  */
 #pragma once
 
+#include <stdexcept>
+
 namespace openPMD
 {
 /** File access mode to use during IO.
@@ -48,6 +50,7 @@ namespace access
         case Access::APPEND:
             return false;
         }
+        throw std::runtime_error("Unreachable!");
     }
 
     inline bool write(Access access)
@@ -67,6 +70,7 @@ namespace access
         case Access::APPEND:
             return true;
         }
+        throw std::runtime_error("Unreachable!");
     }
 
     inline bool read(Access access)

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -66,7 +66,10 @@ enum class Access
     READ_RANDOM_ACCESS = READ_ONLY, //!< more explicit alias for READ_ONLY
     /*
      * Open Series as read-only, fails if Series is not found.
-     * This access mode requires use of Series::readIterations()
+     * This access mode requires use of Series::readIterations().
+     * Global attributes are available directly after calling
+     * Series::readIterations(), Iterations and all their corresponding data
+     * become available by use of the returned Iterator, e.g. in a foreach loop.
      * See Access::READ_ONLY for when to use this.
      */
     READ_LINEAR,

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -28,10 +28,53 @@ namespace openPMD
  */
 enum class Access
 {
-    READ_ONLY, //!< open series as read-only, fails if series is not found
-    READ_RANDOM_ACCESS = READ_ONLY,
+    /**
+     * Open Series as read-only, fails if Series is not found.
+     * When to use READ_ONLY or READ_LINEAR:
+     *
+     * * When intending to use Series::readIterations()
+     *   (i.e. step-by-step reading of iterations, e.g. in streaming),
+     *   then Access::READ_LINEAR is preferred and always supported.
+     *   Data is parsed inside Series::readIterations(), no data is available
+     *   right after opening the Series.
+     * * Otherwise (i.e. for random-access workflows), Access::READ_ONLY
+     *   is required, but works only in backends that support random access.
+     *   Data is parsed and available right after opening the Series.
+     *
+     * In both modes, parsing of iterations can be deferred with the JSON/TOML
+     * option `defer_iteration_parsing`.
+     *
+     * Detailed rules:
+     *
+     * 1. In backends that have no notion of IO steps (all except ADIOS2),
+     *    Access::READ_ONLY can always be used.
+     * 2. In backends that can be accessed either in random-access or
+     *    step-by-step, the chosen access mode decides which approach is used.
+     *    Examples are the BP4 and BP5 engines of ADIOS2.
+     * 3. In streaming backends, random-access is not possible.
+     *    When using such a backend, the access mode will be coerced
+     *    automatically to Access::READ_LINEAR. Use of Series::readIterations()
+     *    is mandatory for access.
+     * 4. Reading a variable-based Series is only fully supported with
+     *    Access::READ_LINEAR.
+     *    If using Access::READ_ONLY, the dataset will be considered to only
+     *    have one single step.
+     *    If the dataset only has one single step, this is guaranteed to work
+     *    as expected. Otherwise, it is undefined which step's data is returned.
+     */
+    READ_ONLY,
+    READ_RANDOM_ACCESS = READ_ONLY, //!< more explicit alias for READ_ONLY
+    /*
+     * Open Series as read-only, fails if Series is not found.
+     * This access mode requires use of Series::readIterations()
+     * See Access::READ_ONLY for when to use this.
+     */
     READ_LINEAR,
-    READ_WRITE, //!< open existing series as writable
+    /**
+     * Open existing Series as writable.
+     * Read mode corresponds with Access::READ_RANDOM_ACCESS.
+     */
+    READ_WRITE,
     CREATE, //!< create new series and truncate existing (files)
     APPEND //!< write new iterations to an existing series without reading
 }; // Access

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -75,6 +75,8 @@ public:
     void
     listDatasets(Writable *, Parameter<Operation::LIST_DATASETS> &) override;
     void listAttributes(Writable *, Parameter<Operation::LIST_ATTS> &) override;
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
 
     std::unordered_map<Writable *, std::string> m_fileNames;
     std::unordered_map<std::string, hid_t> m_fileNamesWithID;

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -52,7 +52,7 @@ public:
         Writable *, Parameter<Operation::EXTEND_DATASET> const &) override;
     void availableChunks(
         Writable *, Parameter<Operation::AVAILABLE_CHUNKS> &) override;
-    void openFile(Writable *, Parameter<Operation::OPEN_FILE> const &) override;
+    void openFile(Writable *, Parameter<Operation::OPEN_FILE> &) override;
     void
     closeFile(Writable *, Parameter<Operation::CLOSE_FILE> const &) override;
     void openPath(Writable *, Parameter<Operation::OPEN_PATH> const &) override;

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -27,6 +27,7 @@
 #include "openPMD/auxiliary/Export.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attribute.hpp"
+#include "openPMD/backend/ParsePreference.hpp"
 
 #include <map>
 #include <memory>
@@ -170,11 +171,7 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_FILE>
      * variableBased encoding.
      */
     IterationEncoding encoding = IterationEncoding::groupBased;
-    enum class ParsePreference : char
-    {
-        UpFront, //<! Data should be parsed right when opening the dataset
-        PerStep //<! Data should be parsed step by step
-    };
+    using ParsePreference = internal::ParsePreference;
     std::shared_ptr<ParsePreference> out_parsePreference =
         std::make_shared<ParsePreference>(ParsePreference::UpFront);
 };

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -45,21 +45,37 @@ Writable *getWritable(Attributable *);
 /** Type of IO operation between logical and persistent data.
  */
 OPENPMDAPI_EXPORT_ENUM_CLASS(Operation){
-    CREATE_FILE,      CHECK_FILE,     OPEN_FILE,     CLOSE_FILE,
+    CREATE_FILE,
+    CHECK_FILE,
+    OPEN_FILE,
+    CLOSE_FILE,
     DELETE_FILE,
 
-    CREATE_PATH,      CLOSE_PATH,     OPEN_PATH,     DELETE_PATH,
+    CREATE_PATH,
+    CLOSE_PATH,
+    OPEN_PATH,
+    DELETE_PATH,
     LIST_PATHS,
 
-    CREATE_DATASET,   EXTEND_DATASET, OPEN_DATASET,  DELETE_DATASET,
-    WRITE_DATASET,    READ_DATASET,   LIST_DATASETS, GET_BUFFER_VIEW,
+    CREATE_DATASET,
+    EXTEND_DATASET,
+    OPEN_DATASET,
+    DELETE_DATASET,
+    WRITE_DATASET,
+    READ_DATASET,
+    LIST_DATASETS,
+    GET_BUFFER_VIEW,
 
-    DELETE_ATT,       WRITE_ATT,      READ_ATT,      LIST_ATTS,
+    DELETE_ATT,
+    WRITE_ATT,
+    READ_ATT,
+    LIST_ATTS,
 
     ADVANCE,
     AVAILABLE_CHUNKS, //!< Query chunks that can be loaded in a dataset
-    KEEP_SYNCHRONOUS //!< Keep two items in the object model synchronous with
-                     //!< each other
+    KEEP_SYNCHRONOUS, //!< Keep two items in the object model synchronous with
+                      //!< each other
+    DEREGISTER //!< Inform the backend that an object has been deleted.
 }; // note: if you change the enum members here, please update
    // docs/source/dev/design.rst
 
@@ -678,6 +694,20 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::KEEP_SYNCHRONOUS>
     }
 
     Writable *otherWritable;
+};
+
+template <>
+struct OPENPMDAPI_EXPORT Parameter<Operation::DEREGISTER>
+    : public AbstractParameter
+{
+    Parameter() = default;
+    Parameter(Parameter const &) : AbstractParameter()
+    {}
+
+    std::unique_ptr<AbstractParameter> clone() const override
+    {
+        return std::make_unique<Parameter<Operation::DEREGISTER>>(*this);
+    }
 };
 
 /** @brief Self-contained description of a single IO operation.

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -172,8 +172,8 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_FILE>
     IterationEncoding encoding = IterationEncoding::groupBased;
     enum class ParsePreference : char
     {
-        UpFront,
-        PerStep
+        UpFront, //<! Data should be parsed right when opening the dataset
+        PerStep //<! Data should be parsed step by step
     };
     std::shared_ptr<ParsePreference> out_parsePreference =
         std::make_shared<ParsePreference>(ParsePreference::UpFront);

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -151,7 +151,10 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_FILE>
 {
     Parameter() = default;
     Parameter(Parameter const &p)
-        : AbstractParameter(), name(p.name), encoding(p.encoding)
+        : AbstractParameter()
+        , name(p.name)
+        , encoding(p.encoding)
+        , out_parsePreference(p.out_parsePreference)
     {}
 
     std::unique_ptr<AbstractParameter> clone() const override
@@ -167,6 +170,13 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_FILE>
      * variableBased encoding.
      */
     IterationEncoding encoding = IterationEncoding::groupBased;
+    enum class ParsePreference : char
+    {
+        UpFront,
+        PerStep
+    };
+    std::shared_ptr<ParsePreference> out_parsePreference =
+        std::make_shared<ParsePreference>(ParsePreference::UpFront);
 };
 
 template <>

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -212,6 +212,9 @@ public:
 
     void listAttributes(Writable *, Parameter<Operation::LIST_ATTS> &) override;
 
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
+
     std::future<void> flush();
 
 private:

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -174,7 +174,7 @@ public:
     void availableChunks(
         Writable *, Parameter<Operation::AVAILABLE_CHUNKS> &) override;
 
-    void openFile(Writable *, Parameter<Operation::OPEN_FILE> const &) override;
+    void openFile(Writable *, Parameter<Operation::OPEN_FILE> &) override;
 
     void
     closeFile(Writable *, Parameter<Operation::CLOSE_FILE> const &) override;

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <deque>
 #include <optional>
+#include <set>
 #include <tuple>
 
 namespace openPMD
@@ -338,8 +339,11 @@ private:
      * Useful in group-based iteration encoding where the Iteration will only
      * be known after opening the step.
      */
-    static BeginStepStatus
-    beginStep(std::optional<Iteration> thisObject, Series &series, bool reread);
+    static BeginStepStatus beginStep(
+        std::optional<Iteration> thisObject,
+        Series &series,
+        bool reread,
+        std::set<IterationIndex_t> const &ignoreIterations = {});
 
     /**
      * @brief End an IO step on the IO file (or file-like object)

--- a/include/openPMD/ReadIterations.hpp
+++ b/include/openPMD/ReadIterations.hpp
@@ -119,6 +119,8 @@ private:
     std::optional<SeriesIterator *> loopBody();
 
     void deactivateDeadIteration(iteration_index_t);
+
+    void initSeriesInLinearReadMode();
 };
 
 /**

--- a/include/openPMD/ReadIterations.hpp
+++ b/include/openPMD/ReadIterations.hpp
@@ -161,8 +161,9 @@ private:
     using iterator_t = SeriesIterator;
 
     Series m_series;
+    std::optional<SeriesIterator> alreadyOpened;
 
-    ReadIterations(Series);
+    ReadIterations(Series, Access);
 
 public:
     iterator_t begin();

--- a/include/openPMD/ReadIterations.hpp
+++ b/include/openPMD/ReadIterations.hpp
@@ -55,9 +55,20 @@ class SeriesIterator
 
     using maybe_series_t = std::optional<Series>;
 
-    maybe_series_t m_series;
-    std::deque<iteration_index_t> m_iterationsInCurrentStep;
-    uint64_t m_currentIteration{};
+    struct SharedData
+    {
+        SharedData() = default;
+        SharedData(SharedData const &) = delete;
+        SharedData(SharedData &&) = delete;
+        SharedData &operator=(SharedData const &) = delete;
+        SharedData &operator=(SharedData &&) = delete;
+
+        maybe_series_t series;
+        std::deque<iteration_index_t> iterationsInCurrentStep;
+        uint64_t currentIteration{};
+    };
+
+    std::shared_ptr<SharedData> m_data;
 
 public:
     //! construct the end() iterator
@@ -78,7 +89,8 @@ public:
 private:
     inline bool setCurrentIteration()
     {
-        if (m_iterationsInCurrentStep.empty())
+        auto &data = *m_data;
+        if (data.iterationsInCurrentStep.empty())
         {
             std::cerr << "[ReadIterations] Encountered a step without "
                          "iterations. Closing the Series."
@@ -86,19 +98,20 @@ private:
             *this = end();
             return false;
         }
-        m_currentIteration = *m_iterationsInCurrentStep.begin();
+        data.currentIteration = *data.iterationsInCurrentStep.begin();
         return true;
     }
 
     inline std::optional<uint64_t> peekCurrentIteration()
     {
-        if (m_iterationsInCurrentStep.empty())
+        auto &data = *m_data;
+        if (data.iterationsInCurrentStep.empty())
         {
             return std::nullopt;
         }
         else
         {
-            return {*m_iterationsInCurrentStep.begin()};
+            return {*data.iterationsInCurrentStep.begin()};
         }
     }
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -30,6 +30,7 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/ParsePreference.hpp"
 #include "openPMD/config.hpp"
 #include "openPMD/version.hpp"
 
@@ -158,6 +159,14 @@ namespace internal
          * The destructor will only attempt flushing again if this is true.
          */
         bool m_lastFlushSuccessful = false;
+
+        /**
+         * Remember the preference that the backend specified for parsing.
+         * Not used in file-based iteration encoding, empty then.
+         * In linear read mode, parsing only starts after calling
+         * Series::readIterations(), empty before that point.
+         */
+        std::optional<ParsePreference> m_parsePreference;
 
         void close();
     }; // SeriesData
@@ -618,8 +627,10 @@ OPENPMD_private
      * ReadIterations since those methods should be aware when the current step
      * is broken).
      */
-    std::optional<std::deque<IterationIndex_t> >
-    readGorVBased(bool do_always_throw_errors, bool init);
+    std::optional<std::deque<IterationIndex_t> > readGorVBased(
+        bool do_always_throw_errors,
+        bool init,
+        std::set<IterationIndex_t> const &ignoreIterations = {});
     void readBase();
     std::string iterationFilename(IterationIndex_t i);
 

--- a/include/openPMD/backend/ParsePreference.hpp
+++ b/include/openPMD/backend/ParsePreference.hpp
@@ -1,0 +1,31 @@
+/* Copyright 2023 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace openPMD::internal
+{
+enum class ParsePreference : char
+{
+    UpFront, //<! Data should be parsed right when opening the dataset
+    PerStep //<! Data should be parsed step by step
+};
+} // namespace openPMD::internal

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -97,7 +97,7 @@ private:
     Writable(internal::AttributableData *);
 
 public:
-    ~Writable() = default;
+    ~Writable();
 
     Writable(Writable const &other) = delete;
     Writable(Writable &&other) = delete;

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -64,7 +64,7 @@ ADIOS1IOHandlerImpl::~ADIOS1IOHandlerImpl()
         close(f.second);
     m_openReadFileHandles.clear();
 
-    if (this->m_handler->m_backendAccess != Access::READ_ONLY)
+    if (access::write(m_handler->m_backendAccess))
     {
         for (auto &group : m_attributeWrites)
             for (auto &att : group.second)

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -102,49 +102,55 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             case O::CREATE_FILE:
                 createFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CHECK_FILE:
                 checkFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_PATH:
                 createPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_PATH:
                 openPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_PATH> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_PATH>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_DATASET:
                 createDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_ATT:
                 writeAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_FILE:
                 openFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_FILE> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_FILE>>(
                         i.parameter.get()));
                 break;
             case O::KEEP_SYNCHRONOUS:
                 keepSynchronous(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS> >(
+                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS>>(
+                        i.parameter.get()));
+                break;
+            case O::DEREGISTER:
+                deregister(
+                    i.writable,
+                    deref_dynamic_cast<Parameter<O::DEREGISTER>>(
                         i.parameter.get()));
                 break;
             default:
@@ -183,19 +189,19 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             case O::EXTEND_DATASET:
                 extendDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_PATH:
                 closePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CLOSE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CLOSE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_DATASET:
                 openDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_FILE:
@@ -207,79 +213,79 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             case O::DELETE_FILE:
                 deleteFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_FILE> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_PATH:
                 deletePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_DATASET:
                 deleteDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_ATT:
                 deleteAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_DATASET:
                 writeDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::READ_DATASET:
                 readDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::READ_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::GET_BUFFER_VIEW:
                 getBufferView(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW> >(
+                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW>>(
                         i.parameter.get()));
                 break;
             case O::READ_ATT:
                 readAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_ATT> >(
+                    deref_dynamic_cast<Parameter<O::READ_ATT>>(
                         i.parameter.get()));
                 break;
             case O::LIST_PATHS:
                 listPaths(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_PATHS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_PATHS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_DATASETS:
                 listDatasets(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_DATASETS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_DATASETS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_ATTS:
                 listAttributes(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_ATTS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_ATTS>>(
                         i.parameter.get()));
                 break;
             case O::ADVANCE:
                 advance(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::ADVANCE> >(
+                    deref_dynamic_cast<Parameter<O::ADVANCE>>(
                         i.parameter.get()));
                 break;
             case O::AVAILABLE_CHUNKS:
                 availableChunks(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS> >(
+                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS>>(
                         i.parameter.get()));
                 break;
             default:
@@ -366,6 +372,7 @@ void ADIOS1IOHandler::enqueue(IOTask const &i)
     case Operation::OPEN_FILE:
     case Operation::WRITE_ATT:
     case Operation::KEEP_SYNCHRONOUS:
+    case Operation::DEREGISTER:
         m_setup.push(i);
         return;
     default:

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -614,7 +614,7 @@ void ADIOS2IOHandlerImpl::createDataset(
         std::string name = auxiliary::removeSlashes(parameters.name);
 
         auto const file =
-            refreshFileFromParent(writable, /* preferParentFile = */ false);
+            refreshFileFromParent(writable, /* preferParentFile = */ true);
         auto filePos = setAndGetFilePosition(writable, name);
         filePos->gd = ADIOS2FilePosition::GD::DATASET;
         auto const varName = nameOfVariable(writable);
@@ -777,7 +777,7 @@ void ADIOS2IOHandlerImpl::openDataset(
     writable->abstractFilePosition.reset();
     auto pos = setAndGetFilePosition(writable, name);
     pos->gd = ADIOS2FilePosition::GD::DATASET;
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto file = refreshFileFromParent(writable, /* preferParentFile = */ true);
     auto varName = nameOfVariable(writable);
     *parameters.dtype =
         detail::fromADIOS2Type(getFileData(file, IfFileNotOpen::ThrowError)
@@ -1271,7 +1271,7 @@ void ADIOS2IOHandlerImpl::listAttributes(
 void ADIOS2IOHandlerImpl::advance(
     Writable *writable, Parameter<Operation::ADVANCE> &parameters)
 {
-    auto file = m_files[writable];
+    auto file = m_files.at(writable);
     auto &ba = getFileData(file, IfFileNotOpen::ThrowError);
     *parameters.status =
         ba.advance(parameters.mode, /* calledExplicitly = */ true);

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -3007,8 +3007,6 @@ namespace detail
                 // usesSteps attribute only written upon ::advance()
                 // this makes sure that the attribute is only put in case
                 // the streaming API was used.
-                m_IO.DefineAttribute<ADIOS2Schema::schema_t>(
-                    ADIOS2Defaults::str_adios2Schema, m_impl->m_schema.value());
                 m_engine = std::make_optional(
                     adios2::Engine(m_IO.Open(m_file, tempMode)));
                 break;
@@ -3268,6 +3266,13 @@ namespace detail
         for (auto &ba : m_buffer)
         {
             ba->run(*this);
+        }
+
+        if (!initializedDefaults)
+        {
+            m_IO.DefineAttribute<ADIOS2Schema::schema_t>(
+                ADIOS2Defaults::str_adios2Schema, m_impl->m_schema.value());
+            initializedDefaults = true;
         }
 
         if (writeAttributes)

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -691,7 +691,7 @@ void ADIOS2IOHandlerImpl::extendDataset(
 }
 
 void ADIOS2IOHandlerImpl::openFile(
-    Writable *writable, const Parameter<Operation::OPEN_FILE> &parameters)
+    Writable *writable, Parameter<Operation::OPEN_FILE> &parameters)
 {
     if (!auxiliary::directory_exists(m_handler->directory))
     {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -748,6 +748,8 @@ void ADIOS2IOHandlerImpl::closeFile(
                 /* flushUnconditionally = */ false);
             m_fileData.erase(it);
         }
+        m_dirty.erase(fileIterator->second);
+        m_files.erase(fileIterator);
     }
 }
 
@@ -1326,6 +1328,12 @@ void ADIOS2IOHandlerImpl::availableChunks(
         engine,
         varName,
         /* allSteps = */ allSteps);
+}
+
+void ADIOS2IOHandlerImpl::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_files.erase(writable);
 }
 
 adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(std::string const &fullPath)

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -1996,6 +1996,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::listAttributes(
 }
 
 template <typename ChildClass>
+void CommonADIOS1IOHandlerImpl<ChildClass>::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_filePaths.erase(writable);
+}
+
+template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::initJson(json::TracingJSON config)
 {
     if (!config.json().contains("adios1"))

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -664,7 +664,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::extendDataset(
 
 template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::openFile(
-    Writable *writable, Parameter<Operation::OPEN_FILE> const &parameters)
+    Writable *writable, Parameter<Operation::OPEN_FILE> &parameters)
 {
     if (!auxiliary::directory_exists(m_handler->directory))
         error::throwReadError(

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -412,7 +412,7 @@ template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::createFile(
     Writable *writable, Parameter<Operation::CREATE_FILE> const &parameters)
 {
-    if (m_handler->m_backendAccess == Access::READ_ONLY)
+    if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(
             "[ADIOS1] Creating a file in read-only mode is not possible.");
 
@@ -470,7 +470,7 @@ template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::createPath(
     Writable *writable, Parameter<Operation::CREATE_PATH> const &parameters)
 {
-    if (m_handler->m_backendAccess == Access::READ_ONLY)
+    if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(
             "[ADIOS1] Creating a path in a file opened as read only is not "
             "possible.");
@@ -534,7 +534,7 @@ template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::createDataset(
     Writable *writable, Parameter<Operation::CREATE_DATASET> const &parameters)
 {
-    if (m_handler->m_backendAccess == Access::READ_ONLY)
+    if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(
             "[ADIOS1] Creating a dataset in a file opened as read only is not "
             "possible.");
@@ -739,7 +739,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::closeFile(
     if (myGroup != m_groups.end())
     {
         auto attributeWrites = m_attributeWrites.find(myGroup->second);
-        if (this->m_handler->m_backendAccess != Access::READ_ONLY &&
+        if (access::write(this->m_handler->m_backendAccess) &&
             attributeWrites != m_attributeWrites.end())
         {
             for (auto &att : attributeWrites->second)
@@ -1017,7 +1017,7 @@ template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::deleteFile(
     Writable *writable, Parameter<Operation::DELETE_FILE> const &parameters)
 {
-    if (m_handler->m_backendAccess == Access::READ_ONLY)
+    if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(
             "[ADIOS1] Deleting a file opened as read only is not possible.");
 
@@ -1103,7 +1103,7 @@ template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::writeDataset(
     Writable *writable, Parameter<Operation::WRITE_DATASET> const &parameters)
 {
-    if (m_handler->m_backendAccess == Access::READ_ONLY)
+    if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(
             "[ADIOS1] Writing into a dataset in a file opened as read-only is "
             "not possible.");
@@ -1149,7 +1149,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::writeAttribute(
         // cannot do this
         return;
     }
-    if (m_handler->m_backendAccess == Access::READ_ONLY)
+    if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(
             "[ADIOS1] Writing an attribute in a file opened as read only is "
             "not possible.");

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -543,9 +543,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::createDataset(
     {
         /* ADIOS variable definitions require the file to be (re-)opened to take
          * effect/not cause errors */
-        auto res = m_filePaths.find(writable);
-        if (res == m_filePaths.end())
-            res = m_filePaths.find(writable->parent);
+        auto res = m_filePaths.find(writable->parent);
 
         int64_t group = m_groups[res->second];
 
@@ -849,9 +847,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
     Writable *writable, Parameter<Operation::OPEN_DATASET> &parameters)
 {
     ADIOS_FILE *f;
-    auto res = m_filePaths.find(writable);
-    if (res == m_filePaths.end())
-        res = m_filePaths.find(writable->parent);
+    auto res = m_filePaths.find(writable->parent);
     f = m_openReadFileHandles.at(res->second);
 
     /* Sanitize name */

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -123,49 +123,55 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             case O::CREATE_FILE:
                 createFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CHECK_FILE:
                 checkFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_PATH:
                 createPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_PATH:
                 openPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_PATH> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_PATH>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_DATASET:
                 createDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_ATT:
                 writeAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_FILE:
                 openFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_FILE> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_FILE>>(
                         i.parameter.get()));
                 break;
             case O::KEEP_SYNCHRONOUS:
                 keepSynchronous(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS> >(
+                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS>>(
+                        i.parameter.get()));
+                break;
+            case O::DEREGISTER:
+                deregister(
+                    i.writable,
+                    deref_dynamic_cast<Parameter<O::DEREGISTER>>(
                         i.parameter.get()));
                 break;
             default:
@@ -202,19 +208,19 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             case O::EXTEND_DATASET:
                 extendDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_PATH:
                 closePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CLOSE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CLOSE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_DATASET:
                 openDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_FILE:
@@ -226,79 +232,79 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             case O::DELETE_FILE:
                 deleteFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_FILE> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_PATH:
                 deletePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_DATASET:
                 deleteDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_ATT:
                 deleteAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_DATASET:
                 writeDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::READ_DATASET:
                 readDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::READ_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::GET_BUFFER_VIEW:
                 getBufferView(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW> >(
+                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW>>(
                         i.parameter.get()));
                 break;
             case O::READ_ATT:
                 readAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_ATT> >(
+                    deref_dynamic_cast<Parameter<O::READ_ATT>>(
                         i.parameter.get()));
                 break;
             case O::LIST_PATHS:
                 listPaths(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_PATHS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_PATHS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_DATASETS:
                 listDatasets(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_DATASETS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_DATASETS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_ATTS:
                 listAttributes(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_ATTS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_ATTS>>(
                         i.parameter.get()));
                 break;
             case O::ADVANCE:
                 advance(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::ADVANCE> >(
+                    deref_dynamic_cast<Parameter<O::ADVANCE>>(
                         i.parameter.get()));
                 break;
             case O::AVAILABLE_CHUNKS:
                 availableChunks(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS> >(
+                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS>>(
                         i.parameter.get()));
                 break;
             default:
@@ -384,6 +390,7 @@ void ParallelADIOS1IOHandler::enqueue(IOTask const &i)
     case Operation::OPEN_FILE:
     case Operation::WRITE_ATT:
     case Operation::KEEP_SYNCHRONOUS:
+    case Operation::DEREGISTER:
         m_setup.push(i);
         return;
     default:

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -772,7 +772,7 @@ void HDF5IOHandlerImpl::availableChunks(
 }
 
 void HDF5IOHandlerImpl::openFile(
-    Writable *writable, Parameter<Operation::OPEN_FILE> const &parameters)
+    Writable *writable, Parameter<Operation::OPEN_FILE> &parameters)
 {
     if (!auxiliary::directory_exists(m_handler->directory))
         throw error::ReadError(

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -2484,6 +2484,12 @@ void HDF5IOHandlerImpl::listAttributes(
         "listing");
 }
 
+void HDF5IOHandlerImpl::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_fileNames.erase(writable);
+}
+
 std::optional<HDF5IOHandlerImpl::File>
 HDF5IOHandlerImpl::getFile(Writable *writable)
 {

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -526,7 +526,7 @@ void JSONIOHandlerImpl::availableChunks(
 }
 
 void JSONIOHandlerImpl::openFile(
-    Writable *writable, Parameter<Operation::OPEN_FILE> const &parameter)
+    Writable *writable, Parameter<Operation::OPEN_FILE> &parameter)
 {
     if (!auxiliary::directory_exists(m_handler->directory))
     {

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -558,6 +558,7 @@ void JSONIOHandlerImpl::closeFile(
     if (fileIterator != m_files.end())
     {
         putJsonContents(fileIterator->second);
+        m_dirty.erase(fileIterator->second);
         // do not invalidate the file
         // it still exists, it is just not open
         m_files.erase(fileIterator);
@@ -938,6 +939,12 @@ void JSONIOHandlerImpl::listAttributes(
     {
         parameters.attributes->push_back(it.key());
     }
+}
+
+void JSONIOHandlerImpl::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_files.erase(writable);
 }
 
 std::shared_ptr<JSONIOHandlerImpl::FILEHANDLE>

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -681,8 +681,10 @@ auto Iteration::beginStep(bool reread) -> BeginStepStatus
 }
 
 auto Iteration::beginStep(
-    std::optional<Iteration> thisObject, Series &series, bool reread)
-    -> BeginStepStatus
+    std::optional<Iteration> thisObject,
+    Series &series,
+    bool reread,
+    std::set<IterationIndex_t> const &ignoreIterations) -> BeginStepStatus
 {
     BeginStepStatus res;
     using IE = IterationEncoding;
@@ -747,7 +749,9 @@ auto Iteration::beginStep(
         try
         {
             res.iterationsInOpenedStep = series.readGorVBased(
-                /* do_always_throw_errors = */ true, /* init = */ false);
+                /* do_always_throw_errors = */ true,
+                /* init = */ false,
+                ignoreIterations);
         }
         catch (...)
         {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -217,16 +217,13 @@ template Mesh &Mesh::setTimeOffset(float);
 void Mesh::flush_impl(
     std::string const &name, internal::FlushParams const &flushParams)
 {
-    switch (IOHandler()->m_frontendAccess)
+    if (access::readOnly(IOHandler()->m_frontendAccess))
     {
-    case Access::READ_ONLY: {
         for (auto &comp : *this)
             comp.second.flush(comp.first, flushParams);
-        break;
     }
-    case Access::READ_WRITE:
-    case Access::CREATE:
-    case Access::APPEND: {
+    else
+    {
         if (!written())
         {
             if (scalar())
@@ -268,8 +265,6 @@ void Mesh::flush_impl(
             }
         }
         flushAttributes(flushParams);
-        break;
-    }
     }
 }
 

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -161,18 +161,15 @@ namespace
 void ParticleSpecies::flush(
     std::string const &path, internal::FlushParams const &flushParams)
 {
-    switch (IOHandler()->m_frontendAccess)
+    if (access::readOnly(IOHandler()->m_frontendAccess))
     {
-    case Access::READ_ONLY: {
         for (auto &record : *this)
             record.second.flush(record.first, flushParams);
         for (auto &patch : particlePatches)
             patch.second.flush(patch.first, flushParams);
-        break;
     }
-    case Access::READ_WRITE:
-    case Access::CREATE:
-    case Access::APPEND: {
+    else
+    {
         auto it = find("position");
         if (it != end())
             it->second.setUnitDimension({{UnitDimension::L, 1}});
@@ -191,8 +188,6 @@ void ParticleSpecies::flush(
             for (auto &patch : particlePatches)
                 patch.second.flush(patch.first, flushParams);
         }
-        break;
-    }
     }
 }
 

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -527,12 +527,23 @@ SeriesIterator SeriesIterator::end()
     return SeriesIterator{};
 }
 
-ReadIterations::ReadIterations(Series series) : m_series(std::move(series))
-{}
+ReadIterations::ReadIterations(Series series, Access access)
+    : m_series(std::move(series))
+{
+    if (access == Access::READ_LINEAR)
+    {
+        // Open the iterator now already, so that metadata may already be read
+        alreadyOpened = iterator_t{m_series};
+    }
+}
 
 ReadIterations::iterator_t ReadIterations::begin()
 {
-    return iterator_t{m_series};
+    if (!alreadyOpened.has_value())
+    {
+        alreadyOpened = iterator_t{m_series};
+    }
+    return alreadyOpened.value();
 }
 
 ReadIterations::iterator_t ReadIterations::end()

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -46,16 +46,13 @@ Record &Record::setUnitDimension(std::map<UnitDimension, double> const &udim)
 void Record::flush_impl(
     std::string const &name, internal::FlushParams const &flushParams)
 {
-    switch (IOHandler()->m_frontendAccess)
+    if (access::readOnly(IOHandler()->m_frontendAccess))
     {
-    case Access::READ_ONLY: {
         for (auto &comp : *this)
             comp.second.flush(comp.first, flushParams);
-        break;
     }
-    case Access::READ_WRITE:
-    case Access::CREATE:
-    case Access::APPEND: {
+    else
+    {
         if (!written())
         {
             if (scalar())
@@ -99,8 +96,6 @@ void Record::flush_impl(
         }
 
         flushAttributes(flushParams);
-        break;
-    }
     }
 }
 

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -200,18 +200,16 @@ void RecordComponent::flush(
         rc.m_name = name;
         return;
     }
-    switch (IOHandler()->m_frontendAccess)
+    if (access::readOnly(IOHandler()->m_frontendAccess))
     {
-    case Access::READ_ONLY:
         while (!rc.m_chunks.empty())
         {
             IOHandler()->enqueue(rc.m_chunks.front());
             rc.m_chunks.pop();
         }
-        break;
-    case Access::READ_WRITE:
-    case Access::CREATE:
-    case Access::APPEND: {
+    }
+    else
+    {
         /*
          * This catches when a user forgets to use resetDataset.
          */
@@ -277,8 +275,6 @@ void RecordComponent::flush(
         }
 
         flushAttributes(flushParams);
-        break;
-    }
     }
 }
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -577,6 +577,7 @@ Given file pattern: ')END"
     switch (IOHandler()->m_frontendAccess)
     {
     case Access::READ_ONLY:
+    case Access::READ_LINEAR: // @todo don't parse the whole thing here
     case Access::READ_WRITE: {
         /* Allow creation of values in Containers and setting of Attributes
          * Would throw for Access::READ_ONLY */
@@ -736,6 +737,7 @@ void Series::flushFileBased(
     switch (IOHandler()->m_frontendAccess)
     {
     case Access::READ_ONLY:
+    case Access::READ_LINEAR:
         for (auto it = begin; it != end; ++it)
         {
             // Phase 1
@@ -845,9 +847,8 @@ void Series::flushGorVBased(
     bool flushIOHandler)
 {
     auto &series = get();
-    switch (IOHandler()->m_frontendAccess)
+    if (access::readOnly(IOHandler()->m_frontendAccess))
     {
-    case Access::READ_ONLY:
         for (auto it = begin; it != end; ++it)
         {
             // Phase 1
@@ -880,10 +881,9 @@ void Series::flushGorVBased(
                 IOHandler()->flush(flushParams);
             }
         }
-        break;
-    case Access::READ_WRITE:
-    case Access::CREATE:
-    case Access::APPEND: {
+    }
+    else
+    {
         if (!written())
         {
             if (IOHandler()->m_frontendAccess == Access::APPEND)
@@ -957,8 +957,6 @@ void Series::flushGorVBased(
         {
             IOHandler()->flush(flushParams);
         }
-        break;
-    }
     }
 }
 
@@ -1020,7 +1018,7 @@ void Series::readFileBased()
         /* Frontend access type might change during Series::read() to allow
          * parameter modification. Backend access type stays unchanged for the
          * lifetime of a Series. */
-        if (IOHandler()->m_backendAccess == Access::READ_ONLY)
+        if (access::readOnly(IOHandler()->m_backendAccess))
             throw error::ReadError(
                 error::AffectedObject::File,
                 error::Reason::Inaccessible,

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -2308,7 +2308,7 @@ ReadIterations Series::readIterations()
 {
     // Use private constructor instead of copy constructor to avoid
     // object slicing
-    return {this->m_series};
+    return {this->m_series, IOHandler()->m_frontendAccess};
 }
 
 WriteIterations Series::writeIterations()

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -84,19 +84,16 @@ void PatchRecordComponent::flush(
     std::string const &name, internal::FlushParams const &flushParams)
 {
     auto &rc = get();
-    switch (IOHandler()->m_frontendAccess)
+    if (access::readOnly(IOHandler()->m_frontendAccess))
     {
-    case Access::READ_ONLY: {
         while (!rc.m_chunks.empty())
         {
             IOHandler()->enqueue(rc.m_chunks.front());
             rc.m_chunks.pop();
         }
-        break;
     }
-    case Access::READ_WRITE:
-    case Access::CREATE:
-    case Access::APPEND: {
+    else
+    {
         if (!written())
         {
             Parameter<Operation::CREATE_DATASET> dCreate;
@@ -114,8 +111,6 @@ void PatchRecordComponent::flush(
         }
 
         flushAttributes(flushParams);
-        break;
-    }
     }
 }
 

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -27,6 +27,21 @@ namespace openPMD
 Writable::Writable(internal::AttributableData *a) : attributable{a}
 {}
 
+Writable::~Writable()
+{
+    if (!IOHandler || !IOHandler->has_value())
+    {
+        return;
+    }
+    /*
+     * Enqueueing a pointer to this object, which is now being deleted.
+     * The DEREGISTER task must not dereference the pointer, but only use it to
+     * remove references to this object from internal data structures.
+     */
+    IOHandler->value()->enqueue(
+        IOTask(this, Parameter<Operation::DEREGISTER>()));
+}
+
 void Writable::seriesFlush(std::string backendConfig)
 {
     seriesFlush({FlushLevel::UserFlush, std::move(backendConfig)});

--- a/src/binding/python/Access.cpp
+++ b/src/binding/python/Access.cpp
@@ -31,5 +31,7 @@ void init_Access(py::module &m)
     py::enum_<Access>(m, "Access")
         .value("read_only", Access::READ_ONLY)
         .value("read_write", Access::READ_WRITE)
-        .value("create", Access::CREATE);
+        .value("create", Access::CREATE)
+        .value("append", Access::APPEND)
+        .value("read_linear", Access::READ_LINEAR);
 }

--- a/src/binding/python/Access.cpp
+++ b/src/binding/python/Access.cpp
@@ -29,9 +29,67 @@ using namespace openPMD;
 void init_Access(py::module &m)
 {
     py::enum_<Access>(m, "Access")
-        .value("read_only", Access::READ_ONLY)
-        .value("read_write", Access::READ_WRITE)
-        .value("create", Access::CREATE)
-        .value("append", Access::APPEND)
-        .value("read_linear", Access::READ_LINEAR);
+        .value(
+            "read_only",
+            Access::READ_ONLY,
+            R"(\
+Open Series as read-only, fails if Series is not found.
+When to use READ_ONLY or READ_LINEAR:
+
+* When intending to use Series.read_iterations()
+(i.e. step-by-step reading of iterations, e.g. in streaming),
+then Access.read_linear is preferred and always supported.
+Data is parsed inside Series.read_iterations(), no data is available
+right after opening the Series.
+* Otherwise (i.e. for random-access workflows), Access.read_only
+is required, but works only in backends that support random access.
+Data is parsed and available right after opening the Series.
+
+In both modes, parsing of iterations can be deferred with the JSON/TOML
+option `defer_iteration_parsing`.
+
+Detailed rules:
+
+1. In backends that have no notion of IO steps (all except ADIOS2),
+Access.read_only can always be used.
+2. In backends that can be accessed either in random-access or
+step-by-step, the chosen access mode decides which approach is used.
+Examples are the BP4 and BP5 engines of ADIOS2.
+3. In streaming backends, random-access is not possible.
+When using such a backend, the access mode will be coerced
+automatically to Access.read_linear. Use of Series.read_iterations()
+is mandatory for access.
+4. Reading a variable-based Series is only fully supported with
+Access.read_linear.
+If using Access.read_only, the dataset will be considered to only
+have one single step.
+If the dataset only has one single step, this is guaranteed to work
+as expected. Otherwise, it is undefined which step's data is returned.)")
+        .value(
+            "read_random_access",
+            Access::READ_RANDOM_ACCESS,
+            "more explicit alias for read_only")
+        .value(
+            "read_write",
+            Access::READ_WRITE,
+            "Open existing Series as writable. Read mode corresponds with "
+            "Access::READ_RANDOM_ACCESS.")
+        .value(
+            "create",
+            Access::CREATE,
+            "create new series and truncate existing (files)")
+        .value(
+            "append",
+            Access::APPEND,
+            "write new iterations to an existing series without reading")
+        .value(
+            "read_linear",
+            Access::READ_LINEAR,
+            R"(\
+            Open Series as read-only, fails if Series is not found.
+This access mode requires use of Series.read_iterations().
+Global attributes are available directly after calling
+Series.read_iterations(), Iterations and all their corresponding data
+become available by use of the returned Iterator, e.g. in a foreach loop.
+See Access.read_only for when to use this.)");
 }

--- a/src/binding/python/openpmd_api/pipe/__main__.py
+++ b/src/binding/python/openpmd_api/pipe/__main__.py
@@ -204,7 +204,7 @@ class pipe:
         if not HAVE_MPI or (args.mpi is None and self.comm.size == 1):
             print("Opening data source")
             sys.stdout.flush()
-            inseries = io.Series(self.infile, io.Access.read_only,
+            inseries = io.Series(self.infile, io.Access.read_linear,
                                  self.inconfig)
             print("Opening data sink")
             sys.stdout.flush()
@@ -215,7 +215,7 @@ class pipe:
         else:
             print("Opening data source on rank {}.".format(self.comm.rank))
             sys.stdout.flush()
-            inseries = io.Series(self.infile, io.Access.read_only, self.comm,
+            inseries = io.Series(self.infile, io.Access.read_linear, self.comm,
                                  self.inconfig)
             print("Opening data sink on rank {}.".format(self.comm.rank))
             sys.stdout.flush()

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1128,9 +1128,12 @@ void adios2_streaming(bool variableBasedLayout)
         using namespace std::chrono_literals;
         std::this_thread::sleep_for(1s);
 
+        /*
+         * Need to fix this, should still be possible READ_ONLY
+         */
         Series readSeries(
             "../samples/adios2_stream.sst",
-            Access::READ_ONLY,
+            Access::READ_LINEAR,
             // inline TOML
             R"(defer_iteration_parsing = true)");
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1712,10 +1712,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 5);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             case ParseMode::WithSnapshot: {
@@ -1731,10 +1727,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 8);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             default:

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -9,6 +9,11 @@
 #if openPMD_HAVE_MPI
 #include <mpi.h>
 
+#if openPMD_HAVE_ADIOS2
+#include <adios2.h>
+#define HAS_ADIOS_2_8 (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 208)
+#endif
+
 #include <algorithm>
 #include <chrono>
 #include <fstream>
@@ -1129,11 +1134,12 @@ void adios2_streaming(bool variableBasedLayout)
         std::this_thread::sleep_for(1s);
 
         /*
-         * Need to fix this, should still be possible READ_ONLY
+         * READ_LINEAR always works in Streaming, but READ_ONLY must stay
+         * working at least for groupbased iteration encoding
          */
         Series readSeries(
             "../samples/adios2_stream.sst",
-            Access::READ_LINEAR,
+            variableBasedLayout ? Access::READ_LINEAR : Access::READ_ONLY,
             // inline TOML
             R"(defer_iteration_parsing = true)");
 
@@ -1391,31 +1397,73 @@ TEST_CASE("adios2_ssc", "[parallel][adios2]")
     adios2_ssc();
 }
 
+enum class ParseMode
+{
+    /*
+     * Conventional workflow. Just parse the whole thing and yield iterations
+     * in rising order.
+     */
+    NoSteps,
+    /*
+     * The Series is parsed ahead of time upon opening, but it has steps.
+     * Parsing ahead of time is the conventional workflow to support
+     * random-access.
+     * Reading such a Series with the streaming API is only possible if all
+     * steps are in ascending order, otherwise the openPMD-api has no way of
+     * associating IO steps with interation indices.
+     * Reading such a Series with the Streaming API will become possible with
+     * the Linear read mode to be introduced by #1291.
+     */
+    AheadOfTimeWithoutSnapshot,
+    /*
+     * In Linear read mode, a Series is not parsed ahead of time, but
+     * step-by-step, giving the openPMD-api a way to associate IO steps with
+     * iterations. No snapshot attribute exists, so the fallback mode is chosen:
+     * Iterations are returned in ascending order.
+     * If an IO step returns an iteration whose index is lower than the
+     * last one, it will be skipped.
+     * This mode of parsing is not available for the BP4 engine with ADIOS2
+     * schema 0, since BP4 does not associate attributes with the step in
+     * which they were created, making it impossible to separate parsing into
+     * single steps.
+     */
+    LinearWithoutSnapshot,
+    /*
+     * Snapshot attribute exists and dictates the iteration index returned by
+     * an IO step. Duplicate iterations will be skipped.
+     */
+    WithSnapshot
+};
+
 void append_mode(
     std::string const &extension,
     bool variableBased,
+    ParseMode parseMode,
     std::string jsonConfig = "{}")
 {
     std::string filename =
         (variableBased ? "../samples/append/append_variablebased."
                        : "../samples/append/append_groupbased.") +
         extension;
+    int mpi_size{}, mpi_rank{};
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
     MPI_Barrier(MPI_COMM_WORLD);
     if (auxiliary::directory_exists("../samples/append"))
     {
         auxiliary::remove_directory("../samples/append");
     }
     MPI_Barrier(MPI_COMM_WORLD);
-    std::vector<int> data(10, 0);
-    auto writeSomeIterations = [&data](
+    std::vector<int> data(10, 999);
+    auto writeSomeIterations = [&data, mpi_size, mpi_rank](
                                    WriteIterations &&writeIterations,
                                    std::vector<uint64_t> indices) {
         for (auto index : indices)
         {
             auto it = writeIterations[index];
             auto dataset = it.meshes["E"]["x"];
-            dataset.resetDataset({Datatype::INT, {10}});
-            dataset.storeChunk(data, {0}, {10});
+            dataset.resetDataset({Datatype::INT, {unsigned(mpi_size), 10}});
+            dataset.storeChunk(data, {unsigned(mpi_rank), 0}, {1, 10});
             // test that it works without closing too
             it.close();
         }
@@ -1433,6 +1481,7 @@ void append_mode(
         writeSomeIterations(
             write.writeIterations(), std::vector<uint64_t>{0, 1});
     }
+    MPI_Barrier(MPI_COMM_WORLD);
     {
         Series write(filename, Access::APPEND, MPI_COMM_WORLD, jsonConfig);
         if (variableBased)
@@ -1451,9 +1500,10 @@ void append_mode(
         }
 
         writeSomeIterations(
-            write.writeIterations(), std::vector<uint64_t>{2, 3});
+            write.writeIterations(), std::vector<uint64_t>{3, 2});
         write.flush();
     }
+    MPI_Barrier(MPI_COMM_WORLD);
     {
         using namespace std::chrono_literals;
         /*
@@ -1479,32 +1529,142 @@ void append_mode(
         }
 
         writeSomeIterations(
-            write.writeIterations(), std::vector<uint64_t>{4, 3});
+            write.writeIterations(), std::vector<uint64_t>{4, 3, 10});
         write.flush();
     }
+    MPI_Barrier(MPI_COMM_WORLD);
     {
-        Series read(filename, Access::READ_ONLY, MPI_COMM_WORLD);
-        if (variableBased || extension == "bp5")
+        Series write(filename, Access::APPEND, MPI_COMM_WORLD, jsonConfig);
+        if (variableBased)
         {
-            // in variable-based encodings, iterations are not parsed ahead of
-            // time but as they go
+            write.setIterationEncoding(IterationEncoding::variableBased);
+        }
+        if (write.backend() == "MPI_ADIOS1")
+        {
+            REQUIRE_THROWS_AS(
+                write.flush(), error::OperationUnsupportedInBackend);
+            // destructor will be noisy now
+            return;
+        }
+
+        writeSomeIterations(
+            write.writeIterations(), std::vector<uint64_t>{7, 1, 11});
+        write.flush();
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    auto verifyIteration = [mpi_size](auto &&it) {
+        auto chunk = it.meshes["E"]["x"].template loadChunk<int>(
+            {0, 0}, {unsigned(mpi_size), 10});
+        it.seriesFlush();
+        for (size_t i = 0; i < unsigned(mpi_size) * 10; ++i)
+        {
+            REQUIRE(chunk.get()[i] == 999);
+        }
+    };
+
+    {
+        switch (parseMode)
+        {
+        case ParseMode::NoSteps: {
+            Series read(filename, Access::READ_LINEAR, MPI_COMM_WORLD);
             unsigned counter = 0;
-            for (auto const &iteration : read.readIterations())
+            uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 7, 10, 11};
+            for (auto iteration : read.readIterations())
             {
-                REQUIRE(iteration.iterationIndex == counter);
+                REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                verifyIteration(iteration);
                 ++counter;
             }
-            REQUIRE(counter == 5);
+            REQUIRE(counter == 8);
         }
-        else
+        break;
+        case ParseMode::LinearWithoutSnapshot: {
+            Series read(filename, Access::READ_LINEAR, MPI_COMM_WORLD);
+            unsigned counter = 0;
+            uint64_t iterationOrder[] = {0, 1, 3, 4, 10, 11};
+            for (auto iteration : read.readIterations())
+            {
+                REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                verifyIteration(iteration);
+                ++counter;
+            }
+            REQUIRE(counter == 6);
+        }
+        break;
+        case ParseMode::WithSnapshot: {
+            // in variable-based encodings, iterations are not parsed ahead of
+            // time but as they go
+            Series read(filename, Access::READ_LINEAR, MPI_COMM_WORLD);
+            unsigned counter = 0;
+            uint64_t iterationOrder[] = {0, 1, 3, 2, 4, 10, 7, 11};
+            for (auto iteration : read.readIterations())
+            {
+                REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                verifyIteration(iteration);
+                ++counter;
+            }
+            REQUIRE(counter == 8);
+            // Cannot do listSeries here because the Series is already drained
+            REQUIRE_THROWS_AS(helper::listSeries(read), error::WrongAPIUsage);
+        }
+        break;
+        case ParseMode::AheadOfTimeWithoutSnapshot: {
+            Series read(filename, Access::READ_LINEAR, MPI_COMM_WORLD);
+            unsigned counter = 0;
+            uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 7, 10, 11};
+            /*
+             * This one is a bit tricky:
+             * The BP4 engine has no way of parsing a Series in the old
+             * ADIOS2 schema step-by-step, since attributes are not
+             * associated with the step in which they were created.
+             * As a result, when readIterations() is called, the whole thing
+             * is parsed immediately ahead-of-time.
+             * We can then iterate through the iterations and access metadata,
+             * but since the IO steps don't correspond with the order of
+             * iterations returned (there is no way to figure out that order),
+             * we cannot load data in here.
+             * BP4 in the old ADIOS2 schema only supports either of the
+             * following: 1) A Series in which the iterations are present in
+             * ascending order. 2) Or accessing the Series in READ_ONLY mode.
+             */
+            for (auto const &iteration : read.readIterations())
+            {
+                REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                ++counter;
+            }
+            REQUIRE(counter == 8);
+            /*
+             * Roadmap: for now, reading this should work by ignoring the last
+             * duplicate iteration.
+             * After merging https://github.com/openPMD/openPMD-api/pull/949, we
+             * should see both instances when reading.
+             * Final goal: Read only the last instance.
+             */
+            REQUIRE_THROWS_AS(helper::listSeries(read), error::WrongAPIUsage);
+        }
+        break;
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (!variableBased)
+    {
+        Series read(filename, Access::READ_ONLY, MPI_COMM_WORLD);
+        REQUIRE(read.iterations.size() == 8);
+        unsigned counter = 0;
+        uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 7, 10, 11};
+        for (auto iteration : read.readIterations())
         {
-            REQUIRE(read.iterations.size() == 5);
-            helper::listSeries(read);
+            REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+            verifyIteration(iteration);
+            ++counter;
         }
+        REQUIRE(counter == 8);
     }
 #if 100000000 * ADIOS2_VERSION_MAJOR + 1000000 * ADIOS2_VERSION_MINOR +        \
         10000 * ADIOS2_VERSION_PATCH + 100 * ADIOS2_VERSION_TWEAK >=           \
     208002700
+    MPI_Barrier(MPI_COMM_WORLD);
     // AppendAfterSteps has a bug before that version
     if (extension == "bp5")
     {
@@ -1536,30 +1696,77 @@ void append_mode(
                 write.writeIterations(), std::vector<uint64_t>{4, 5});
             write.flush();
         }
+        MPI_Barrier(MPI_COMM_WORLD);
+        {
+            Series read(filename, Access::READ_LINEAR, MPI_COMM_WORLD);
+            switch (parseMode)
+            {
+            case ParseMode::LinearWithoutSnapshot: {
+                uint64_t iterationOrder[] = {0, 1, 3, 4, 10};
+                unsigned counter = 0;
+                for (auto iteration : read.readIterations())
+                {
+                    REQUIRE(
+                        iteration.iterationIndex == iterationOrder[counter]);
+                    verifyIteration(iteration);
+                    ++counter;
+                }
+                REQUIRE(counter == 5);
+                // Cannot do listSeries here because the Series is already
+                // drained
+                REQUIRE_THROWS_AS(
+                    helper::listSeries(read), error::WrongAPIUsage);
+            }
+            break;
+            case ParseMode::WithSnapshot: {
+                // in variable-based encodings, iterations are not parsed ahead
+                // of time but as they go
+                unsigned counter = 0;
+                uint64_t iterationOrder[] = {0, 1, 3, 2, 4, 10, 7, 5};
+                for (auto iteration : read.readIterations())
+                {
+                    REQUIRE(
+                        iteration.iterationIndex == iterationOrder[counter]);
+                    verifyIteration(iteration);
+                    ++counter;
+                }
+                REQUIRE(counter == 8);
+                // Cannot do listSeries here because the Series is already
+                // drained
+                REQUIRE_THROWS_AS(
+                    helper::listSeries(read), error::WrongAPIUsage);
+            }
+            break;
+            default:
+                throw std::runtime_error("Test configured wrong.");
+                break;
+            }
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        if (!variableBased)
         {
             Series read(filename, Access::READ_ONLY, MPI_COMM_WORLD);
-            // in variable-based encodings, iterations are not parsed ahead of
-            // time but as they go
+            uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 5, 7, 10};
             unsigned counter = 0;
             for (auto const &iteration : read.readIterations())
             {
-                REQUIRE(iteration.iterationIndex == counter);
+                REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
                 ++counter;
             }
-            REQUIRE(counter == 6);
-            helper::listSeries(read);
+            REQUIRE(counter == 8);
+            // Cannot do listSeries here because the Series is already
+            // drained
+            REQUIRE_THROWS_AS(helper::listSeries(read), error::WrongAPIUsage);
         }
     }
 #endif
 }
 
-TEST_CASE("append_mode", "[parallel]")
+TEST_CASE("append_mode", "[serial]")
 {
     for (auto const &t : testedFileExtensions())
     {
-        if (t == "bp" || t == "bp4" || t == "bp5")
-        {
-            std::string jsonConfigOld = R"END(
+        std::string jsonConfigOld = R"END(
 {
     "adios2":
     {
@@ -1570,7 +1777,7 @@ TEST_CASE("append_mode", "[parallel]")
         }
     }
 })END";
-            std::string jsonConfigNew = R"END(
+        std::string jsonConfigNew = R"END(
 {
     "adios2":
     {
@@ -1581,28 +1788,27 @@ TEST_CASE("append_mode", "[parallel]")
         }
     }
 })END";
+        if (t == "bp" || t == "bp4" || t == "bp5")
+        {
             /*
              * Troublesome combination:
              * 1) ADIOS2 v2.7
              * 2) Parallel writer
              * 3) Append mode
-             * 4) Writing to a scalar variable
              *
-             * 4) is done by schema 2021 which will be phased out, so the tests
-             * are just deactivated.
              */
-            if (auxiliary::getEnvNum("OPENPMD2_ADIOS2_SCHEMA", 0) != 0)
-            {
-                continue;
-            }
-            append_mode(t, false, jsonConfigOld);
-            // append_mode(t, true, jsonConfigOld);
-            // append_mode(t, false, jsonConfigNew);
-            // append_mode(t, true, jsonConfigNew);
+#if HAS_ADIOS_2_8
+            append_mode(
+                t, false, ParseMode::LinearWithoutSnapshot, jsonConfigOld);
+            append_mode(t, false, ParseMode::WithSnapshot, jsonConfigNew);
+            // This test config does not make sense
+            // append_mode(t, true, ParseMode::WithSnapshot, jsonConfigOld);
+            append_mode(t, true, ParseMode::WithSnapshot, jsonConfigNew);
+#endif
         }
         else
         {
-            append_mode(t, false);
+            append_mode(t, false, ParseMode::NoSteps);
         }
     }
 }
@@ -1666,4 +1872,4 @@ TEST_CASE("unavailable_backend", "[core][parallel]")
     }
 #endif
 }
-#endif
+#endif // openPMD_HAVE_ADIOS2 && openPMD_HAVE_MPI

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6893,10 +6893,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 5);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             case ParseMode::WithSnapshot: {
@@ -6912,10 +6908,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 8);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             default:

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5382,6 +5382,7 @@ void variableBasedSeries(std::string const &file)
     constexpr Extent::value_type extent = 1000;
     {
         Series writeSeries(file, Access::CREATE, selectADIOS2);
+        writeSeries.setAttribute("some_global", "attribute");
         writeSeries.setIterationEncoding(IterationEncoding::variableBased);
         REQUIRE(
             writeSeries.iterationEncoding() ==
@@ -5438,6 +5439,11 @@ void variableBasedSeries(std::string const &file)
             file, Access::READ_LINEAR, json::merge(selectADIOS2, jsonConfig));
 
         size_t last_iteration_index = 0;
+        REQUIRE(!readSeries.containsAttribute("some_global"));
+        readSeries.readIterations();
+        REQUIRE(
+            readSeries.getAttribute("some_global").get<std::string>() ==
+            "attribute");
         for (auto iteration : readSeries.readIterations())
         {
             if (iteration.iterationIndex > 2)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4837,7 +4837,8 @@ this = "should not warn"
 void bp4_steps(
     std::string const &file,
     std::string const &options_write,
-    std::string const &options_read)
+    std::string const &options_read,
+    Access access = Access::READ_ONLY)
 {
     {
         Series writeSeries(file, Access::CREATE, options_write);
@@ -4862,7 +4863,7 @@ void bp4_steps(
         return;
     }
 
-    Series readSeries(file, Access::READ_ONLY, options_read);
+    Series readSeries(file, access, options_read);
 
     size_t last_iteration_index = 0;
     for (auto iteration : readSeries.readIterations())
@@ -4915,6 +4916,7 @@ TEST_CASE("bp4_steps", "[serial][adios2]")
         type = "bp4"
         UseSteps = false
     )";
+
     // sing the yes no song
     bp4_steps("../samples/bp4steps_yes_yes.bp", useSteps, useSteps);
     bp4_steps("../samples/bp4steps_no_yes.bp", dontUseSteps, useSteps);
@@ -4922,6 +4924,17 @@ TEST_CASE("bp4_steps", "[serial][adios2]")
     bp4_steps("../samples/bp4steps_no_no.bp", dontUseSteps, dontUseSteps);
     bp4_steps("../samples/nullcore.bp", nullcore, "");
     bp4_steps("../samples/bp4steps_default.bp", "{}", "{}");
+
+    // bp4_steps(
+    //     "../samples/newlayout_bp4steps_yes_yes.bp",
+    //     useSteps,
+    //     useSteps,
+    //     Access::READ_LINEAR);
+    // bp4_steps(
+    //     "../samples/newlayout_bp4steps_yes_no.bp",
+    //     useSteps,
+    //     dontUseSteps,
+    //     Access::READ_LINEAR);
 
     /*
      * Do this whole thing once more, but this time use the new attribute
@@ -4957,6 +4970,17 @@ TEST_CASE("bp4_steps", "[serial][adios2]")
         "../samples/newlayout_bp4steps_no_yes.bp", dontUseSteps, useSteps);
     bp4_steps(
         "../samples/newlayout_bp4steps_no_no.bp", dontUseSteps, dontUseSteps);
+
+    bp4_steps(
+        "../samples/newlayout_bp4steps_yes_yes.bp",
+        useSteps,
+        useSteps,
+        Access::READ_LINEAR);
+    bp4_steps(
+        "../samples/newlayout_bp4steps_yes_no.bp",
+        useSteps,
+        dontUseSteps,
+        Access::READ_LINEAR);
 }
 #endif
 
@@ -5814,42 +5838,46 @@ void iterate_nonstreaming_series(
         }
     }
 
-    Series readSeries(
-        file,
-        Access::READ_ONLY,
-        json::merge(jsonConfig, R"({"defer_iteration_parsing": true})"));
-
-    size_t last_iteration_index = 0;
-    // conventionally written Series must be readable with streaming-aware API!
-    for (auto iteration : readSeries.readIterations())
+    for (auto access : {Access::READ_LINEAR, Access::READ_ONLY})
     {
-        // ReadIterations takes care of Iteration::open()ing iterations
-        auto E_x = iteration.meshes["E"]["x"];
-        REQUIRE(E_x.getDimensionality() == 2);
-        REQUIRE(E_x.getExtent()[0] == 2);
-        REQUIRE(E_x.getExtent()[1] == extent);
-        auto chunk = E_x.loadChunk<int>({0, 0}, {1, extent});
-        auto chunk2 = E_x.loadChunk<int>({1, 0}, {1, extent});
-        // we encourage manually closing iterations, but it should not matter
-        // so let's do the switcharoo for this test
-        if (last_iteration_index % 2 == 0)
-        {
-            readSeries.flush();
-        }
-        else
-        {
-            iteration.close();
-        }
+        Series readSeries(
+            file,
+            access,
+            json::merge(jsonConfig, R"({"defer_iteration_parsing": true})"));
 
-        int value = variableBasedLayout ? 0 : iteration.iterationIndex;
-        for (size_t i = 0; i < extent; ++i)
+        size_t last_iteration_index = 0;
+        // conventionally written Series must be readable with streaming-aware
+        // API!
+        for (auto iteration : readSeries.readIterations())
         {
-            REQUIRE(chunk.get()[i] == value);
-            REQUIRE(chunk2.get()[i] == int(i));
+            // ReadIterations takes care of Iteration::open()ing iterations
+            auto E_x = iteration.meshes["E"]["x"];
+            REQUIRE(E_x.getDimensionality() == 2);
+            REQUIRE(E_x.getExtent()[0] == 2);
+            REQUIRE(E_x.getExtent()[1] == extent);
+            auto chunk = E_x.loadChunk<int>({0, 0}, {1, extent});
+            auto chunk2 = E_x.loadChunk<int>({1, 0}, {1, extent});
+            // we encourage manually closing iterations, but it should not
+            // matter so let's do the switcharoo for this test
+            if (last_iteration_index % 2 == 0)
+            {
+                readSeries.flush();
+            }
+            else
+            {
+                iteration.close();
+            }
+
+            int value = variableBasedLayout ? 0 : iteration.iterationIndex;
+            for (size_t i = 0; i < extent; ++i)
+            {
+                REQUIRE(chunk.get()[i] == value);
+                REQUIRE(chunk2.get()[i] == int(i));
+            }
+            last_iteration_index = iteration.iterationIndex;
         }
-        last_iteration_index = iteration.iterationIndex;
+        REQUIRE(last_iteration_index == 9);
     }
-    REQUIRE(last_iteration_index == 9);
 }
 
 TEST_CASE("iterate_nonstreaming_series", "[serial][adios2]")
@@ -5874,13 +5902,13 @@ TEST_CASE("iterate_nonstreaming_series", "[serial][adios2]")
                     backend.extension,
                 false,
                 json::merge(
-                    backend.jsonBaseConfig(), "adios2.engine = \"bp5\""));
+                    backend.jsonBaseConfig(), "adios2.engine.type = \"bp5\""));
             iterate_nonstreaming_series(
                 "../samples/iterate_nonstreaming_series_groupbased_bp5." +
                     backend.extension,
                 false,
                 json::merge(
-                    backend.jsonBaseConfig(), "adios2.engine = \"bp5\""));
+                    backend.jsonBaseConfig(), "adios2.engine.type = \"bp5\""));
         }
 #endif
     }
@@ -6344,11 +6372,13 @@ TEST_CASE("chaotic_stream", "[serial]")
 
 #ifdef openPMD_USE_INVASIVE_TESTS
 void unfinished_iteration_test(
-    std::string const &ext, bool filebased, std::string const &config = "{}")
+    std::string const &ext,
+    IterationEncoding encoding,
+    std::string const &config = "{}")
 {
     std::cout << "\n\nTESTING " << ext << "\n\n" << std::endl;
     std::string file = std::string("../samples/unfinished_iteration") +
-        (filebased ? "_%T." : ".") + ext;
+        (encoding == IterationEncoding::fileBased ? "_%T." : ".") + ext;
     {
         Series write(file, Access::CREATE, config);
         auto it0 = write.writeIterations()[0];
@@ -6365,11 +6395,11 @@ void unfinished_iteration_test(
         auto electron_mass =
             it10.particles["e"]["mass"][RecordComponent::SCALAR];
     }
-    auto tryReading = [&config, file, filebased](
+    auto tryReading = [&config, file, encoding](
+                          Access access,
                           std::string const &additionalConfig = "{}") {
         {
-            Series read(
-                file, Access::READ_ONLY, json::merge(config, additionalConfig));
+            Series read(file, access, json::merge(config, additionalConfig));
 
             std::vector<decltype(Series::iterations)::key_type> iterations;
             std::cout << "Going to list iterations in " << file << ":"
@@ -6397,10 +6427,10 @@ void unfinished_iteration_test(
                  std::vector<decltype(Series::iterations)::key_type>{0, 10}));
         }
 
-        if (filebased)
+        if (encoding == IterationEncoding::fileBased &&
+            access == Access::READ_ONLY)
         {
-            Series read(
-                file, Access::READ_ONLY, json::merge(config, additionalConfig));
+            Series read(file, access, json::merge(config, additionalConfig));
             if (additionalConfig == "{}")
             {
                 // Eager parsing, defective iteration has already been removed
@@ -6417,46 +6447,54 @@ void unfinished_iteration_test(
         }
     };
 
-    tryReading();
-    tryReading(R"({"defer_iteration_parsing": true})");
+    tryReading(Access::READ_LINEAR);
+    tryReading(Access::READ_LINEAR, R"({"defer_iteration_parsing": true})");
+    if (encoding != IterationEncoding::variableBased)
+    {
+        /*
+         * In variable-based iteration encoding, READ_ONLY mode will make
+         * iteration metadata leak into other iterations, causing iteration 0
+         * to fail being parsed.
+         * (See also the warning that occurs when trying to access a variable-
+         * based Series in READ_ONLY mode)
+         */
+        tryReading(Access::READ_ONLY);
+        tryReading(Access::READ_ONLY, R"({"defer_iteration_parsing": true})");
+    }
 }
 
 TEST_CASE("unfinished_iteration_test", "[serial]")
 {
 #if openPMD_HAVE_ADIOS2
-    unfinished_iteration_test("bp", false, R"({"backend": "adios2"})");
-    /*
-     * Need linear read mode variable-based iteration encoding, to be
-     * activated by next commit.
-     * Random-access mode will only parse one single iteration, consisting of
-     * whatever ADIOS2 decides to show us before opening a step.
-     * This will include the erroneous attribute defined in the second step
-     * / fifth iteration, making the constructor fail.
-     */
-    //     unfinished_iteration_test(
-    //         "bp",
-    //         false,
-    //         R"(
-    // {
-    //   "backend": "adios2",
-    //   "iteration_encoding": "variable_based",
-    //   "adios2": {
-    //     "schema": 20210209
-    //   }
-    // }
-    // )");
-    unfinished_iteration_test("bp", true, R"({"backend": "adios2"})");
+    unfinished_iteration_test(
+        "bp", IterationEncoding::groupBased, R"({"backend": "adios2"})");
+    unfinished_iteration_test(
+        "bp",
+        IterationEncoding::variableBased,
+        R"(
+    {
+      "backend": "adios2",
+      "iteration_encoding": "variable_based",
+      "adios2": {
+        "schema": 20210209
+      }
+    }
+    )");
+    unfinished_iteration_test(
+        "bp", IterationEncoding::fileBased, R"({"backend": "adios2"})");
 #endif
 #if openPMD_HAVE_ADIOS1
-    unfinished_iteration_test("adios1.bp", false, R"({"backend": "adios1"})");
-    unfinished_iteration_test("adios1.bp", true, R"({"backend": "adios1"})");
+    unfinished_iteration_test(
+        "adios1.bp", IterationEncoding::groupBased, R"({"backend": "adios1"})");
+    unfinished_iteration_test(
+        "adios1.bp", IterationEncoding::fileBased, R"({"backend": "adios1"})");
 #endif
 #if openPMD_HAVE_HDF5
-    unfinished_iteration_test("h5", false);
-    unfinished_iteration_test("h5", true);
+    unfinished_iteration_test("h5", IterationEncoding::groupBased);
+    unfinished_iteration_test("h5", IterationEncoding::fileBased);
 #endif
-    unfinished_iteration_test("json", false);
-    unfinished_iteration_test("json", true);
+    unfinished_iteration_test("json", IterationEncoding::groupBased);
+    unfinished_iteration_test("json", IterationEncoding::fileBased);
 }
 #endif
 
@@ -6571,14 +6609,16 @@ enum class ParseMode
      */
     AheadOfTimeWithoutSnapshot,
     /*
-     * A Series of the BP5 engine is not parsed ahead of time, but step-by-step,
-     * giving the openPMD-api a way to associate IO steps with iterations.
-     * No snapshot attribute exists, so the fallback mode is chosen:
+     * In Linear read mode, a Series is not parsed ahead of time, but
+     * step-by-step, giving the openPMD-api a way to associate IO steps with
+     * iterations. No snapshot attribute exists, so the fallback mode is chosen:
      * Iterations are returned in ascending order.
      * If an IO step returns an iteration whose index is lower than the
      * last one, it will be skipped.
-     * This mode of parsing will be generalized into the Linear read mode with
-     * PR #1291.
+     * This mode of parsing is not available for the BP4 engine with ADIOS2
+     * schema 0, since BP4 does not associate attributes with the step in
+     * which they were created, making it impossible to separate parsing into
+     * single steps.
      */
     LinearWithoutSnapshot,
     /*
@@ -6598,7 +6638,7 @@ void append_mode(
     {
         auxiliary::remove_directory("../samples/append");
     }
-    std::vector<int> data(10, 0);
+    std::vector<int> data(10, 999);
     auto writeSomeIterations = [&data](
                                    WriteIterations &&writeIterations,
                                    std::vector<uint64_t> indices) {
@@ -6643,7 +6683,7 @@ void append_mode(
         }
 
         writeSomeIterations(
-            write.writeIterations(), std::vector<uint64_t>{2, 3});
+            write.writeIterations(), std::vector<uint64_t>{3, 2});
         write.flush();
     }
     {
@@ -6692,40 +6732,55 @@ void append_mode(
             write.writeIterations(), std::vector<uint64_t>{7, 1, 11});
         write.flush();
     }
+
+    auto verifyIteration = [](auto &&it) {
+        auto chunk = it.meshes["E"]["x"].template loadChunk<int>({0}, {10});
+        it.seriesFlush();
+        for (size_t i = 0; i < 10; ++i)
+        {
+            REQUIRE(chunk.get()[i] == 999);
+        }
+    };
+
     {
-        Series read(filename, Access::READ_ONLY);
         switch (parseMode)
         {
         case ParseMode::NoSteps: {
+            Series read(filename, Access::READ_LINEAR);
             unsigned counter = 0;
             uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 7, 10, 11};
-            for (auto const &iteration : read.readIterations())
+            for (auto iteration : read.readIterations())
             {
                 REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                verifyIteration(iteration);
                 ++counter;
             }
             REQUIRE(counter == 8);
         }
         break;
         case ParseMode::LinearWithoutSnapshot: {
+            Series read(filename, Access::READ_LINEAR);
             unsigned counter = 0;
-            uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 10, 11};
-            for (auto const &iteration : read.readIterations())
+            uint64_t iterationOrder[] = {0, 1, 3, 4, 10, 11};
+            for (auto iteration : read.readIterations())
             {
                 REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                verifyIteration(iteration);
                 ++counter;
             }
-            REQUIRE(counter == 7);
+            REQUIRE(counter == 6);
         }
         break;
         case ParseMode::WithSnapshot: {
             // in variable-based encodings, iterations are not parsed ahead of
             // time but as they go
+            Series read(filename, Access::READ_LINEAR);
             unsigned counter = 0;
-            uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 10, 7, 11};
-            for (auto const &iteration : read.readIterations())
+            uint64_t iterationOrder[] = {0, 1, 3, 2, 4, 10, 7, 11};
+            for (auto iteration : read.readIterations())
             {
                 REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                verifyIteration(iteration);
                 ++counter;
             }
             REQUIRE(counter == 8);
@@ -6734,17 +6789,27 @@ void append_mode(
         }
         break;
         case ParseMode::AheadOfTimeWithoutSnapshot: {
-            REQUIRE(read.iterations.size() == 8);
+            Series read(filename, Access::READ_LINEAR);
             unsigned counter = 0;
             uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 7, 10, 11};
             /*
-             * Use conventional read API since streaming API is not possible
-             * without Linear read mode.
-             * (See also comments inside ParseMode enum).
+             * This one is a bit tricky:
+             * The BP4 engine has no way of parsing a Series in the old
+             * ADIOS2 schema step-by-step, since attributes are not
+             * associated with the step in which they were created.
+             * As a result, when readIterations() is called, the whole thing
+             * is parsed immediately ahead-of-time.
+             * We can then iterate through the iterations and access metadata,
+             * but since the IO steps don't correspond with the order of
+             * iterations returned (there is no way to figure out that order),
+             * we cannot load data in here.
+             * BP4 in the old ADIOS2 schema only supports either of the
+             * following: 1) A Series in which the iterations are present in
+             * ascending order. 2) Or accessing the Series in READ_ONLY mode.
              */
-            for (auto const &iteration : read.iterations)
+            for (auto const &iteration : read.readIterations())
             {
-                REQUIRE(iteration.first == iterationOrder[counter]);
+                REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
                 ++counter;
             }
             REQUIRE(counter == 8);
@@ -6755,12 +6820,25 @@ void append_mode(
              * should see both instances when reading.
              * Final goal: Read only the last instance.
              */
-            helper::listSeries(read);
+            REQUIRE_THROWS_AS(helper::listSeries(read), error::WrongAPIUsage);
         }
         break;
         }
     }
-#if 0 // test is configured such that linear read mode is now needed
+    if (!variableBased)
+    {
+        Series read(filename, Access::READ_ONLY);
+        REQUIRE(read.iterations.size() == 8);
+        unsigned counter = 0;
+        uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 7, 10, 11};
+        for (auto iteration : read.readIterations())
+        {
+            REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+            verifyIteration(iteration);
+            ++counter;
+        }
+        REQUIRE(counter == 8);
+    }
     // AppendAfterSteps has a bug before that version
 #if 100000000 * ADIOS2_VERSION_MAJOR + 1000000 * ADIOS2_VERSION_MINOR +        \
         10000 * ADIOS2_VERSION_PATCH + 100 * ADIOS2_VERSION_TWEAK >=           \
@@ -6795,19 +6873,20 @@ void append_mode(
             write.flush();
         }
         {
-            Series read(filename, Access::READ_ONLY);
+            Series read(filename, Access::READ_LINEAR);
             switch (parseMode)
             {
             case ParseMode::LinearWithoutSnapshot: {
-                uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 10};
+                uint64_t iterationOrder[] = {0, 1, 3, 4, 10};
                 unsigned counter = 0;
-                for (auto const &iteration : read.readIterations())
+                for (auto iteration : read.readIterations())
                 {
                     REQUIRE(
                         iteration.iterationIndex == iterationOrder[counter]);
+                    verifyIteration(iteration);
                     ++counter;
                 }
-                REQUIRE(counter == 6);
+                REQUIRE(counter == 5);
                 // Cannot do listSeries here because the Series is already
                 // drained
                 REQUIRE_THROWS_AS(
@@ -6818,11 +6897,12 @@ void append_mode(
                 // in variable-based encodings, iterations are not parsed ahead
                 // of time but as they go
                 unsigned counter = 0;
-                uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 10, 7, 5};
-                for (auto const &iteration : read.readIterations())
+                uint64_t iterationOrder[] = {0, 1, 3, 2, 4, 10, 7, 5};
+                for (auto iteration : read.readIterations())
                 {
                     REQUIRE(
                         iteration.iterationIndex == iterationOrder[counter]);
+                    verifyIteration(iteration);
                     ++counter;
                 }
                 REQUIRE(counter == 8);
@@ -6832,14 +6912,27 @@ void append_mode(
                     helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
-            case ParseMode::NoSteps:
-            case ParseMode::AheadOfTimeWithoutSnapshot:
+            default:
                 throw std::runtime_error("Test configured wrong.");
                 break;
             }
         }
+        if (!variableBased)
+        {
+            Series read(filename, Access::READ_ONLY);
+            uint64_t iterationOrder[] = {0, 1, 2, 3, 4, 5, 7, 10};
+            unsigned counter = 0;
+            for (auto const &iteration : read.readIterations())
+            {
+                REQUIRE(iteration.iterationIndex == iterationOrder[counter]);
+                ++counter;
+            }
+            REQUIRE(counter == 8);
+            // Cannot do listSeries here because the Series is already
+            // drained
+            REQUIRE_THROWS_AS(helper::listSeries(read), error::WrongAPIUsage);
+        }
     }
-#endif
 #endif
 }
 
@@ -6869,51 +6962,29 @@ TEST_CASE("append_mode", "[serial]")
         }
     }
 })END";
-        if (t == "bp5")
-        {
-            append_mode(
-                "../samples/append/groupbased." + t,
-                false,
-                ParseMode::AheadOfTimeWithoutSnapshot,
-                jsonConfigOld);
-            append_mode(
-                "../samples/append/groupbased_newschema." + t,
-                false,
-                ParseMode::AheadOfTimeWithoutSnapshot,
-                jsonConfigNew);
-            // append_mode(
-            //     "../samples/append/variablebased." + t,
-            //     true,
-            //     ParseMode::WithSnapshot,
-            //     jsonConfigOld);
-            // append_mode(
-            //     "../samples/append/variablebased_newschema." + t,
-            //     true,
-            //     ParseMode::WithSnapshot,
-            //     jsonConfigNew);
-        }
-        else if (t == "bp" || t == "bp4")
+        if (t == "bp" || t == "bp4" || t == "bp5")
         {
             append_mode(
                 "../samples/append/append_groupbased." + t,
                 false,
-                ParseMode::AheadOfTimeWithoutSnapshot,
+                ParseMode::LinearWithoutSnapshot,
                 jsonConfigOld);
             append_mode(
                 "../samples/append/append_groupbased." + t,
                 false,
-                ParseMode::AheadOfTimeWithoutSnapshot,
+                ParseMode::WithSnapshot,
                 jsonConfigNew);
+            // This test config does not make sense
             // append_mode(
             //     "../samples/append/append_variablebased." + t,
             //     true,
             //     ParseMode::WithSnapshot,
             //     jsonConfigOld);
-            // append_mode(
-            //     "../samples/append/append_variablebased." + t,
-            //     true,
-            //     ParseMode::WithSnapshot,
-            //     jsonConfigNew);
+            append_mode(
+                "../samples/append/append_variablebased." + t,
+                true,
+                ParseMode::WithSnapshot,
+                jsonConfigNew);
         }
         else
         {


### PR DESCRIPTION
Situation:
Using ADIOS2 steps in openPMD was always a bit challenging due to slightly incompatible IO workflows.
Traditionally in openPMD, we parse a Series upon opening it and users expect to use random-access for navigating through the Series. Alternatively, in ADIOS2 one can parse each iteration only after opening its corresponding IO step. With an IO step opened, ADIOS2 will only show the data pertaining to exactly that step and no other data (except for attributes that are designed to be constant). With the novel BP5 engine, this distinction is now mandatory to make since it has two access modes: `adios2::Mode::Read` and `adios2::Mode::ReadRandomAccess`.

Also adds the missing Append mode to the Python bindings.

This PR adds a new read mode `READ_LINEAR` and slightly restricts the usage of `READ_ONLY`:

* `READ_ONLY` corresponds to our traditional workflow of parsing everything up-front and then not again. It is implemented in the backend via `adios2::Mode::ReadRandomAccess`. 
    New in this PR: If the engine supports it at all, the Series **will** be parsed before opening any IO step. In variable-based iteration encoding, this means that data from a later iteration might leak into the first.
    Iterations that were parsed up front will not be parsed again upon opening their corresponding IO step.
   Optionally: Stop using IO steps altogether in this access mode in front- and backend. That would be API breaking for streaming (all other API breakage of this PR only affects the experimental new ADIOS2 schema), but with streaming, the other read mode makes more sense anyway.
* `READ_LINEAR`: Don't parse anything upon opening the Series. To get any data, `Series::readIterations()` must be used.

TODO

- [ ] Don't use steps at all in READ_ONLY (-> breaking change since this makes READ_LINEAR required for streaming workflows)
    → Probably best for the next release: Give a runtime warning when using READ_ONLY in contexts that should require READ_LINEAR (such as streaming), and disable the functionality altogether in the release after that
- [x] Memory optimization: Delete old iterations in READ_LINEAR mode (also ok for a future PR)
- [x] Merge #1237 first
- [x] ADIOS 2.7 compatibility
- [x] Actually test BP5, especially with old iteration encoding
- [x] Documentation
- [x] Test that Streaming keeps working with READ_ONLY mode for now
- [x] What happens if writing a Series with /data/snapshot attribute and then reading in random-access mode
    -> /data/snapshot gets properly ignored, bp4_steps tests this
- [x] Ignore /data/snapshot attribute if the backend reports that it prefers upfront parsing


### Commits:

**Basic implementation**
9a7fab780 Prepare scaffolding for Access::ReadLinearly
6f0e74c0f Adapt frontend to linear read mode
ed4083717 Make OPEN_FILE task parameters writable
73bae08ec ADIOS2 implementation

**Testing and bindings**
0b64fa2e1 Necessary fixes for tests
8dad84524 Add and adapt Python bindings
0ff801b65 Testing

**Documentation**
b06d257f6 Documentation: C++ and Python
fbca5e814 rst documentation

**Allow parsing global attributes before opening first iteration¹**
c841156e6 Make SeriesIterator into a handle
357e48723 Reading attributes without needing to open the first step

**Workaround for ADIOS2 aggregation issue**
891cba0d1 Don't write attributes too early

**Delete old iterations from data structures** ²
dd4228a41 Delete old iterations in READ_LINEAR mode
87d2004c3 DEREGISTER task

**¹)** In READ_LINEAR, the `Series` object is completely empty after constructing it. This is weird when we want to read global attributes:
```cpp
Series s("data.bp", Access::READ_LINEAR);
// no attributes available
for(auto iteration: s.readIterations())
{
    // Attributes are now readable
    // It's weird having to open the first iteration for this
}
```
Solution:
```cpp
Series s("data.bp", Access::READ_LINEAR);
// no attributes available
s.readIterations();
// global attributes can now be read, no iterations yet accessible
for(auto iteration: s.readIterations()) ...
```

**²)** In READ_LINEAR mode, iterations can only be accessed via `series.readIterations()`. We should not store them into `series.iterations` (except the currently active one), to avoid (1) users getting confused why old iterations are still there and (2) slowly rising memory usage in long-running simulation workflows. 