### PR TITLE
Add unique_ptr overloads for storeChunk calls

### DIFF
--- a/examples/12_span_write.cpp
+++ b/examples/12_span_write.cpp
@@ -82,6 +82,36 @@ void span_write(std::string const &filename)
             }
             ++j;
         }
+
+        using mesh_type = position_t;
+
+        RecordComponent chargeDensity =
+            iteration.meshes["e_chargeDensity"][RecordComponent::SCALAR];
+
+        /*
+         * A similar memory optimization is possible by using a unique_ptr type
+         * in the call to storeChunk().
+         * Unlike the Span API, the buffer here is user-created, but in both
+         * approaches, the backend will manage the memory after the call to
+         * storeChunk().
+         * Some backends (especially: ADIOS2 BP5) will benefit from being able
+         * to avoid memcopies since they know that they can just keep the memory
+         * and noone else is reading it.
+         */
+        chargeDensity.resetDataset(dataset);
+        /*
+         * The class template OpenpmdUniquePtr (subclass of std::unique_ptr)
+         * can be used to specify custom destructors, e.g. for deallocating
+         * GPU pointers.
+         * Normal std::unique_ptr types can also be used, even with custom
+         * destructors.
+         */
+        OpenpmdUniquePtr<mesh_type> data(
+            new mesh_type[length](), [](auto const *ptr) { delete[] ptr; });
+        /*
+         * Move the unique_ptr into openPMD. It must now no longer be accessed.
+         */
+        chargeDensity.storeChunk(std::move(data), {0}, extent);
         iteration.close();
     }
 }

--- a/examples/12_span_write.cpp
+++ b/examples/12_span_write.cpp
@@ -100,13 +100,13 @@ void span_write(std::string const &filename)
          */
         chargeDensity.resetDataset(dataset);
         /*
-         * The class template OpenpmdUniquePtr (subclass of std::unique_ptr)
+         * The class template UniquePtrWithLambda (subclass of std::unique_ptr)
          * can be used to specify custom destructors, e.g. for deallocating
          * GPU pointers.
          * Normal std::unique_ptr types can also be used, even with custom
          * destructors.
          */
-        OpenpmdUniquePtr<mesh_type> data(
+        UniquePtrWithLambda<mesh_type> data(
             new mesh_type[length](), [](auto const *ptr) { delete[] ptr; });
         /*
          * Move the unique_ptr into openPMD. It must now no longer be accessed.

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -188,8 +188,8 @@ public:
     void deleteAttribute(
         Writable *, Parameter<Operation::DELETE_ATT> const &) override;
 
-    void writeDataset(
-        Writable *, Parameter<Operation::WRITE_DATASET> const &) override;
+    void
+    writeDataset(Writable *, Parameter<Operation::WRITE_DATASET> &) override;
 
     void writeAttribute(
         Writable *, Parameter<Operation::WRITE_ATT> const &) override;

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -919,7 +919,7 @@ namespace detail
         std::string name;
         Offset offset;
         Extent extent;
-        OpenpmdUniquePtr<void> data;
+        UniquePtrWithLambda<void> data;
         Datatype dtype;
 
         void run(BufferedActions &);

--- a/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
@@ -74,8 +74,8 @@ public:
         Writable *, Parameter<Operation::DELETE_DATASET> const &) override;
     void deleteAttribute(
         Writable *, Parameter<Operation::DELETE_ATT> const &) override;
-    void writeDataset(
-        Writable *, Parameter<Operation::WRITE_DATASET> const &) override;
+    void
+    writeDataset(Writable *, Parameter<Operation::WRITE_DATASET> &) override;
     void writeAttribute(
         Writable *, Parameter<Operation::WRITE_ATT> const &) override;
     void readDataset(Writable *, Parameter<Operation::READ_DATASET> &) override;

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -456,7 +456,7 @@ public:
      * storage after the operation completes successfully.
      */
     virtual void
-    writeDataset(Writable *, Parameter<Operation::WRITE_DATASET> const &) = 0;
+    writeDataset(Writable *, Parameter<Operation::WRITE_DATASET> &) = 0;
 
     /** Get a view into a dataset buffer that can be filled by a user.
      *

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -65,8 +65,8 @@ public:
         Writable *, Parameter<Operation::DELETE_DATASET> const &) override;
     void deleteAttribute(
         Writable *, Parameter<Operation::DELETE_ATT> const &) override;
-    void writeDataset(
-        Writable *, Parameter<Operation::WRITE_DATASET> const &) override;
+    void
+    writeDataset(Writable *, Parameter<Operation::WRITE_DATASET> &) override;
     void writeAttribute(
         Writable *, Parameter<Operation::WRITE_ATT> const &) override;
     void readDataset(Writable *, Parameter<Operation::READ_DATASET> &) override;

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -25,6 +25,7 @@
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/Streaming.hpp"
 #include "openPMD/auxiliary/Export.hpp"
+#include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/ParsePreference.hpp"
@@ -33,6 +34,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace openPMD
@@ -92,12 +94,17 @@ struct OPENPMDAPI_EXPORT AbstractParameter
 {
     virtual ~AbstractParameter() = default;
     AbstractParameter() = default;
-    // AbstractParameter(AbstractParameter&&) = default;
 
+    virtual std::unique_ptr<AbstractParameter> to_heap() && = 0;
+
+protected:
     // avoid object slicing
-    AbstractParameter(const AbstractParameter &) = delete;
-    AbstractParameter &operator=(const AbstractParameter &) = delete;
-    virtual std::unique_ptr<AbstractParameter> clone() const = 0;
+    // by allow only child classes to use these things for defining their own
+    // copy/move constructors/assignment operators
+    AbstractParameter(const AbstractParameter &) = default;
+    AbstractParameter &operator=(const AbstractParameter &) = default;
+    AbstractParameter(AbstractParameter &&) = default;
+    AbstractParameter &operator=(AbstractParameter &&) = default;
 };
 
 /** @brief Typesafe description of all required arguments for a specified
@@ -122,14 +129,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::CREATE_FILE>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter(), name(p.name), encoding(p.encoding)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::CREATE_FILE>(*this));
+            new Parameter<Operation::CREATE_FILE>(std::move(*this)));
     }
 
     std::string name = "";
@@ -141,14 +149,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::CHECK_FILE>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter(), name(p.name), fileExists(p.fileExists)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::CHECK_FILE>(*this));
+            new Parameter<Operation::CHECK_FILE>(std::move(*this)));
     }
 
     std::string name = "";
@@ -167,17 +176,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_FILE>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter()
-        , name(p.name)
-        , encoding(p.encoding)
-        , out_parsePreference(p.out_parsePreference)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::OPEN_FILE>(*this));
+            new Parameter<Operation::OPEN_FILE>(std::move(*this)));
     }
 
     std::string name = "";
@@ -197,13 +204,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::CLOSE_FILE>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &) : AbstractParameter()
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::CLOSE_FILE>(*this));
+            new Parameter<Operation::CLOSE_FILE>(std::move(*this)));
     }
 };
 
@@ -212,13 +221,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::DELETE_FILE>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), name(p.name)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::DELETE_FILE>(*this));
+            new Parameter<Operation::DELETE_FILE>(std::move(*this)));
     }
 
     std::string name = "";
@@ -229,13 +240,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::CREATE_PATH>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), path(p.path)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::CREATE_PATH>(*this));
+            new Parameter<Operation::CREATE_PATH>(std::move(*this)));
     }
 
     std::string path = "";
@@ -246,18 +259,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::CLOSE_PATH>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &) : AbstractParameter()
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    Parameter &operator=(Parameter const &)
-    {
-        return *this;
-    }
-
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::CLOSE_PATH>(*this));
+            new Parameter<Operation::CLOSE_PATH>(std::move(*this)));
     }
 };
 
@@ -266,13 +276,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_PATH>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), path(p.path)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::OPEN_PATH>(*this));
+            new Parameter<Operation::OPEN_PATH>(std::move(*this)));
     }
 
     std::string path = "";
@@ -283,13 +295,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::DELETE_PATH>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), path(p.path)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::DELETE_PATH>(*this));
+            new Parameter<Operation::DELETE_PATH>(std::move(*this)));
     }
 
     std::string path = "";
@@ -300,13 +314,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::LIST_PATHS>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), paths(p.paths)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::LIST_PATHS>(*this));
+            new Parameter<Operation::LIST_PATHS>(std::move(*this)));
     }
 
     std::shared_ptr<std::vector<std::string>> paths =
@@ -318,18 +334,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::CREATE_DATASET>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter()
-        , name(p.name)
-        , extent(p.extent)
-        , dtype(p.dtype)
-        , options(p.options)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::CREATE_DATASET>(*this));
+            new Parameter<Operation::CREATE_DATASET>(std::move(*this)));
     }
 
     std::string name = "";
@@ -355,13 +368,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::EXTEND_DATASET>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), extent(p.extent)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::EXTEND_DATASET>(*this));
+            new Parameter<Operation::EXTEND_DATASET>(std::move(*this)));
     }
 
     Extent extent = {};
@@ -372,14 +387,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_DATASET>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter(), name(p.name), dtype(p.dtype), extent(p.extent)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::OPEN_DATASET>(*this));
+            new Parameter<Operation::OPEN_DATASET>(std::move(*this)));
     }
 
     std::string name = "";
@@ -392,13 +408,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::DELETE_DATASET>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), name(p.name)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::DELETE_DATASET>(*this));
+            new Parameter<Operation::DELETE_DATASET>(std::move(*this)));
     }
 
     std::string name = "";
@@ -409,27 +427,16 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::WRITE_DATASET>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter<Operation::WRITE_DATASET> const &p)
-        : AbstractParameter()
-        , extent(p.extent)
-        , offset(p.offset)
-        , dtype(p.dtype)
-        , data(p.data)
-    {}
 
-    Parameter &operator=(const Parameter &p)
-    {
-        this->extent = p.extent;
-        this->offset = p.offset;
-        this->dtype = p.dtype;
-        this->data = p.data;
-        return *this;
-    }
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::WRITE_DATASET>(*this));
+            new Parameter<Operation::WRITE_DATASET>(std::move(*this)));
     }
 
     Extent extent = {};
@@ -443,27 +450,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::READ_DATASET>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter<Operation::READ_DATASET> const &p)
-        : AbstractParameter()
-        , extent(p.extent)
-        , offset(p.offset)
-        , dtype(p.dtype)
-        , data(p.data)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    Parameter &operator=(const Parameter &p)
-    {
-        this->extent = p.extent;
-        this->offset = p.offset;
-        this->dtype = p.dtype;
-        this->data = p.data;
-        return *this;
-    }
-
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::READ_DATASET>(*this));
+            new Parameter<Operation::READ_DATASET>(std::move(*this)));
     }
 
     Extent extent = {};
@@ -477,13 +472,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::LIST_DATASETS>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), datasets(p.datasets)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::LIST_DATASETS>(*this));
+            new Parameter<Operation::LIST_DATASETS>(std::move(*this)));
     }
 
     std::shared_ptr<std::vector<std::string>> datasets =
@@ -495,28 +492,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::GET_BUFFER_VIEW>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter()
-        , offset(p.offset)
-        , extent(p.extent)
-        , dtype(p.dtype)
-        , update(p.update)
-        , out(p.out)
-    {}
-    Parameter &operator=(Parameter const &p)
-    {
-        offset = p.offset;
-        extent = p.extent;
-        dtype = p.dtype;
-        update = p.update;
-        out = p.out;
-        return *this;
-    }
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::GET_BUFFER_VIEW>(*this));
+            new Parameter<Operation::GET_BUFFER_VIEW>(std::move(*this)));
     }
 
     // in parameters
@@ -539,13 +523,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::DELETE_ATT>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), name(p.name)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::DELETE_ATT>(*this));
+            new Parameter<Operation::DELETE_ATT>(std::move(*this)));
     }
 
     std::string name = "";
@@ -556,18 +542,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::WRITE_ATT>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter()
-        , name(p.name)
-        , dtype(p.dtype)
-        , changesOverSteps(p.changesOverSteps)
-        , resource(p.resource)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::WRITE_ATT>(*this));
+            new Parameter<Operation::WRITE_ATT>(std::move(*this)));
     }
 
     std::string name = "";
@@ -587,25 +570,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::READ_ATT>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter()
-        , name(p.name)
-        , dtype(p.dtype)
-        , resource(p.resource)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    Parameter &operator=(const Parameter &p)
-    {
-        this->name = p.name;
-        this->dtype = p.dtype;
-        this->resource = p.resource;
-        return *this;
-    }
-
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::READ_ATT>(*this));
+            new Parameter<Operation::READ_ATT>(std::move(*this)));
     }
 
     std::string name = "";
@@ -619,14 +592,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::LIST_ATTS>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter(), attributes(p.attributes)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::LIST_ATTS>(*this));
+            new Parameter<Operation::LIST_ATTS>(std::move(*this)));
     }
 
     std::shared_ptr<std::vector<std::string>> attributes =
@@ -638,14 +612,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::ADVANCE>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter(), mode(p.mode), status(p.status)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::ADVANCE>(*this));
+            new Parameter<Operation::ADVANCE>(std::move(*this)));
     }
 
     //! input parameter
@@ -660,19 +635,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::AVAILABLE_CHUNKS>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p) : AbstractParameter(), chunks(p.chunks)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    Parameter &operator=(Parameter const &p)
-    {
-        chunks = p.chunks;
-        return *this;
-    }
-
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::unique_ptr<AbstractParameter>(
-            new Parameter<Operation::AVAILABLE_CHUNKS>(*this));
+            new Parameter<Operation::AVAILABLE_CHUNKS>(std::move(*this)));
     }
 
     // output parameter
@@ -684,13 +655,15 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::KEEP_SYNCHRONOUS>
     : public AbstractParameter
 {
     Parameter() = default;
-    Parameter(Parameter const &p)
-        : AbstractParameter(), otherWritable(p.otherWritable)
-    {}
+    Parameter(Parameter &&) = default;
+    Parameter(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+    Parameter &operator=(Parameter const &) = default;
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
-        return std::make_unique<Parameter<Operation::KEEP_SYNCHRONOUS>>(*this);
+        return std::make_unique<Parameter<Operation::KEEP_SYNCHRONOUS>>(
+            std::move(*this));
     }
 
     Writable *otherWritable;
@@ -704,9 +677,10 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::DEREGISTER>
     Parameter(Parameter const &) : AbstractParameter()
     {}
 
-    std::unique_ptr<AbstractParameter> clone() const override
+    std::unique_ptr<AbstractParameter> to_heap() && override
     {
-        return std::make_unique<Parameter<Operation::DEREGISTER>>(*this);
+        return std::make_unique<Parameter<Operation::DEREGISTER>>(
+            std::move(*this));
     }
 };
 
@@ -730,13 +704,15 @@ public:
      * parameters to the operation.
      */
     template <Operation op>
-    explicit IOTask(Writable *w, Parameter<op> const &p)
-        : writable{w}, operation{op}, parameter{p.clone()}
+    explicit IOTask(Writable *w, Parameter<op> p)
+        : writable{w}, operation{op}, parameter{std::move(p).to_heap()}
     {}
 
     template <Operation op>
-    explicit IOTask(Attributable *a, Parameter<op> const &p)
-        : writable{getWritable(a)}, operation{op}, parameter{p.clone()}
+    explicit IOTask(Attributable *a, Parameter<op> p)
+        : writable{getWritable(a)}
+        , operation{op}
+        , parameter{std::move(p).to_heap()}
     {}
 
     explicit IOTask(IOTask const &other)

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -429,9 +429,9 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::WRITE_DATASET>
     Parameter() = default;
 
     Parameter(Parameter &&) = default;
-    Parameter(Parameter const &) = default;
+    Parameter(Parameter const &) = delete;
     Parameter &operator=(Parameter &&) = default;
-    Parameter &operator=(Parameter const &) = default;
+    Parameter &operator=(Parameter const &) = delete;
 
     std::unique_ptr<AbstractParameter> to_heap() && override
     {
@@ -442,7 +442,7 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::WRITE_DATASET>
     Extent extent = {};
     Offset offset = {};
     Datatype dtype = Datatype::UNDEFINED;
-    std::shared_ptr<void const> data = nullptr;
+    auxiliary::WriteBuffer data;
 };
 
 template <>

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -195,8 +195,8 @@ public:
     void deleteAttribute(
         Writable *, Parameter<Operation::DELETE_ATT> const &) override;
 
-    void writeDataset(
-        Writable *, Parameter<Operation::WRITE_DATASET> const &) override;
+    void
+    writeDataset(Writable *, Parameter<Operation::WRITE_DATASET> &) override;
 
     void writeAttribute(
         Writable *, Parameter<Operation::WRITE_ATT> const &) override;

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -21,7 +21,9 @@
 #pragma once
 
 #include "openPMD/Dataset.hpp"
+#include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
+#include "openPMD/auxiliary/UniquePtr.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 
 #include <array>
@@ -291,6 +293,21 @@ public:
     template <typename T>
     void storeChunk(std::shared_ptr<T[]> data, Offset offset, Extent extent);
 
+    /** Store a chunk of data from a chunk of memory, unique pointer version.
+     *
+     * @param data   Preallocated, contiguous buffer, large enough to read the
+     *               the specified data from it.
+     *               The unique pointer must own and manage the buffer.
+     *               Optimizations might be implemented based on this
+     *               assumption (e.g. further deferring the operation if the
+     *               backend is the unique owner).
+     *               For raw pointers, use storeChunkRaw().
+     * @param offset Offset within the dataset.
+     * @param extent Extent within the dataset, counted from the offset.
+     */
+    template <typename T>
+    void storeChunk(OpenpmdUniquePtr<T> data, Offset offset, Extent extent);
+
     /** Store a chunk of data from a chunk of memory, raw pointer version.
      *
      * @param data   Preallocated, contiguous buffer, large enough to read the
@@ -386,6 +403,9 @@ private:
      * @return Reference to this RecordComponent instance.
      */
     RecordComponent &makeEmpty(Dataset d);
+
+    void storeChunk(
+        auxiliary::WriteBuffer buffer, Datatype datatype, Offset o, Extent e);
 
     /**
      * @brief Check recursively whether this RecordComponent is dirty.

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -308,6 +308,21 @@ public:
     template <typename T>
     void storeChunk(OpenpmdUniquePtr<T> data, Offset offset, Extent extent);
 
+    /** Store a chunk of data from a chunk of memory, unique pointer version.
+     *
+     * @param data   Preallocated, contiguous buffer, large enough to read the
+     *               the specified data from it.
+     *               The unique pointer must own and manage the buffer.
+     *               Optimizations might be implemented based on this
+     *               assumption (e.g. further deferring the operation if the
+     *               backend is the unique owner).
+     *               For raw pointers, use storeChunkRaw().
+     * @param offset Offset within the dataset.
+     * @param extent Extent within the dataset, counted from the offset.
+     */
+    template <typename T, typename Del>
+    void storeChunk(std::unique_ptr<T, Del> data, Offset offset, Extent extent);
+
     /** Store a chunk of data from a chunk of memory, raw pointer version.
      *
      * @param data   Preallocated, contiguous buffer, large enough to read the

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -306,7 +306,7 @@ public:
      * @param extent Extent within the dataset, counted from the offset.
      */
     template <typename T>
-    void storeChunk(OpenpmdUniquePtr<T> data, Offset offset, Extent extent);
+    void storeChunk(UniquePtrWithLambda<T> data, Offset offset, Extent extent);
 
     /** Store a chunk of data from a chunk of memory, unique pointer version.
      *

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -23,8 +23,10 @@
 
 #include "openPMD/RecordComponent.hpp"
 #include "openPMD/Span.hpp"
+#include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/auxiliary/ShareRawInternal.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
+#include "openPMD/auxiliary/UniquePtr.hpp"
 
 namespace openPMD
 {
@@ -194,51 +196,33 @@ template< typename T >
 inline void
 RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
 {
-    if( constant() )
-        throw std::runtime_error("Chunks cannot be written for a constant RecordComponent.");
-    if( empty() )
-        throw std::runtime_error("Chunks cannot be written for an empty RecordComponent.");
-    if( !data )
-        throw std::runtime_error("Unallocated pointer passed during chunk store.");
+    if (!data)
+        throw std::runtime_error(
+            "Unallocated pointer passed during chunk store.");
     Datatype dtype = determineDatatype(data);
-    if( dtype != getDatatype() )
-    {
-        std::ostringstream oss;
-        oss << "Datatypes of chunk data ("
-            << dtype
-            << ") and record component ("
-            << getDatatype()
-            << ") do not match.";
-        throw std::runtime_error(oss.str());
-    }
-    uint8_t dim = getDimensionality();
-    if( e.size() != dim || o.size() != dim )
-    {
-        std::ostringstream oss;
-        oss << "Dimensionality of chunk ("
-            << "offset=" << o.size() << "D, "
-            << "extent=" << e.size() << "D) "
-            << "and record component ("
-            << int(dim) << "D) "
-            << "do not match.";
-        throw std::runtime_error(oss.str());
-    }
-    Extent dse = getExtent();
-    for( uint8_t i = 0; i < dim; ++i )
-        if( dse[i] < o[i] + e[i] )
-            throw std::runtime_error("Chunk does not reside inside dataset (Dimension on index " + std::to_string(i)
-                                     + ". DS: " + std::to_string(dse[i])
-                                     + " - Chunk: " + std::to_string(o[i] + e[i])
-                                     + ")");
 
-    Parameter< Operation::WRITE_DATASET > dWrite;
-    dWrite.offset = o;
-    dWrite.extent = e;
-    dWrite.dtype = dtype;
     /* std::static_pointer_cast correctly reference-counts the pointer */
-    dWrite.data = std::static_pointer_cast< void const >(data);
-    auto & rc = get();
-    rc.m_chunks.push(IOTask(this, std::move(dWrite)));
+    storeChunk(
+        auxiliary::WriteBuffer(std::static_pointer_cast<void const>(data)),
+        dtype,
+        std::move(o),
+        std::move(e));
+}
+
+template <typename T>
+inline void
+RecordComponent::storeChunk(OpenpmdUniquePtr<T> data, Offset o, Extent e)
+{
+    if (!data)
+        throw std::runtime_error(
+            "Unallocated pointer passed during chunk store.");
+    Datatype dtype = determineDatatype<>(data);
+
+    storeChunk(
+        auxiliary::WriteBuffer{std::move(data).template static_cast_<void>()},
+        dtype,
+        std::move(o),
+        std::move(e));
 }
 
 template <typename T>

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -238,7 +238,7 @@ RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
     /* std::static_pointer_cast correctly reference-counts the pointer */
     dWrite.data = std::static_pointer_cast< void const >(data);
     auto & rc = get();
-    rc.m_chunks.push(IOTask(this, dWrite));
+    rc.m_chunks.push(IOTask(this, std::move(dWrite)));
 }
 
 template <typename T>

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -211,7 +211,7 @@ RecordComponent::storeChunk(std::shared_ptr<T> data, Offset o, Extent e)
 
 template <typename T>
 inline void
-RecordComponent::storeChunk(OpenpmdUniquePtr<T> data, Offset o, Extent e)
+RecordComponent::storeChunk(UniquePtrWithLambda<T> data, Offset o, Extent e)
 {
     if (!data)
         throw std::runtime_error(
@@ -230,7 +230,7 @@ inline void
 RecordComponent::storeChunk(std::unique_ptr<T, Del> data, Offset o, Extent e)
 {
     storeChunk(
-        OpenpmdUniquePtr<T>(std::move(data)), std::move(o), std::move(e));
+        UniquePtrWithLambda<T>(std::move(data)), std::move(o), std::move(e));
 }
 
 template <typename T>

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -225,6 +225,14 @@ RecordComponent::storeChunk(OpenpmdUniquePtr<T> data, Offset o, Extent e)
         std::move(e));
 }
 
+template <typename T, typename Del>
+inline void
+RecordComponent::storeChunk(std::unique_ptr<T, Del> data, Offset o, Extent e)
+{
+    storeChunk(
+        OpenpmdUniquePtr<T>(std::move(data)), std::move(o), std::move(e));
+}
+
 template <typename T>
 inline void
 RecordComponent::storeChunk(std::shared_ptr<T[]> data, Offset o, Extent e)

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -173,11 +173,11 @@ namespace auxiliary
      */
     struct WriteBuffer
     {
-        using EligibleTypes =
-            std::variant<std::shared_ptr<void const>, OpenpmdUniquePtr<void>>;
+        using EligibleTypes = std::
+            variant<std::shared_ptr<void const>, UniquePtrWithLambda<void>>;
         EligibleTypes m_buffer;
 
-        WriteBuffer() : m_buffer(OpenpmdUniquePtr<void>())
+        WriteBuffer() : m_buffer(UniquePtrWithLambda<void>())
         {}
 
         template <typename... Args>
@@ -196,7 +196,7 @@ namespace auxiliary
             return *this;
         }
 
-        WriteBuffer const &operator=(OpenpmdUniquePtr<void const> ptr)
+        WriteBuffer const &operator=(UniquePtrWithLambda<void const> ptr)
         {
             m_buffer = std::move(ptr);
             return *this;

--- a/include/openPMD/auxiliary/TypeTraits.hpp
+++ b/include/openPMD/auxiliary/TypeTraits.hpp
@@ -84,7 +84,7 @@ namespace detail
     };
 
     template <typename T>
-    struct IsPointer<OpenpmdUniquePtr<T>>
+    struct IsPointer<UniquePtrWithLambda<T>>
     {
         constexpr static bool value = true;
         using type = T;

--- a/include/openPMD/auxiliary/TypeTraits.hpp
+++ b/include/openPMD/auxiliary/TypeTraits.hpp
@@ -21,8 +21,11 @@
 
 #pragma once
 
+#include "openPMD/auxiliary/UniquePtr.hpp"
+
 #include <array>
 #include <cstddef> // size_t
+#include <memory>
 #include <vector>
 
 namespace openPMD::auxiliary
@@ -36,7 +39,7 @@ namespace detail
     };
 
     template <typename T>
-    struct IsVector<std::vector<T> >
+    struct IsVector<std::vector<T>>
     {
         static constexpr bool value = true;
     };
@@ -48,9 +51,43 @@ namespace detail
     };
 
     template <typename T, size_t n>
-    struct IsArray<std::array<T, n> >
+    struct IsArray<std::array<T, n>>
     {
         static constexpr bool value = true;
+    };
+
+    template <typename T>
+    struct IsPointer
+    {
+        constexpr static bool value = false;
+    };
+
+    template <typename T>
+    struct IsPointer<T *>
+    {
+        constexpr static bool value = true;
+        using type = T;
+    };
+
+    template <typename T>
+    struct IsPointer<std::shared_ptr<T>>
+    {
+        constexpr static bool value = true;
+        using type = T;
+    };
+
+    template <typename T, typename Del>
+    struct IsPointer<std::unique_ptr<T, Del>>
+    {
+        constexpr static bool value = true;
+        using type = T;
+    };
+
+    template <typename T>
+    struct IsPointer<OpenpmdUniquePtr<T>>
+    {
+        constexpr static bool value = true;
+        using type = T;
     };
 } // namespace detail
 
@@ -59,6 +96,12 @@ inline constexpr bool IsVector_v = detail::IsVector<T>::value;
 
 template <typename T>
 inline constexpr bool IsArray_v = detail::IsArray<T>::value;
+
+template <typename T>
+inline constexpr bool IsPointer_v = detail::IsPointer<T>::value;
+
+template <typename T>
+using IsPointer_t = typename detail::IsPointer<T>::type;
 
 /** Emulate in the C++ concept ContiguousContainer
  *

--- a/include/openPMD/auxiliary/UniquePtr.hpp
+++ b/include/openPMD/auxiliary/UniquePtr.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <type_traits>
+
+namespace openPMD
+{
+
+namespace auxiliary
+{
+    /**
+     * @brief Custom deleter type based on std::function.
+     *
+     * No need to interact with this class directly, used implicitly
+     * by OpenpmdUniquePtr.
+     *
+     * Has some special treatment for array types and falls back
+     * to std::default_delete by default.
+     *
+     * @tparam T The to-be-deleted type, possibly an array.
+     */
+    template <typename T>
+    class CustomDelete : public std::function<void(std::remove_extent_t<T> *)>
+    {
+    private:
+        using T_decayed = std::remove_extent_t<T>;
+
+    public:
+        using deleter_type = std::function<void(T_decayed *)>;
+
+        deleter_type const &get_deleter() const
+        {
+            return *this;
+        }
+        deleter_type &get_deleter()
+        {
+            return *this;
+        }
+
+        /*
+         * Default constructor: Use std::default_delete<T>.
+         * This ensures correct destruction of arrays by using delete[].
+         */
+        CustomDelete()
+            : deleter_type{[](T_decayed *ptr) {
+                if constexpr (std::is_void_v<T_decayed>)
+                {
+                    (void)ptr;
+                    std::cerr << "[Warning] Cannot standard-delete a void-type "
+                                 "pointer. Please specify a custom destructor. "
+                                 "Will let the memory leak."
+                              << std::endl;
+                }
+                else
+                {
+                    std::default_delete<T>{}(ptr);
+                }
+            }}
+        {}
+
+        CustomDelete(deleter_type func) : deleter_type(std::move(func))
+        {}
+    };
+} // namespace auxiliary
+
+/**
+ * @brief Unique Pointer class that uses a dynamic destructor type.
+ *
+ * Unlike std::shared_ptr, std::unique_ptr has a second type parameter for the
+ * destructor, in order to have as little runtime overhead as possible over
+ * raw pointers.
+ * This unique pointer class behaves like a std::unique_ptr with a std::function
+ * based deleter type, making it possible to have one single unique_ptr-like
+ * class that still enables user to specify custom destruction behavior, e.g.
+ * for GPU buffers.
+ *
+ * If not specifying a custom deleter explicitly, this class emulates the
+ * behavior of a std::unique_ptr with std::default_delete.
+ * This also means that array types are supported as expected.
+ *
+ * @tparam T The pointer type, as in std::unique_ptr.
+ */
+template <typename T>
+class OpenpmdUniquePtr
+    : public std::unique_ptr<
+          T,
+          /* Deleter = */ auxiliary::CustomDelete<T>>
+{
+private:
+    using BasePtr = std::unique_ptr<T, auxiliary::CustomDelete<T>>;
+
+public:
+    using T_decayed = std::remove_extent_t<T>;
+
+    OpenpmdUniquePtr() = default;
+
+    OpenpmdUniquePtr(OpenpmdUniquePtr &&) = default;
+    OpenpmdUniquePtr &operator=(OpenpmdUniquePtr &&) = default;
+
+    OpenpmdUniquePtr(OpenpmdUniquePtr const &) = delete;
+    OpenpmdUniquePtr &operator=(OpenpmdUniquePtr const &) = delete;
+
+    /**
+     * Conversion constructor from std::unique_ptr<T> with default deleter.
+     */
+    OpenpmdUniquePtr(std::unique_ptr<T>);
+
+    /**
+     * Conversion constructor from std::unique_ptr<T> with custom deleter.
+     *
+     * @tparam Del Custom deleter type.
+     */
+    template <typename Del>
+    OpenpmdUniquePtr(std::unique_ptr<T, Del>);
+
+    /**
+     * Construct from raw pointer with default deleter.
+     */
+    OpenpmdUniquePtr(T_decayed *);
+
+    /**
+     * Construct from raw pointer with custom deleter.
+     */
+    OpenpmdUniquePtr(T_decayed *, std::function<void(T_decayed *)>);
+
+    /**
+     * Like std::static_pointer_cast.
+     * The dynamic destructor type makes this possible to implement in this
+     * case.
+     *
+     * @tparam U Convert to unique pointer of this type.
+     */
+    template <typename U>
+    OpenpmdUniquePtr<U> static_cast_() &&;
+};
+
+template <typename T>
+OpenpmdUniquePtr<T>::OpenpmdUniquePtr(std::unique_ptr<T> stdPtr)
+    : BasePtr{stdPtr.release()}
+{}
+
+template <typename T>
+template <typename Del>
+OpenpmdUniquePtr<T>::OpenpmdUniquePtr(std::unique_ptr<T, Del> ptr)
+    : BasePtr{
+          ptr.release(),
+          auxiliary::CustomDelete<T>{
+              [deleter = std::move(ptr.get_deleter())](T_decayed *del_ptr) {
+                  deleter.get_deleter()(del_ptr);
+              }}}
+{}
+
+template <typename T>
+OpenpmdUniquePtr<T>::OpenpmdUniquePtr(T_decayed *ptr) : BasePtr{ptr}
+{}
+
+template <typename T>
+OpenpmdUniquePtr<T>::OpenpmdUniquePtr(
+    T_decayed *ptr, std::function<void(T_decayed *)> deleter)
+    : BasePtr{ptr, std::move(deleter)}
+{}
+
+template <typename T>
+template <typename U>
+OpenpmdUniquePtr<U> OpenpmdUniquePtr<T>::static_cast_() &&
+{
+    using other_type = std::remove_extent_t<U>;
+    return OpenpmdUniquePtr<U>{
+        static_cast<other_type *>(this->release()),
+        [deleter = std::move(this->get_deleter())](other_type *ptr) {
+            deleter.get_deleter()(static_cast<T_decayed *>(ptr));
+        }};
+}
+} // namespace openPMD

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -218,6 +218,6 @@ inline void PatchRecordComponent::store(uint64_t idx, T data)
     dWrite.dtype = dtype;
     dWrite.data = std::make_shared<T>(data);
     auto &rc = get();
-    rc.m_chunks.push(IOTask(this, dWrite));
+    rc.m_chunks.push(IOTask(this, std::move(dWrite)));
 }
 } // namespace openPMD

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1962,7 +1962,7 @@ namespace detail
                 }
                 else if constexpr (std::is_same_v<
                                        ptr_type,
-                                       OpenpmdUniquePtr<void>>)
+                                       UniquePtrWithLambda<void>>)
                 {
                     BufferedUniquePtrPut bput;
                     bput.name = std::move(bp.name);

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -816,7 +816,7 @@ void ADIOS2IOHandlerImpl::deleteAttribute(
 }
 
 void ADIOS2IOHandlerImpl::writeDataset(
-    Writable *writable, const Parameter<Operation::WRITE_DATASET> &parameters)
+    Writable *writable, Parameter<Operation::WRITE_DATASET> &parameters)
 {
     VERIFY_ALWAYS(
         access::write(m_handler->m_backendAccess),
@@ -826,7 +826,7 @@ void ADIOS2IOHandlerImpl::writeDataset(
     detail::BufferedActions &ba = getFileData(file, IfFileNotOpen::ThrowError);
     detail::BufferedPut bp;
     bp.name = nameOfVariable(writable);
-    bp.param = parameters;
+    bp.param = std::move(parameters);
     ba.enqueue(std::move(bp));
     m_dirty.emplace(std::move(file));
     writable->written = true; // TODO erst nach dem Schreiben?
@@ -1947,7 +1947,7 @@ namespace detail
             access::write(impl->m_handler->m_backendAccess),
             "[ADIOS2] Cannot write data in read-only mode.");
 
-        auto ptr = std::static_pointer_cast<const T>(bp.param.data).get();
+        auto ptr = static_cast<T const *>(bp.param.data.get());
 
         adios2::Variable<T> var = impl->verifyDataset<T>(
             bp.param.offset, bp.param.extent, IO, bp.name);

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -1097,7 +1097,7 @@ int64_t CommonADIOS1IOHandlerImpl<ChildClass>::GetFileHandle(Writable *writable)
 
 template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::writeDataset(
-    Writable *writable, Parameter<Operation::WRITE_DATASET> const &parameters)
+    Writable *writable, Parameter<Operation::WRITE_DATASET> &parameters)
 {
     if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1235,7 +1235,7 @@ void HDF5IOHandlerImpl::deleteAttribute(
 }
 
 void HDF5IOHandlerImpl::writeDataset(
-    Writable *writable, Parameter<Operation::WRITE_DATASET> const &parameters)
+    Writable *writable, Parameter<Operation::WRITE_DATASET> &parameters)
 {
     if (access::readOnly(m_handler->m_backendAccess))
         throw std::runtime_error(
@@ -1277,7 +1277,7 @@ void HDF5IOHandlerImpl::writeDataset(
         "[HDF5] Internal error: Failed to select hyperslab during dataset "
         "write");
 
-    std::shared_ptr<void const> data = parameters.data;
+    void const *data = parameters.data.get();
 
     GetH5DataType getH5DataType({
         {typeid(bool).name(), m_H5T_BOOL_ENUM},
@@ -1321,7 +1321,7 @@ void HDF5IOHandlerImpl::writeDataset(
             memspace,
             filespace,
             m_datasetTransferProperty,
-            data.get());
+            data);
         VERIFY(
             status == 0,
             "[HDF5] Internal error: Failed to write dataset " +

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -781,7 +781,7 @@ void JSONIOHandlerImpl::deleteAttribute(
 }
 
 void JSONIOHandlerImpl::writeDataset(
-    Writable *writable, Parameter<Operation::WRITE_DATASET> const &parameters)
+    Writable *writable, Parameter<Operation::WRITE_DATASET> &parameters)
 {
     VERIFY_ALWAYS(
         access::write(m_handler->m_backendAccess),

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -7,6 +7,7 @@
 
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/auxiliary/UniquePtr.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -1358,4 +1359,21 @@ TEST_CASE("unavailable_backend", "[core]")
             "'HDF5'.");
     }
 #endif
+}
+
+TEST_CASE("unique_ptr", "[core]")
+{
+    auto stdptr = std::make_unique<int>(5);
+    OpenpmdUniquePtr<int> ptr = std::move(stdptr);
+    auto stdptr_with_custom_del =
+        std::unique_ptr<int, auxiliary::CustomDelete<int>>{
+            new int{5},
+            auxiliary::CustomDelete<int>{[](int *del_ptr) { delete del_ptr; }}};
+    OpenpmdUniquePtr<int> ptr2 = std::move(stdptr_with_custom_del);
+
+    OpenpmdUniquePtr<int[]> arrptr;
+    // valgrind can detect mismatched new/delete pairs
+    OpenpmdUniquePtr<int[]> arrptrFilled{new int[5]{}};
+    OpenpmdUniquePtr<int[]> arrptrFilledCustom{
+        new int[5]{}, [](int const *p) { delete[] p; }};
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1369,8 +1369,9 @@ TEST_CASE("unique_ptr", "[core]")
     OpenpmdUniquePtr<int> ptr = std::move(stdptr);
     auto stdptr_with_custom_del =
         std::unique_ptr<int, auxiliary::CustomDelete<int>>{
-            new int{5},
-            auxiliary::CustomDelete<int>{[](int *del_ptr) { delete del_ptr; }}};
+            new int{5}, auxiliary::CustomDelete<int>{[](int const *del_ptr) {
+                delete del_ptr;
+            }}};
     OpenpmdUniquePtr<int> ptr2 = std::move(stdptr_with_custom_del);
 
     OpenpmdUniquePtr<int[]> arrptr;

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -69,11 +69,11 @@ TEST_CASE("attribute_dtype_test", "[core]")
     REQUIRE(Datatype::DOUBLE == a.dtype);
     a = Attribute(static_cast<long double>(0.));
     REQUIRE(Datatype::LONG_DOUBLE == a.dtype);
-    a = Attribute(static_cast<std::complex<float> >(0.));
+    a = Attribute(static_cast<std::complex<float>>(0.));
     REQUIRE(Datatype::CFLOAT == a.dtype);
-    a = Attribute(static_cast<std::complex<double> >(0.));
+    a = Attribute(static_cast<std::complex<double>>(0.));
     REQUIRE(Datatype::CDOUBLE == a.dtype);
-    a = Attribute(static_cast<std::complex<long double> >(0.));
+    a = Attribute(static_cast<std::complex<long double>>(0.));
     REQUIRE(Datatype::CLONG_DOUBLE == a.dtype);
     a = Attribute(std::string(""));
     REQUIRE(Datatype::STRING == a.dtype);
@@ -990,9 +990,11 @@ TEST_CASE("use_count_test", "[core]")
     pprc.resetDataset(Dataset(determineDatatype<uint64_t>(), {4}));
     pprc.store(0, static_cast<uint64_t>(1));
     REQUIRE(
-        static_cast<Parameter<Operation::WRITE_DATASET> *>(
-            pprc.get().m_chunks.front().parameter.get())
-            ->data.use_count() == 1);
+        std::get<std::shared_ptr<void const>>(
+            static_cast<Parameter<Operation::WRITE_DATASET> *>(
+                pprc.get().m_chunks.front().parameter.get())
+                ->data.m_buffer)
+            .use_count() == 1);
 #endif
 }
 
@@ -1268,12 +1270,12 @@ TEST_CASE("DoConvert_single_value_to_vector", "[core]")
         REQUIRE(attr.get<unsigned char>() == 'x');
         REQUIRE(attr.get<signed char>() == 'x');
         // all the previous ones, but make them single-element vectors now
-        REQUIRE(attr.get<std::vector<char> >() == std::vector<char>{'x'});
+        REQUIRE(attr.get<std::vector<char>>() == std::vector<char>{'x'});
         REQUIRE(
-            attr.get<std::vector<unsigned char> >() ==
+            attr.get<std::vector<unsigned char>>() ==
             std::vector<unsigned char>{'x'});
         REQUIRE(
-            attr.get<std::vector<signed char> >() ==
+            attr.get<std::vector<signed char>>() ==
             std::vector<signed char>{'x'});
     }
     {
@@ -1281,14 +1283,14 @@ TEST_CASE("DoConvert_single_value_to_vector", "[core]")
         Attribute attr{array};
 
         // the following conversions should be possible
-        REQUIRE(attr.get<std::array<double, 7> >() == array);
+        REQUIRE(attr.get<std::array<double, 7>>() == array);
         // we don't need array-to-array conversions,
         // so array< int, 7 > cannot be loaded here
         REQUIRE(
-            attr.get<std::vector<double> >() ==
+            attr.get<std::vector<double>>() ==
             std::vector<double>{0, 1, 2, 3, 4, 5, 6});
         REQUIRE(
-            attr.get<std::vector<int> >() ==
+            attr.get<std::vector<int>>() ==
             std::vector<int>{0, 1, 2, 3, 4, 5, 6});
     }
     {
@@ -1298,17 +1300,17 @@ TEST_CASE("DoConvert_single_value_to_vector", "[core]")
         Attribute attr{vector};
 
         // the following conversions should be possible
-        REQUIRE(attr.get<std::array<double, 7> >() == arraydouble);
-        REQUIRE(attr.get<std::array<int, 7> >() == arrayint);
+        REQUIRE(attr.get<std::array<double, 7>>() == arraydouble);
+        REQUIRE(attr.get<std::array<int, 7>>() == arrayint);
         REQUIRE_THROWS_WITH(
-            (attr.get<std::array<int, 8> >()),
+            (attr.get<std::array<int, 8>>()),
             Catch::Equals("getCast: no vector to array conversion possible "
                           "(wrong requested array size)."));
         REQUIRE(
-            attr.get<std::vector<double> >() ==
+            attr.get<std::vector<double>>() ==
             std::vector<double>{0, 1, 2, 3, 4, 5, 6});
         REQUIRE(
-            attr.get<std::vector<int> >() ==
+            attr.get<std::vector<int>>() ==
             std::vector<int>{0, 1, 2, 3, 4, 5, 6});
     }
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1366,17 +1366,17 @@ TEST_CASE("unavailable_backend", "[core]")
 TEST_CASE("unique_ptr", "[core]")
 {
     auto stdptr = std::make_unique<int>(5);
-    OpenpmdUniquePtr<int> ptr = std::move(stdptr);
+    UniquePtrWithLambda<int> ptr = std::move(stdptr);
     auto stdptr_with_custom_del =
         std::unique_ptr<int, auxiliary::CustomDelete<int>>{
             new int{5}, auxiliary::CustomDelete<int>{[](int const *del_ptr) {
                 delete del_ptr;
             }}};
-    OpenpmdUniquePtr<int> ptr2 = std::move(stdptr_with_custom_del);
+    UniquePtrWithLambda<int> ptr2 = std::move(stdptr_with_custom_del);
 
-    OpenpmdUniquePtr<int[]> arrptr;
+    UniquePtrWithLambda<int[]> arrptr;
     // valgrind can detect mismatched new/delete pairs
-    OpenpmdUniquePtr<int[]> arrptrFilled{new int[5]{}};
-    OpenpmdUniquePtr<int[]> arrptrFilledCustom{
+    UniquePtrWithLambda<int[]> arrptrFilled{new int[5]{}};
+    UniquePtrWithLambda<int[]> arrptrFilledCustom{
         new int[5]{}, [](int const *p) { delete[] p; }};
 }

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -52,7 +52,8 @@ std::vector<std::string> testedFileExtensions()
         allExtensions.begin(), allExtensions.end(), [](std::string const &ext) {
             // sst and ssc need a receiver for testing
             // bp4 is already tested via bp
-            return ext == "sst" || ext == "ssc" || ext == "bp4" | ext == "json";
+            return ext == "sst" || ext == "ssc" || ext == "bp4" ||
+                ext == "toml" || ext == "json";
         });
     return {allExtensions.begin(), newEnd};
 }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -697,7 +697,7 @@ void close_and_copy_attributable_test(std::string file_ending)
         // scalar unique_ptr, default delete
         auto pos_x = electronPositions["x"];
         pos_x.resetDataset(Dataset{datatype, {1}});
-        pos_x.storeChunk(std::unique_ptr<int>{new int{5}}, {0}, {1});
+        pos_x.storeChunk(std::make_unique<int>(5), {0}, {1});
 
         // array unique_ptr, default delete
         auto posOff_x = electronPositionsOffset["x"];
@@ -708,8 +708,7 @@ void close_and_copy_attributable_test(std::string file_ending)
             {global_extent});
 
         using CD = auxiliary::CustomDelete<int>;
-        CD deleter{[](int *ptr) { delete ptr; }};
-        CD array_deleter{[](int *ptr) { delete[] ptr; }};
+        CD array_deleter{[](int const *ptr) { delete[] ptr; }};
 
         // scalar unique_ptr, custom delete
         auto pos_y = electronPositions["y"];

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -728,39 +728,39 @@ void close_and_copy_attributable_test(std::string file_ending)
             {0},
             {global_extent});
 
-        // scalar OpenpmdUniquePtr, default delete
+        // scalar UniquePtrWithLambda, default delete
         auto pos_z = electronPositions["z"];
         pos_z.resetDataset(dataset);
         pos_z.storeChunk(
-            OpenpmdUniquePtr<int>{
+            UniquePtrWithLambda<int>{
                 new int[10]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, array_deleter},
             {0},
             {global_extent});
 
-        // array OpenpmdUniquePtr, default delete
+        // array UniquePtrWithLambda, default delete
         auto posOff_z = electronPositionsOffset["z"];
         posOff_z.resetDataset(dataset);
         posOff_z.storeChunk(
-            OpenpmdUniquePtr<int[]>{
+            UniquePtrWithLambda<int[]>{
                 new int[10]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, array_deleter},
             {0},
             {global_extent});
 
-        // scalar OpenpmdUniquePtr, custom delete
+        // scalar UniquePtrWithLambda, custom delete
         // we're playing 4D now
         auto pos_w = electronPositions["w"];
         pos_w.resetDataset(dataset);
         pos_w.storeChunk(
-            OpenpmdUniquePtr<int>{
+            UniquePtrWithLambda<int>{
                 new int[10]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, array_deleter},
             {0},
             {global_extent});
 
-        // array OpenpmdUniquePtr, custom delete
+        // array UniquePtrWithLambda, custom delete
         auto posOff_w = electronPositionsOffset["w"];
         posOff_w.resetDataset(dataset);
         posOff_w.storeChunk(
-            OpenpmdUniquePtr<int[]>{
+            UniquePtrWithLambda<int[]>{
                 new int[10]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, array_deleter},
             {0},
             {global_extent});
@@ -963,7 +963,7 @@ inline void constant_scalar(std::string file_ending)
         E_x.makeConstant(static_cast<float>(13.37));
         auto E_y = s.iterations[1].meshes["E"]["y"];
         E_y.resetDataset(Dataset(Datatype::UINT, {1, 2, 3}));
-        OpenpmdUniquePtr<unsigned int> E(
+        UniquePtrWithLambda<unsigned int> E(
             new unsigned int[6], [](unsigned int const *p) { delete[] p; });
         unsigned int e{0};
         std::generate(E.get(), E.get() + 6, [&e] { return e++; });
@@ -998,7 +998,7 @@ inline void constant_scalar(std::string file_ending)
         vel_x.makeConstant(static_cast<short>(-1));
         auto vel_y = s.iterations[1].particles["e"]["velocity"]["y"];
         vel_y.resetDataset(Dataset(Datatype::ULONGLONG, {3, 2, 1}));
-        OpenpmdUniquePtr<unsigned long long> vel(
+        UniquePtrWithLambda<unsigned long long> vel(
             new unsigned long long[6],
             [](unsigned long long const *p) { delete[] p; });
         unsigned long long v{0};
@@ -4258,7 +4258,7 @@ void adios2_bp5_flush(std::string const &cfg, FlushDuringStep flushDuringStep)
         }
 
         bool has_been_deleted = false;
-        OpenpmdUniquePtr<int32_t> copied_as_unique(
+        UniquePtrWithLambda<int32_t> copied_as_unique(
             new int[size], [&has_been_deleted](int const *ptr) {
                 delete[] ptr;
                 has_been_deleted = true;

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -899,11 +899,11 @@ inline void constant_scalar(std::string file_ending)
         E_x.makeConstant(static_cast<float>(13.37));
         auto E_y = s.iterations[1].meshes["E"]["y"];
         E_y.resetDataset(Dataset(Datatype::UINT, {1, 2, 3}));
-        std::shared_ptr<unsigned int> E(
+        OpenpmdUniquePtr<unsigned int> E(
             new unsigned int[6], [](unsigned int const *p) { delete[] p; });
         unsigned int e{0};
         std::generate(E.get(), E.get() + 6, [&e] { return e++; });
-        E_y.storeChunk(E, {0, 0, 0}, {1, 2, 3});
+        E_y.storeChunk(std::move(E), {0, 0, 0}, {1, 2, 3});
 
         // store a number of predefined attributes in E
         Mesh &E_mesh = s.iterations[1].meshes["E"];
@@ -934,12 +934,12 @@ inline void constant_scalar(std::string file_ending)
         vel_x.makeConstant(static_cast<short>(-1));
         auto vel_y = s.iterations[1].particles["e"]["velocity"]["y"];
         vel_y.resetDataset(Dataset(Datatype::ULONGLONG, {3, 2, 1}));
-        std::shared_ptr<unsigned long long> vel(
+        OpenpmdUniquePtr<unsigned long long> vel(
             new unsigned long long[6],
             [](unsigned long long const *p) { delete[] p; });
         unsigned long long v{0};
         std::generate(vel.get(), vel.get() + 6, [&v] { return v++; });
-        vel_y.storeChunk(vel, {0, 0, 0}, {3, 2, 1});
+        vel_y.storeChunk(std::move(vel), {0, 0, 0}, {3, 2, 1});
     }
 
     {


### PR DESCRIPTION
See https://github.com/openPMD/openPMD-api/issues/1216 for an explanation. The approach in this PR is to use `unique_ptr`s instead of relying on the refcount of `shared_ptr`s to make this optimization more explicit to the user.

TODO

- [x] Add a class `OpenpmdUniquePtr` that allows specifying dynamic destructors via `std::function<void(T*)>`, similar to `std::shared_ptr`. In the STL, `unique_ptr`s have a different type depending on their destructor, which is annoying for our use case, and the overhead of making this dynamic is negligible in our use case.
    This way, it's easily possible to e.g. pass ownership of pinned memory to openPMD and still let it correctly destroy it once used.
- [x] Extend the IOTask for `Write_Dataset` operations to accept `std::variant<std::shared_ptr<void const>, OpenpmdUniquePtr<void const>>` as a buffer.
    This requires some light refactoring because with this change, the IOTask is not copyable any more.
    This includes making the backends deal with both types correctly.
- [x] Add a `storeChunk` overload that accepts `OpenpmdUniquePtr`s
- [x] Actually implement the intended optimization in the ADIOS2 backend
- [x] testing, documentation
- [x] support for determineDatatype
- [x] Merge #1207 first
- [x] Check if it also works to let this be handled by `Engine::close()`.
- [x] I think it might be possible to implement this in such a way that makes `OpenpmdUniquePtr` not leak into the public API.


@ax3l This PR should not be too much work any more, so we might as well add this to 0.15.*?