### PR TITLE
Avoid LD_PRELOAD in ASAN UBSAN script, use LD_LIBRARY_PATH instead

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -71,7 +71,10 @@ jobs:
         cmake --build build --parallel 2
         export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         export LSAN_OPTIONS=suppressions="$SOURCEPATH/.github/ci/sanitizer/clang/Leak.supp"
-        export LD_PRELOAD=/usr/lib/clang/10/lib/linux/libclang_rt.asan-x86_64.so
+        # This path contains libclang_rt.asan-x86_64.so
+        # openPMD-api was linked to that library by specification of the linker
+        # flags above, but we still need to tell the system where the lib is.
+        export LD_LIBRARY_PATH="/usr/lib/clang/10/lib/linux/:$LD_LIBRARY_PATH"
         ctest --test-dir build -E 3b --output-on-failure
         export OPENPMD_HDF5_CHUNKS="auto"
         ctest --test-dir build -R 3b --output-on-failure


### PR DESCRIPTION
Doesn't really matter for the CI, but I often use these scripts as a blueprint for other stuff and it's good to avoid `LD_PRELOAD` if possible.