### PR TITLE
Wheels: Fix HDF5 on Windows (0.14.5.post1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,8 @@ jobs:
         CIBW_BEFORE_BUILD_WINDOWS: 'cmd /E:ON /V:ON /C .github\library_builders.bat'
         # for the openPMD-api build, CMake shall search for
         # static dependencies of HDF5 and ADIOS1 (see setup.py)
-        CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' ADIOS_USE_STATIC_LIBS='ON'
-        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' CMAKE_PREFIX_PATH='C:/Program Files (x86)/ADIOS2;C:/Program Files (x86)/blosc;C:/Program Files/HDF_Group/HDF5/1.12.0;C:/Program Files (x86)/ZFP;C:/Program Files (x86)/zlib/'
+        CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' ADIOS_USE_STATIC_LIBS='ON' openPMD_CMAKE_openPMD_USE_HDF5='ON' openPMD_CMAKE_openPMD_USE_ADIOS2='ON'
+        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' openPMD_CMAKE_openPMD_USE_HDF5='ON' openPMD_CMAKE_openPMD_USE_ADIOS2='ON' CMAKE_PREFIX_PATH='C:/Program Files (x86)/ADIOS2;C:/Program Files (x86)/blosc;C:/Program Files (x86)/HDF5;C:/Program Files (x86)/ZFP;C:/Program Files (x86)/zlib'
         # C++11 & 14 support in macOS 10.9+
         # C++17 support in macOS 10.13+/10.14+
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,18 +92,29 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install cibuildwheel==2.2.2
 
-    - name: Download Patch 1/1
+    # 0.14.5: macOS ADIOS1 Linker Error
+    # https://github.com/openPMD/openPMD-api/issues/1287
+    - name: Download Patch 1/2
       uses: suisei-cn/actions-download-file@v1
-      id: setupversion
+      id: adiosbuild
       with:
         url: "https://github.com/ax3l/openPMD-api/commit/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch"
         target: src/.patch/
 
-    - name: Apply Patch
+    # 0.14.5.post1 bump
+    - name: Download Patch 2/2
+      uses: suisei-cn/actions-download-file@v1
+      id: setupversion
+      with:
+        url: "https://gist.githubusercontent.com/ax3l/4db2f1744e0e28e6c013ee4e752b3cb7/raw/ceb03d11a10e2e2f8cd9c74bff524a21ba8eb92b/setupversion.patch"
+        target: src/.patch/
+
+    - name: Apply Patches
       run: |
         python -m pip install "patch==1.*"
         cd src
         python -m patch .patch/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
+        python -m patch .patch/setupversion.patch
 
     - name: Build wheel
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - CIBW_BEFORE_BUILD="bash -x .github/library_builders.sh"
     # for the openPMD-api build, CMake shall search for
     # static dependencies of HDF5 and ADIOS1 (see setup.py)
-    - CIBW_ENVIRONMENT="HDF5_USE_STATIC_LIBRARIES='ON' ADIOS_USE_STATIC_LIBS='ON'"
+    - CIBW_ENVIRONMENT="HDF5_USE_STATIC_LIBRARIES='ON' ADIOS_USE_STATIC_LIBS='ON' openPMD_CMAKE_openPMD_USE_HDF5='ON' openPMD_CMAKE_openPMD_USE_ADIOS1='ON'" openPMD_CMAKE_openPMD_USE_ADIOS2='ON'"
     # Show a bit more output (pip -v)
     - CIBW_BUILD_VERBOSITY="1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,8 +138,10 @@ before_script:
   - mkdir -p src/.patch
   - cd src/.patch
   - curl -sOL https://github.com/ax3l/openPMD-api/commit/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
+  - curl -sOL https://gist.githubusercontent.com/ax3l/4db2f1744e0e28e6c013ee4e752b3cb7/raw/ceb03d11a10e2e2f8cd9c74bff524a21ba8eb92b/setupversion.patch
   - cd ..
   - python3 -m patch .patch/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
+  - python3 -m patch .patch/setupversion.patch
   - cd ..
 
 script:

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -1,6 +1,6 @@
 set CURRENTDIR="%cd%"
 
-:: BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
+set BUILD_PREFIX="C:/Program Files (x86)"
 set CPU_COUNT="2"
 
 echo "CFLAGS: %CFLAGS%"
@@ -100,7 +100,8 @@ exit /b 0
     -DHDF5_BUILD_TOOLS=OFF      ^
     -DHDF5_ENABLE_PARALLEL=OFF  ^
     -DHDF5_ENABLE_SZIP_SUPPORT=OFF ^
-    -DHDF5_ENABLE_Z_LIB_SUPPORT=ON
+    -DHDF5_ENABLE_Z_LIB_SUPPORT=ON ^
+    -DCMAKE_INSTALL_PREFIX=%BUILD_PREFIX%/HDF5
   if errorlevel 1 exit 1
 
   cmake --build build-hdf5 --parallel %CPU_COUNT%
@@ -151,6 +152,8 @@ exit /b 0
     -DBUILD_SHARED_LIBS=OFF ^
     -DCMAKE_BUILD_TYPE=Release
   if errorlevel 1 exit 1
+:: Manually-specified variables were not used by the project:
+::   CMAKE_BUILD_TYPE
 
   cmake --build build-zlib --parallel %CPU_COUNT%
   if errorlevel 1 exit 1


### PR DESCRIPTION
Fix the missing HDF5 dependency on Windows.
Update the build logic to error out if ADIOS2 or HDF5 are not found (instead of using auto-accept or disable logic).

- [x] bump version to `.post1`

## Note

`Build x86_64 wheel on macos-10.15`
This is a scheduled macOS-10.15 brownout. The macOS-10.15 environment is deprecated and will be removed on August 30th, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5583

Not a big problem, we can restart after merge and do not really need this platform the be rebuilt.