### PR TITLE
Fix `operationAsString` Export

### DIFF
--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -67,7 +67,7 @@ namespace internal
      * The returned strings are compile-time constants, so no worries about
      * pointer validity.
      */
-    std::string operationAsString(Operation);
+    OPENPMDAPI_EXPORT std::string operationAsString(Operation);
 } // namespace internal
 
 struct OPENPMDAPI_EXPORT AbstractParameter


### PR DESCRIPTION
The `operationAsString` function is used in the ADIOS1 backend, which does symbol hiding to wrap ADIOS1's MPI mock library. Thus, we need to export this symbol once we wrap ADIOS1.

Fix #1308