### PR TITLE
Remove caching cmake vars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -740,16 +740,16 @@ if(openPMD_HAVE_PYTHON)
 
     if(WIN32)
         set(CMAKE_INSTALL_PYTHONDIR_DEFAULT
-            "${CMAKE_INSTALL_LIBDIR}/site-packages"
-        )
+            "${CMAKE_INSTALL_LIBDIR}/site-packages")
     else()
         set(CMAKE_INSTALL_PYTHONDIR_DEFAULT
             "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages"
         )
     endif()
+    # Location for installed python package
     set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_PYTHONDIR_DEFAULT}")
-    set(CMAKE_PYTHON_OUTPUT_DIRECTORY
-        "${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}")
+    # Build directory for python modules
+    set(CMAKE_PYTHON_OUTPUT_DIRECTORY "${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}")
     set_target_properties(openPMD.py PROPERTIES
         ARCHIVE_OUTPUT_NAME openpmd_api_cxx
         LIBRARY_OUTPUT_NAME openpmd_api_cxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,26 +44,21 @@ endif()
 #
 # temporary build directories
 if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-        CACHE PATH "Build directory for archives")
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 endif()
 if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-        CACHE PATH "Build directory for libraries")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 endif()
 if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-        CACHE PATH "Build directory for binaries")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 endif()
 # install directories
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     include(GNUInstallDirs)
-    set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/openPMD"
-        CACHE PATH "CMake config package location for installed targets")
+    set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/openPMD")
     if(WIN32)
-        set(CMAKE_INSTALL_LIBDIR Lib
-            CACHE PATH "Object code libraries")
-        set_property(CACHE CMAKE_INSTALL_CMAKEDIR PROPERTY VALUE "cmake")
+        set(CMAKE_INSTALL_LIBDIR Lib)
+        set_property(CMAKE_INSTALL_CMAKEDIR PROPERTY VALUE "cmake")
     endif()
 endif()
 
@@ -98,8 +93,7 @@ option(openPMD_USE_VERIFY "Enable internal VERIFY (assert) macro independent of 
 
 set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
-        "Choose the build type, e.g. Release or Debug." FORCE)
+    set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 include(CMakeDependentOption)
@@ -753,13 +747,9 @@ if(openPMD_HAVE_PYTHON)
             "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages"
         )
     endif()
-    set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_PYTHONDIR_DEFAULT}"
-        CACHE STRING "Location for installed python package"
-    )
+    set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_PYTHONDIR_DEFAULT}")
     set(CMAKE_PYTHON_OUTPUT_DIRECTORY
-        "${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}"
-        CACHE PATH "Build directory for python modules"
-    )
+        "${openPMD_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}")
     set_target_properties(openPMD.py PROPERTIES
         ARCHIVE_OUTPUT_NAME openpmd_api_cxx
         LIBRARY_OUTPUT_NAME openpmd_api_cxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/openPMD")
     if(WIN32)
         set(CMAKE_INSTALL_LIBDIR Lib)
-        set_property(CMAKE_INSTALL_CMAKEDIR PROPERTY VALUE "cmake")
+        set(CMAKE_INSTALL_CMAKEDIR "cmake")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1166,7 +1166,7 @@ if(openPMD_BUILD_TESTING)
         if(${testname} MATCHES "^Parallel.*$")
             if(openPMD_HAVE_MPI)
                 add_test(NAME MPI.${testname}
-                    COMMAND ${MPI_TEST_EXE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
+                    COMMAND ${MPI_TEST_EXE}  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
                     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
                 )
             endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1166,7 +1166,7 @@ if(openPMD_BUILD_TESTING)
         if(${testname} MATCHES "^Parallel.*$")
             if(openPMD_HAVE_MPI)
                 add_test(NAME MPI.${testname}
-                    COMMAND ${MPI_TEST_EXE}  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
+                    COMMAND ${MPI_TEST_EXE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname}Tests
                     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
                 )
             endif()


### PR DESCRIPTION
If openPMD is included into a CMake project as a subproject it modifies variables in or adds variables to the CACHE.
This can lead to conflicts in the parent project since these variables are overwritten in or set for the parent project.

Not adding variables to the [CACHE limits the scope of variables](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-variables) to the openPMD project which makes it safer for other developers to add openPMD as a subproject.

This is a less invasive approach to the pull request #1312 and it is more complete since in #1312 only `CMAKE_RUNTIME_OUTPUT_DIRECTORY` is substituted by a new openPMD specific variable.

List of variables handled in this pull request:
```
CMAKE_ARCHIVE_OUTPUT_DIRECTORY
CMAKE_LIBRARY_OUTPUT_DIRECTORY
CMAKE_RUNTIME_OUTPUT_DIRECTORY
CMAKE_INSTALL_CMAKEDIR
CMAKE_BUILD_TYPE
```

Close #1312