### PR TITLE
Deprecate ADIOS1 backend

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,14 +82,14 @@ jobs:
         export OPENPMD_BP_BACKEND=ADIOS1
         ctest --test-dir build --output-on-failure
 
-  clang7_nopy_ompi_h5_ad1_ad2_newLayout:
+  clang7_nopy_ompi_h5_ad2_newLayout:
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Spack Cache
       uses: actions/cache@v2
-      with: {path: /opt/spack, key: clang7_nopy_ompi_h5_ad1_ad2_v2 }
+      with: {path: /opt/spack, key: clang7_nopy_ompi_h5_ad2_v2 }
     - name: Install
       run: |
         sudo apt-get update
@@ -237,7 +237,7 @@ jobs:
         cmake --build build --parallel 2
         ctest --test-dir build --output-on-failure
 
-  gcc9_py38_pd_nompi_h5_ad1_ad2_libcpp:
+  gcc9_py38_pd_nompi_h5_ad2_libcpp:
     runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
     steps:
@@ -246,7 +246,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install g++ libopenmpi-dev libhdf5-openmpi-dev libadios-dev python3 python3-numpy python3-mpi4py python3-pandas
-#       TODO ADIOS1 (.pc file broken?) ADIOS2
+#       TODO ADIOS2
     - name: Build
       env: {CXXFLAGS: -Werror, PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig}
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ endfunction()
 
 openpmd_option(MPI            "Parallel, Multi-Node I/O for clusters"     AUTO)
 openpmd_option(HDF5           "HDF5 backend (.h5 files)"                  AUTO)
-openpmd_option(ADIOS1         "ADIOS1 backend (.bp files)"                AUTO)
+openpmd_option(ADIOS1         "ADIOS1 backend (.bp files)"                 OFF)
 openpmd_option(ADIOS2         "ADIOS2 backend (.bp files)"                AUTO)
 openpmd_option(PYTHON         "Enable Python bindings"                    AUTO)
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Shipped internally in `share/openPMD/thirdParty/`:
 I/O backends:
 * [JSON](https://en.wikipedia.org/wiki/JSON)
 * [HDF5](https://support.hdfgroup.org/HDF5) 1.8.13+ (optional)
-* [ADIOS1](https://www.olcf.ornl.gov/center-projects/adios) 1.13.1+ (optional)
+* [ADIOS1](https://www.olcf.ornl.gov/center-projects/adios) 1.13.1+ (optional, deprecated)
 * [ADIOS2](https://github.com/ornladios/ADIOS2) 2.7.0+ (optional)
 
 while those can be built either with or without:

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ CMake controls options with prefixed `-D`, e.g. `-DopenPMD_USE_MPI=OFF`:
 |------------------------------|------------------|------------------------------------------------------------------------------|
 | `openPMD_USE_MPI`            | **AUTO**/ON/OFF  | Parallel, Multi-Node I/O for clusters                                        |
 | `openPMD_USE_HDF5`           | **AUTO**/ON/OFF  | HDF5 backend (`.h5` files)                                                   |
-| `openPMD_USE_ADIOS1`         | **AUTO**/ON/OFF  | ADIOS1 backend (`.bp` files up to version BP3)                               |
+| `openPMD_USE_ADIOS1`         | AUTO/ON/**OFF**  | ADIOS1 backend (`.bp` files up to version BP3) - deprecated                  |
 | `openPMD_USE_ADIOS2`         | **AUTO**/ON/OFF  | ADIOS2 backend (`.bp` files in BP3, BP4 or higher)                           |
 | `openPMD_USE_PYTHON`         | **AUTO**/ON/OFF  | Enable Python bindings                                                       |
 | `openPMD_USE_INVASIVE_TESTS` | ON/**OFF**       | Enable unit tests that modify source code <sup>1</sup>                       |

--- a/docs/source/backends/adios1.rst
+++ b/docs/source/backends/adios1.rst
@@ -27,14 +27,15 @@ Backend-Specific Controls
 The following environment variables control ADIOS1 I/O behavior at runtime.
 Fine-tuning these is especially useful when running at large scale.
 
-==================================== ========== ================================================================================
-environment variable                 default    description
-==================================== ========== ================================================================================
-``OPENPMD_ADIOS_NUM_AGGREGATORS``    ``1``      Number of I/O aggregator nodes for ADIOS1 ``MPI_AGGREGATE`` transport method.
-``OPENPMD_ADIOS_NUM_OST``            ``0``      Number of I/O OSTs for ADIOS1 ``MPI_AGGREGATE`` transport method.
-``OPENPMD_ADIOS_HAVE_METADATA_FILE`` ``1``      Online creation of the adios journal file (``1``: yes, ``0``: no).
-``OPENPMD_BP_BACKEND``               ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
-==================================== ========== ================================================================================
+============================================== ========== ================================================================================
+environment variable                           default    description
+============================================== ========== ================================================================================
+``OPENPMD_ADIOS_NUM_AGGREGATORS``              ``1``      Number of I/O aggregator nodes for ADIOS1 ``MPI_AGGREGATE`` transport method.
+``OPENPMD_ADIOS_NUM_OST``                      ``0``      Number of I/O OSTs for ADIOS1 ``MPI_AGGREGATE`` transport method.
+``OPENPMD_ADIOS_HAVE_METADATA_FILE``           ``1``      Online creation of the adios journal file (``1``: yes, ``0``: no).
+``OPENPMD_BP_BACKEND``                         ``ADIOS2`` Chose preferred ``.bp`` file backend if ``ADIOS1`` and ``ADIOS2`` are available.
+``OPENPMD_ADIOS_SUPPRESS_DEPRECATED_WARNING``  ``0``      Set to ``1`` to suppress ADIOS1 deprecation warnings.
+============================================== ========== ================================================================================
 
 Please refer to the `ADIOS1 manual, section 6.1.5 <https://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.13.1.pdf>`_ for details on I/O tuning.
 

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -14,7 +14,7 @@ CMake Option                   Values          Description
 ============================== =============== ========================================================================
 ``openPMD_USE_MPI``            **AUTO**/ON/OFF Parallel, Multi-Node I/O for clusters
 ``openPMD_USE_HDF5``           **AUTO**/ON/OFF HDF5 backend (``.h5`` files)
-``openPMD_USE_ADIOS1``         **AUTO**/ON/OFF ADIOS1 backend (``.bp`` files up to version BP3)
+``openPMD_USE_ADIOS1``         AUTO/ON/**OFF** ADIOS1 backend (``.bp`` files up to version BP3) - deprecated
 ``openPMD_USE_ADIOS2``         **AUTO**/ON/OFF ADIOS2 backend (``.bp`` files in BP3, BP4 or higher)
 ``openPMD_USE_PYTHON``         **AUTO**/ON/OFF Enable Python bindings
 ``openPMD_USE_INVASIVE_TESTS`` ON/**OFF**      Enable unit tests that modify source code :sup:`1`

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -27,7 +27,7 @@ Optional: I/O backends
 
 * `JSON <https://en.wikipedia.org/wiki/JSON>`_
 * `HDF5 <https://support.hdfgroup.org/HDF5>`_ 1.8.13+
-* `ADIOS1 <https://www.olcf.ornl.gov/center-projects/adios>`_ 1.13.1+
+* `ADIOS1 <https://www.olcf.ornl.gov/center-projects/adios>`_ 1.13.1+ (deprecated)
 * `ADIOS2 <https://github.com/ornladios/ADIOS2>`_ 2.7.0+
 
 while those can be build either with or without:

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -20,6 +20,8 @@
  */
 #include "openPMD/IO/AbstractIOHandlerHelper.hpp"
 
+#include "openPMD/config.hpp"
+
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/ADIOS/ADIOS1IOHandler.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
@@ -28,7 +30,12 @@
 #include "openPMD/IO/HDF5/HDF5IOHandler.hpp"
 #include "openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp"
 #include "openPMD/IO/JSON/JSONIOHandler.hpp"
+#include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
+
+#if openPMD_HAVE_MPI
+#include <mpi.h>
+#endif
 
 #include <memory>
 #include <utility>
@@ -65,7 +72,12 @@ namespace
     Please consider switching to ADIOS2.
     We recommend checking your ADIOS1 datasets for compatibility with ADIOS2.
     Conversion of data from one backend to another may optionally be achieved
-    by using the `openpmd-pipe` tool.)";
+    by using the `openpmd-pipe` tool.)
+
+    Suppress this warning via `export OPENPMD_WARNING_SUPPRESS_ADIOS1_DEPRECATED=1`.)";
+
+    constexpr char const *suppressAdios1DeprecationWarning =
+        "OPENPMD_WARNING_SUPPRESS_ADIOS1_DEPRECATED";
 } // namespace
 
 #if openPMD_HAVE_MPI
@@ -86,7 +98,15 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<ParallelHDF5IOHandler, openPMD_HAVE_HDF5>(
             "HDF5", path, access, comm, std::move(options));
     case Format::ADIOS1:
-        std::cerr << adios1Deprecation << std::endl;
+        if (auxiliary::getEnvNum(suppressAdios1DeprecationWarning, 0) == 0)
+        {
+            int rank;
+            MPI_Comm_rank(comm, &rank);
+            if (rank == 0)
+            {
+                std::cerr << adios1Deprecation << std::endl;
+            }
+        }
         return constructIOHandler<ParallelADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options), comm);
     case Format::ADIOS2_BP:
@@ -156,7 +176,10 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<HDF5IOHandler, openPMD_HAVE_HDF5>(
             "HDF5", path, access, std::move(options));
     case Format::ADIOS1:
-        std::cerr << adios1Deprecation << std::endl;
+        if (auxiliary::getEnvNum(suppressAdios1DeprecationWarning, 0) == 0)
+        {
+            std::cerr << adios1Deprecation << std::endl;
+        }
         return constructIOHandler<ADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options));
     case Format::ADIOS2_BP:

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -55,6 +55,17 @@ namespace
         }
         throw "Unreachable";
     }
+
+    constexpr char const *adios1Deprecation = R"(
+[Deprecation warning]
+    Development on the ADIOS1 IO library has ceased.
+    Support for ADIOS1 in the openPMD-api has been deprecated
+    and will be removed in a future version.
+
+    Please consider switching to ADIOS2.
+    We recommend checking your ADIOS1 datasets for compatibility with ADIOS2.
+    Conversion of data from one backend to another may optionally be achieved
+    by using the `openpmd-pipe` tool.)";
 } // namespace
 
 #if openPMD_HAVE_MPI
@@ -75,6 +86,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<ParallelHDF5IOHandler, openPMD_HAVE_HDF5>(
             "HDF5", path, access, comm, std::move(options));
     case Format::ADIOS1:
+        std::cerr << adios1Deprecation << std::endl;
         return constructIOHandler<ParallelADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options), comm);
     case Format::ADIOS2_BP:
@@ -144,6 +156,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<HDF5IOHandler, openPMD_HAVE_HDF5>(
             "HDF5", path, access, std::move(options));
     case Format::ADIOS1:
+        std::cerr << adios1Deprecation << std::endl;
         return constructIOHandler<ADIOS1IOHandler, openPMD_HAVE_ADIOS1>(
             "ADIOS1", path, access, std::move(options));
     case Format::ADIOS2_BP:

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -74,10 +74,10 @@ namespace
     Conversion of data from one backend to another may optionally be achieved
     by using the `openpmd-pipe` tool.)
 
-    Suppress this warning via `export OPENPMD_WARNING_SUPPRESS_ADIOS1_DEPRECATED=1`.)";
+    Suppress this warning via `export OPENPMD_ADIOS_SUPPRESS_DEPRECATED_WARNING=1`.)";
 
     constexpr char const *suppressAdios1DeprecationWarning =
-        "OPENPMD_WARNING_SUPPRESS_ADIOS1_DEPRECATED";
+        "OPENPMD_ADIOS_SUPPRESS_DEPRECATED_WARNING";
 } // namespace
 
 #if openPMD_HAVE_MPI

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -10,10 +10,6 @@
 
 #include <catch2/catch.hpp>
 
-#if openPMD_HAVE_MPI
-#include <mpi.h>
-#endif
-
 #include <algorithm>
 #include <array>
 #include <complex>
@@ -1357,66 +1353,5 @@ TEST_CASE("unavailable_backend", "[core]")
             "Wrong API usage: openPMD-api built without support for backend "
             "'HDF5'.");
     }
-#endif
-
-#if openPMD_HAVE_MPI
-    MPI_Init(nullptr, nullptr);
-#if !openPMD_HAVE_ADIOS1
-    {
-        auto fail = []() {
-            Series(
-                "unavailable.bp",
-                Access::CREATE,
-                MPI_COMM_WORLD,
-                R"({"backend": "ADIOS1"})");
-        };
-        REQUIRE_THROWS_WITH(
-            fail(),
-            "Wrong API usage: openPMD-api built without support for backend "
-            "'ADIOS1'.");
-    }
-#endif
-#if !openPMD_HAVE_ADIOS2
-    {
-        auto fail = []() {
-            Series(
-                "unavailable.bp",
-                Access::CREATE,
-                MPI_COMM_WORLD,
-                R"({"backend": "ADIOS2"})");
-        };
-        REQUIRE_THROWS_WITH(
-            fail(),
-            "Wrong API usage: openPMD-api built without support for backend "
-            "'ADIOS2'.");
-    }
-#endif
-#if !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
-    {
-        auto fail = []() {
-            Series("unavailable.bp", Access::CREATE, MPI_COMM_WORLD);
-        };
-        REQUIRE_THROWS_WITH(
-            fail(),
-            "Wrong API usage: openPMD-api built without support for backend "
-            "'ADIOS2'.");
-    }
-#endif
-#if !openPMD_HAVE_HDF5
-    {
-        auto fail = []() {
-            Series(
-                "unavailable.h5",
-                Access::CREATE,
-                MPI_COMM_WORLD,
-                R"({"backend": "HDF5"})");
-        };
-        REQUIRE_THROWS_WITH(
-            fail(),
-            "Wrong API usage: openPMD-api built without support for backend "
-            "'HDF5'.");
-    }
-#endif
-    MPI_Finalize();
 #endif
 }

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -10,6 +10,10 @@
 
 #include <catch2/catch.hpp>
 
+#if openPMD_HAVE_MPI
+#include <mpi.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <complex>
@@ -1356,6 +1360,7 @@ TEST_CASE("unavailable_backend", "[core]")
 #endif
 
 #if openPMD_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
 #if !openPMD_HAVE_ADIOS1
     {
         auto fail = []() {
@@ -1412,5 +1417,6 @@ TEST_CASE("unavailable_backend", "[core]")
             "'HDF5'.");
     }
 #endif
+    MPI_Finalize();
 #endif
 }

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1604,4 +1604,64 @@ TEST_CASE("append_mode", "[parallel]")
         }
     }
 }
+
+TEST_CASE("unavailable_backend", "[core][parallel]")
+{
+#if !openPMD_HAVE_ADIOS1
+    {
+        auto fail = []() {
+            Series(
+                "unavailable.bp",
+                Access::CREATE,
+                MPI_COMM_WORLD,
+                R"({"backend": "ADIOS1"})");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS1'.");
+    }
+#endif
+#if !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() {
+            Series(
+                "unavailable.bp",
+                Access::CREATE,
+                MPI_COMM_WORLD,
+                R"({"backend": "ADIOS2"})");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+#if !openPMD_HAVE_ADIOS1 && !openPMD_HAVE_ADIOS2
+    {
+        auto fail = []() {
+            Series("unavailable.bp", Access::CREATE, MPI_COMM_WORLD);
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'ADIOS2'.");
+    }
+#endif
+#if !openPMD_HAVE_HDF5
+    {
+        auto fail = []() {
+            Series(
+                "unavailable.h5",
+                Access::CREATE,
+                MPI_COMM_WORLD,
+                R"({"backend": "HDF5"})");
+        };
+        REQUIRE_THROWS_WITH(
+            fail(),
+            "Wrong API usage: openPMD-api built without support for backend "
+            "'HDF5'.");
+    }
+#endif
+}
 #endif


### PR DESCRIPTION
* print deprecation warning when selecting ADIOS1 backend
* deactivate ADIOS1 build by default

TODO
- [x] We might want to manually specify ADIOS1=ON in CI and package managers