### PR TITLE
Constant scalars: Don't flush double

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -243,25 +243,29 @@ void Mesh::flush_impl(
                 pCreate.path = name;
                 IOHandler()->enqueue(IOTask(this, pCreate));
                 for (auto &comp : *this)
+                {
                     comp.second.parent() = &this->writable();
-            }
-        }
-
-        if (scalar())
-        {
-            for (auto &comp : *this)
-            {
-                comp.second.flush(name, flushParams);
-                writable().abstractFilePosition =
-                    comp.second.writable().abstractFilePosition;
+                    comp.second.flush(comp.first, flushParams);
+                }
             }
         }
         else
         {
-            for (auto &comp : *this)
-                comp.second.flush(comp.first, flushParams);
+            if (scalar())
+            {
+                for (auto &comp : *this)
+                {
+                    comp.second.flush(name, flushParams);
+                    writable().abstractFilePosition =
+                        comp.second.writable().abstractFilePosition;
+                }
+            }
+            else
+            {
+                for (auto &comp : *this)
+                    comp.second.flush(comp.first, flushParams);
+            }
         }
-
         flushAttributes(flushParams);
         break;
     }

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -73,23 +73,29 @@ void Record::flush_impl(
                 pCreate.path = name;
                 IOHandler()->enqueue(IOTask(this, pCreate));
                 for (auto &comp : *this)
+                {
                     comp.second.parent() = getWritable(this);
-            }
-        }
-
-        if (scalar())
-        {
-            for (auto &comp : *this)
-            {
-                comp.second.flush(name, flushParams);
-                writable().abstractFilePosition =
-                    comp.second.writable().abstractFilePosition;
+                    comp.second.flush(comp.first, flushParams);
+                }
             }
         }
         else
         {
-            for (auto &comp : *this)
-                comp.second.flush(comp.first, flushParams);
+
+            if (scalar())
+            {
+                for (auto &comp : *this)
+                {
+                    comp.second.flush(name, flushParams);
+                    writable().abstractFilePosition =
+                        comp.second.writable().abstractFilePosition;
+                }
+            }
+            else
+            {
+                for (auto &comp : *this)
+                    comp.second.flush(comp.first, flushParams);
+            }
         }
 
         flushAttributes(flushParams);


### PR DESCRIPTION
Bug introduced in #1264 (only in dev, no releases affected). Constant scalar components were flushed twice, creating paths  created in duplicate:

Without this PR:
```
> bpls -a openPMD/simData_000200.bp/ -le '.*/particles/e/charge/.*'
  uint64_t  /data/200/particles/e/charge/charge/shape                        attr   = 65535994
  double    /data/200/particles/e/charge/charge/value                        attr   = -0.00014378
  int32_t   /data/200/particles/e/charge/macroWeighted                       attr   = 0
  uint64_t  /data/200/particles/e/charge/shape                               attr   = 65535994
  double    /data/200/particles/e/charge/timeOffset                          attr   = 0
  double    /data/200/particles/e/charge/unitDimension                       attr   = {0, 0, 1, 1, 0, 0, 0}
  double    /data/200/particles/e/charge/unitSI                              attr   = 1.11432e-15
  double    /data/200/particles/e/charge/value                               attr   = -0.00014378
  double    /data/200/particles/e/charge/weightingPower                      attr   = 1
```

With the PR:
```
> bpls -a openPMD/simData_000200.bp/ -le '.*/particles/e/charge/.*'
  int32_t   /data/200/particles/e/charge/macroWeighted                       attr   = 0
  uint64_t  /data/200/particles/e/charge/shape                               attr   = 65535994
  double    /data/200/particles/e/charge/timeOffset                          attr   = 0
  double    /data/200/particles/e/charge/unitDimension                       attr   = {0, 0, 1, 1, 0, 0, 0}
  double    /data/200/particles/e/charge/unitSI                              attr   = 1.11432e-15
  double    /data/200/particles/e/charge/value                               attr   = -0.00014378
  double    /data/200/particles/e/charge/weightingPower                      attr   = 1
```