### PR TITLE
RecordComponent: Properly handle uninitialized datasets

### DIFF
--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -83,8 +83,9 @@ int main()
                 {{io::UnitDimension::M, 1}});
             electrons["displacement"]["x"].setUnitSI(1e-6);
             electrons.erase("displacement");
-            electrons["weighting"][io::RecordComponent::SCALAR].makeConstant(
-                1.e-5);
+            electrons["weighting"][io::RecordComponent::SCALAR]
+                .resetDataset({io::Datatype::FLOAT, {1}})
+                .makeConstant(1.e-5);
         }
 
         io::Mesh mesh = cur_it.meshes["lowRez_2D_field"];

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -90,7 +90,9 @@ if __name__ == "__main__":
     electrons["displacement"].unit_dimension = {Unit_Dimension.M: 1}
     electrons["displacement"]["x"].unit_SI = 1.e-6
     del electrons["displacement"]
-    electrons["weighting"][SCALAR].make_constant(1.e-5)
+    electrons["weighting"][SCALAR] \
+        .reset_dataset(Dataset(np.dtype("float32"), extent=[1])) \
+        .make_constant(1.e-5)
 
     mesh = cur_it.meshes["lowRez_2D_field"]
     mesh.axis_labels = ["x", "y"]

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -44,7 +44,9 @@ if __name__ == "__main__":
     # don't like it anymore? remove it with:
     # del electrons["displacement"]
 
-    electrons["weighting"][SCALAR].make_constant(1.e-5)
+    electrons["weighting"][SCALAR] \
+        .reset_dataset(Dataset(np.dtype("float32"), extent=[1])) \
+        .make_constant(1.e-5)
 
     particlePos_x = np.random.rand(234).astype(np.float32)
     particlePos_y = np.random.rand(234).astype(np.float32)

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -332,7 +332,13 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
         dCreate.name = rc.m_name;
         dCreate.extent = getExtent();
         dCreate.dtype = getDatatype();
-        dCreate.options = rc.m_dataset.options;
+        if (!rc.m_dataset.has_value())
+        {
+            throw error::WrongAPIUsage(
+                "[RecordComponent] Must specify dataset type and extent before "
+                "using storeChunk() (see RecordComponent::resetDataset()).");
+        }
+        dCreate.options = rc.m_dataset.value().options;
         IOHandler()->enqueue(IOTask(this, dCreate));
     }
     Parameter<Operation::GET_BUFFER_VIEW> getBufferView;

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -24,6 +24,8 @@
 #include "openPMD/Error.hpp"
 #include "openPMD/backend/Attributable.hpp"
 
+#include <optional>
+
 // expose private and protected members for invasive testing
 #ifndef OPENPMD_protected
 #define OPENPMD_protected protected:
@@ -39,7 +41,7 @@ namespace internal
         /**
          * The type and extent of the dataset defined by this component.
          */
-        Dataset m_dataset{Datatype::UNDEFINED, {}};
+        std::optional<Dataset> m_dataset;
         /**
          * True if this is defined as a constant record component as specified
          * in the openPMD standard.

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -58,23 +58,7 @@ JSONIOHandlerImpl::JSONIOHandlerImpl(AbstractIOHandler *handler)
     : AbstractIOHandlerImpl(handler)
 {}
 
-JSONIOHandlerImpl::~JSONIOHandlerImpl()
-{
-    // we must not throw in a destructor
-    try
-    {
-        flush();
-    }
-    catch (std::exception const &ex)
-    {
-        std::cerr << "[~JSONIOHandlerImpl] An error occurred: " << ex.what()
-                  << std::endl;
-    }
-    catch (...)
-    {
-        std::cerr << "[~JSONIOHandlerImpl] An error occurred." << std::endl;
-    }
-}
+JSONIOHandlerImpl::~JSONIOHandlerImpl() = default;
 
 std::future<void> JSONIOHandlerImpl::flush()
 {

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -242,9 +242,21 @@ void RecordComponent::flush(
          */
         if (!rc.m_dataset.has_value())
         {
-            throw error::WrongAPIUsage(
-                "[RecordComponent] Must specify dataset type and extent before "
-                "flushing (see RecordComponent::resetDataset()).");
+            // The check for !written() is technically not needed, just
+            // defensive programming against internal bugs that go on us.
+            if (!written() && rc.m_chunks.empty())
+            {
+                // No data written yet, just accessed the object so far without
+                // doing anything
+                // Just do nothing and skip this record component.
+                return;
+            }
+            else
+            {
+                throw error::WrongAPIUsage(
+                    "[RecordComponent] Must specify dataset type and extent "
+                    "before flushing (see RecordComponent::resetDataset()).");
+            }
         }
         if (!written())
         {

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -104,10 +104,22 @@ void PatchRecordComponent::flush(
     {
         if (!rc.m_dataset.has_value())
         {
-            throw error::WrongAPIUsage(
-                "[PatchRecordComponent] Must specify dataset type and extent "
-                "before "
-                "flushing (see RecordComponent::resetDataset()).");
+            // The check for !written() is technically not needed, just
+            // defensive programming against internal bugs that go on us.
+            if (!written() && rc.m_chunks.empty())
+            {
+                // No data written yet, just accessed the object so far without
+                // doing anything
+                // Just do nothing and skip this record component.
+                return;
+            }
+            else
+            {
+                throw error::WrongAPIUsage(
+                    "[PatchRecordComponent] Must specify dataset type and "
+                    "extent before flushing (see "
+                    "RecordComponent::resetDataset()).");
+            }
         }
         if (!written())
         {

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -25,6 +25,8 @@
 
 using namespace openPMD;
 
+Dataset globalDataset(Datatype::CHAR, {1});
+
 TEST_CASE("versions_test", "[core]")
 {
     auto const apiVersion = getVersion();
@@ -439,11 +441,11 @@ TEST_CASE("record_constructor_test", "[core]")
     ps["position"][RecordComponent::SCALAR].resetDataset(dset);
     ps["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
 
-    REQUIRE(r["x"].unitSI() == 1);
+    REQUIRE(r["x"].resetDataset(dset).unitSI() == 1);
     REQUIRE(r["x"].numAttributes() == 1); /* unitSI */
-    REQUIRE(r["y"].unitSI() == 1);
+    REQUIRE(r["y"].resetDataset(dset).unitSI() == 1);
     REQUIRE(r["y"].numAttributes() == 1); /* unitSI */
-    REQUIRE(r["z"].unitSI() == 1);
+    REQUIRE(r["z"].resetDataset(dset).unitSI() == 1);
     REQUIRE(r["z"].numAttributes() == 1); /* unitSI */
     std::array<double, 7> zeros{{0., 0., 0., 0., 0., 0., 0.}};
     REQUIRE(r.unitDimension() == zeros);
@@ -488,13 +490,15 @@ TEST_CASE("recordComponent_modification_test", "[core]")
 
     r["x"].setUnitSI(2.55999e-7);
     r["y"].setUnitSI(4.42999e-8);
-    REQUIRE(r["x"].unitSI() == static_cast<double>(2.55999e-7));
+    REQUIRE(
+        r["x"].resetDataset(dset).unitSI() == static_cast<double>(2.55999e-7));
     REQUIRE(r["x"].numAttributes() == 1); /* unitSI */
-    REQUIRE(r["y"].unitSI() == static_cast<double>(4.42999e-8));
+    REQUIRE(
+        r["y"].resetDataset(dset).unitSI() == static_cast<double>(4.42999e-8));
     REQUIRE(r["y"].numAttributes() == 1); /* unitSI */
 
     r["z"].setUnitSI(1);
-    REQUIRE(r["z"].unitSI() == static_cast<double>(1));
+    REQUIRE(r["z"].resetDataset(dset).unitSI() == static_cast<double>(1));
     REQUIRE(r["z"].numAttributes() == 1); /* unitSI */
 }
 
@@ -505,13 +509,13 @@ TEST_CASE("mesh_constructor_test", "[core]")
     Mesh &m = o.iterations[42].meshes["E"];
 
     std::vector<double> pos{0};
-    REQUIRE(m["x"].unitSI() == 1);
+    REQUIRE(m["x"].resetDataset(globalDataset).unitSI() == 1);
     REQUIRE(m["x"].numAttributes() == 2); /* unitSI, position */
     REQUIRE(m["x"].position<double>() == pos);
-    REQUIRE(m["y"].unitSI() == 1);
+    REQUIRE(m["y"].resetDataset(globalDataset).unitSI() == 1);
     REQUIRE(m["y"].numAttributes() == 2); /* unitSI, position */
     REQUIRE(m["y"].position<double>() == pos);
-    REQUIRE(m["z"].unitSI() == 1);
+    REQUIRE(m["z"].resetDataset(globalDataset).unitSI() == 1);
     REQUIRE(m["z"].numAttributes() == 2); /* unitSI, position */
     REQUIRE(m["z"].position<double>() == pos);
     REQUIRE(m.geometry() == Mesh::Geometry::cartesian);
@@ -534,9 +538,9 @@ TEST_CASE("mesh_modification_test", "[core]")
     Series o = Series("./MyOutput_%T.json", Access::CREATE);
 
     Mesh &m = o.iterations[42].meshes["E"];
-    m["x"];
-    m["y"];
-    m["z"];
+    m["x"].resetDataset(globalDataset);
+    m["y"].resetDataset(globalDataset);
+    m["z"].resetDataset(globalDataset);
 
     m.setGeometry(Mesh::Geometry::spherical);
     REQUIRE(m.geometry() == Mesh::Geometry::spherical);

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6430,11 +6430,19 @@ void unfinished_iteration_test(
          */
         it5.setAttribute("__openPMD_internal_fail", "asking for trouble");
         auto it10 = write.writeIterations()[10];
+        Dataset ds(Datatype::INT, {10});
         auto E_x = it10.meshes["E"]["x"];
         auto e_density = it10.meshes["e_density"][RecordComponent::SCALAR];
         auto electron_x = it10.particles["e"]["position"]["x"];
         auto electron_mass =
             it10.particles["e"]["mass"][RecordComponent::SCALAR];
+
+        RecordComponent *resetThese[] = {
+            &E_x, &e_density, &electron_x, &electron_mass};
+        for (RecordComponent *rc : resetThese)
+        {
+            rc->resetDataset(ds);
+        }
     }
     auto tryReading = [&config, file, encoding](
                           Access access,


### PR DESCRIPTION
We currently have a non-functional check during `flush()` that a dataset has been initialized.
The check tests that the `Datatype` is not `UNDEFINED`, but it is never undefined since the constructor initializes it as `CHAR`.

We can use a `std::optional` to have a trustworthy check. This gives users a better feedback if they forget this call.

TODO

- [x] Merge #1278 first
- [x] The newly-added check uncovers that the CoreTests are mostly wrong, since they don't initialize the dataset. Since the CoreTests usually don't need to actually interact with the resulting dataset, they still run fine, but show a warning in the destructor. Maybe fix them.
    ```
    [~Series] An error occurred: Wrong API usage: [RecordComponent] Must specify dataset type and extent before flushing (see RecordComponent::resetDataset()).
    [~Series] An error occurred: Wrong API usage: [RecordComponent] Must specify dataset type and extent before flushing (see RecordComponent::resetDataset()).
    [~Series] An error occurred: Wrong API usage: [RecordComponent] Must specify dataset type and extent before flushing (see RecordComponent::resetDataset()).
    [~Series] An error occurred: Wrong API usage: [RecordComponent] Must specify dataset type and extent before flushing (see RecordComponent::resetDataset()).
    [~Series] An error occurred: Wrong API usage: [RecordComponent] Must specify dataset type and extent before flushing (see RecordComponent::resetDataset()).
    [~Series] An error occurred: Wrong API usage: [RecordComponent] Must specify dataset type and extent before flushing (see RecordComponent::resetDataset()).
    ```
- [ ] Maybe turn this into a warning, and default to `{CHAR, {1}}` instead
- [x] Wait for release 0.15 before merging this. This might uncover bugs in downstream code, and they should have time to fix it.
- [x] Still problems at `myPath` and `structure_test` of CoreTests
- [x] Maybe check if the JSONIOHandlerImpl fix should be applied to other backends, too: The other backends only free their resources in the destructor, but don't flush

Notes:

* This is also useful for things like #1277, since that PR actually gives a dataset with UNDEFINED datatype a meaning (inside TOML templates). Distinguishing between "forgotten to specify" and "explicitly specified as UNDEFINED" is useful here.
  This is an argument in favor of **not** defaulting to `{CHAR, {1}}`
* This seems to uncover some such bugs in our own test suite.