### PR TITLE
Add Series::close() call

### DIFF
--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -100,6 +100,8 @@ int main()
     /* The files in 'series' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.
      * When running out of scope on return, the 'Series' destructor is called.
+     * Alternatively, one can call `series.close()` to the same effect as
+     * calling the destructor, including the release of file handles.
      */
     return 0;
 }

--- a/examples/2_read_serial.py
+++ b/examples/2_read_serial.py
@@ -65,8 +65,9 @@ if __name__ == "__main__":
     print("Full E/x is of shape {0} and starts with:".format(all_data.shape))
     print(all_data[0, 0, :5])
 
-    # The files in 'series' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
-    del series
+    # The files in 'series' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
+    series.close()

--- a/examples/2a_read_thetaMode_serial.cpp
+++ b/examples/2a_read_thetaMode_serial.cpp
@@ -72,6 +72,8 @@ int main()
     /* The files in 'series' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.
      * When running out of scope on return, the 'Series' destructor is called.
+     * Alternatively, one can call `series.close()` to the same effect as
+     * calling the destructor, including the release of file handles.
      */
     return 0;
 }

--- a/examples/2a_read_thetaMode_serial.py
+++ b/examples/2a_read_thetaMode_serial.py
@@ -51,8 +51,9 @@ if __name__ == "__main__":
     # E_z_yz  = toCartesianSliceYZ(E_z_modes)[:, :]  # (y, z)
     # series.flush()
 
-    # The files in 'series' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
-    del series
+    # The files in 'series' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
+    series.close()

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -73,6 +73,8 @@ int main(int argc, char *argv[])
     /* The files in 'series' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.
      * When running out of scope on return, the 'Series' destructor is called.
+     * Alternatively, one can call `series.close()` to the same effect as
+     * calling the destructor, including the release of file handles.
      */
     return 0;
 }

--- a/examples/3_write_serial.py
+++ b/examples/3_write_serial.py
@@ -50,8 +50,9 @@ if __name__ == "__main__":
     series.flush()
     print("Dataset content has been fully written")
 
-    # The files in 'series' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
-    del series
+    # The files in 'series' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
+    series.close()

--- a/examples/3a_write_thetaMode_serial.cpp
+++ b/examples/3a_write_thetaMode_serial.cpp
@@ -89,6 +89,8 @@ int main()
     /* The files in 'series' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.
      * When running out of scope on return, the 'Series' destructor is called.
+     * Alternatively, one can call `series.close()` to the same effect as
+     * calling the destructor, including the release of file handles.
      */
     return 0;
 }

--- a/examples/3a_write_thetaMode_serial.py
+++ b/examples/3a_write_thetaMode_serial.py
@@ -64,8 +64,9 @@ if __name__ == "__main__":
 
     series.flush()
 
-    # The files in 'series' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
-    del series
+    # The files in 'series' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
+    series.close()

--- a/examples/3b_write_resizable_particles.cpp
+++ b/examples/3b_write_resizable_particles.cpp
@@ -86,6 +86,8 @@ int main()
     /* The files in 'series' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.
      * When running out of scope on return, the 'Series' destructor is called.
+     * Alternatively, one can call `series.close()` to the same effect as
+     * calling the destructor, including the release of file handles.
      */
     return 0;
 }

--- a/examples/3b_write_resizable_particles.py
+++ b/examples/3b_write_resizable_particles.py
@@ -65,8 +65,9 @@ if __name__ == "__main__":
 
     # rinse and repeat as needed :)
 
-    # The files in 'series' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
-    del series
+    # The files in 'series' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
+    series.close()

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -39,56 +39,48 @@ int main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-    /* note: this scope is intentional to destruct the openPMD::Series object
-     *       prior to MPI_Finalize();
-     */
+    Series series = Series(
+        "../samples/git-sample/data%T.h5", Access::READ_ONLY, MPI_COMM_WORLD);
+    if (0 == mpi_rank)
+        cout << "Read a series in parallel with " << mpi_size << " MPI ranks\n";
+
+    MeshRecordComponent E_x = series.iterations[100].meshes["E"]["x"];
+
+    Offset chunk_offset = {static_cast<long unsigned int>(mpi_rank) + 1, 1, 1};
+    Extent chunk_extent = {2, 2, 1};
+
+    auto chunk_data = E_x.loadChunk<double>(chunk_offset, chunk_extent);
+
+    if (0 == mpi_rank)
+        cout << "Queued the loading of a single chunk per MPI rank from "
+                "disk, "
+                "ready to execute\n";
+    series.flush();
+
+    if (0 == mpi_rank)
+        cout << "Chunks have been read from disk\n";
+
+    for (int i = 0; i < mpi_size; ++i)
     {
-        Series series = Series(
-            "../samples/git-sample/data%T.h5",
-            Access::READ_ONLY,
-            MPI_COMM_WORLD);
-        if (0 == mpi_rank)
-            cout << "Read a series in parallel with " << mpi_size
-                 << " MPI ranks\n";
-
-        MeshRecordComponent E_x = series.iterations[100].meshes["E"]["x"];
-
-        Offset chunk_offset = {
-            static_cast<long unsigned int>(mpi_rank) + 1, 1, 1};
-        Extent chunk_extent = {2, 2, 1};
-
-        auto chunk_data = E_x.loadChunk<double>(chunk_offset, chunk_extent);
-
-        if (0 == mpi_rank)
-            cout << "Queued the loading of a single chunk per MPI rank from "
-                    "disk, "
-                    "ready to execute\n";
-        series.flush();
-
-        if (0 == mpi_rank)
-            cout << "Chunks have been read from disk\n";
-
-        for (int i = 0; i < mpi_size; ++i)
+        if (i == mpi_rank)
         {
-            if (i == mpi_rank)
+            cout << "Rank " << mpi_rank << " - Read chunk contains:\n";
+            for (size_t row = 0; row < chunk_extent[0]; ++row)
             {
-                cout << "Rank " << mpi_rank << " - Read chunk contains:\n";
-                for (size_t row = 0; row < chunk_extent[0]; ++row)
-                {
-                    for (size_t col = 0; col < chunk_extent[1]; ++col)
-                        cout << "\t" << '(' << row + chunk_offset[0] << '|'
-                             << col + chunk_offset[1] << '|' << 1 << ")\t"
-                             << chunk_data.get()[row * chunk_extent[1] + col];
-                    cout << std::endl;
-                }
+                for (size_t col = 0; col < chunk_extent[1]; ++col)
+                    cout << "\t" << '(' << row + chunk_offset[0] << '|'
+                         << col + chunk_offset[1] << '|' << 1 << ")\t"
+                         << chunk_data.get()[row * chunk_extent[1] + col];
+                cout << std::endl;
             }
-
-            // this barrier is not necessary but structures the example output
-            MPI_Barrier(MPI_COMM_WORLD);
         }
-    }
 
-    // openPMD::Series MUST be destructed at this point
+        // this barrier is not necessary but structures the example output
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+    series.close();
+
+    // openPMD::Series MUST be destructed or closed at this point
     MPI_Finalize();
 
     return 0;

--- a/examples/4_read_parallel.py
+++ b/examples/4_read_parallel.py
@@ -56,10 +56,11 @@ if __name__ == "__main__":
         # this barrier is not necessary but structures the example output
         comm.Barrier()
 
-    # The files in 'series' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
+    # The files in 'series' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
     # In any case, this must happen before MPI_Finalize() is called
     # (usually in the mpi4py exit hook).
-    del series
+    series.close()

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -39,58 +39,54 @@ int main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-    /* note: this scope is intentional to destruct the openPMD::Series object
-     *       prior to MPI_Finalize();
-     */
-    {
-        // global data set to write: [MPI_Size * 10, 300]
-        // each rank writes a 10x300 slice with its MPI rank as values
-        auto const value = float(mpi_size);
-        std::vector<float> local_data(10 * 300, value);
-        if (0 == mpi_rank)
-            cout << "Set up a 2D array with 10x300 elements per MPI rank ("
-                 << mpi_size << "x) that will be written to disk\n";
+    // global data set to write: [MPI_Size * 10, 300]
+    // each rank writes a 10x300 slice with its MPI rank as values
+    auto const value = float(mpi_size);
+    std::vector<float> local_data(10 * 300, value);
+    if (0 == mpi_rank)
+        cout << "Set up a 2D array with 10x300 elements per MPI rank ("
+             << mpi_size << "x) that will be written to disk\n";
 
-        // open file for writing
-        Series series = Series(
-            "../samples/5_parallel_write.h5", Access::CREATE, MPI_COMM_WORLD);
-        if (0 == mpi_rank)
-            cout << "Created an empty series in parallel with " << mpi_size
-                 << " MPI ranks\n";
+    // open file for writing
+    Series series = Series(
+        "../samples/5_parallel_write.h5", Access::CREATE, MPI_COMM_WORLD);
+    if (0 == mpi_rank)
+        cout << "Created an empty series in parallel with " << mpi_size
+             << " MPI ranks\n";
 
-        MeshRecordComponent mymesh =
-            series.iterations[1].meshes["mymesh"][MeshRecordComponent::SCALAR];
+    MeshRecordComponent mymesh =
+        series.iterations[1].meshes["mymesh"][MeshRecordComponent::SCALAR];
 
-        // example 1D domain decomposition in first index
-        Datatype datatype = determineDatatype<float>();
-        Extent global_extent = {10ul * mpi_size, 300};
-        Dataset dataset = Dataset(datatype, global_extent);
+    // example 1D domain decomposition in first index
+    Datatype datatype = determineDatatype<float>();
+    Extent global_extent = {10ul * mpi_size, 300};
+    Dataset dataset = Dataset(datatype, global_extent);
 
-        if (0 == mpi_rank)
-            cout << "Prepared a Dataset of size " << dataset.extent[0] << "x"
-                 << dataset.extent[1] << " and Datatype " << dataset.dtype
-                 << '\n';
+    if (0 == mpi_rank)
+        cout << "Prepared a Dataset of size " << dataset.extent[0] << "x"
+             << dataset.extent[1] << " and Datatype " << dataset.dtype << '\n';
 
-        mymesh.resetDataset(dataset);
-        if (0 == mpi_rank)
-            cout << "Set the global Dataset properties for the scalar field "
-                    "mymesh in iteration 1\n";
+    mymesh.resetDataset(dataset);
+    if (0 == mpi_rank)
+        cout << "Set the global Dataset properties for the scalar field "
+                "mymesh in iteration 1\n";
 
-        // example shows a 1D domain decomposition in first index
-        Offset chunk_offset = {10ul * mpi_rank, 0};
-        Extent chunk_extent = {10, 300};
-        mymesh.storeChunk(local_data, chunk_offset, chunk_extent);
-        if (0 == mpi_rank)
-            cout << "Registered a single chunk per MPI rank containing its "
-                    "contribution, "
-                    "ready to write content to disk\n";
+    // example shows a 1D domain decomposition in first index
+    Offset chunk_offset = {10ul * mpi_rank, 0};
+    Extent chunk_extent = {10, 300};
+    mymesh.storeChunk(local_data, chunk_offset, chunk_extent);
+    if (0 == mpi_rank)
+        cout << "Registered a single chunk per MPI rank containing its "
+                "contribution, "
+                "ready to write content to disk\n";
 
-        series.flush();
-        if (0 == mpi_rank)
-            cout << "Dataset content has been fully written to disk\n";
-    }
+    series.flush();
+    if (0 == mpi_rank)
+        cout << "Dataset content has been fully written to disk\n";
 
-    // openPMD::Series MUST be destructed at this point
+    series.close();
+
+    // openPMD::Series MUST be destructed or closed at this point
     MPI_Finalize();
 
     return 0;

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -63,8 +63,9 @@ if __name__ == "__main__":
     if 0 == comm.rank:
         print("Dataset content has been fully written to disk")
 
-    # The files in 'series' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
-    del series
+    # The files in 'series' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
+    series.close()

--- a/examples/6_dump_filebased_series.cpp
+++ b/examples/6_dump_filebased_series.cpp
@@ -172,6 +172,8 @@ int main()
     /* The files in 'o' are still open until the object is destroyed, on
      * which it cleanly flushes and closes all open file handles.
      * When running out of scope on return, the 'Series' destructor is called.
+     * Alternatively, one can call `series.close()` to the same effect as
+     * calling the destructor, including the release of file handles.
      */
     return 0;
 }

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -229,7 +229,9 @@ int main()
         /* The files in 'f' are still open until the object is destroyed, on
          * which it cleanly flushes and closes all open file handles.
          * When running out of scope on return, the 'Series' destructor is
-         * called.
+         * called. Alternatively, one can call `series.close()` to the same
+         * effect as calling the destructor, including the release of file
+         * handles.
          */
     } // namespace ;
 

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -206,8 +206,9 @@ if __name__ == "__main__":
     # constant records
     mesh["y"].make_constant(constant_value)
 
-    # The files in 'f' are still open until the object is destroyed, on
-    # which it cleanly flushes and closes all open file handles.
-    # One can delete the object explicitly (or let it run out of scope) to
-    # trigger this.
-    del f
+    # The files in 'f' are still open until the series is closed, at which
+    # time it cleanly flushes and closes all open file handles.
+    # One can close the object explicitly to trigger this.
+    # Alternatively, this will automatically happen once the garbage collector
+    # claims (every copy of) the series object.
+    f.close()

--- a/examples/9_particle_write_serial.py
+++ b/examples/9_particle_write_serial.py
@@ -69,4 +69,4 @@ if __name__ == "__main__":
     f.flush()
 
     # now the file is closed
-    del f
+    f.close()

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -45,7 +45,7 @@ namespace openPMD
  * @return  Smart pointer to created IOHandler.
  */
 template <typename JSON>
-std::shared_ptr<AbstractIOHandler> createIOHandler(
+std::unique_ptr<AbstractIOHandler> createIOHandler(
     std::string path,
     Access access,
     Format format,
@@ -70,7 +70,7 @@ std::shared_ptr<AbstractIOHandler> createIOHandler(
  * @return  Smart pointer to created IOHandler.
  */
 template <typename JSON>
-std::shared_ptr<AbstractIOHandler> createIOHandler(
+std::unique_ptr<AbstractIOHandler> createIOHandler(
     std::string path,
     Access access,
     Format format,
@@ -78,7 +78,7 @@ std::shared_ptr<AbstractIOHandler> createIOHandler(
     JSON options = JSON());
 
 // version without configuration to use in AuxiliaryTest
-std::shared_ptr<AbstractIOHandler> createIOHandler(
+std::unique_ptr<AbstractIOHandler> createIOHandler(
     std::string path,
     Access access,
     Format format,

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -158,6 +158,8 @@ namespace internal
          * The destructor will only attempt flushing again if this is true.
          */
         bool m_lastFlushSuccessful = false;
+
+        void close();
     }; // SeriesData
 
     class SeriesInternal;
@@ -500,6 +502,8 @@ public:
      */
     WriteIterations writeIterations();
 
+    void close();
+
     // clang-format off
 OPENPMD_private
     // clang-format on
@@ -552,7 +556,7 @@ OPENPMD_private
     void parseJsonOptions(TracingJSON &options, ParsedInput &);
     bool hasExpansionPattern(std::string filenameWithExtension);
     bool reparseExpansionPattern(std::string filenameWithExtension);
-    void init(std::shared_ptr<AbstractIOHandler>, std::unique_ptr<ParsedInput>);
+    void init(std::unique_ptr<AbstractIOHandler>, std::unique_ptr<ParsedInput>);
     void initDefaults(IterationEncoding, bool initAll = false);
     /**
      * @brief Internal call for flushing a Series.

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -509,6 +509,8 @@ public:
      * would do otherwise.
      * All backends are closed after calling this method.
      * The Series should be treated as destroyed after calling this method.
+     * The Series will be evaluated as false in boolean contexts after calling
+     * this method.
      */
     void close();
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -502,6 +502,14 @@ public:
      */
     WriteIterations writeIterations();
 
+    /**
+     * @brief Close the Series and release the data storage/transport backends.
+     *
+     * This is an explicit API call for what the Series::~Series() destructor
+     * would do otherwise.
+     * All backends are closed after calling this method.
+     * The Series should be treated as destroyed after calling this method.
+     */
     void close();
 
     // clang-format off

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -375,11 +375,17 @@ OPENPMD_protected
      * through m_writable-> */
     AbstractIOHandler *IOHandler()
     {
-        return m_attri->m_writable.IOHandler.get();
+        return const_cast<AbstractIOHandler *>(
+            static_cast<Attributable const *>(this)->IOHandler());
     }
     AbstractIOHandler const *IOHandler() const
     {
-        return m_attri->m_writable.IOHandler.get();
+        auto &opt = m_attri->m_writable.IOHandler;
+        if (!opt || !opt->has_value())
+        {
+            return nullptr;
+        }
+        return &*opt->value();
     }
     Writable *&parent()
     {

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -48,7 +48,8 @@ class Span;
 namespace internal
 {
     class AttributableData;
-}
+    class SeriesData;
+} // namespace internal
 
 /** @brief Layer to mirror structure of logical data and persistent data in
  * file.
@@ -63,6 +64,7 @@ namespace internal
 class Writable final
 {
     friend class internal::AttributableData;
+    friend class internal::SeriesData;
     friend class Attributable;
     template <typename T_elem>
     friend class BaseRecord;
@@ -121,7 +123,14 @@ OPENPMD_private
      * Writable may share them.
      */
     std::shared_ptr<AbstractFilePosition> abstractFilePosition = nullptr;
-    std::shared_ptr<AbstractIOHandler> IOHandler = nullptr;
+    /*
+     * shared_ptr since the IOHandler is shared by multiple Writable instances.
+     * optional to make it possible to release the IOHandler, without first
+     * having to destroy every single Writable.
+     * unique_ptr since AbstractIOHandler is an abstract class.
+     */
+    std::shared_ptr<std::optional<std::unique_ptr<AbstractIOHandler>>>
+        IOHandler = nullptr;
     internal::AttributableData *attributable = nullptr;
     Writable *parent = nullptr;
     bool dirty = true;

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -39,12 +39,12 @@ namespace openPMD
 namespace
 {
     template <typename Backend, bool enabled, typename... Args>
-    std::shared_ptr<Backend>
+    std::unique_ptr<Backend>
     constructIOHandler(std::string const &backendName, Args &&...args)
     {
         if constexpr (enabled)
         {
-            return std::make_shared<Backend>(std::forward<Args>(args)...);
+            return std::make_unique<Backend>(std::forward<Args>(args)...);
         }
         else
         {
@@ -59,7 +59,7 @@ namespace
 
 #if openPMD_HAVE_MPI
 template <>
-std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
+std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     std::string path,
     Access access,
     Format format,
@@ -130,7 +130,7 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
 #endif
 
 template <>
-std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
+std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     std::string path,
     Access access,
     Format format,
@@ -195,7 +195,7 @@ std::shared_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     }
 }
 
-std::shared_ptr<AbstractIOHandler> createIOHandler(
+std::unique_ptr<AbstractIOHandler> createIOHandler(
     std::string path,
     Access access,
     Format format,

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -2066,6 +2066,8 @@ WriteIterations Series::writeIterations()
 void Series::close()
 {
     get().close();
+    m_series.reset();
+    m_attri.reset();
 }
 
 auto Series::currentSnapshot() const

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -540,11 +540,13 @@ namespace
 } // namespace
 
 void Series::init(
-    std::shared_ptr<AbstractIOHandler> ioHandler,
+    std::unique_ptr<AbstractIOHandler> ioHandler,
     std::unique_ptr<Series::ParsedInput> input)
 {
     auto &series = get();
-    writable().IOHandler = ioHandler;
+    writable().IOHandler =
+        std::make_shared<std::optional<std::unique_ptr<AbstractIOHandler>>>(
+            std::move(ioHandler));
     series.iterations.linkHierarchy(writable());
     series.iterations.writable().ownKeyWithinParent = {"iterations"};
 
@@ -1941,26 +1943,7 @@ namespace internal
         // we must not throw in a destructor
         try
         {
-            // WriteIterations gets the first shot at flushing
-            this->m_writeIterations = std::optional<WriteIterations>();
-            /*
-             * Scenario: A user calls `Series::flush()` but does not check for
-             * thrown exceptions. The exception will propagate further up,
-             * usually thereby popping the stack frame that holds the `Series`
-             * object. `Series::~Series()` will run. This check avoids that the
-             * `Series` is needlessly flushed a second time. Otherwise, error
-             * messages can get very confusing.
-             */
-            if (this->m_lastFlushSuccessful)
-            {
-                Series impl{{this, [](auto const *) {}}};
-                impl.flush();
-                impl.flushStep(/* doFlush = */ true);
-            }
-            if (m_writeIterations.has_value())
-            {
-                m_writeIterations = std::optional<WriteIterations>();
-            }
+            close();
         }
         catch (std::exception const &ex)
         {
@@ -1970,6 +1953,39 @@ namespace internal
         catch (...)
         {
             std::cerr << "[~Series] An error occurred." << std::endl;
+        }
+    }
+
+    void SeriesData::close()
+    {
+        // WriteIterations gets the first shot at flushing
+        this->m_writeIterations = std::optional<WriteIterations>();
+        /*
+         * Scenario: A user calls `Series::flush()` but does not check for
+         * thrown exceptions. The exception will propagate further up,
+         * usually thereby popping the stack frame that holds the `Series`
+         * object. `Series::~Series()` will run. This check avoids that the
+         * `Series` is needlessly flushed a second time. Otherwise, error
+         * messages can get very confusing.
+         */
+        if (this->m_lastFlushSuccessful && m_writable.IOHandler &&
+            m_writable.IOHandler->has_value())
+        {
+            Series impl{{this, [](auto const *) {}}};
+            impl.flush();
+            impl.flushStep(/* doFlush = */ true);
+        }
+        if (m_writeIterations.has_value())
+        {
+            m_writeIterations = std::optional<WriteIterations>();
+        }
+        // Not strictly necessary, but clear the map of iterations
+        // This releases the openPMD hierarchy
+        iterations.container().clear();
+        // Release the IO Handler
+        if (m_writable.IOHandler)
+        {
+            *m_writable.IOHandler = std::nullopt;
         }
     }
 } // namespace internal
@@ -2004,7 +2020,7 @@ Series::Series(
         input->filenameExtension,
         comm,
         optionsJson);
-    init(handler, std::move(input));
+    init(std::move(handler), std::move(input));
     json::warnGlobalUnusedOptions(optionsJson);
 }
 #endif
@@ -2021,7 +2037,7 @@ Series::Series(
     parseJsonOptions(optionsJson, *input);
     auto handler = createIOHandler(
         input->path, at, input->format, input->filenameExtension, optionsJson);
-    init(handler, std::move(input));
+    init(std::move(handler), std::move(input));
     json::warnGlobalUnusedOptions(optionsJson);
 }
 
@@ -2045,6 +2061,11 @@ WriteIterations Series::writeIterations()
         series.m_writeIterations = WriteIterations(this->iterations);
     }
     return series.m_writeIterations.value();
+}
+
+void Series::close()
+{
+    get().close();
 }
 
 auto Series::currentSnapshot() const

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -151,7 +151,15 @@ void init_Series(py::module &m)
             py::arg("mpi_communicator"),
             py::arg("options") = "{}")
 #endif
-        .def("close", &Series::close)
+        .def("__bool__", &Series::operator bool)
+        .def("close", &Series::close, R"(
+Closes the Series and release the data storage/transport backends.
+
+All backends are closed after calling this method.
+The Series should be treated as destroyed after calling this method.
+The Series will be evaluated as false in boolean contexts after calling
+this method.
+        )")
 
         .def_property("openPMD", &Series::openPMD, &Series::setOpenPMD)
         .def_property(

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -151,6 +151,7 @@ void init_Series(py::module &m)
             py::arg("mpi_communicator"),
             py::arg("options") = "{}")
 #endif
+        .def("close", &Series::close)
 
         .def_property("openPMD", &Series::openPMD, &Series::setOpenPMD)
         .def_property(

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -148,7 +148,8 @@ TEST_CASE("container_default_test", "[auxiliary]")
 #if openPMD_USE_INVASIVE_TESTS
     Container<openPMD::test::S> c = Container<openPMD::test::S>();
     c.writable().IOHandler =
-        createIOHandler(".", Access::CREATE, Format::JSON, ".json");
+        std::make_shared<std::optional<std::unique_ptr<AbstractIOHandler>>>(
+            createIOHandler(".", Access::CREATE, Format::JSON, ".json"));
 
     REQUIRE(c.empty());
     REQUIRE(c.erase("nonExistentKey") == false);
@@ -186,7 +187,8 @@ TEST_CASE("container_retrieve_test", "[auxiliary]")
     using structure = openPMD::test::structure;
     Container<structure> c = Container<structure>();
     c.writable().IOHandler =
-        createIOHandler(".", Access::CREATE, Format::JSON, ".json");
+        std::make_shared<std::optional<std::unique_ptr<AbstractIOHandler>>>(
+            createIOHandler(".", Access::CREATE, Format::JSON, ".json"));
 
     structure s;
     std::string text =
@@ -259,7 +261,8 @@ TEST_CASE("container_access_test", "[auxiliary]")
     using Widget = openPMD::test::Widget;
     Container<Widget> c = Container<Widget>();
     c.writable().IOHandler =
-        createIOHandler(".", Access::CREATE, Format::JSON, ".json");
+        std::make_shared<std::optional<std::unique_ptr<AbstractIOHandler>>>(
+            createIOHandler(".", Access::CREATE, Format::JSON, ".json"));
 
     c["1firstWidget"] = Widget(0);
     REQUIRE(c.size() == 1);

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -34,7 +34,8 @@ struct TestHelper : public Attributable
     TestHelper()
     {
         writable().IOHandler =
-            createIOHandler(".", Access::CREATE, Format::JSON, ".json");
+            std::make_shared<std::optional<std::unique_ptr<AbstractIOHandler>>>(
+                createIOHandler(".", Access::CREATE, Format::JSON, ".json"));
     }
 };
 } // namespace openPMD::test

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6224,23 +6224,21 @@ void chaotic_stream(std::string filename, bool variableBased)
     }
     series.close();
 
+    Series read(filename, Access::READ_ONLY);
+    size_t index = 0;
+    for (const auto &iteration : read.readIterations())
     {
-        Series series(filename, Access::READ_ONLY);
-        size_t index = 0;
-        for (const auto &iteration : series.readIterations())
+        if (weirdOrderWhenReading)
         {
-            if (weirdOrderWhenReading)
-            {
-                REQUIRE(iteration.iterationIndex == iterations[index]);
-            }
-            else
-            {
-                REQUIRE(iteration.iterationIndex == index);
-            }
-            ++index;
+            REQUIRE(iteration.iterationIndex == iterations[index]);
         }
-        REQUIRE(index == iterations.size());
+        else
+        {
+            REQUIRE(iteration.iterationIndex == index);
+        }
+        ++index;
     }
+    REQUIRE(index == iterations.size());
 }
 
 TEST_CASE("chaotic_stream", "[serial]")

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6222,7 +6222,9 @@ void chaotic_stream(std::string filename, bool variableBased)
         dataset.storeChunk(iterations, {0}, {10});
         // series.writeIterations()[ currentIteration ].close();
     }
+    REQUIRE(series.operator bool());
     series.close();
+    REQUIRE(!series.operator bool());
 
     Series read(filename, Access::READ_ONLY);
     size_t index = 0;

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -1715,7 +1715,7 @@ class APITest(unittest.TestCase):
 
             for i in range(len(data)):
                 self.assertEqual(data[i], chunk[i])
-            del read
+            read.close()
 
         it1 = series.iterations[1]
         E_x = it1.meshes["E"]["x"]
@@ -1737,7 +1737,7 @@ class APITest(unittest.TestCase):
 
             for i in range(len(data)):
                 self.assertEqual(data[i], chunk[i])
-            del read
+            read.close()
 
     def testCloseIteration(self):
         for ext in tested_file_extensions:
@@ -1804,7 +1804,7 @@ class APITest(unittest.TestCase):
             self.assertEqual(chunk2[0, 1], 1)
             self.assertEqual(chunk2[1, 0], 2)
             self.assertEqual(chunk2[1, 1], 3)
-        del read
+        read.close()
         self.assertEqual(lastIterationIndex, 9)
 
     def testIterator(self):
@@ -1838,6 +1838,9 @@ class APITest(unittest.TestCase):
         data3 = np.array([[2], [4], [6], [8]], dtype=np.dtype("int"))
         E_x.store_chunk(data3, [6, 0], [4, 1])
 
+        # Cleaner: write.close()
+        # But let's keep this instance to test that that workflow stays
+        # functional.
         del write
 
         read = io.Series(
@@ -1899,7 +1902,7 @@ class APITest(unittest.TestCase):
         self.writeFromTemporaryStore(E_x)
         gc.collect()  # trigger removal of temporary data to check its copied
 
-        del write
+        write.close()
 
         read = io.Series(
             name,
@@ -2051,7 +2054,7 @@ class APITest(unittest.TestCase):
         e_chargeDensity_x.reset_dataset(DS(DT.LONG, [10]))
         e_chargeDensity_x[:] = sample_data
 
-        del write
+        write.close()
 
         read = io.Series("../samples/custom_geometries_python.json",
                          io.Access.read_only)

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -252,7 +252,7 @@ class APITest(unittest.TestCase):
         # TODO init of > e304 ?
         series.set_attribute("longdouble_c", ctypes.c_longdouble(6.e200).value)
 
-        del series
+        series.close()
 
         # read back
         series = io.Series(
@@ -461,7 +461,7 @@ class APITest(unittest.TestCase):
                     np.clongdouble(1.23456789 + 2.34567890j))
 
         # flush and close file
-        del series
+        series.close()
 
         # read back
         series = io.Series(
@@ -609,7 +609,7 @@ class APITest(unittest.TestCase):
                 np.clongdouble(1.23456789 + 2.34567890j))
 
         # flush and close file
-        del series
+        series.close()
 
         # read back
         series = io.Series(
@@ -690,7 +690,7 @@ class APITest(unittest.TestCase):
             ms["np_double"][SCALAR].make_empty(np.dtype("double"), 21)
 
         # flush and close file
-        del series
+        series.close()
 
         # read back
         series = io.Series(
@@ -1607,7 +1607,7 @@ class APITest(unittest.TestCase):
         e.particle_patches["extent"]["y"].store(1, np.single(123.))
 
         # read back
-        del series
+        series.close()
 
         series = io.Series(
             "unittest_py_particle_patches." + file_ending,
@@ -1781,7 +1781,7 @@ class APITest(unittest.TestCase):
             it.close()
             del it
 
-        del series
+        series.close()
 
         # read
 
@@ -1995,7 +1995,7 @@ class APITest(unittest.TestCase):
         E_y.reset_dataset(DS(np.dtype("double"), [1000], local_config))
         E_y.store_chunk(data, [0], [1000])
 
-        del series
+        series.close()
 
         read = io.Series(
             "../samples/unittest_jsonConfiguredBP3.bp",

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -252,7 +252,9 @@ class APITest(unittest.TestCase):
         # TODO init of > e304 ?
         series.set_attribute("longdouble_c", ctypes.c_longdouble(6.e200).value)
 
+        self.assertTrue(series)
         series.close()
+        self.assertFalse(series)
 
         # read back
         series = io.Series(
@@ -461,7 +463,9 @@ class APITest(unittest.TestCase):
                     np.clongdouble(1.23456789 + 2.34567890j))
 
         # flush and close file
+        self.assertTrue(series)
         series.close()
+        self.assertFalse(series)
 
         # read back
         series = io.Series(
@@ -609,7 +613,9 @@ class APITest(unittest.TestCase):
                 np.clongdouble(1.23456789 + 2.34567890j))
 
         # flush and close file
+        self.assertTrue(series)
         series.close()
+        self.assertFalse(series)
 
         # read back
         series = io.Series(
@@ -690,7 +696,9 @@ class APITest(unittest.TestCase):
             ms["np_double"][SCALAR].make_empty(np.dtype("double"), 21)
 
         # flush and close file
+        self.assertTrue(series)
         series.close()
+        self.assertFalse(series)
 
         # read back
         series = io.Series(
@@ -1607,7 +1615,9 @@ class APITest(unittest.TestCase):
         e.particle_patches["extent"]["y"].store(1, np.single(123.))
 
         # read back
+        self.assertTrue(series)
         series.close()
+        self.assertFalse(series)
 
         series = io.Series(
             "unittest_py_particle_patches." + file_ending,
@@ -1715,7 +1725,9 @@ class APITest(unittest.TestCase):
 
             for i in range(len(data)):
                 self.assertEqual(data[i], chunk[i])
+            self.assertTrue(read)
             read.close()
+            self.assertFalse(read)
 
         it1 = series.iterations[1]
         E_x = it1.meshes["E"]["x"]
@@ -1737,7 +1749,9 @@ class APITest(unittest.TestCase):
 
             for i in range(len(data)):
                 self.assertEqual(data[i], chunk[i])
+            self.assertTrue(read)
             read.close()
+            self.assertFalse(read)
 
     def testCloseIteration(self):
         for ext in tested_file_extensions:
@@ -1781,7 +1795,9 @@ class APITest(unittest.TestCase):
             it.close()
             del it
 
+        self.assertTrue(series)
         series.close()
+        self.assertFalse(series)
 
         # read
 
@@ -1804,7 +1820,9 @@ class APITest(unittest.TestCase):
             self.assertEqual(chunk2[0, 1], 1)
             self.assertEqual(chunk2[1, 0], 2)
             self.assertEqual(chunk2[1, 1], 3)
+        self.assertTrue(read)
         read.close()
+        self.assertFalse(read)
         self.assertEqual(lastIterationIndex, 9)
 
     def testIterator(self):
@@ -1902,7 +1920,9 @@ class APITest(unittest.TestCase):
         self.writeFromTemporaryStore(E_x)
         gc.collect()  # trigger removal of temporary data to check its copied
 
+        self.assertTrue(write)
         write.close()
+        self.assertFalse(write)
 
         read = io.Series(
             name,
@@ -1998,7 +2018,9 @@ class APITest(unittest.TestCase):
         E_y.reset_dataset(DS(np.dtype("double"), [1000], local_config))
         E_y.store_chunk(data, [0], [1000])
 
+        self.assertTrue(series)
         series.close()
+        self.assertFalse(series)
 
         read = io.Series(
             "../samples/unittest_jsonConfiguredBP3.bp",
@@ -2054,7 +2076,9 @@ class APITest(unittest.TestCase):
         e_chargeDensity_x.reset_dataset(DS(DT.LONG, [10]))
         e_chargeDensity_x[:] = sample_data
 
+        self.assertTrue(write)
         write.close()
+        self.assertFalse(write)
 
         read = io.Series("../samples/custom_geometries_python.json",
                          io.Access.read_only)


### PR DESCRIPTION
We currently often use `del series` in Python which is not ideal for a garbage collected language, as you cannot rely on the garbage collector to actually trigger application logic.
So, add a call `Series::close` whose effects are equivalent to destroying all `Series` instances.

TODO
- [x] Documentation
- [x] Keep at least some `del series` instances to ensure that this keeps working during the next release cycle