### PR TITLE
Docs: Recommend Static Build for Superbuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 set(openPMD_BUILD_CLI_TOOLS OFF)
 set(openPMD_BUILD_EXAMPLES OFF)
 set(openPMD_BUILD_TESTING OFF)
-# set(openPMD_BUILD_SHARED_LIBS OFF)  # precedence over BUILD_SHARED_LIBS if needed; or:
-set(openPMD_INSTALL ${BUILD_SHARED_LIBS})  # only install if used as shared a library
+set(openPMD_BUILD_SHARED_LIBS OFF)  # precedence over BUILD_SHARED_LIBS if needed
+set(openPMD_INSTALL OFF)            # or instead use:
+# set(openPMD_INSTALL ${BUILD_SHARED_LIBS})  # only install if used as a shared library
 set(openPMD_USE_PYTHON OFF)
 FetchContent_Declare(openPMD
   GIT_REPOSITORY "https://github.com/openPMD/openPMD-api.git"


### PR DESCRIPTION
Better default to recommend for pure C++ superbuilds.

First seen with @s-sajid-ali in https://github.com/fnalacceleratormodeling/synergia2/pull/100

cc @DerNils-git 