### PR TITLE
json::merge(): Two little fixes

### DIFF
--- a/include/openPMD/auxiliary/JSON.hpp
+++ b/include/openPMD/auxiliary/JSON.hpp
@@ -28,16 +28,16 @@ namespace openPMD
 namespace json
 {
     /**
-     * @brief Merge two JSON datasets into one.
+     * @brief Merge two JSON/TOML datasets into one.
      *
      * Merging rules:
-     * 1. If both `defaultValue` and `overwrite` are JSON objects, then the
-     *    resulting JSON object will contain the union of both objects' keys.
-     *    If a key is specified in both objects, the values corresponding to the
-     *    key are merged recursively.
-     *    Keys that point to a null value after this procedure will be pruned.
-     * 2. In any other case, the JSON dataset `defaultValue` is replaced in its
-     *    entirety with the JSON dataset `overwrite`.
+     * 1. If both `defaultValue` and `overwrite` are JSON/TOML objects, then the
+     *    resulting JSON/TOML object will contain the union of both objects'
+     *    keys. If a key is specified in both objects, the values corresponding
+     *    to the key are merged recursively. Keys that point to a null value
+     *    after this procedure will be pruned.
+     * 2. In any other case, the JSON/TOML dataset `defaultValue` is replaced in
+     *    its entirety with the JSON/TOML dataset `overwrite`.
      *
      * Note that item 2 means that datasets of different type will replace each
      * other without error.
@@ -46,15 +46,18 @@ namespace json
      *
      * Possible use case:
      * An application uses openPMD-api and wants to do the following:
-     * 1. Set some default backend options as JSON parameters.
+     * 1. Set some default backend options as JSON/TOML parameters.
      * 2. Let its users specify custom backend options additionally.
      *
      * By using the json::merge() function, this application can then allow
      * users to overwrite default options, while keeping any other ones.
      *
-     * @param defaultValue
-     * @param overwrite
-     * @return std::string
+     * @param defaultValue A string containing either a JSON or a TOML dataset.
+     * @param overwrite A string containing either a JSON or TOML dataset (does
+     * not need to be the same as `defaultValue`).
+     * @return std::string The merged dataset, according to the above rules. If
+     * `defaultValue` was a JSON dataset, then as a JSON string, otherwise as a
+     * TOML string.
      */
     std::string
     merge(std::string const &defaultValue, std::string const &overwrite);

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -570,8 +570,21 @@ merge(nlohmann::json &defaultVal, nlohmann::json const &overwrite)
 
 std::string merge(std::string const &defaultValue, std::string const &overwrite)
 {
-    auto res = parseOptions(defaultValue, /* considerFiles = */ false).config;
+    auto [res, returnFormat] =
+        parseOptions(defaultValue, /* considerFiles = */ false);
     merge(res, parseOptions(overwrite, /* considerFiles = */ false).config);
-    return res.dump();
+    switch (returnFormat)
+    {
+    case SupportedLanguages::JSON:
+        return res.dump();
+        break;
+    case SupportedLanguages::TOML: {
+        auto asToml = json::jsonToToml(res);
+        std::stringstream sstream;
+        sstream << asToml;
+        return sstream.str();
+    }
+    }
+    throw std::runtime_error("Unreachable!");
 }
 } // namespace openPMD::json

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -174,6 +174,33 @@ TEST_CASE("json_merging", "auxiliary")
     REQUIRE(
         json::merge(defaultVal, overwrite) ==
         json::parseOptions(expect, false).config.dump());
+
+    {
+        std::string leftJson = R"({"left": "val"})";
+        std::string rightJson = R"({"right": "val"})";
+        std::string leftToml = R"(left = "val")";
+        std::string rightToml = R"(right = "val")";
+
+        std::string resJson =
+            nlohmann::json::parse(R"({"left": "val", "right": "val"})").dump();
+        std::string resToml = []() {
+            constexpr char const *raw = R"(
+left = "val"
+right = "val"
+        )";
+            std::istringstream istream(
+                raw, std::ios_base::binary | std::ios_base::in);
+            toml::value tomlVal = toml::parse(istream);
+            std::stringstream sstream;
+            sstream << tomlVal;
+            return sstream.str();
+        }();
+
+        REQUIRE(json::merge(leftJson, rightJson) == resJson);
+        REQUIRE(json::merge(leftJson, rightToml) == resJson);
+        REQUIRE(json::merge(leftToml, rightJson) == resToml);
+        REQUIRE(json::merge(leftToml, rightToml) == resToml);
+    }
 }
 
 /*

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -126,6 +126,7 @@ TEST_CASE("json_parsing", "[auxiliary]")
     REQUIRE(jsonUpper.dump() == jsonLower.dump());
 }
 
+#if !__NVCOMPILER // see https://github.com/ToruNiina/toml11/issues/205
 TEST_CASE("json_merging", "auxiliary")
 {
     std::string defaultVal = R"END(
@@ -219,6 +220,7 @@ right = "val"
         REQUIRE(sort_lines(json::merge(leftToml, rightToml)) == resToml);
     }
 }
+#endif
 
 /*
  * This tests two things about the /data/snapshot attribute:

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -205,13 +205,8 @@ TEST_CASE("json_merging", "auxiliary")
 left = "val"
 right = "val"
         )";
-#if !__NVCOMPILER
-            constexpr std::ios::openmode openmode =
-                std::ios_base::in | std::ios_base::binary;
-#else
-            constexpr std::ios::openmode openmode = std::ios_base::in;
-#endif
-            std::istringstream istream(raw, openmode);
+            std::istringstream istream(
+                raw, std::ios_base::binary | std::ios_base::in);
             toml::value tomlVal = toml::parse(istream);
             std::stringstream sstream;
             sstream << tomlVal;

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -205,8 +205,13 @@ TEST_CASE("json_merging", "auxiliary")
 left = "val"
 right = "val"
         )";
-            std::istringstream istream(
-                raw, std::ios_base::binary | std::ios_base::in);
+#if !__NVCOMPILER
+            constexpr std::ios::openmode openmode =
+                std::ios_base::in | std::ios_base::binary;
+#else
+            constexpr std::ios::openmode openmode = std::ios_base::in;
+#endif
+            std::istringstream istream(raw, openmode);
             toml::value tomlVal = toml::parse(istream);
             std::stringstream sstream;
             sstream << tomlVal;


### PR DESCRIPTION
* We did not specify behavior concerning TOML. Specify, implement and test it.
* Add Python bindings (including docstring).