### PR TITLE
Enable empty string attributes

### DIFF
--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -90,39 +90,6 @@ namespace internal
         A_MAP m_attributes;
     };
 
-    enum class SetAttributeMode : char
-    {
-        WhileReadingAttributes,
-        FromPublicAPICall
-    };
-
-    /** Verify values of attributes in the frontend
-     *
-     * verify string attributes are not empty (backend restriction, e.g., HDF5)
-     */
-    template <typename T>
-    inline void attr_value_check(
-        std::string const /* key */, T /* value */, SetAttributeMode)
-    {}
-
-    template <>
-    inline void attr_value_check(
-        std::string const key, std::string const value, SetAttributeMode mode)
-    {
-        switch (mode)
-        {
-        case SetAttributeMode::FromPublicAPICall:
-            if (value.empty())
-                throw std::runtime_error(
-                    "[setAttribute] Value for string attribute '" + key +
-                    "' must not be empty!");
-            break;
-        case SetAttributeMode::WhileReadingAttributes:
-            // no checks while reading
-            break;
-        }
-    }
-
     template <typename>
     class BaseRecordData;
 } // namespace internal
@@ -298,12 +265,6 @@ OPENPMD_protected
 
     void flushAttributes(internal::FlushParams const &);
 
-    template <typename T>
-    bool setAttributeImpl(
-        std::string const &key, T value, internal::SetAttributeMode);
-    bool setAttributeImpl(
-        std::string const &key, char const value[], internal::SetAttributeMode);
-
     enum ReadMode
     {
         /**
@@ -444,30 +405,11 @@ private:
     virtual void linkHierarchy(Writable &w);
 }; // Attributable
 
-template <typename T>
-inline bool Attributable::setAttribute(std::string const &key, T value)
-{
-    return setAttributeImpl(
-        key, std::move(value), internal::SetAttributeMode::FromPublicAPICall);
-}
-
-inline bool
-Attributable::setAttribute(std::string const &key, char const value[])
-{
-    return setAttributeImpl(
-        key, value, internal::SetAttributeMode::FromPublicAPICall);
-}
-
 // note: we explicitly instantiate Attributable::setAttributeImpl for all T in
 // Datatype in Attributable.cpp
 template <typename T>
-inline bool Attributable::setAttributeImpl(
-    std::string const &key,
-    T value,
-    internal::SetAttributeMode setAttributeMode)
+inline bool Attributable::setAttribute(std::string const &key, T value)
 {
-    internal::attr_value_check(key, value, setAttributeMode);
-
     auto &attri = get();
     if (IOHandler() &&
         IOHandler()->m_seriesStatus == internal::SeriesStatus::Default &&
@@ -496,12 +438,10 @@ inline bool Attributable::setAttributeImpl(
     }
 }
 
-inline bool Attributable::setAttributeImpl(
-    std::string const &key,
-    char const value[],
-    internal::SetAttributeMode setAttributeMode)
+inline bool
+Attributable::setAttribute(std::string const &key, char const value[])
 {
-    return this->setAttributeImpl(key, std::string(value), setAttributeMode);
+    return this->setAttribute(key, std::string(value));
 }
 
 template <typename T>

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -235,6 +235,11 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::flush_attribute(
     }
     case DT::STRING: {
         auto const &v = att.get<std::string>();
+        if (v.empty())
+        {
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "Empty string attributes not supported.");
+        }
         values = auxiliary::allocatePtr(Datatype::CHAR, v.length() + 1u);
         strcpy((char *)values.get(), v.c_str());
         break;
@@ -352,6 +357,11 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::flush_attribute(
         auto const &vec = att.get<std::vector<std::string> >();
         for (size_t i = 0; i < vec.size(); ++i)
         {
+            if (vec[i].empty())
+            {
+                error::throwOperationUnsupportedInBackend(
+                    "ADIOS1", "Empty string attributes not supported.");
+            }
             size_t size = vec[i].size() + 1;
             ptr[i] = new char[size];
             strncpy(ptr[i], vec[i].c_str(), size);

--- a/src/IO/HDF5/HDF5Auxiliary.cpp
+++ b/src/IO/HDF5/HDF5Auxiliary.cpp
@@ -111,8 +111,7 @@ hid_t openPMD::GetH5DataType::operator()(Attribute const &att)
             m_userTypes.at(typeid(std::complex<long double>).name()));
     case DT::STRING: {
         hid_t string_t_id = H5Tcopy(H5T_C_S1);
-        size_t const max_len = att.get<std::string>().size();
-        VERIFY(max_len > 0, "[HDF5] max_len must be >0 for STRING");
+        size_t const max_len = att.get<std::string>().size() + 1;
         herr_t status = H5Tset_size(string_t_id, max_len);
         VERIFY(
             status >= 0,
@@ -123,7 +122,7 @@ hid_t openPMD::GetH5DataType::operator()(Attribute const &att)
         hid_t string_t_id = H5Tcopy(H5T_C_S1);
         size_t max_len = 0;
         for (std::string const &s : att.get<std::vector<std::string> >())
-            max_len = std::max(max_len, s.size());
+            max_len = std::max(max_len, s.size() + 1);
         VERIFY(max_len > 0, "[HDF5] max_len must be >0 for VEC_STRING");
         herr_t status = H5Tset_size(string_t_id, max_len);
         VERIFY(

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1621,8 +1621,8 @@ void HDF5IOHandlerImpl::writeAttribute(
         auto vs = att.get<std::vector<std::string> >();
         size_t max_len = 0;
         for (std::string const &s : vs)
-            max_len = std::max(max_len, s.size());
-        std::unique_ptr<char[]> c_str(new char[max_len * vs.size()]);
+            max_len = std::max(max_len, s.size() + 1);
+        std::unique_ptr<char[]> c_str(new char[max_len * vs.size()]());
         for (size_t i = 0; i < vs.size(); ++i)
             strncpy(c_str.get() + i * max_len, vs[i].c_str(), max_len);
         status = H5Awrite(attribute_id, dataType, c_str.get());

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -310,189 +310,99 @@ void Attributable::readAttributes(ReadMode mode)
                 }
                 std::array<double, 7> arr;
                 std::copy_n(vector.begin(), 7, arr.begin());
-                setAttributeImpl(
-                    key,
-                    std::move(arr),
-                    internal::SetAttributeMode::WhileReadingAttributes);
+                setAttribute(key, std::move(arr));
             }
             else
             {
-                setAttributeImpl(
-                    key,
-                    std::move(vector),
-                    internal::SetAttributeMode::WhileReadingAttributes);
+                setAttribute(key, std::move(vector));
             }
         };
 
         switch (*aRead.dtype)
         {
         case DT::CHAR:
-            setAttributeImpl(
-                att,
-                a.get<char>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<char>());
             break;
         case DT::UCHAR:
-            setAttributeImpl(
-                att,
-                a.get<unsigned char>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<unsigned char>());
             break;
         case DT::SCHAR:
-            setAttributeImpl(
-                att,
-                a.get<signed char>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<signed char>());
             break;
         case DT::SHORT:
-            setAttributeImpl(
-                att,
-                a.get<short>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<short>());
             break;
         case DT::INT:
-            setAttributeImpl(
-                att,
-                a.get<int>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<int>());
             break;
         case DT::LONG:
-            setAttributeImpl(
-                att,
-                a.get<long>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<long>());
             break;
         case DT::LONGLONG:
-            setAttributeImpl(
-                att,
-                a.get<long long>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<long long>());
             break;
         case DT::USHORT:
-            setAttributeImpl(
-                att,
-                a.get<unsigned short>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<unsigned short>());
             break;
         case DT::UINT:
-            setAttributeImpl(
-                att,
-                a.get<unsigned int>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<unsigned int>());
             break;
         case DT::ULONG:
-            setAttributeImpl(
-                att,
-                a.get<unsigned long>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<unsigned long>());
             break;
         case DT::ULONGLONG:
-            setAttributeImpl(
-                att,
-                a.get<unsigned long long>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<unsigned long long>());
             break;
         case DT::FLOAT:
-            setAttributeImpl(
-                att,
-                a.get<float>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<float>());
             break;
         case DT::DOUBLE:
-            setAttributeImpl(
-                att,
-                a.get<double>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<double>());
             break;
         case DT::LONG_DOUBLE:
-            setAttributeImpl(
-                att,
-                a.get<long double>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<long double>());
             break;
         case DT::CFLOAT:
-            setAttributeImpl(
-                att,
-                a.get<std::complex<float> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::complex<float> >());
             break;
         case DT::CDOUBLE:
-            setAttributeImpl(
-                att,
-                a.get<std::complex<double> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::complex<double> >());
             break;
         case DT::CLONG_DOUBLE:
-            setAttributeImpl(
-                att,
-                a.get<std::complex<long double> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::complex<long double> >());
             break;
         case DT::STRING:
-            setAttributeImpl(
-                att,
-                a.get<std::string>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::string>());
             break;
         case DT::VEC_CHAR:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<char> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<char> >());
             break;
         case DT::VEC_SHORT:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<short> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<short> >());
             break;
         case DT::VEC_INT:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<int> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<int> >());
             break;
         case DT::VEC_LONG:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<long> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<long> >());
             break;
         case DT::VEC_LONGLONG:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<long long> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<long long> >());
             break;
         case DT::VEC_UCHAR:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<unsigned char> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<unsigned char> >());
             break;
         case DT::VEC_USHORT:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<unsigned short> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<unsigned short> >());
             break;
         case DT::VEC_UINT:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<unsigned int> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<unsigned int> >());
             break;
         case DT::VEC_ULONG:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<unsigned long> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<unsigned long> >());
             break;
         case DT::VEC_ULONGLONG:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<unsigned long long> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<unsigned long long> >());
             break;
         case DT::VEC_FLOAT:
             guardUnitDimension(att, a.get<std::vector<float> >());
@@ -504,46 +414,26 @@ void Attributable::readAttributes(ReadMode mode)
             guardUnitDimension(att, a.get<std::vector<long double> >());
             break;
         case DT::VEC_CFLOAT:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<std::complex<float> > >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<std::complex<float> > >());
             break;
         case DT::VEC_CDOUBLE:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<std::complex<double> > >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<std::complex<double> > >());
             break;
         case DT::VEC_CLONG_DOUBLE:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<std::complex<long double> > >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(
+                att, a.get<std::vector<std::complex<long double> > >());
             break;
         case DT::VEC_SCHAR:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<signed char> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<signed char> >());
             break;
         case DT::VEC_STRING:
-            setAttributeImpl(
-                att,
-                a.get<std::vector<std::string> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::vector<std::string> >());
             break;
         case DT::ARR_DBL_7:
-            setAttributeImpl(
-                att,
-                a.get<std::array<double, 7> >(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<std::array<double, 7> >());
             break;
         case DT::BOOL:
-            setAttributeImpl(
-                att,
-                a.get<bool>(),
-                internal::SetAttributeMode::WhileReadingAttributes);
+            setAttribute(att, a.get<bool>());
             break;
         case DT::UNDEFINED:
             throw error::ReadError(

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -305,7 +305,6 @@ TEST_CASE("hdf5_write_test", "[parallel][hdf5]")
     Series o =
         Series("../samples/parallel_write.h5", Access::CREATE, MPI_COMM_WORLD);
 
-    o.setAuthor("");
     o.setAuthor("Parallel HDF5");
     ParticleSpecies &e = o.iterations[1].particles["e"];
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -305,7 +305,7 @@ TEST_CASE("hdf5_write_test", "[parallel][hdf5]")
     Series o =
         Series("../samples/parallel_write.h5", Access::CREATE, MPI_COMM_WORLD);
 
-    REQUIRE_THROWS_AS(o.setAuthor(""), std::runtime_error);
+    o.setAuthor("");
     o.setAuthor("Parallel HDF5");
     ParticleSpecies &e = o.iterations[1].particles["e"];
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1281,6 +1281,7 @@ inline void dtype_test(const std::string &backend)
         }
         std::string str = "string";
         s.setAttribute("string", str);
+        s.setAttribute("emptyString", "");
         s.setAttribute("vecChar", std::vector<char>({'c', 'h', 'a', 'r'}));
         s.setAttribute("vecInt16", std::vector<int16_t>({32766, 32767}));
         s.setAttribute(
@@ -1310,6 +1311,9 @@ inline void dtype_test(const std::string &backend)
         }
         s.setAttribute(
             "vecString", std::vector<std::string>({"vector", "of", "strings"}));
+        s.setAttribute("vecEmptyString", std::vector<std::string>{"", "", ""});
+        s.setAttribute(
+            "vecMixedString", std::vector<std::string>{"hi", "", "ho"});
         s.setAttribute("bool", true);
         s.setAttribute("boolF", false);
 
@@ -1386,6 +1390,7 @@ inline void dtype_test(const std::string &backend)
         REQUIRE(s.getAttribute("longdouble").get<long double>() == 1.e80L);
     }
     REQUIRE(s.getAttribute("string").get<std::string>() == "string");
+    REQUIRE(s.getAttribute("emptyString").get<std::string>().empty());
     REQUIRE(
         s.getAttribute("vecChar").get<std::vector<char> >() ==
         std::vector<char>({'c', 'h', 'a', 'r'}));
@@ -1429,6 +1434,12 @@ inline void dtype_test(const std::string &backend)
     REQUIRE(
         s.getAttribute("vecString").get<std::vector<std::string> >() ==
         std::vector<std::string>({"vector", "of", "strings"}));
+    REQUIRE(
+        s.getAttribute("vecEmptyString").get<std::vector<std::string> >() ==
+        std::vector<std::string>({"", "", ""}));
+    REQUIRE(
+        s.getAttribute("vecMixedString").get<std::vector<std::string> >() ==
+        std::vector<std::string>({"hi", "", "ho"}));
     REQUIRE(s.getAttribute("bool").get<bool>() == true);
     REQUIRE(s.getAttribute("boolF").get<bool>() == false);
 
@@ -2191,7 +2202,7 @@ inline void bool_test(const std::string &backend)
     {
         Series o = Series("../samples/serial_bool." + backend, Access::CREATE);
 
-        REQUIRE_THROWS_AS(o.setAuthor(""), std::runtime_error);
+        o.setAuthor("");
         o.setAttribute("Bool attribute true", true);
         o.setAttribute("Bool attribute false", false);
     }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1251,6 +1251,7 @@ inline void dtype_test(const std::string &backend)
     bool test_long_long = (backend != "json") || sizeof(long long) <= 8;
     {
         Series s = Series("../samples/dtype_test." + backend, Access::CREATE);
+        bool adios1 = s.backend() == "ADIOS1" || s.backend() == "MPI_ADIOS1";
 
         char c = 'c';
         s.setAttribute("char", c);
@@ -1281,7 +1282,10 @@ inline void dtype_test(const std::string &backend)
         }
         std::string str = "string";
         s.setAttribute("string", str);
-        s.setAttribute("emptyString", "");
+        if (!adios1)
+        {
+            s.setAttribute("emptyString", "");
+        }
         s.setAttribute("vecChar", std::vector<char>({'c', 'h', 'a', 'r'}));
         s.setAttribute("vecInt16", std::vector<int16_t>({32766, 32767}));
         s.setAttribute(
@@ -1311,9 +1315,13 @@ inline void dtype_test(const std::string &backend)
         }
         s.setAttribute(
             "vecString", std::vector<std::string>({"vector", "of", "strings"}));
-        s.setAttribute("vecEmptyString", std::vector<std::string>{"", "", ""});
-        s.setAttribute(
-            "vecMixedString", std::vector<std::string>{"hi", "", "ho"});
+        if (!adios1)
+        {
+            s.setAttribute(
+                "vecEmptyString", std::vector<std::string>{"", "", ""});
+            s.setAttribute(
+                "vecMixedString", std::vector<std::string>{"hi", "", "ho"});
+        }
         s.setAttribute("bool", true);
         s.setAttribute("boolF", false);
 
@@ -1373,6 +1381,7 @@ inline void dtype_test(const std::string &backend)
     }
 
     Series s = Series("../samples/dtype_test." + backend, Access::READ_ONLY);
+    bool adios1 = s.backend() == "ADIOS1" || s.backend() == "MPI_ADIOS1";
 
     REQUIRE(s.getAttribute("char").get<char>() == 'c');
     REQUIRE(s.getAttribute("uchar").get<unsigned char>() == 'u');
@@ -1390,7 +1399,10 @@ inline void dtype_test(const std::string &backend)
         REQUIRE(s.getAttribute("longdouble").get<long double>() == 1.e80L);
     }
     REQUIRE(s.getAttribute("string").get<std::string>() == "string");
-    REQUIRE(s.getAttribute("emptyString").get<std::string>().empty());
+    if (!adios1)
+    {
+        REQUIRE(s.getAttribute("emptyString").get<std::string>().empty());
+    }
     REQUIRE(
         s.getAttribute("vecChar").get<std::vector<char> >() ==
         std::vector<char>({'c', 'h', 'a', 'r'}));
@@ -1434,12 +1446,15 @@ inline void dtype_test(const std::string &backend)
     REQUIRE(
         s.getAttribute("vecString").get<std::vector<std::string> >() ==
         std::vector<std::string>({"vector", "of", "strings"}));
-    REQUIRE(
-        s.getAttribute("vecEmptyString").get<std::vector<std::string> >() ==
-        std::vector<std::string>({"", "", ""}));
-    REQUIRE(
-        s.getAttribute("vecMixedString").get<std::vector<std::string> >() ==
-        std::vector<std::string>({"hi", "", "ho"}));
+    if (!adios1)
+    {
+        REQUIRE(
+            s.getAttribute("vecEmptyString").get<std::vector<std::string> >() ==
+            std::vector<std::string>({"", "", ""}));
+        REQUIRE(
+            s.getAttribute("vecMixedString").get<std::vector<std::string> >() ==
+            std::vector<std::string>({"hi", "", "ho"}));
+    }
     REQUIRE(s.getAttribute("bool").get<bool>() == true);
     REQUIRE(s.getAttribute("boolF").get<bool>() == false);
 
@@ -2202,7 +2217,6 @@ inline void bool_test(const std::string &backend)
     {
         Series o = Series("../samples/serial_bool." + backend, Access::CREATE);
 
-        o.setAuthor("");
         o.setAttribute("Bool attribute true", true);
         o.setAttribute("Bool attribute false", false);
     }


### PR DESCRIPTION
Close #1329. 
I think the original issue why we had this restriction in the first place can be understood from the documentation of `H5Tset_size` in HDF5:
> size must have a positive value, unless it is passed in as [H5T_VARIABLE](https://docs.hdfgroup.org/hdf5/develop/_h5_tpublic_8h.html#a5185e14efde13b48249fe391324331bc) and the datatype is a string datatype.
> […]
> String or character datatypes: The size set for a string datatype should include space for the null-terminator character, otherwise it will not be stored on (or retrieved from) disk. Adjusting the size of a string automatically sets the precision to 8*size.

* HDF5 supports storing null-terminated strings as well as non-null-terminated strings, but recommends using null-terminated strings
* Non-variable strings (which are used by openPMD) must have a positive size >0, meaning that empty strings must be null-terminated
* openPMD so far used non-null-terminated strings, so storing empty strings was not possible

This commit switches to using null-terminated strings.

- [x] Merge #1237 first