### PR TITLE
Prefer parallel HDF5 in find_package in downstream use

### DIFF
--- a/.rodare.json
+++ b/.rodare.json
@@ -114,6 +114,12 @@
       "name": "Bez, Jean Luca",
       "orcid": "0000-0002-3915-1135",
       "type": "Other"
+    },
+    {
+      "affiliation": "CERN",
+      "name": "Gruber, Bernhard Manfred",
+      "orcid": "0000-0001-7848-1690",
+      "type": "Other"
     }
   ],
   "title": "C++ & Python API for Scientific I/O with openPMD",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,10 @@ Features
 Bug Fixes
 """""""""
 
+- CMake:
+
+  - MPI: prefer HDF5 in Config package, too #1340
+
 Other
 """""
 - Catch2: updated to 2.13.9 #1299

--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ Further thanks go to improvements and contributions from:
   C++ API bug fixes
 * [Jean Luca Bez (LBNL)](https://github.com/jeanbez):
   HDF5 performance tuning
+* [Bernhard Manfred Gruber (CERN)](https://github.com/bernhardmgruber):
+  CMake fix for parallel HDF5
 
 ### Grants
 

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -24,7 +24,7 @@ set(openPMD_MPI_FOUND ${openPMD_HAVE_MPI})
 
 set(openPMD_HAVE_HDF5 @openPMD_HAVE_HDF5@)
 if(openPMD_HAVE_HDF5)
-    set(HDF5_PREFER_PARALLEL ON)
+    set(HDF5_PREFER_PARALLEL ${openPMD_HAVE_MPI})
     find_dependency(HDF5)
 endif()
 set(openPMD_HDF5_FOUND ${openPMD_HAVE_HDF5})

--- a/openPMDConfig.cmake.in
+++ b/openPMDConfig.cmake.in
@@ -24,6 +24,7 @@ set(openPMD_MPI_FOUND ${openPMD_HAVE_MPI})
 
 set(openPMD_HAVE_HDF5 @openPMD_HAVE_HDF5@)
 if(openPMD_HAVE_HDF5)
+    set(HDF5_PREFER_PARALLEL ON)
     find_dependency(HDF5)
 endif()
 set(openPMD_HDF5_FOUND ${openPMD_HAVE_HDF5})


### PR DESCRIPTION
This aligns different behavior in finding HDF5 during cmake configure and use of openPMD in a downstream project. In both cases, the parallel HDF5 version is preferred now.

Fixes: #1339