### PR TITLE
Unify exception types

### DIFF
--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -106,6 +106,12 @@ namespace error
             std::optional<std::string> backend_in,
             std::string description_in);
     };
+
+    class NoSuchAttribute : public Error
+    {
+    public:
+        NoSuchAttribute(std::string attributeName);
+    };
 } // namespace error
 
 /**
@@ -119,4 +125,10 @@ using no_such_file_error = error::ReadError;
  *
  */
 using unsupported_data_error = error::OperationUnsupportedInBackend;
+
+/**
+ * @brief Backward-compatibility alias for no_such_attribute_error.
+ *
+ */
+using no_such_attribute_error = error::NoSuchAttribute;
 } // namespace openPMD

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -106,15 +106,6 @@ namespace error
             std::optional<std::string> backend_in,
             std::string description_in);
     };
-
-    /*
-     * Inrecoverable parse error from the frontend.
-     */
-    class ParseError : public Error
-    {
-    public:
-        ParseError(std::string what);
-    };
 } // namespace error
 
 /**

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -113,4 +113,10 @@ namespace error
  *
  */
 using no_such_file_error = error::ReadError;
+
+/**
+ * @brief Backward-compatibility alias for unsupported_data_error.
+ *
+ */
+using unsupported_data_error = error::OperationUnsupportedInBackend;
 } // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS1Auxiliary.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/IO/ADIOS/ADIOS1FilePosition.hpp"
+#include "openPMD/ThrowError.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/Writable.hpp"
@@ -102,8 +103,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(long) == 8u)
             return adios_long;
         else
-            throw unsupported_data_error(
-                "No native equivalent for Datatype::SHORT found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "No native equivalent for Datatype::SHORT found.");
     case DT::INT:
     case DT::VEC_INT:
         if (sizeof(int) == 2u)
@@ -113,8 +114,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(int) == 8u)
             return adios_long;
         else
-            throw unsupported_data_error(
-                "No native equivalent for Datatype::INT found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "No native equivalent for Datatype::INT found.");
     case DT::LONG:
     case DT::VEC_LONG:
         if (sizeof(long) == 2u)
@@ -124,8 +125,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(long) == 8u)
             return adios_long;
         else
-            throw unsupported_data_error(
-                "No native equivalent for Datatype::LONG found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "No native equivalent for Datatype::LONG found.");
     case DT::LONGLONG:
     case DT::VEC_LONGLONG:
         if (sizeof(long long) == 2u)
@@ -135,8 +136,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(long long) == 8u)
             return adios_long;
         else
-            throw unsupported_data_error(
-                "No native equivalent for Datatype::LONGLONG found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "No native equivalent for Datatype::LONGLONG found.");
     case DT::USHORT:
     case DT::VEC_USHORT:
         if (sizeof(unsigned short) == 2u)
@@ -146,8 +147,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(unsigned long) == 8u)
             return adios_unsigned_long;
         else
-            throw unsupported_data_error(
-                "No native equivalent for Datatype::USHORT found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "No native equivalent for Datatype::USHORT found.");
     case DT::UINT:
     case DT::VEC_UINT:
         if (sizeof(unsigned int) == 2u)
@@ -157,8 +158,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(unsigned int) == 8u)
             return adios_unsigned_long;
         else
-            throw unsupported_data_error(
-                "No native equivalent for Datatype::UINT found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "No native equivalent for Datatype::UINT found.");
     case DT::ULONG:
     case DT::VEC_ULONG:
         if (sizeof(unsigned long) == 2u)
@@ -168,8 +169,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(unsigned long) == 8u)
             return adios_unsigned_long;
         else
-            throw unsupported_data_error(
-                "No native equivalent for Datatype::ULONG found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1", "No native equivalent for Datatype::ULONG found.");
     case DT::ULONGLONG:
     case DT::VEC_ULONGLONG:
         if (sizeof(unsigned long long) == 2u)
@@ -179,7 +180,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         else if (sizeof(unsigned long long) == 8u)
             return adios_unsigned_long;
         else
-            throw unsupported_data_error(
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1",
                 "No native equivalent for Datatype::ULONGLONG found.");
     case DT::FLOAT:
     case DT::VEC_FLOAT:
@@ -199,8 +201,8 @@ inline ADIOS_DATATYPES getBP1DataType(Datatype dtype)
         return adios_double_complex;
     case DT::CLONG_DOUBLE:
     case DT::VEC_CLONG_DOUBLE:
-        throw unsupported_data_error(
-            "No native equivalent for Datatype::CLONG_DOUBLE found.");
+        error::throwOperationUnsupportedInBackend(
+            "ADIOS1", "No native equivalent for Datatype::CLONG_DOUBLE found.");
     case DT::STRING:
         return adios_string;
     case DT::VEC_STRING:

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -38,17 +38,6 @@
 
 namespace openPMD
 {
-
-class unsupported_data_error : public std::runtime_error
-{
-public:
-    unsupported_data_error(std::string const &what_arg)
-        : std::runtime_error(what_arg)
-    {}
-    virtual ~unsupported_data_error()
-    {}
-};
-
 /**
  * @brief Determine what items should be flushed upon Series::flush()
  *

--- a/include/openPMD/ThrowError.hpp
+++ b/include/openPMD/ThrowError.hpp
@@ -67,4 +67,7 @@ throwOperationUnsupportedInBackend(std::string backend, std::string what);
     Reason reason_in,
     std::optional<std::string> backend,
     std::string description_in);
+
+[[noreturn]] OPENPMDAPI_EXPORT void
+throwNoSuchAttribute(std::string attributeName);
 } // namespace openPMD::error

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/ThrowError.hpp"
 #include "openPMD/auxiliary/OutOfRangeMsg.hpp"
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/Writable.hpp"
@@ -49,16 +50,6 @@ class AbstractFilePosition;
 class Attributable;
 class Iteration;
 class Series;
-
-class no_such_attribute_error : public std::runtime_error
-{
-public:
-    no_such_attribute_error(std::string const &what_arg)
-        : std::runtime_error(what_arg)
-    {}
-    virtual ~no_such_attribute_error()
-    {}
-};
 
 namespace internal
 {
@@ -475,7 +466,7 @@ inline bool Attributable::setAttributeImpl(
     {
         auxiliary::OutOfRangeMsg const out_of_range_msg(
             "Attribute", "can not be set (read-only).");
-        throw no_such_attribute_error(out_of_range_msg(key));
+        error::throwNoSuchAttribute(out_of_range_msg(key));
     }
 
     dirty() = true;

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -132,8 +132,5 @@ namespace error
         throw ReadError(
             affectedObject, reason, std::move(backend), std::move(description));
     }
-
-    ParseError::ParseError(std::string what) : Error("Parse Error: " + what)
-    {}
 } // namespace error
 } // namespace openPMD

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -132,5 +132,14 @@ namespace error
         throw ReadError(
             affectedObject, reason, std::move(backend), std::move(description));
     }
+
+    NoSuchAttribute::NoSuchAttribute(std::string attributeName)
+        : Error(std::move(attributeName))
+    {}
+
+    void throwNoSuchAttribute(std::string attributeName)
+    {
+        throw NoSuchAttribute(std::move(attributeName));
+    }
 } // namespace error
 } // namespace openPMD

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -882,9 +882,9 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
         else if (sizeof(long long) == 2u)
             dtype = DT::LONGLONG;
         else
-            throw unsupported_data_error(
-                "[ADIOS1] No native equivalent for Datatype adios_short "
-                "found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1",
+                "No native equivalent for Datatype adios_short found.");
         break;
     case adios_integer:
         if (sizeof(short) == 4u)
@@ -896,9 +896,9 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
         else if (sizeof(long long) == 4u)
             dtype = DT::LONGLONG;
         else
-            throw unsupported_data_error(
-                "[ADIOS1] No native equivalent for Datatype adios_integer "
-                "found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1",
+                "No native equivalent for Datatype adios_integer found.");
         break;
     case adios_long:
         if (sizeof(short) == 8u)
@@ -910,8 +910,9 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
         else if (sizeof(long long) == 8u)
             dtype = DT::LONGLONG;
         else
-            throw unsupported_data_error(
-                "[ADIOS1] No native equivalent for Datatype adios_long found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1",
+                "No native equivalent for Datatype adios_long found.");
         break;
     case adios_unsigned_byte:
         dtype = DT::UCHAR;
@@ -926,9 +927,10 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
         else if (sizeof(unsigned long long) == 2u)
             dtype = DT::ULONGLONG;
         else
-            throw unsupported_data_error(
-                "[ADIOS1] No native equivalent for Datatype "
-                "adios_unsigned_short found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1",
+                "No native equivalent for Datatype adios_unsigned_short "
+                "found.");
         break;
     case adios_unsigned_integer:
         if (sizeof(unsigned short) == 4u)
@@ -940,9 +942,10 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
         else if (sizeof(unsigned long long) == 4u)
             dtype = DT::ULONGLONG;
         else
-            throw unsupported_data_error(
-                "[ADIOS1] No native equivalent for Datatype "
-                "adios_unsigned_integer found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1",
+                "No native equivalent for Datatype adios_unsigned_integer "
+                "found.");
         break;
     case adios_unsigned_long:
         if (sizeof(unsigned short) == 8u)
@@ -954,9 +957,9 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
         else if (sizeof(unsigned long long) == 8u)
             dtype = DT::ULONGLONG;
         else
-            throw unsupported_data_error(
-                "[ADIOS1] No native equivalent for Datatype "
-                "adios_unsigned_long found.");
+            error::throwOperationUnsupportedInBackend(
+                "ADIOS1",
+                "No native equivalent for Datatype adios_unsigned_long found.");
         break;
     case adios_real:
         dtype = DT::FLOAT;
@@ -977,7 +980,8 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
     case adios_string:
     case adios_string_array:
     default:
-        throw unsupported_data_error(
+        error::throwOperationUnsupportedInBackend(
+            "ADIOS1",
             "[ADIOS1] Datatype not implemented for ADIOS dataset writing");
     }
     *parameters.dtype = dtype;

--- a/src/binding/python/Error.cpp
+++ b/src/binding/python/Error.cpp
@@ -15,6 +15,8 @@ void init_Error(py::module &m)
     py::register_exception<error::BackendConfigSchema>(
         m, "ErrorBackendConfigSchema", baseError);
     py::register_exception<error::Internal>(m, "ErrorInternal", baseError);
+    py::register_exception<error::NoSuchAttribute>(
+        m, "ErrorNoSuchAttribute", baseError);
 
 #ifndef NDEBUG
     m.def("test_throw", [](std::string description) {


### PR DESCRIPTION
This PR:

1. Removes `ParseError` from `Error.hpp`. It's a leftover from #1237 that I ended up not using.
2. Uses `error::OperationUnsupportedInBackend` instead of `unsupported_data_error` and removes `unsupported_data_error` (only used in ADIOS1 implementation)
3. Puts `no_such_attribute_error` into `Error.hpp`, moves it into the `error` namespace as `error::NoSuchAttribute`, creates a compatibility alias for it and creates a Python binding for it.

Fix #1354.