### PR TITLE
Add error/warning in ADIOS2 when an attribute's datatype is changed

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1745,6 +1745,29 @@ namespace detail
             }
             else if (attributeModifiable())
             {
+                if (detail::fromADIOS2Type(t) !=
+                    basicDatatype(determineDatatype<T>()))
+                {
+                    if (impl->m_engineType == "bp5")
+                    {
+                        throw error::OperationUnsupportedInBackend(
+                            "ADIOS2",
+                            "Attempting to change datatype of attribute '" +
+                                fullName +
+                                "'. In the BP5 engine, this will lead to "
+                                "corrupted "
+                                "datasets.");
+                    }
+                    else
+                    {
+                        std::cerr << "[ADIOS2] Attempting to change datatype "
+                                     "of attribute '"
+                                  << fullName
+                                  << "'. This invokes undefined behavior. Will "
+                                     "proceed."
+                                  << std::endl;
+                    }
+                }
                 IO.RemoveAttribute(fullName);
             }
             else


### PR DESCRIPTION
Changing the datatype of an attribute is unsupported in ADIOS2, but will work in certain engines: https://github.com/ornladios/ADIOS2/issues/3413

This is not a common situation, but it can happen when defining a default openPMD attribute with specific datatype after the first flush, i.e.:

```cpp
Series s("asdf.bp", Access::CREATE);
auto iteration = s.iterations[0];
// ...
s.flush(); // This implicitly sets the attribute /data/0/dt = double(0.0)
iteration.setDt<float>();
s.flush(); // Datatype is changed to float
```

For now, the solution is to simply avoid that situation, so we print a warning / throw an error for awareness of this. (The BP5 engine will silently create a corrupt dataset that cannot be read. So, BP5 throws an error, other engines print a warning.)

The proper solution will be to define the openPMD defaults at a better time, i.e. at `Iteration::close()` and `Series::close()`.