### PR TITLE
Parallel Write Benchmark: Fix 1D

### DIFF
--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -701,7 +701,7 @@ void AbstractPattern::run()
                 store(series, step);
             }
         }
-	return;
+        return;
     }
 
     { // group/var based
@@ -1026,20 +1026,20 @@ bool OneDimPattern::setLayOut(int step)
         }
     }
     */
-    if ( 1 == numPartition )
+    if (1 == numPartition)
     {
-      Offset offset = { unitOffset * m_MinBlock[0] };
-      Extent count  = { unitCount * m_MinBlock[0]  };
-      m_InRankMeshLayout.emplace_back(offset, count);
+        Offset offset = {unitOffset * m_MinBlock[0]};
+        Extent count = {unitCount * m_MinBlock[0]};
+        m_InRankMeshLayout.emplace_back(offset, count);
     }
     else
     {
-      Extent count  = { m_MinBlock[0]  };
-      for (unsigned long i=0; i<unitCount; i++)
-      {
-         Offset offset = { (unitOffset+i) * m_MinBlock[0]  };
-         m_InRankMeshLayout.emplace_back(offset, count);
-      }
+        Extent count = {m_MinBlock[0]};
+        for (unsigned long i = 0; i < unitCount; i++)
+        {
+            Offset offset = {(unitOffset + i) * m_MinBlock[0]};
+            m_InRankMeshLayout.emplace_back(offset, count);
+        }
     }
 
     return true;

--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -701,6 +701,7 @@ void AbstractPattern::run()
                 store(series, step);
             }
         }
+	return;
     }
 
     { // group/var based
@@ -1004,6 +1005,7 @@ bool OneDimPattern::setLayOut(int step)
         return true;
 
     auto numPartition = m_Input.GetSeg();
+    /*
     if (unitCount < numPartition)
         numPartition = unitCount;
 
@@ -1022,6 +1024,22 @@ bool OneDimPattern::setLayOut(int step)
             Extent count = {res * m_MinBlock[0]};
             m_InRankMeshLayout.emplace_back(offset, count);
         }
+    }
+    */
+    if ( 1 == numPartition )
+    {
+      Offset offset = { unitOffset * m_MinBlock[0] };
+      Extent count  = { unitCount * m_MinBlock[0]  };
+      m_InRankMeshLayout.emplace_back(offset, count);
+    }
+    else
+    {
+      Extent count  = { m_MinBlock[0]  };
+      for (unsigned long i=0; i<unitCount; i++)
+      {
+         Offset offset = { (unitOffset+i) * m_MinBlock[0]  };
+         m_InRankMeshLayout.emplace_back(offset, count);
+      }
     }
 
     return true;

--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -1005,7 +1005,7 @@ bool OneDimPattern::setLayOut(int step)
         return true;
 
     auto numPartition = m_Input.GetSeg();
-     
+
     if (1 == numPartition)
     {
         Offset offset = {unitOffset * m_MinBlock[0]};

--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -1005,27 +1005,7 @@ bool OneDimPattern::setLayOut(int step)
         return true;
 
     auto numPartition = m_Input.GetSeg();
-    /*
-    if (unitCount < numPartition)
-        numPartition = unitCount;
-
-    auto avg = unitCount / numPartition;
-    for (unsigned int i = 0; i < numPartition; i++)
-    {
-        Offset offset = {unitOffset * m_MinBlock[0]};
-        if (i < (numPartition - 1))
-        {
-            Extent count = {avg * m_MinBlock[0]};
-            m_InRankMeshLayout.emplace_back(offset, count);
-        }
-        else
-        {
-            auto res = unitCount - avg * (numPartition - 1);
-            Extent count = {res * m_MinBlock[0]};
-            m_InRankMeshLayout.emplace_back(offset, count);
-        }
-    }
-    */
+     
     if (1 == numPartition)
     {
         Offset offset = {unitOffset * m_MinBlock[0]};


### PR DESCRIPTION
Found a bug when computing block offset/count with the multi block per rank option is on.    Fixed. 