### PR TITLE
Deactivate warning when opening single file of file-based Series

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1196,10 +1196,17 @@ void Series::readOneIterationFileBased(std::string const &filePath)
         else if (encoding == "groupBased")
         {
             series.m_iterationEncoding = IterationEncoding::groupBased;
-            std::cerr << "Series constructor called with iteration "
-                         "regex '%T' suggests loading a "
-                      << "time series with fileBased iteration "
-                         "encoding. Loaded file is groupBased.\n";
+            /*
+             * Opening a single file of a file-based Series is a valid workflow,
+             * warnings are not necessary here.
+             * Leaving the old warning as a comment, because we might want to
+             * add this back in again if we add some kind of verbosity level
+             * specification or logging.
+             */
+            // std::cerr << "Series constructor called with iteration "
+            //              "regex '%T' suggests loading a "
+            //           << "time series with fileBased iteration "
+            //              "encoding. Loaded file is groupBased.\n";
         }
         else if (encoding == "variableBased")
         {
@@ -1315,10 +1322,18 @@ auto Series::readGorVBased(bool do_always_throw_errors, bool do_init)
             else if (encoding == "fileBased")
             {
                 series.m_iterationEncoding = IterationEncoding::fileBased;
-                std::cerr << "Series constructor called with explicit "
-                             "iteration suggests loading a "
-                          << "single file with groupBased iteration encoding. "
-                             "Loaded file is fileBased.\n";
+                /*
+                 * Opening a single file of a file-based Series is a valid
+                 * workflow, warnings are not necessary here.
+                 * Leaving the old warning as a comment, because we might want
+                 * to add this back in again if we add some kind of verbosity
+                 * level specification or logging.
+                 */
+                // std::cerr << "Series constructor called with explicit "
+                //              "iteration suggests loading a "
+                //           << "single file with groupBased iteration encoding.
+                //           "
+                //              "Loaded file is fileBased.\n";
                 /*
                  * We'll want the openPMD API to continue series.m_name to open
                  * the file instead of piecing the name together via


### PR DESCRIPTION
Deactivated warning: `"Series constructor called with explicit iteration suggests loading a single file with groupBased iteration encoding. Loaded file is fileBased."`

Opening a single file of a file-based Series is a valid workflow, warnings are not necessary here. The warning can currently not be deactivated and is annoying.
The PR leaves the old warning as a comment, because we might want to add this back in again if we add some kind of verbosity level specification or logging.