### PR TITLE
Some fixes for char signs

### DIFF
--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -28,6 +28,7 @@
 
 #include <exception>
 #include <string>
+#include <type_traits>
 
 namespace openPMD
 {
@@ -36,9 +37,23 @@ inline Datatype dtype_from_numpy(pybind11::dtype const dt)
     // ref: https://docs.scipy.org/doc/numpy/user/basics.types.html
     // ref: https://github.com/numpy/numpy/issues/10678#issuecomment-369363551
     if (dt.char_() == pybind11::dtype("b").char_())
-        return Datatype::CHAR;
+        if constexpr (std::is_signed_v<char>)
+        {
+            return Datatype::CHAR;
+        }
+        else
+        {
+            return Datatype::SCHAR;
+        }
     else if (dt.char_() == pybind11::dtype("B").char_())
-        return Datatype::UCHAR;
+        if constexpr (std::is_unsigned_v<char>)
+        {
+            return Datatype::CHAR;
+        }
+        else
+        {
+            return Datatype::UCHAR;
+        }
     else if (dt.char_() == pybind11::dtype("short").char_())
         return Datatype::SHORT;
     else if (dt.char_() == pybind11::dtype("intc").char_())

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -978,6 +978,8 @@ void HDF5IOHandlerImpl::openDataset(
             d = DT::CHAR;
         else if (H5Tequal(dataset_type, H5T_NATIVE_UCHAR))
             d = DT::UCHAR;
+        else if (H5Tequal(dataset_type, H5T_NATIVE_SCHAR))
+            d = DT::SCHAR;
         else if (H5Tequal(dataset_type, H5T_NATIVE_SHORT))
             d = DT::SHORT;
         else if (H5Tequal(dataset_type, H5T_NATIVE_INT))
@@ -1729,6 +1731,7 @@ void HDF5IOHandlerImpl::readDataset(
     case DT::ULONGLONG:
     case DT::CHAR:
     case DT::UCHAR:
+    case DT::SCHAR:
     case DT::BOOL:
         break;
     case DT::UNDEFINED:

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1863,6 +1863,12 @@ void HDF5IOHandlerImpl::readAttribute(
             status = H5Aread(attr_id, attr_type, &u);
             a = Attribute(u);
         }
+        else if (H5Tequal(attr_type, H5T_NATIVE_SCHAR))
+        {
+            signed char u;
+            status = H5Aread(attr_id, attr_type, &u);
+            a = Attribute(u);
+        }
         else if (H5Tequal(attr_type, H5T_NATIVE_SHORT))
         {
             short i;
@@ -2086,6 +2092,12 @@ void HDF5IOHandlerImpl::readAttribute(
         else if (H5Tequal(attr_type, H5T_NATIVE_UCHAR))
         {
             std::vector<unsigned char> vu(dims[0], 0);
+            status = H5Aread(attr_id, attr_type, vu.data());
+            a = Attribute(vu);
+        }
+        else if (H5Tequal(attr_type, H5T_NATIVE_SCHAR))
+        {
+            std::vector<signed char> vu(dims[0], 0);
             status = H5Aread(attr_id, attr_type, vu.data());
             a = Attribute(vu);
         }


### PR DESCRIPTION
* HDF5 backend did not yet fully support signed char, making tests fail on Summit
* Numpy bindings assumed that `char` is signed

Follow-up to #1275