### PR TITLE
Fix for openpmd-pipe in Linear read mode: Open first iteration before reading any attributes

### DIFF
--- a/src/binding/python/openpmd_api/pipe/__main__.py
+++ b/src/binding/python/openpmd_api/pipe/__main__.py
@@ -223,6 +223,9 @@ class pipe:
                                   self.outconfig)
             print("Opened input and output on rank {}.".format(self.comm.rank))
             sys.stdout.flush()
+        # In Linear read mode, global attributes are only present after calling
+        # this method to access the first iteration
+        inseries.read_iterations()
         self.__copy(inseries, outseries)
 
     def __copy(self, src, dest, current_path="/data/"):


### PR DESCRIPTION
Follow-up to #1291 
With the linear read mode, attributes are only guaranteed to be present after accessing the first iteration.