### PR TITLE
Python bindings: Release GIL during IO wait operations

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -420,4 +420,24 @@ inline T Iteration::dt() const
 {
     return this->readFloatingpoint<T>("dt");
 }
+
+/**
+ * @brief Subclass of Iteration that knows its own index withing the containing
+ *        Series.
+ */
+class IndexedIteration : public Iteration
+{
+    friend class SeriesIterator;
+    friend class WriteIterations;
+
+public:
+    using index_t = Iteration::IterationIndex_t;
+    index_t const iterationIndex;
+
+private:
+    template <typename Iteration_t>
+    IndexedIteration(Iteration_t &&it, index_t index)
+        : Iteration(std::forward<Iteration_t>(it)), iterationIndex(index)
+    {}
+};
 } // namespace openPMD

--- a/include/openPMD/ReadIterations.hpp
+++ b/include/openPMD/ReadIterations.hpp
@@ -31,26 +31,6 @@
 
 namespace openPMD
 {
-/**
- * @brief Subclass of Iteration that knows its own index withing the containing
- *        Series.
- */
-class IndexedIteration : public Iteration
-{
-    friend class SeriesIterator;
-
-public:
-    using iterations_t = decltype(internal::SeriesData::iterations);
-    using index_t = iterations_t::key_type;
-    index_t const iterationIndex;
-
-private:
-    template <typename Iteration_t>
-    IndexedIteration(Iteration_t &&it, index_t index)
-        : Iteration(std::forward<Iteration_t>(it)), iterationIndex(index)
-    {}
-};
-
 class SeriesIterator
 {
     using iteration_index_t = IndexedIteration::index_t;

--- a/include/openPMD/WriteIterations.hpp
+++ b/include/openPMD/WriteIterations.hpp
@@ -87,5 +87,10 @@ private:
 public:
     mapped_type &operator[](key_type const &key);
     mapped_type &operator[](key_type &&key);
+
+    /**
+     * Return the iteration that is currently being written to, if it exists.
+     */
+    std::optional<IndexedIteration> currentIteration();
 };
 } // namespace openPMD

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -63,8 +63,20 @@ void init_Iteration(py::module &m)
             "dt", &Iteration::dt<long double>, &Iteration::setDt<double>)
         .def_property(
             "time_unit_SI", &Iteration::timeUnitSI, &Iteration::setTimeUnitSI)
-        .def("open", &Iteration::open)
-        .def("close", &Iteration::close, py::arg("flush") = true)
+        .def(
+            "open",
+            [](Iteration &it) {
+                py::gil_scoped_release release;
+                return it.open();
+            })
+        .def(
+            "close",
+            /*
+             * Cannot release the GIL here since Python buffers might be
+             * accessed in deferred tasks
+             */
+            &Iteration::close,
+            py::arg("flush") = true)
 
         // TODO remove in future versions (deprecated)
         .def("set_time", &Iteration::setTime<double>)

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -65,12 +65,41 @@ void init_Series(py::module &m)
             py::return_value_policy::copy);
     py::class_<IndexedIteration, Iteration>(m, "IndexedIteration")
         .def_readonly("iteration_index", &IndexedIteration::iterationIndex);
+
+    py::class_<SeriesIterator>(m, "SeriesIterator")
+        .def(
+            "__next__",
+            [](SeriesIterator &iterator) {
+                if (iterator == SeriesIterator::end())
+                {
+                    throw py::stop_iteration();
+                }
+                {
+                    py::gil_scoped_release release;
+                    ++iterator;
+                }
+                if (iterator == SeriesIterator::end())
+                {
+                    throw py::stop_iteration();
+                }
+                else
+                {
+                    return *iterator;
+                }
+            }
+
+        );
+
     py::class_<ReadIterations>(m, "ReadIterations")
         .def(
             "__iter__",
             [](ReadIterations &readIterations) {
-                return py::make_iterator(
-                    readIterations.begin(), readIterations.end());
+                // Simple iterator implementation:
+                // But we need to release the GIL inside
+                // SeriesIterator::operator++, so manually it is
+                // return py::make_iterator(
+                //     readIterations.begin(), readIterations.end());
+                return readIterations.begin();
             },
             // keep handle alive while iterator exists
             py::keep_alive<0, 1>());

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -59,6 +59,7 @@ void init_Series(py::module &m)
         .def(
             "__getitem__",
             [](WriteIterations writeIterations, Series::IterationIndex_t key) {
+                py::gil_scoped_release release;
                 return writeIterations[key];
             },
             // copy + keepalive
@@ -74,6 +75,11 @@ void init_Series(py::module &m)
                 {
                     throw py::stop_iteration();
                 }
+                /*
+                 * Closing the iteration must happen under the GIL lock since
+                 * Python buffers might be accessed
+                 */
+                (*iterator).close();
                 {
                     py::gil_scoped_release release;
                     ++iterator;


### PR DESCRIPTION
Fix #1380

This releases the GIL basically in those calls that trigger `adios2::Engine::BeginStep()`. Releasing the GIL for `adios2::Engine::EndStep`, and during flushes is more difficult since those calls may imply write access to Python buffers.

For a follow-up PR, we could try adding an `async for` implementation for the `ReadIterations` API.