### PR TITLE
Joined arrays in ADIOS2

### DIFF
--- a/docs/source/usage/workflow.rst
+++ b/docs/source/usage/workflow.rst
@@ -25,6 +25,7 @@ Storing and reading chunks
    The chunk is then stored by specifying an empty offset vector ``{}``.
    The chunk extent vector must be equivalent to the global extent in all non-joined dimensions (i.e. joined arrays allow no further sub-chunking other than concatenation along the joined dimension).
    The joined dimension of the extent vector specifies the extent that this piece should have along the joined dimension.
+   In the Python API, the slice-based setter syntax can be used as an abbreviation since the necessary information is determined from the passed array, e.g. ``record_component[()] = local_data``.
    The global extent of the dataset along the joined dimension will then be the sum of all local chunk extents along the joined dimension.
 
    Since openPMD follows a struct-of-array layout of data, it is important not to lose correlation of data between components. E.g., joining an array must take care that ``particles/e/position/x`` and ``particles/e/position/y`` are joined in uniform way.

--- a/docs/source/usage/workflow.rst
+++ b/docs/source/usage/workflow.rst
@@ -3,6 +3,48 @@
 Workflow
 ========
 
+Storing and reading chunks
+--------------------------
+
+1. **Chunks within an n-dimensional dataset**
+
+   Most commonly, chunks within an n-dimensional dataset are identified by their offset and extent.
+   The extent is the size of the chunk in each dimension, NOT the absolute coordinate within the entire dataset.
+
+   In the Python API, this is modeled to conform to the conventional ``__setitem__``/``__getitem__`` protocol.
+
+2. **Joined arrays (write only)**
+
+   (Currently) only supported in ADIOS2 no older than v2.9.0 under the conditions listed in the `ADIOS2 documentation on joined arrays <https://adios2.readthedocs.io/en/latest/components/components.html#shapes>`_.
+
+   In some cases, the concrete chunk within a dataset does not matter and the computation of indexes is a needless computational and mental overhead.
+   This commonly occurs for particle data which the openPMD-standard models as a list of particles.
+   The order of particles does not matter greatly, and making different parallel processes agree on indexing is error-prone boilerplate.
+
+   In such a case, at most one *joined dimension* can be specified in the Dataset, e.g. ``{Dataset::JOINED_DIMENSION, 128, 128}`` (3D for the sake of explanation, particle data would normally be 1D).
+   The chunk is then stored by specifying an empty offset vector ``{}``.
+   The chunk extent vector must be equivalent to the global extent in all non-joined dimensions (i.e. joined arrays allow no further sub-chunking other than concatenation along the joined dimension).
+   The joined dimension of the extent vector specifies the extent that this piece should have along the joined dimension.
+   The global extent of the dataset along the joined dimension will then be the sum of all local chunk extents along the joined dimension.
+
+   Since openPMD follows a struct-of-array layout of data, it is important not to lose correlation of data between components. E.g., joining an array must take care that ``particles/e/position/x`` and ``particles/e/position/y`` are joined in uniform way.
+
+   The openPMD-api makes the **following guarantee**:
+
+   Consider a Series written from ``N`` parallel processes between two (collective) flush points. For each parallel process ``n`` and dataset ``D``, let:
+
+    * ``chunk(D, n, i)`` be the ``i``'th chunk written to dataset ``D`` on process ``n``
+    * ``num_chunks(D, n)`` be the count of chunks written by ``n`` to ``D``
+    * ``joined_index(D, c)`` be the index of chunk ``c`` in the joining order of ``D``
+
+  Then for any two datasets ``x`` and ``y``:
+
+    * If for any parallel process ``n`` the condition holds that ``num_chunks(x, n) = num_chunks(y, n)`` (between the two flush points!)...
+    * ...then for any parallel process ``n`` and chunk index ``i`` less than ``num_chunks(x, n)``: ``joined_index(x, chunk(x, n, i)) = joined_index(y, chunk(y, n, i))``.
+
+  **TLDR:** Writing chunks to two joined arrays in synchronous way (**1.** same order of store operations and **2.** between the same flush operations) will result in the same joining order in both arrays.
+
+
 Access modes
 ------------
 

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -38,8 +38,8 @@ if __name__ == "__main__":
     # open file for writing
     series = io.Series(
         "../samples/5_parallel_write_py.bp"
-            if USE_JOINED_DIMENSION
-            else "../samples/5_parallel_write_py.h5",
+        if USE_JOINED_DIMENSION
+        else "../samples/5_parallel_write_py.h5",
         io.Access.create,
         comm
     )

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     series = io.Series(
         "../samples/5_parallel_write_py.bp"
             if USE_JOINED_DIMENSION
-            else "../samples/5_parallel_write_py.bp",
+            else "../samples/5_parallel_write_py.h5",
         io.Access.create,
         comm
     )

--- a/examples/5_write_parallel.py
+++ b/examples/5_write_parallel.py
@@ -21,13 +21,14 @@ try:
         version.parse(adios2.__version__) >= version.parse('2.9.0')
 except ImportError:
     USE_JOINED_DIMENSION = False
+
 if __name__ == "__main__":
     # also works with any other MPI communicator
     comm = MPI.COMM_WORLD
 
     # global data set to write: [MPI_Size * 10, 300]
     # each rank writes a 10x300 slice with its MPI rank as values
-    local_value = comm.size
+    local_value = comm.rank
     local_data = np.ones(10 * 300,
                          dtype=np.double).reshape(10, 300) * local_value
     if 0 == comm.rank:
@@ -77,7 +78,11 @@ if __name__ == "__main__":
     # example shows a 1D domain decomposition in first index
 
     if USE_JOINED_DIMENSION:
-        mymesh.store_chunk(local_data, [], [10, 300])
+        # explicit API
+        # mymesh.store_chunk(local_data, [], [10, 300])
+        mymesh[:, :] = local_data
+        # or short:
+        # mymesh[()] = local_data
     else:
         mymesh[comm.rank*10:(comm.rank+1)*10, :] = local_data
     if 0 == comm.rank:

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -22,7 +22,9 @@
 
 #include "openPMD/Datatype.hpp"
 
+#include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -37,6 +39,11 @@ class Dataset
     friend class RecordComponent;
 
 public:
+    enum : std::uint64_t
+    {
+        JOINED_DIMENSION = std::numeric_limits<std::uint64_t>::max()
+    };
+
     Dataset(Datatype, Extent, std::string options = "{}");
 
     /**
@@ -53,5 +60,9 @@ public:
     Datatype dtype;
     uint8_t rank;
     std::string options = "{}"; //!< backend-dependent JSON configuration
+
+    bool empty() const;
+
+    std::optional<size_t> joinedDimension() const;
 };
 } // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -446,21 +446,35 @@ private:
             }
         }
         auto joinedDim = joinedDimension(shape);
-        for (unsigned int i = 0; i < actualDim; i++)
+        if (joinedDim.has_value())
         {
-            if (!(joinedDim.has_value() && *joinedDim == i) &&
-                offset[i] + extent[i] > shape[i])
+            if (!offset.empty())
             {
                 throw std::runtime_error(
-                    "[ADIOS2] Dataset access out of bounds.");
+                    "[ADIOS2] Offset must be an empty vector in case of joined "
+                    "array.");
+            }
+            for (unsigned int i = 0; i < actualDim; i++)
+            {
+                if (*joinedDim != i && extent[i] != shape[i])
+                {
+                    throw std::runtime_error(
+                        "[ADIOS2] store_chunk extent of non-joined dimensions "
+                        "must be equivalent to the total extent.");
+                }
             }
         }
-
-        if (joinedDim.has_value() && !offset.empty())
+        else
         {
-            throw std::runtime_error(
-                "[ADIOS2] Offset must be an empty vector in case of joined "
-                "array.");
+            for (unsigned int i = 0; i < actualDim; i++)
+            {
+                if (!(joinedDim.has_value() && *joinedDim == i) &&
+                    offset[i] + extent[i] > shape[i])
+                {
+                    throw std::runtime_error(
+                        "[ADIOS2] Dataset access out of bounds.");
+                }
+            }
         }
 
         var.SetSelection(

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -60,6 +60,8 @@ namespace openPMD
 {
 #if openPMD_HAVE_ADIOS2
 
+std::optional<size_t> joinedDimension(adios2::Dims const &dims);
+
 class ADIOS2IOHandler;
 
 namespace detail
@@ -443,13 +445,22 @@ private:
                         std::to_string(actualDim) + ")");
             }
         }
+        auto joinedDim = joinedDimension(shape);
         for (unsigned int i = 0; i < actualDim; i++)
         {
-            if (offset[i] + extent[i] > shape[i])
+            if (!(joinedDim.has_value() && *joinedDim == i) &&
+                offset[i] + extent[i] > shape[i])
             {
                 throw std::runtime_error(
                     "[ADIOS2] Dataset access out of bounds.");
             }
+        }
+
+        if (joinedDim.has_value() && !offset.empty())
+        {
+            throw std::runtime_error(
+                "[ADIOS2] Offset must be an empty vector in case of joined "
+                "array.");
         }
 
         var.SetSelection(

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -326,6 +326,7 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::CREATE_DATASET>
     Extent extent = {};
     Datatype dtype = Datatype::UNDEFINED;
     std::string options = "{}";
+    std::optional<size_t> joinedDimension;
 
     /** Warn about unused JSON paramters
      *

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -537,6 +537,11 @@ OPENPMD_protected
     }
 
     void readBase(bool require_unit_si);
+
+    template <typename T>
+    void verifyChunk(Offset const &, Extent const &) const;
+
+    void verifyChunk(Datatype, Offset const &, Extent const &) const;
 }; // RecordComponent
 
 } // namespace openPMD

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -259,8 +259,17 @@ RecordComponent::storeChunk(T_ContiguousContainer &data, Offset o, Extent e)
     // default arguments
     //   offset = {0u}: expand to right dim {0u, 0u, ...}
     Offset offset = o;
-    if (o.size() == 1u && o.at(0) == 0u && dim > 1u)
-        offset = Offset(dim, 0u);
+    if (o.size() == 1u && o.at(0) == 0u)
+    {
+        if (joinedDimension().has_value())
+        {
+            offset.clear();
+        }
+        else if (dim > 1u)
+        {
+            offset = Offset(dim, 0u);
+        }
+    }
 
     //   extent = {-1u}: take full size
     Extent extent(dim, 1u);
@@ -303,6 +312,7 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
         dCreate.name = rc.m_name;
         dCreate.extent = getExtent();
         dCreate.dtype = getDatatype();
+        dCreate.joinedDimension = joinedDimension();
         if (!rc.m_dataset.has_value())
         {
             throw error::WrongAPIUsage(

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -143,6 +143,8 @@ public:
      */
     bool constant() const;
 
+    std::optional<size_t> joinedDimension() const;
+
     /**
      * Get data chunks that are available to be loaded from the backend.
      * Note that this is backend-dependent information and the returned

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -20,10 +20,10 @@
  */
 #pragma once
 
-#include "openPMD/auxiliary/ShareRawInternal.hpp"
-#include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/Error.hpp"
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/auxiliary/ShareRawInternal.hpp"
+#include "openPMD/backend/BaseRecordComponent.hpp"
 
 #include <memory>
 #include <sstream>

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include "openPMD/Dataset.hpp"
+#include "openPMD/Error.hpp"
 
 #include <cstddef>
 #include <iostream>
@@ -30,6 +31,9 @@ Dataset::Dataset(Datatype d, Extent e, std::string options_in)
 {
     // avoid initialization order issues
     rank = static_cast<uint8_t>(extent.size());
+    // Call this in order to have early error message in case of wrong
+    // specification of joined dimensions
+    joinedDimension();
 }
 
 Dataset::Dataset(Extent e) : Dataset(Datatype::UNDEFINED, std::move(e))
@@ -48,5 +52,42 @@ Dataset &Dataset::extend(Extent newExtents)
 
     extent = newExtents;
     return *this;
+}
+
+bool Dataset::empty() const
+{
+    auto jd = joinedDimension();
+    for (size_t i = 0; i < extent.size(); ++i)
+    {
+        if (extent[i] == 0 && (!jd.has_value() || jd.value() != i))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::optional<size_t> Dataset::joinedDimension() const
+{
+    std::optional<size_t> res;
+    for (size_t i = 0; i < extent.size(); ++i)
+    {
+        if (extent[i] == JOINED_DIMENSION)
+        {
+            if (res.has_value())
+            {
+                throw error::WrongAPIUsage(
+                    "Must specify JOINED_DIMENSION at most once (found at "
+                    "indices " +
+                    std::to_string(res.value()) + " and " + std::to_string(i) +
+                    ")");
+            }
+            else
+            {
+                res = i;
+            }
+        }
+    }
+    return res;
 }
 } // namespace openPMD

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -68,17 +68,17 @@ namespace openPMD
 
 #if openPMD_HAVE_ADIOS2
 
-    std::optional<size_t> joinedDimension(adios2::Dims const &dims)
+std::optional<size_t> joinedDimension(adios2::Dims const &dims)
+{
+    for (size_t i = 0; i < dims.size(); ++i)
     {
-        for (size_t i = 0; i < dims.size(); ++i)
+        if (dims[i] == adios2::JoinedDim)
         {
-            if (dims[i] == adios2::JoinedDim)
-            {
-                return i;
-            }
+            return i;
         }
-        return std::nullopt;
     }
+    return std::nullopt;
+}
 
 #if openPMD_HAVE_MPI
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -68,6 +68,18 @@ namespace openPMD
 
 #if openPMD_HAVE_ADIOS2
 
+    std::optional<size_t> joinedDimension(adios2::Dims const &dims)
+    {
+        for (size_t i = 0; i < dims.size(); ++i)
+        {
+            if (dims[i] == adios2::JoinedDim)
+            {
+                return i;
+            }
+        }
+        return std::nullopt;
+    }
+
 #if openPMD_HAVE_MPI
 
 ADIOS2IOHandlerImpl::ADIOS2IOHandlerImpl(
@@ -741,8 +753,11 @@ void ADIOS2IOHandlerImpl::createDataset(
                 varName + "' remain unused:\n");
 
         // cast from openPMD::Extent to adios2::Dims
-        adios2::Dims const shape(
-            parameters.extent.begin(), parameters.extent.end());
+        adios2::Dims shape(parameters.extent.begin(), parameters.extent.end());
+        if (auto jd = parameters.joinedDimension; jd.has_value())
+        {
+            shape[jd.value()] = adios2::JoinedDim;
+        }
 
         auto &fileData = getFileData(file, IfFileNotOpen::ThrowError);
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -720,6 +720,13 @@ void ADIOS2IOHandlerImpl::createDataset(
             "[ADIOS2] Creating a dataset in a file opened as read "
             "only is not possible.");
     }
+#if !openPMD_HAS_ADIOS_2_9
+    if (parameters.joinedDimension.has_value())
+    {
+        error::throwOperationUnsupportedInBackend(
+            "ADIOS1", "Joined Arrays require ADIOS2 >= v2.9");
+    }
+#endif
     if (!writable->written)
     {
         /* Sanitize name */

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -446,6 +446,12 @@ void HDF5IOHandlerImpl::createDataset(
             "[HDF5] Creating a dataset in a file opened as read only is not "
             "possible.");
 
+    if (parameters.joinedDimension.has_value())
+    {
+        error::throwOperationUnsupportedInBackend(
+            "ADIOS1", "Joined Arrays currently only supported in ADIOS2");
+    }
+
     if (!writable->written)
     {
         /* Sanitize name */

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -260,6 +260,12 @@ void JSONIOHandlerImpl::createDataset(
             "[JSON] Creating a dataset in a file opened as read only is not "
             "possible.");
     }
+    if (parameter.joinedDimension.has_value())
+    {
+        error::throwOperationUnsupportedInBackend(
+            "ADIOS1", "Joined Arrays currently only supported in ADIOS2");
+    }
+
     if (!writable->written)
     {
         /* Sanitize name */

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -65,6 +65,19 @@ bool BaseRecordComponent::constant() const
     return get().m_isConstant;
 }
 
+std::optional<size_t> BaseRecordComponent::joinedDimension() const
+{
+    auto &rc = get();
+    if (rc.m_dataset.has_value())
+    {
+        return rc.m_dataset.value().joinedDimension();
+    }
+    else
+    {
+        return false;
+    }
+}
+
 ChunkTable BaseRecordComponent::availableChunks()
 {
     auto &rc = get();

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -42,14 +42,11 @@ PatchRecordComponent &PatchRecordComponent::resetDataset(Dataset d)
             "written.");
     if (d.extent.empty())
         throw std::runtime_error("Dataset extent must be at least 1D.");
-    if (std::any_of(
-            d.extent.begin(), d.extent.end(), [](Extent::value_type const &i) {
-                return i == 0u;
-            }))
+    if (d.empty())
         throw std::runtime_error(
             "Dataset extent must not be zero in any dimension.");
 
-    get().m_dataset = d;
+    get().m_dataset = std::move(d);
     dirty() = true;
     return *this;
 }

--- a/src/binding/python/PatchRecordComponent.cpp
+++ b/src/binding/python/PatchRecordComponent.cpp
@@ -189,12 +189,14 @@ void init_PatchRecordComponent(py::module &m)
         // allowed python intrinsics, after (!) buffer matching
         .def(
             "store",
-            &PatchRecordComponent::store<double>,
+            py::overload_cast<uint64_t, double>(
+                &PatchRecordComponent::store<double>),
             py::arg("idx"),
             py::arg("data"))
         .def(
             "store",
-            &PatchRecordComponent::store<long>,
+            py::overload_cast<uint64_t, long>(
+                &PatchRecordComponent::store<long>),
             py::arg("idx"),
             py::arg("data"))
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1785,4 +1785,160 @@ TEST_CASE("unavailable_backend", "[core][parallel]")
     }
 #endif
 }
+
+void joined_dim(std::string const &ext)
+{
+    using type = float;
+    using patchType = uint64_t;
+    constexpr size_t patches_per_rank = 5;
+    constexpr size_t length_of_patch = 10;
+
+    int size{-1};
+    int rank{-1};
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    {
+        Series s(
+            "../samples/joinedDimParallel." + ext,
+            Access::CREATE,
+            MPI_COMM_WORLD);
+        std::vector<UniquePtrWithLambda<type>> writeFrom(patches_per_rank);
+
+        auto it = s.writeIterations()[100];
+
+        Dataset numParticlesDS(
+            determineDatatype<patchType>(), {Dataset::JOINED_DIMENSION});
+        auto numParticles =
+            it.particles["e"]
+                .particlePatches["numParticles"][RecordComponent::SCALAR];
+        auto numParticlesOffset =
+            it.particles["e"]
+                .particlePatches["numParticlesOffset"][RecordComponent::SCALAR];
+        numParticles.resetDataset(numParticlesDS);
+        numParticlesOffset.resetDataset(numParticlesDS);
+
+        auto patchOffset = it.particles["e"].particlePatches["offset"]["x"];
+        auto patchExtent = it.particles["e"].particlePatches["extent"]["x"];
+        Dataset particlePatchesDS(
+            determineDatatype<float>(), {Dataset::JOINED_DIMENSION});
+        patchOffset.resetDataset(particlePatchesDS);
+        patchExtent.resetDataset(particlePatchesDS);
+
+        float start_value = rank * patches_per_rank * length_of_patch;
+        for (size_t i = 0; i < 5; ++i)
+        {
+            writeFrom[i] = UniquePtrWithLambda<type>(
+                new type[length_of_patch],
+                [](auto const *ptr) { delete[] ptr; });
+            std::iota(
+                writeFrom[i].get(),
+                writeFrom[i].get() + 10,
+                start_value + length_of_patch * i);
+            patchOffset.store<type>(start_value + length_of_patch * i);
+        }
+
+        auto epx = it.particles["e"]["position"]["x"];
+        Dataset ds(determineDatatype<type>(), {Dataset::JOINED_DIMENSION});
+        epx.resetDataset(ds);
+
+        size_t counter = 0;
+        for (auto &chunk : writeFrom)
+        {
+            epx.storeChunk(std::move(chunk), {}, {length_of_patch});
+            numParticles.store<patchType>(length_of_patch);
+            /*
+             * For the sake of the test case, we know that the
+             * numParticlesOffset has this value. In general, the purpose of the
+             * joined array is that we don't need to know these values, so the
+             * specification of particle patches is somewhat difficult.
+             */
+            numParticlesOffset.store<patchType>(
+                start_value + counter++ * length_of_patch);
+            patchExtent.store<type>(10);
+        }
+        writeFrom.clear();
+        it.close();
+        s.close();
+    }
+
+    {
+        Series s(
+            "../samples/joinedDimParallel." + ext,
+            Access::READ_ONLY,
+            MPI_COMM_WORLD);
+        auto it = s.iterations[100];
+        auto e = it.particles["e"];
+
+        auto particleData = e["position"]["x"].loadChunk<type>();
+        auto numParticles =
+            e.particlePatches["numParticles"][RecordComponent::SCALAR]
+                .load<patchType>();
+        auto numParticlesOffset =
+            e.particlePatches["numParticlesOffset"][RecordComponent::SCALAR]
+                .load<patchType>();
+        auto patchOffset = e.particlePatches["offset"]["x"].load<type>();
+        auto patchExtent = e.particlePatches["extent"]["x"].load<type>();
+
+        it.close();
+
+        // check validity of particle patches
+        auto numPatches =
+            e.particlePatches["numParticlesOffset"][RecordComponent::SCALAR]
+                .getExtent()[0];
+        REQUIRE(
+            e.particlePatches["numParticles"][RecordComponent::SCALAR]
+                .getExtent()[0] == numPatches);
+        for (size_t i = 0; i < numPatches; ++i)
+        {
+            for (size_t j = 0; j < numParticles.get()[i]; ++j)
+            {
+                REQUIRE(
+                    patchOffset.get()[i] <=
+                    particleData.get()[numParticlesOffset.get()[i] + j]);
+                REQUIRE(
+                    particleData.get()[numParticlesOffset.get()[i] + j] <
+                    patchOffset.get()[i] + patchExtent.get()[i]);
+            }
+        }
+
+        /*
+         * Check that joined array joins early writes before later writes from
+         * the same rank
+         */
+        for (size_t i = 0; i < size * length_of_patch * patches_per_rank; ++i)
+        {
+            REQUIRE(float(i) == particleData.get()[i]);
+        }
+        for (size_t i = 0; i < size * patches_per_rank; ++i)
+        {
+            REQUIRE(length_of_patch * i == numParticlesOffset.get()[i]);
+            REQUIRE(type(length_of_patch * i) == patchOffset.get()[i]);
+        }
+    }
+}
+
+TEST_CASE("joined_dim", "[parallel]")
+{
+#if 100000000 * ADIOS2_VERSION_MAJOR + 1000000 * ADIOS2_VERSION_MINOR +        \
+        10000 * ADIOS2_VERSION_PATCH + 100 * ADIOS2_VERSION_TWEAK >=           \
+    209000000
+    constexpr char const *supportsJoinedDims[] = {"bp", "bp4", "bp5"};
+#else
+    // no zero-size arrays
+    std::vector<char const *> supportsJoinedDims;
+#endif
+    for (auto const &t : testedFileExtensions())
+    {
+        for (auto const supported : supportsJoinedDims)
+        {
+            if (t == supported)
+            {
+                joined_dim(t);
+                break;
+            }
+        }
+    }
+}
+
 #endif // openPMD_HAVE_ADIOS2 && openPMD_HAVE_MPI


### PR DESCRIPTION
This implements https://github.com/ornladios/ADIOS2/issues/3452 in openPMD and (partially) fixes #1374.

We will need a fallback implementation for backends other than ADIOS2. Quoting the discussion in #1374:

> Since this feature is relevant for basically all parallel code that writes particles, we should (as a second step) implement this also in openPMD, so that those codes still stay compatible with HDF5.
> Using MPI collectives to determine local block offsets inside the particle list is a really common pattern for using openPMD in such code, and this is a great chance to eliminate this pattern, while still staying compatible with all openPMD backends.

TODO
- [x] More extensive testing, parallel tests
- [x] documentation
- [x] Merge #1316 first
- [x] Don't use .joinedDimension, magic number instead
- [x] ~Needs a standard update: numParticlesOffset may optionally be skipped, particlePatches must then be in order so they can be reconstructed from numParticles~ Not updating the standard yet
- [x] Merge #1577 first