### PR TITLE
Close HFD5 handles in availableChunks task

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -769,6 +769,19 @@ void HDF5IOHandlerImpl::availableChunks(
     }
     parameters.chunks->push_back(
         WrittenChunkInfo(std::move(offset), std::move(extent)));
+
+    herr_t status;
+    status = H5Sclose(dataset_space);
+    VERIFY(
+        status == 0,
+        "[HDF5] Internal error: Failed to close HDF5 dataset space during "
+        "availableChunks task");
+
+    status = H5Dclose(dataset_id);
+    VERIFY(
+        status == 0,
+        "[HDF5] Internal error: Failed to close HDF5 dataset during "
+        "availableChunks task");
 }
 
 void HDF5IOHandlerImpl::openFile(


### PR DESCRIPTION
I forgot this back then. When using `availableChunks` in parallel code, this leads to errors when closing HDF5.

Follow up to #802 and #1035