### PR TITLE
Wheels: 0.15.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,8 @@ jobs:
           - os: ubuntu-20.04
             arch: "x86_64"
 
-          # 32bit Linux builds blocked by:
-          # GNU 7.3.1 & MPark.Variant 1.4.0 on i686:
-          #     https://github.com/pypa/manylinux/issues/543
-          #       variant.hpp:2241:9: internal compiler error:
-          #       unexpected expression ‘I’ of kind template_parm_index
-          #       typename T = lib::type_pack_element_t<I, Ts...>,
-          #- os: ubuntu-20.04
-          #  arch: "i686"
+          - os: ubuntu-20.04
+            arch: "i686"
 
           # builds faster on Travis-CI:
           #- os: ubuntu-20.04
@@ -49,7 +43,7 @@ jobs:
           - os: macos-10.15
             arch: "x86_64"
             env:
-              MACOSX_DEPLOYMENT_TARGET: 10.9
+              MACOSX_DEPLOYMENT_TARGET: 10.15
 
           # Apple Silicon M1/arm64/aarch64 builds:
           #   https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
@@ -76,7 +70,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'src'
-        ref: '0.14.5'
+        ref: '0.15.0'
 
     - uses: actions/checkout@v2
       with:
@@ -90,44 +84,40 @@ jobs:
     - name: Install cibuildwheel
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install cibuildwheel==2.2.2
+        python -m pip install cibuildwheel==2.12.1
 
-    # 0.14.5: macOS ADIOS1 Linker Error
-    # https://github.com/openPMD/openPMD-api/issues/1287
-    - name: Download Patch 1/2
+    # 0.15.0: CMake: Fix Python Install Directory
+    # https://github.com/openPMD/openPMD-api/pull/1393
+    - name: Download Patch 1/1
       uses: suisei-cn/actions-download-file@v1
       id: adiosbuild
       with:
-        url: "https://github.com/ax3l/openPMD-api/commit/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch"
+        url: "https://github.com/ax3l/openPMD-api/commit/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch"
         target: src/.patch/
 
-    # 0.14.5.post1 bump
+    # 0.15.0: macOS AppleClang12 Fixes
+    # https://github.com/openPMD/openPMD-api/pull/1395
     - name: Download Patch 2/2
       uses: suisei-cn/actions-download-file@v1
       id: setupversion
       with:
-        url: "https://gist.githubusercontent.com/ax3l/4db2f1744e0e28e6c013ee4e752b3cb7/raw/ceb03d11a10e2e2f8cd9c74bff524a21ba8eb92b/setupversion.patch"
+        url: "https://github.com/ax3l/openPMD-api/commit/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch"
         target: src/.patch/
 
     - name: Apply Patches
       run: |
         python -m pip install "patch==1.*"
         cd src
-        python -m patch .patch/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
-        python -m patch .patch/setupversion.patch
+        python -m patch .patch/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
+        python -m patch .patch/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
 
     - name: Build wheel
       env:
-        # (1) GNU 7.3.1 & MPark.Variant 1.4.0 on i686:
-        #     https://github.com/pypa/manylinux/issues/543
-        #       variant.hpp:2241:9: internal compiler error:
-        #       unexpected expression ‘I’ of kind template_parm_index
-        #       typename T = lib::type_pack_element_t<I, Ts...>,
-        # (2) Disable PyPy (manylinux image: yum repo issues)
+        # (1) Disable PyPy (manylinux image: yum repo issues)
         #     https://github.com/pypa/manylinux/issues/899
-        CIBW_SKIP: "*-manylinux_i686 pp*-manylinux*"
+        CIBW_SKIP: "pp*-manylinux*"
         CIBW_ARCHS: "${{ matrix.arch }}"
-        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6"
+        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
         # Install dependencies
         CIBW_BEFORE_BUILD_LINUX: bash -x .github/library_builders.sh
         CIBW_BEFORE_BUILD_MACOS: bash -x .github/library_builders.sh
@@ -136,8 +126,7 @@ jobs:
         # static dependencies of HDF5 and ADIOS1 (see setup.py)
         CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' ADIOS_USE_STATIC_LIBS='ON' openPMD_CMAKE_openPMD_USE_HDF5='ON' openPMD_CMAKE_openPMD_USE_ADIOS2='ON'
         CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' openPMD_CMAKE_openPMD_USE_HDF5='ON' openPMD_CMAKE_openPMD_USE_ADIOS2='ON' CMAKE_PREFIX_PATH='C:/Program Files (x86)/ADIOS2;C:/Program Files (x86)/blosc;C:/Program Files (x86)/HDF5;C:/Program Files (x86)/ZFP;C:/Program Files (x86)/zlib'
-        # C++11 & 14 support in macOS 10.9+
-        # C++17 support in macOS 10.13+/10.14+
+        # C++17 support in macOS 10.13+ (partial) and 10.14+ (std::visit) and 10.15+ (std::filesystem::path)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
         # arm64 Python interpreters are built with 11.0
         MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.MACOSX_DEPLOYMENT_TARGET }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.14.5"
+    - OPENPMD_GIT_REF="0.15.0"
 
-    - CIBW_PROJECT_REQUIRES_PYTHON=">=3.6"
+    - CIBW_PROJECT_REQUIRES_PYTHON=">=3.7"
     # Install dependencies on Linux and OSX
     - CIBW_BEFORE_BUILD="bash -x .github/library_builders.sh"
     # for the openPMD-api build, CMake shall search for
@@ -21,48 +21,45 @@ jobs:
   include:
     # perform a linux ARMv8 build
     # note: takes >50min, so we need to split
+    # +manylinux
     - services: docker
       arch: arm64
       dist: focal
       env:
-        - CIBW_BUILD="*_aarch64"
-        - CIBW_SKIP="cp38-* cp39-* pp36-* pp37-* cp310-* *-musllinux_*"
+        - CIBW_BUILD="cp37-manylinux_aarch64 cp38-manylinux_aarch64"
     - services: docker
       arch: arm64
       dist: focal
       env:
-        - CIBW_BUILD="*_aarch64"
-        - CIBW_SKIP="cp36-* cp37-* pp36-* pp37-* cp310-* *-musllinux_*"
+        - CIBW_BUILD="cp39-manylinux_aarch64 cp310-manylinux_aarch64"
     - services: docker
       arch: arm64
       dist: focal
       env:
-        - CIBW_BUILD="*_aarch64"
-        - CIBW_SKIP="cp38-* cp39-* cp36-* cp37-* cp310-* *-musllinux_*"
+        - CIBW_BUILD="cp311-manylinux_aarch64 pp37-manylinux_aarch64"
     - services: docker
       arch: arm64
       dist: focal
       env:
-        - CIBW_BUILD="*-musllinux_aarch64"
-        - CIBW_SKIP="cp38-* cp39-* cp310-*"
+        - CIBW_BUILD="pp38-manylinux_aarch64 pp39-manylinux_aarch64"
+    # +musllinux
     - services: docker
       arch: arm64
       dist: focal
       env:
-        - CIBW_BUILD="*-musllinux_aarch64"
-        - CIBW_SKIP="cp36-* cp37-* cp310-*"
+        - CIBW_BUILD="cp37-musllinux_aarch64 cp38-musllinux_aarch64"
     - services: docker
       arch: arm64
       dist: focal
       env:
-        - CIBW_BUILD="cp310-musllinux_aarch64"
+        - CIBW_BUILD="cp39-musllinux_aarch64 cp310-musllinux_aarch64"
+    - services: docker
+      arch: arm64
+      dist: focal
+      env:
+        - CIBW_BUILD="cp311-musllinux_aarch64"
 
     # perform a linux PPC64LE build
-    - services: docker
-      arch: ppc64le
-      dist: focal
-      env:
-        - CIBW_BUILD="cp36-manylinux_ppc64le"
     - services: docker
       arch: ppc64le
       dist: focal
@@ -87,7 +84,7 @@ jobs:
       arch: ppc64le
       dist: focal
       env:
-        - CIBW_BUILD="cp36-musllinux_ppc64le"
+        - CIBW_BUILD="cp311-manylinux_ppc64le"
     - services: docker
       arch: ppc64le
       dist: focal
@@ -108,6 +105,11 @@ jobs:
       dist: focal
       env:
         - CIBW_BUILD="cp310-musllinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp311-musllinux_ppc64le"
 
     # perform a linux S390X build
     # blocked by https://github.com/GTkorvo/dill/issues/15
@@ -126,7 +128,7 @@ jobs:
 install:
   - git clone --branch ${OPENPMD_GIT_REF} --depth 1 https://github.com/openPMD/openPMD-api.git src
   - cp library_builders.sh src/.github/
-  - python3 -m pip install git+https://github.com/ax3l/cibuildwheel.git@fix-ppc64leNetworkTravis
+  - python -m pip install cibuildwheel==2.12.1
   # twine & cryptography: see
   #   https://github.com/scikit-build/cmake-python-distributions/blob/4730aeee240917303f293dffc89a8d8d5a4787c4/requirements-deploy.txt
   #   https://github.com/pyca/cryptography/issues/6086
@@ -137,11 +139,11 @@ install:
 before_script:
   - mkdir -p src/.patch
   - cd src/.patch
-  - curl -sOL https://github.com/ax3l/openPMD-api/commit/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
-  - curl -sOL https://gist.githubusercontent.com/ax3l/4db2f1744e0e28e6c013ee4e752b3cb7/raw/ceb03d11a10e2e2f8cd9c74bff524a21ba8eb92b/setupversion.patch
+  - curl -sOL https://github.com/ax3l/openPMD-api/commit/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
+  - curl -sOL https://github.com/ax3l/openPMD-api/commit/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
   - cd ..
   - python3 -m patch .patch/dfd65f23af7f907851d44ceb9e3aebdd05b4045f.patch
-  - python3 -m patch .patch/setupversion.patch
+  - python3 -m patch .patch/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
   - cd ..
 
 script:


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.15.0 release.

Includes:
- Python 3.11 added, 3.6 dropped
- C++17 builds, thus
  - macOS 10.9+ bumped to:
    - 10.14+ due to `std::visit`
    - 10.15+ due to `std::filesystem::path` in toml11 unless `-DTOML11_DISABLE_STD_FILESYSTEM` is set
- 32bit Linux support (i686)

## Applied Post-Release Patches

- [x] #1395 
- [x] #1393 

### Not Yet Ready

- [ ] #1396 

## Notes

- Due to lacking Travis-CI credits, Linux aarch64 and ppc64le runners did not start.
- Windows wheels broke, pybind module artifact accidentally installed in root directory of wheel (now removed from pypi)