### PR TITLE
macOS AppleClang12 Fixes

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,9 +51,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install
       run: |
-        rm -rf /usr/local/bin/2to3
         set +e
-        python3 -m pip install -U mpi4py numpy pandas
+        python3 -m pip install -U numpy pandas
         set -e
     - name: Build
       env: {CXXFLAGS: -Werror -DTOML11_DISABLE_STD_FILESYSTEM, MACOSX_DEPLOYMENT_TARGET: 10.14}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
 #  appleclang10_py37_h5_ad2_libcpp
 #  appleclang11_nopy_nompi_h5_ad2
 
-  appleclang12_py_mpi_h5_ad2:
+  appleclang14_py_mpi_h5_ad2:
     runs-on: macos-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -28,11 +28,10 @@ jobs:
         python3 -m pip install -U mpi4py numpy pandas
         set -e
     - name: Build
-      env: {CXXFLAGS: -Werror -DTOML11_DISABLE_STD_FILESYSTEM, MACOSX_DEPLOYMENT_TARGET: 10.13}
-      # C++11 & 14 support in macOS 10.9+
-      # C++17 support in macOS 10.13+/10.14+
+      env: {CXXFLAGS: -Werror, MACOSX_DEPLOYMENT_TARGET: 10.15}
+      # 10.14+ due to std::visit
+      # 10.15+ due to std::filesystem in toml11
       #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
-      # std::filesystem needs macOS 10.15
       run: |
         share/openPMD/download_samples.sh build
         cmake -S . -B build \
@@ -40,6 +39,34 @@ jobs:
           -DopenPMD_USE_MPI=ON    \
           -DopenPMD_USE_HDF5=ON   \
           -DopenPMD_USE_ADIOS2=ON \
+          -DopenPMD_USE_INVASIVE_TESTS=ON
+        cmake --build build --parallel 2
+        ctest --test-dir build --verbose
+
+  appleclang12_py:
+    runs-on: macos-10.15
+    # next: macOS-11
+    if: github.event.pull_request.draft == false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install
+      run: |
+        rm -rf /usr/local/bin/2to3
+        set +e
+        python3 -m pip install -U mpi4py numpy pandas
+        set -e
+    - name: Build
+      env: {CXXFLAGS: -Werror -DTOML11_DISABLE_STD_FILESYSTEM, MACOSX_DEPLOYMENT_TARGET: 10.14}
+      # 10.14+ due to std::visit
+      # std::filesystem in toml11 needs macOS 10.15
+      #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
+      run: |
+        share/openPMD/download_samples.sh build
+        cmake -S . -B build \
+          -DopenPMD_USE_PYTHON=ON  \
+          -DopenPMD_USE_MPI=OFF    \
+          -DopenPMD_USE_HDF5=OFF   \
+          -DopenPMD_USE_ADIOS2=OFF \
           -DopenPMD_USE_INVASIVE_TESTS=ON
         cmake --build build --parallel 2
         ctest --test-dir build --verbose

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -28,6 +28,9 @@
 #include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/auxiliary/UniquePtr.hpp"
 
+#include <memory>
+
+
 namespace openPMD
 {
 template< typename T >
@@ -80,7 +83,8 @@ inline std::shared_ptr< T > RecordComponent::loadChunk(
     for( auto const& dimensionSize : extent )
         numPoints *= dimensionSize;
 
-#if defined(__clang_major__) && __clang_major__ < 7
+#if (defined(__clang_major__) && __clang_major__ < 7) ||                       \
+    (defined(__apple_build_version__) && __clang_major__ < 14)
     auto newData =
         std::shared_ptr<T>(new T[numPoints], [](T *p) { delete[] p; });
     loadChunk(newData, offset, extent);
@@ -374,7 +378,8 @@ RecordComponent::storeChunk( Offset offset, Extent extent )
         std::move( extent ),
         []( size_t size )
         {
-#if defined(__clang_major__) && __clang_major__ < 7
+#if (defined(__clang_major__) && __clang_major__ < 7) ||                       \
+    (defined(__apple_build_version__) && __clang_major__ < 14)
             return std::shared_ptr< T >{
                 new T[ size ], []( auto * ptr ) { delete[] ptr; } };
 #else

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -23,6 +23,7 @@
 #include "openPMD/auxiliary/ShareRawInternal.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -144,7 +145,8 @@ template <typename T>
 inline std::shared_ptr<T> PatchRecordComponent::load()
 {
     uint64_t numPoints = getExtent()[0];
-#if defined(__clang_major__) && __clang_major__ < 7
+#if (defined(__clang_major__) && __clang_major__ < 7) ||                       \
+    (defined(__apple_build_version__) && __clang_major__ < 14)
     auto newData =
         std::shared_ptr<T>(new T[numPoints], [](T *p) { delete[] p; });
     load(newData);


### PR DESCRIPTION
## CI: macOS-10.15

CI already runs on macOS-12. Adds an older runner.
Needs to update to `macOS-11` soon.

## Fix: Older libc++ (e.g. AppleClang, LLVM Clang <7)

```
    In file included from /Users/runner/work/openPMD-api/openPMD-api/src/include/openPMD/RecordComponent.hpp:467:
    /Users/runner/work/openPMD-api/openPMD-api/src/include/openPMD/RecordComponent.tpp:381:20: error: no matching constructor for initialization of 'std::shared_ptr<char []>'
                return std::shared_ptr< T[] >{ new T[ size ] };
                       ^                     ~~~~~~~~~~~~~~~~~
```

Issue seen with AppleClang 12.0 and not seen with 14.0.
Assume 13 might be affected, too.