### PR TITLE
ADIOS1 on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,16 +43,24 @@ jobs:
         cmake --build build --parallel 2
         ctest --test-dir build --verbose
 
-  appleclang12_py:
+  appleclang12_py_ad1:
     runs-on: macos-10.15
     # next: macOS-11
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v3
     - name: Install
+      env: {MACOSX_DEPLOYMENT_TARGET: 10.14}
       run: |
         set +e
         python3 -m pip install -U numpy pandas
+
+        curl -Lo adios-1.13.1.tar.gz http://users.nccs.gov/~pnorbert/adios-1.13.1.tar.gz
+        tar -xzf adios-1.13.1.tar.gz
+        cd adios-1.13.1/
+        CFLAGS="-fPIC" ./configure --enable-static --enable-shared --prefix=/usr/local --without-mpi --disable-fortran
+        make -j 2
+        make install
         set -e
     - name: Build
       env: {CXXFLAGS: -Werror -DTOML11_DISABLE_STD_FILESYSTEM, MACOSX_DEPLOYMENT_TARGET: 10.14}
@@ -65,6 +73,7 @@ jobs:
           -DopenPMD_USE_PYTHON=ON  \
           -DopenPMD_USE_MPI=OFF    \
           -DopenPMD_USE_HDF5=OFF   \
+          -DopenPMD_USE_ADIOS1=ON \
           -DopenPMD_USE_ADIOS2=OFF \
           -DopenPMD_USE_INVASIVE_TESTS=ON
         cmake --build build --parallel 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,13 +543,21 @@ set(IO_SOURCE
         src/IO/InvalidatableFile.cpp)
 set(IO_ADIOS1_SEQUENTIAL_SOURCE
         src/auxiliary/Filesystem.cpp
+        src/auxiliary/JSON.cpp
+        src/IO/AbstractIOHandlerImpl.cpp
         src/ChunkInfo.cpp
+        src/Error.cpp
+        src/IO/IOTask.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
         src/IO/ADIOS/ADIOS1IOHandler.cpp
         src/IO/IOTask.cpp)
 set(IO_ADIOS1_SOURCE
         src/auxiliary/Filesystem.cpp
+        src/auxiliary/JSON.cpp
+        src/IO/AbstractIOHandlerImpl.cpp
         src/ChunkInfo.cpp
+        src/Error.cpp
+        src/IO/IOTask.cpp
         src/IO/ADIOS/CommonADIOS1IOHandler.cpp
         src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
         src/IO/IOTask.cpp)
@@ -715,9 +723,6 @@ if(openPMD_HAVE_ADIOS1)
     target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE openPMD_HAVE_ADIOS1=1)
     target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE openPMD_HAVE_MPI=0)
     target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE _NOMPI)  # ADIOS header
-    # This ensures that the ADIOS1 targets don't ever include Error.hpp
-    # To avoid incompatible error types in weird compile configurations
-    target_compile_definitions(openPMD.ADIOS1.Serial PRIVATE OPENPMD_ADIOS1_IMPLEMENTATION)
 
     if(openPMD_HAVE_MPI)
         set_target_properties(openPMD.ADIOS1.Parallel PROPERTIES

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -8,10 +8,6 @@
 #include <utility>
 #include <vector>
 
-#if defined(OPENPMD_ADIOS1_IMPLEMENTATION)
-static_assert(false, "ADIOS1 implementation must not include Error.hpp");
-#endif
-
 namespace openPMD
 {
 /**

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -231,7 +231,7 @@ namespace json
      * Vector containing the lower-case keys to the single backends'
      * configurations.
      */
-    extern std::vector<std::string> backendKeys;
+    extern std::vector<std::string> backendKeys();
 
     /**
      * Function that can be called after reading all global options from the

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp"
-#include "openPMD/ThrowError.hpp"
+#include "openPMD/Error.hpp"
 
 #if openPMD_HAVE_ADIOS1
 

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -50,7 +50,7 @@ void Parameter<Operation::CREATE_DATASET>::warnUnusedParameters<
     auto shadow = config.invertShadow();
     // The backends are supposed to deal with this
     // Only global options here
-    for (auto const &backendKey : json::backendKeys)
+    for (auto const &backendKey : json::backendKeys())
     {
         if (backendKey != currentBackendName)
         {

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -499,14 +499,17 @@ std::optional<std::string> asLowerCaseStringDynamic(nlohmann::json const &value)
     return maybeString;
 }
 
-std::vector<std::string> backendKeys{"adios1", "adios2", "json", "hdf5"};
+std::vector<std::string> backendKeys()
+{
+    return {"adios1", "adios2", "json", "hdf5"};
+}
 
 void warnGlobalUnusedOptions(TracingJSON const &config)
 {
     auto shadow = config.invertShadow();
     // The backends are supposed to deal with this
     // Only global options here
-    for (auto const &backendKey : json::backendKeys)
+    for (auto const &backendKey : json::backendKeys())
     {
         shadow.erase(backendKey);
     }

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6564,10 +6564,15 @@ TEST_CASE("unfinished_iteration_test", "[serial]")
         "bp", IterationEncoding::fileBased, R"({"backend": "adios2"})");
 #endif
 #if openPMD_HAVE_ADIOS1
-    unfinished_iteration_test(
-        "adios1.bp", IterationEncoding::groupBased, R"({"backend": "adios1"})");
-    unfinished_iteration_test(
-        "adios1.bp", IterationEncoding::fileBased, R"({"backend": "adios1"})");
+    /*
+     * Catching errors from ADIOS1 is not generally supported
+     */
+    // unfinished_iteration_test(
+    //     "adios1.bp", IterationEncoding::groupBased, R"({"backend":
+    //     "adios1"})");
+    // unfinished_iteration_test(
+    //     "adios1.bp", IterationEncoding::fileBased, R"({"backend":
+    //     "adios1"})");
 #endif
 #if openPMD_HAVE_HDF5
     unfinished_iteration_test("h5", IterationEncoding::groupBased);


### PR DESCRIPTION
## CI: macOS ADIOS1

Ensure symbol exports are properly set.

## Fix

Disable runtime error recovery in ADIOS1, include missing symbols, avoid globals in `JSON.cpp` options.

First seen on https://github.com/conda-forge/openpmd-api-feedstock/pull/99