### PR TITLE
Fix: Artifact Placement in Windows Wheels

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,28 @@ jobs:
 # add before install, and fix Python path:
 # ctest --test-dir build -C Debug --output-on-failure
 
+  build_win_msvc_pip:
+    name: MSVC w/o MPI via pip
+    runs-on: windows-latest
+    if: github.event.pull_request.draft == false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build & Install
+      run: |
+        python3.exe -m pip install --upgrade pip setuptools wheel
+        python3.exe -m pip install --upgrade cmake
+        python3.exe -m pip install --upgrade numpy
+
+        python3.exe -m pip wheel .
+        if(!$?) { Exit $LASTEXITCODE }
+        python3.exe -m pip install openPMD_api-0.15.0-cp39-cp39-win_amd64.whl
+        if(!$?) { Exit $LASTEXITCODE }
+
+        python3.exe -c "import openpmd_api as api; print(api.variants)"
+        if(!$?) { Exit $LASTEXITCODE }
+
+        python3.exe -m openpmd_api.ls --help
+        if(!$?) { Exit $LASTEXITCODE }
 
   build_win_clang:
     name: Clang w/o MPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,15 +578,26 @@ set_target_properties(openPMD PROPERTIES
 )
 # note: same as above, but for Multi-Config generators
 if(isMultiConfig)
+    # this is a tweak for setup.py to pick up our libs & pybind module properly
+    # this assumes there will only be one config built
+    option(openPMD_BUILD_NO_CFG_SUBPATH
+           "For multi-config builds, do not appends the config to build dir" OFF)
+    mark_as_advanced(openPMD_BUILD_NO_CFG_SUBPATH)
+
     foreach(CFG IN LISTS CMAKE_CONFIGURATION_TYPES)
         string(TOUPPER "${CFG}" CFG_UPPER)
+        if(openPMD_BUILD_NO_CFG_SUBPATH)  # for setup.py
+            set(CFG_PATH "")
+        else()
+            set(CFG_PATH "/${CFG}")
+        endif()
         set_target_properties(openPMD PROPERTIES
             COMPILE_PDB_NAME_${CFG_UPPER} openPMD
-            ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_ARCHIVE_OUTPUT_DIRECTORY}/${CFG}
-            LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_LIBRARY_OUTPUT_DIRECTORY}/${CFG}
-            RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/${CFG}
-            PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PDB_OUTPUT_DIRECTORY}/${CFG}
-            COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_COMPILE_PDB_OUTPUT_DIRECTORY}/${CFG}
+            ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_ARCHIVE_OUTPUT_DIRECTORY}${CFG_PATH}
+            LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_LIBRARY_OUTPUT_DIRECTORY}${CFG_PATH}
+            RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_RUNTIME_OUTPUT_DIRECTORY}${CFG_PATH}
+            PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PDB_OUTPUT_DIRECTORY}${CFG_PATH}
+            COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_COMPILE_PDB_OUTPUT_DIRECTORY}${CFG_PATH}
         )
     endforeach()
 endif()
@@ -893,13 +904,18 @@ if(openPMD_HAVE_PYTHON)
     if(isMultiConfig)
         foreach(CFG IN LISTS CMAKE_CONFIGURATION_TYPES)
             string(TOUPPER "${CFG}" CFG_UPPER)
+            if(openPMD_BUILD_NO_CFG_SUBPATH)  # for setup.py
+                set(CFG_PATH "")
+            else()
+                set(CFG_PATH "/${CFG}")
+            endif()
             set_target_properties(openPMD.py PROPERTIES
                 COMPILE_PDB_NAME_${CFG_UPPER} openpmd_api_cxx
-                ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}/${CFG}/openpmd_api
-                LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}/${CFG}/openpmd_api
-                RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}/${CFG}/openpmd_api
-                PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}/${CFG}/openpmd_api
-                COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}/${CFG}/openpmd_api
+                ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}${CFG_PATH}/openpmd_api
+                LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}${CFG_PATH}/openpmd_api
+                RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}${CFG_PATH}/openpmd_api
+                PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}${CFG_PATH}/openpmd_api
+                COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${openPMD_PYTHON_OUTPUT_DIRECTORY}${CFG_PATH}/openpmd_api
             )
         endforeach()
     endif()

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,10 @@ class CMakeBuild(build_ext):
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
 
+        # Assumption: Windows builds are always multi-config (MSVC VS)
         if platform.system() == "Windows":
             cmake_args += [
+                '-DopenPMD_BUILD_NO_CFG_SUBPATH:BOOL=ON',
                 '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(
                     cfg.upper(),
                     os.path.join(extdir, "openpmd_api")


### PR DESCRIPTION
Our `setup.py` wheel logic currently picks up our libs and Python module straight from the build directory. The latest changes then misplaced the artifacts in the final wheel.

Add a tweak to CMake that allows to overwrite this for the two targets (lib and python module).

This will be modernized at some point using `scikit-build`.

Regression to #1384 

- [x] add CI test that ensures the MSVC build logic via pip works & modules are usable
- [x] checked wheel artifact produced in #1401