### PR TITLE
Fix docs post 0.15

### DIFF
--- a/docs/source/details/adios1.json
+++ b/docs/source/details/adios1.json
@@ -1,5 +1,5 @@
 {
-  "adios2": {
+  "adios1": {
     "dataset": {
       "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
     }

--- a/docs/source/details/adios1.toml
+++ b/docs/source/details/adios1.toml
@@ -1,2 +1,2 @@
-[adios.dataset]
+[adios1.dataset]
 transform = "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"


### PR DESCRIPTION
1. Typos in JSON/TOML configs for ADIOS1
2. Update best practises for ADIOS2