### PR TITLE
Fix Missing ADIOS1 Stubs in Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -785,6 +785,9 @@ if(openPMD_HAVE_ADIOS1)
 
     target_link_libraries(openPMD PUBLIC openPMD.ADIOS1.Serial)
     target_link_libraries(openPMD PUBLIC openPMD.ADIOS1.Parallel)
+else()
+    # add stubs to prevent missing symbols in Clang ASAN/UBSAN
+    target_sources(openPMD PRIVATE ${IO_ADIOS1_SEQUENTIAL_SOURCE} ${IO_ADIOS1_SOURCE})
 endif()
 
 # ADIOS2 Backend


### PR DESCRIPTION
The ADIOS1 stubs are still defined in those files, and some compilers (clang 14 with asan & ubsan active) will fail due to  missing symbols this at link time.