### PR TITLE
Work-Around: libc++ shared_ptr array

### DIFF
--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -83,7 +83,7 @@ inline std::shared_ptr< T > RecordComponent::loadChunk(
     for( auto const& dimensionSize : extent )
         numPoints *= dimensionSize;
 
-#if (defined(__clang_major__) && __clang_major__ < 7) ||                       \
+#if (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 11000) ||                   \
     (defined(__apple_build_version__) && __clang_major__ < 14)
     auto newData =
         std::shared_ptr<T>(new T[numPoints], [](T *p) { delete[] p; });
@@ -378,7 +378,7 @@ RecordComponent::storeChunk( Offset offset, Extent extent )
         std::move( extent ),
         []( size_t size )
         {
-#if (defined(__clang_major__) && __clang_major__ < 7) ||                       \
+#if (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 11000) ||                   \
     (defined(__apple_build_version__) && __clang_major__ < 14)
             return std::shared_ptr< T >{
                 new T[ size ], []( auto * ptr ) { delete[] ptr; } };

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -145,7 +145,7 @@ template <typename T>
 inline std::shared_ptr<T> PatchRecordComponent::load()
 {
     uint64_t numPoints = getExtent()[0];
-#if (defined(__clang_major__) && __clang_major__ < 7) ||                       \
+#if (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 11000) ||                   \
     (defined(__apple_build_version__) && __clang_major__ < 14)
     auto newData =
         std::shared_ptr<T>(new T[numPoints], [](T *p) { delete[] p; });


### PR DESCRIPTION
```C++
auto newData = std::shared_ptr<T[]>(new T[numPoints]);
```
This is an issue fixed in LLVM libc++ 11.0+.
https://godbolt.org/z/8fT4TYrdj

Follow-up to #1395