### PR TITLE
CMake 3.24+: ZLIB_USE_STATIC_LIBS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN        curl -sLo c-blosc-1.15.0.tar.gz https://github.com/Blosc/c-blosc/arch
            && PY_TARGET=${PY_VERSIONS%% *} \
            && PY_BIN=/opt/python/cp${PY_TARGET:0:2}-cp${PY_TARGET}/bin/python \
            && CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/" \
-           && PATH=${CMAKE_BIN}:${PATH} cmake -DDEACTIVATE_SNAPPY=ON -DBUILD_SHARED=OFF -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DCMAKE_INSTALL_PREFIX=/usr ../c-blosc-* \
+           && PATH=${CMAKE_BIN}:${PATH} cmake -DDEACTIVATE_SNAPPY=ON -DBUILD_SHARED=OFF -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DPREFER_EXTERNAL_ZLIB=ON -DZLIB_USE_STATIC_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr ../c-blosc-* \
            && make \
            && make install
 
@@ -74,7 +74,7 @@ RUN        curl -sLo adios2-2.7.1.tar.gz https://github.com/ornladios/ADIOS2/arc
            && PY_TARGET=${PY_VERSIONS%% *} \
            && PY_BIN=/opt/python/cp${PY_TARGET:0:2}-cp${PY_TARGET}/bin/python \
            && CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/" \
-           && PATH=${CMAKE_BIN}:${PATH} cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_BUILD_TESTING=OFF -DCMAKE_DISABLE_FIND_PACKAGE_LibFFI=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_BISON=TRUE -DCMAKE_INSTALL_PREFIX=/usr ../ADIOS2-* \
+           && PATH=${CMAKE_BIN}:${PATH} cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_BUILD_TESTING=OFF -DZLIB_USE_STATIC_LIBS=ON -DCMAKE_DISABLE_FIND_PACKAGE_LibFFI=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_BISON=TRUE -DCMAKE_INSTALL_PREFIX=/usr ../ADIOS2-* \
            && make \
            && make install
 
@@ -83,6 +83,7 @@ ADD        . /opt/src
 RUN        ls /opt/python/
 
 ENV        HDF5_USE_STATIC_LIBRARIES=ON \
+           ZLIB_USE_STATIC_LIBS=ON \
            ADIOS_USE_STATIC_LIBS=ON \
            openPMD_BUILD_TESTING=OFF \
            openPMD_BUILD_EXAMPLES=OFF
@@ -103,6 +104,7 @@ RUN        cd /opt/src; \
 #           && /opt/cmake/bin/cmake \
 #               -DPython_ROOT_DIR=$(which /opt/python/cp${PY_TARGET}-cp${PY_TARGET}m) \
 #               -DHDF5_USE_STATIC_LIBRARIES=ON \
+#               -DZLIB_USE_STATIC_LIBS=ON \
 #               -DBUILD_SHARED_LIBS=OFF \
 #               -DopenPMD_BUILD_TESTING=OFF \
 #               -DopenPMD_BUILD_EXAMPLES=OFF \


### PR DESCRIPTION
Recent CMake versions add a control variable to ensure only a static zlib is picked up.

This should not be needed in our own build (`setup.py`, similar to `HDF5_USE_STATIC_LIBRARIES`) because we do not depend on ZLIB _directly_, but transitively through dependencies such as HDF5 and ADIOS1/2->c-blosc