### PR TITLE
Instantiate only parallel ADIOS1 IO Handler in parallel ADIOS1 library

### DIFF
--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -2035,9 +2035,19 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::initJson(json::TracingJSON config)
     }
 }
 
-template class CommonADIOS1IOHandlerImpl<ADIOS1IOHandlerImpl>;
+/*
+ * Sic!
+ * The ADIOS1 IO Handler is built as two CMake targets: serial and parallel.
+ * One receives the definition openPMD_HAVE_MPI=0, the other receives
+ * openPMD_HAVE_MPI=1.
+ * So, if openPMD_HAVE_MPI is true, then we do not need to instantiate both
+ * the serial and the parallel handler down here, since the serial handler will
+ * be instantiated in another target.
+ */
 #if openPMD_HAVE_MPI
 template class CommonADIOS1IOHandlerImpl<ParallelADIOS1IOHandlerImpl>;
+#else
+template class CommonADIOS1IOHandlerImpl<ADIOS1IOHandlerImpl>;
 #endif // openPMD_HAVE_MPI
 
 } // namespace openPMD


### PR DESCRIPTION
This hopefully fixes the error seen on https://github.com/conda-forge/openpmd-api-feedstock/pull/99
```
[ 14%] Linking CXX shared library lib/libopenPMD.ADIOS1.Parallel.dylib
$BUILD_PREFIX/bin/cmake -E cmake_link_script CMakeFiles/openPMD.ADIOS1.Parallel.dir/link.txt --verbose=1
$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang++ -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wsign-compare -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0 -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/openpmd-api-0.15.0 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -D_LIBCPP_DISABLE_AVAILABILITY -O3 -DNDEBUG -isysroot /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk -mmacosx-version-min=10.9 -dynamiclib -Wl,-headerpad_max_install_names -Wl,-rpath,$PREFIX/lib -Wl,-pie -Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -o lib/libopenPMD.ADIOS1.Parallel.dylib -install_name @rpath/libopenPMD.ADIOS1.Parallel.dylib CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/auxiliary/Filesystem.cpp.o CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/auxiliary/JSON.cpp.o CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/IO/AbstractIOHandlerImpl.cpp.o CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/ChunkInfo.cpp.o CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/Error.cpp.o CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/IO/IOTask.cpp.o CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/IO/ADIOS/CommonADIOS1IOHandler.cpp.o CMakeFiles/openPMD.ADIOS1.Parallel.dir/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp.o  $PREFIX/lib/libadios.a $PREFIX/lib/libz.dylib $PREFIX/lib/libbz2.dylib $PREFIX/lib/libblosc.dylib $PREFIX/lib/libmpi.dylib 
ld: warning: -pie being ignored. It is only used when linking a main executable
Undefined symbols for architecture x86_64:
  "openPMD::ADIOS1IOHandlerImpl::initialize_group(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      openPMD::CommonADIOS1IOHandlerImpl<openPMD::ADIOS1IOHandlerImpl>::GetFileHandle(openPMD::Writable*) in CommonADIOS1IOHandler.cpp.o
      openPMD::CommonADIOS1IOHandlerImpl<openPMD::ADIOS1IOHandlerImpl>::openFile(openPMD::Writable*, openPMD::Parameter<(openPMD::Operation)2>&) in CommonADIOS1IOHandler.cpp.o
```

For more details, see the in-code comment.