### PR TITLE
Wheels: 0.15.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'src'
-        ref: '0.15.0'
+        ref: '0.15.1'
 
     - uses: actions/checkout@v2
       with:
@@ -86,49 +86,29 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install cibuildwheel==2.12.1
 
-    # 0.15.0: CMake: Fix Python Install Directory
-    # https://github.com/openPMD/openPMD-api/pull/1393
-    - name: Download Patch 1/4
-      uses: suisei-cn/actions-download-file@v1
-      id: patch1
-      with:
-        url: "https://github.com/ax3l/openPMD-api/commit/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch"
-        target: src/.patch/
+#    # 0.15.0: CMake: Fix Python Install Directory
+#    # https://github.com/openPMD/openPMD-api/pull/1393
+#    - name: Download Patch 1/2
+#      uses: suisei-cn/actions-download-file@v1
+#      id: patch1
+#      with:
+#        url: "https://github.com/ax3l/openPMD-api/commit/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch"
+#        target: src/.patch/
+#
+#    # 0.15.0.post2 bump
+#    - name: Download Patch 2/2
+#      uses: suisei-cn/actions-download-file@v1
+#      id: setupversion
+#      with:
+#        url: "https://gist.githubusercontent.com/ax3l/5e83edefe4b05cf6aa2a971649285fe0/raw/023cbd69e06715e5191ece741bb1de56560a9f96/0001-Bump-setup.py.patch"
+#        target: src/.patch/
 
-    # 0.15.0: macOS AppleClang12 Fixes
-    # https://github.com/openPMD/openPMD-api/pull/1395
-    - name: Download Patch 2/4
-      uses: suisei-cn/actions-download-file@v1
-      id: patch2
-      with:
-        url: "https://github.com/ax3l/openPMD-api/commit/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch"
-        target: src/.patch/
-
-    # 0.15.0: Fix: Artifact Placement in Windows Wheels
-    # https://github.com/openPMD/openPMD-api/pull/1400
-    - name: Download Patch 3/4
-      uses: suisei-cn/actions-download-file@v1
-      id: patch3
-      with:
-        url: "https://github.com/ax3l/openPMD-api/commit/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch"
-        target: src/.patch/
-
-    # 0.15.0.post2 bump
-    - name: Download Patch 4/4
-      uses: suisei-cn/actions-download-file@v1
-      id: setupversion
-      with:
-        url: "https://gist.githubusercontent.com/ax3l/5e83edefe4b05cf6aa2a971649285fe0/raw/023cbd69e06715e5191ece741bb1de56560a9f96/0001-Bump-setup.py.patch"
-        target: src/.patch/
-
-    - name: Apply Patches
-      run: |
-        python -m pip install "patch==1.*"
-        cd src
-        python -m patch .patch/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
-        python -m patch .patch/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
-        python -m patch .patch/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch
-        python -m patch .patch/0001-Bump-setup.py.patch
+#    - name: Apply Patches
+#      run: |
+#        python -m pip install "patch==1.*"
+#        cd src
+#        python -m patch .patch/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
+#        python -m patch .patch/0001-Bump-setup.py.patch
 
     - name: Build wheel
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.15.0"
+    - OPENPMD_GIT_REF="0.15.1"
 
     - CIBW_PROJECT_REQUIRES_PYTHON=">=3.7"
     # Install dependencies on Linux and OSX
@@ -139,19 +139,19 @@ install:
   - python3 -m pip install "patch==1.*"
 
 # Download & Apply Patches
-before_script:
-  - mkdir -p src/.patch
-  - cd src/.patch
-  - curl -sOL https://github.com/ax3l/openPMD-api/commit/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
-  - curl -sOL https://github.com/ax3l/openPMD-api/commit/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
-  - curl -sOL https://github.com/ax3l/openPMD-api/commit/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch
-  - curl -sOL https://gist.githubusercontent.com/ax3l/5e83edefe4b05cf6aa2a971649285fe0/raw/023cbd69e06715e5191ece741bb1de56560a9f96/0001-Bump-setup.py.patch
-  - cd ..
-  - python3 -m patch .patch/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
-  - python3 -m patch .patch/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
-  - python3 -m patch .patch/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch
-  - python3 -m patch .patch/0001-Bump-setup.py.patch
-  - cd ..
+#before_script:
+#  - mkdir -p src/.patch
+#  - cd src/.patch
+#  - curl -sOL https://github.com/ax3l/openPMD-api/commit/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
+#  - curl -sOL https://github.com/ax3l/openPMD-api/commit/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
+#  - curl -sOL https://github.com/ax3l/openPMD-api/commit/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch
+#  - curl -sOL https://gist.githubusercontent.com/ax3l/5e83edefe4b05cf6aa2a971649285fe0/raw/023cbd69e06715e5191ece741bb1de56560a9f96/0001-Bump-setup.py.patch
+#  - cd ..
+#  - python3 -m patch .patch/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
+#  - python3 -m patch .patch/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
+#  - python3 -m patch .patch/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch
+#  - python3 -m patch .patch/0001-Bump-setup.py.patch
+#  - cd ..
 
 script:
   - cd src


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.15.1 release.

Mostly fixes build issues.