### PR TITLE
Doc: Fix Bib Authors

### DIFF
--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -30,6 +30,7 @@ The equivalent BibTeX code is:
                      Sbalzarini, Ivo and
                      Kuschel, Stephan and
                      Sagan, David and
+                     Mayes, Christopher and
                      P{\'e}rez, Fr{\'e}d{\'e}ric and
                      Koller, Fabian and
                      Bussmann, Michael},


### PR DESCRIPTION
Make sure the bib authors match the quoted openPMD-standard authors.