### PR TITLE
Document OpenMPI-ROMIO/HDF5/Chunking issue

### DIFF
--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -102,8 +102,8 @@ Known Issues
 
 .. warning::
 
-   The ROMIO backend of OpenMPI has `a bug <https://github.com/open-mpi/ompi/issues/7795>`_ that leads to segmentation faults in combination with parallel HDF5 I/O with chunking enabled.
-   This bug usually does not occur when using default configurations as OpenMPI `uses the OMPIO component by default <https://docs.open-mpi.org/en/v5.0.x/mca.html>`_.
+   The ROMIO backend of OpenMPI has `a bug <https://github.com/open-mpi/ompi/issues/7795>`__ that leads to segmentation faults in combination with parallel HDF5 I/O with chunking enabled.
+   This bug usually does not occur when using default configurations as OpenMPI `uses the OMPIO component by default <https://docs.open-mpi.org/en/v5.0.x/mca.html>`__.
    The bug affects at least the entire OpenMPI 4.* release range and is currently set to be fixed for release 5.0 (release candidate available at the time of writing this).
 
 

--- a/docs/source/backends/hdf5.rst
+++ b/docs/source/backends/hdf5.rst
@@ -100,6 +100,12 @@ Known Issues
    Collective HDF5 metadata reads (``OPENPMD_HDF5_COLLECTIVE_METADATA=ON``) broke in 1.10.5, falling back to individual metadata operations.
    HDF5 releases 1.10.4 and earlier are not affected; versions 1.10.9+, 1.12.2+ and 1.13.1+ fixed the issue.
 
+.. warning::
+
+   The ROMIO backend of OpenMPI has `a bug <https://github.com/open-mpi/ompi/issues/7795>`_ that leads to segmentation faults in combination with parallel HDF5 I/O with chunking enabled.
+   This bug usually does not occur when using default configurations as OpenMPI `uses the OMPIO component by default <https://docs.open-mpi.org/en/v5.0.x/mca.html>`_.
+   The bug affects at least the entire OpenMPI 4.* release range and is currently set to be fixed for release 5.0 (release candidate available at the time of writing this).
+
 
 Selected References
 -------------------


### PR DESCRIPTION
https://github.com/open-mpi/ompi/issues/7795

Ideally, we would deactivate chunking by default when detecting use of OpenMPI 4.* + ROMIO, but the only way I found to figure this out is by environment variable:

```
$ mpirun --mca io ompio -n 1 env | grep 'OMPI_MCA_io'
OMPI_MCA_io=ompio
$ mpirun --mca io romio -n 1 env | grep 'OMPI_MCA_io'
OMPI_MCA_io=romio
```

Imo, trying to parse this env variable is not worth the effort for a bug that only occurs when not using defaults.

X-ref: https://github.com/open-mpi/ompi/issues/11715