### PR TITLE
Use lazy imports for dask and pandas

### DIFF
--- a/src/binding/python/openpmd_api/DaskArray.py
+++ b/src/binding/python/openpmd_api/DaskArray.py
@@ -9,12 +9,6 @@ import math
 
 import numpy as np
 
-try:
-    from dask.array import from_array
-    found_dask = True
-except ImportError:
-    found_dask = False
-
 
 class DaskRecordComponent:
     # shape, .ndim, .dtype and support numpy-style slicing
@@ -80,6 +74,13 @@ def record_component_to_daskarray(record_component):
         are used internally to parallelize reading
     dask.array : the (potentially distributed) array object created here
     """
+    # Import dask here for a lazy import
+    try:
+        from dask.array import from_array
+        found_dask = True
+    except ImportError:
+        found_dask = False
+
     if not found_dask:
         raise ImportError("dask NOT found. Install dask for Dask DataFrame "
                           "support.")

--- a/src/binding/python/openpmd_api/DaskDataFrame.py
+++ b/src/binding/python/openpmd_api/DaskDataFrame.py
@@ -7,18 +7,6 @@ License: LGPLv3+
 """
 import numpy as np
 
-try:
-    import dask.dataframe as dd
-    from dask.delayed import delayed
-    found_dask = True
-except ImportError:
-    found_dask = False
-try:
-    import pandas  # noqa
-    found_pandas = True
-except ImportError:
-    found_pandas = False
-
 
 def read_chunk_to_df(species, chunk):
     stride = np.s_[chunk.offset[0]:chunk.offset[0]+chunk.extent[0]]
@@ -51,6 +39,19 @@ def particles_to_daskdataframe(particle_species):
         are used internally to parallelize particle processing
     dask.dataframe : the central dataframe object created here
     """
+    # import here for lazy imports
+    try:
+        import dask.dataframe as dd
+        from dask.delayed import delayed
+        found_dask = True
+    except ImportError:
+        found_dask = False
+    try:
+        import pandas  # noqa
+        found_pandas = True
+    except ImportError:
+        found_pandas = False
+
     if not found_dask:
         raise ImportError("dask NOT found. Install dask for Dask DataFrame "
                           "support.")

--- a/src/binding/python/openpmd_api/DataFrame.py
+++ b/src/binding/python/openpmd_api/DataFrame.py
@@ -9,12 +9,6 @@ import math
 
 import numpy as np
 
-try:
-    import pandas as pd
-    found_pandas = True
-except ImportError:
-    found_pandas = False
-
 
 def particles_to_dataframe(particle_species, slice=None):
     """
@@ -46,6 +40,13 @@ def particles_to_dataframe(particle_species, slice=None):
         are optimal arguments for the slice parameter
     pandas.DataFrame : the central dataframe object created here
     """
+    # import pandas here for a lazy import
+    try:
+        import pandas as pd
+        found_pandas = True
+    except ImportError:
+        found_pandas = False
+
     if not found_pandas:
         raise ImportError("pandas NOT found. Install pandas for DataFrame "
                           "support.")


### PR DESCRIPTION
Lazy imports are done to speed up the import of the module when dask and pandas are not needed. In those cases, this will speed up the import of openpmd-api.