### PR TITLE
CI: macOS-11 Update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,9 +43,8 @@ jobs:
         cmake --build build --parallel 3
         ctest --test-dir build --verbose
 
-  appleclang12_py:
-    runs-on: macos-10.15
-    # next: macOS-11
+  appleclang13_py:
+    runs-on: macos-11
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v3
@@ -67,7 +66,8 @@ jobs:
           -DopenPMD_USE_MPI=OFF    \
           -DopenPMD_USE_HDF5=OFF   \
           -DopenPMD_USE_ADIOS2=OFF \
-          -DopenPMD_USE_INVASIVE_TESTS=ON
+          -DopenPMD_USE_INVASIVE_TESTS=ON \
+          -DPython_EXECUTABLE=$(which python3)
         cmake --build build --parallel 3
         ctest --test-dir build --verbose
 


### PR DESCRIPTION
The older macOS image is now removed. The latest points already to macOS-12. macoS-13 runners are marked experimental.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources