### PR TITLE
Python: Better error message when loading to a buffer with mismatched type

### DIFF
--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -23,6 +23,7 @@
 #include <pybind11/stl.h>
 
 #include "openPMD/DatatypeHelpers.hpp"
+#include "openPMD/Error.hpp"
 #include "openPMD/RecordComponent.hpp"
 #include "openPMD/Series.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
@@ -35,6 +36,7 @@
 #include <cstring>
 #include <exception>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -519,18 +521,28 @@ void load_chunk(
     // whether we have that
     if (strides.size() == 0)
     {
-        throw std::runtime_error(
+        throw error::WrongAPIUsage(
             "[Record_Component::load_chunk()] Empty buffer passed.");
     }
     {
         py::ssize_t accumulator = toBytes(r.getDatatype());
+        if (buffer_info.itemsize != accumulator)
+        {
+            std::stringstream errorMsg;
+            errorMsg << "[Record_Component::load_chunk()] Loading from a "
+                        "record component of type "
+                     << r.getDatatype() << " with item size " << accumulator
+                     << ", but Python buffer has item size "
+                     << buffer_info.itemsize << ".";
+            throw error::WrongAPIUsage(errorMsg.str());
+        }
         size_t dim = strides.size();
         while (dim > 0)
         {
             --dim;
             if (strides[dim] != accumulator)
             {
-                throw std::runtime_error(
+                throw error::WrongAPIUsage(
                     "[Record_Component::load_chunk()] Requires contiguous slab"
                     " of memory.");
             }


### PR DESCRIPTION
In the Python API, when using `load_chunk()` to a preallocated buffer, the buffer is checked for being contiguous.
The calculations happen on the basis of the record component's datatype, not on the datatype of the buffer (the datatype of the buffer cannot be queried on a `py::buffer` object, just the item size).
If the datatypes are mismatched, the error message is very confusing (and in fact wrong): `[Record_Component::load_chunk()] Requires contiguous slab of memory.` 

This checks if the item size matches the datatype before doing and check for contiguous data.