### PR TITLE
openpmd-pipe: set correct install permissions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1100,10 +1100,9 @@ if(openPMD_INSTALL)
         if(openPMD_BUILD_CLI_TOOLS)
             foreach(toolname ${openPMD_PYTHON_CLI_TOOL_NAMES})
                 install(
-                    FILES ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
+                    PROGRAMS ${openPMD_SOURCE_DIR}/src/cli/${toolname}.py
                     DESTINATION ${openPMD_INSTALL_BINDIR}
                     RENAME openpmd-${toolname}
-                    PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                 )
             endforeach()
         endif()


### PR DESCRIPTION
`openpmd-pipe` is currently installed with odd permissions, since the `install()` command manually specifies the permissions. This implicitly strips all permissions that would normally be installed, but are not listed.

Before this fix:
```
$ ls install_dir/bin/ -lisah
total 16M
177477809 4.0K drwxr-xr-x 2 franzpoeschel franzpoeschel 4.0K Jun  7 17:26 .
177477392 4.0K drwxr-xr-x 5 franzpoeschel franzpoeschel 4.0K Jun  7 17:26 ..
177478070  16M -rwxr-xr-x 1 franzpoeschel franzpoeschel  16M Jun  7 17:07 openpmd-ls
177479928 4.0K -rwx------ 1 franzpoeschel franzpoeschel  411 May 22 10:36 openpmd-pipe
```

With the fix:
```
$ ls install_dir/bin/ -lisah
total 16M
177477809 4.0K drwxr-xr-x 2 franzpoeschel franzpoeschel 4.0K Jun  7 17:26 .
177477392 4.0K drwxr-xr-x 5 franzpoeschel franzpoeschel 4.0K Jun  7 17:26 ..
177478070  16M -rwxr-xr-x 1 franzpoeschel franzpoeschel  16M Jun  7 17:07 openpmd-ls
177479928 4.0K -rwxr-xr-x 1 franzpoeschel franzpoeschel  411 May 22 10:36 openpmd-pipe
```