### PR TITLE
Doc: Sphinx Copybutton and Design

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,8 @@ pygments
 recommonmark
 scipy
 sphinx>=5.3
+sphinx-copybutton
+sphinx-design
 sphinx_rtd_theme>=1.1.1
 sphinxcontrib-svg2pdfconverter
 sphinxcontrib.programoutput

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,8 @@ show_authors = True
 # ones.
 extensions = ['sphinx.ext.mathjax',
               'breathe',
+              'sphinx_copybutton',
+              'sphinx_design',
               'sphinxcontrib.programoutput',
               'sphinxcontrib.rsvgconverter',
               'matplotlib.sphinxext.plot_directive']


### PR DESCRIPTION
Add the Sphinx extensions [copybutton](https://sphinx-copybutton.readthedocs.io/) (copy code blocks with a single click) and [design](https://sphinx-design.readthedocs.io) (for boxes, tabs, dropdowns, etc.).