### PR TITLE
Add Python bindings for myPath

### DIFF
--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -362,6 +362,14 @@ bool setAttributeFromObject(
 
 void init_Attributable(py::module &m)
 {
+    py::class_<Attributable::MyPath>(m, "AttributablePath")
+        .def_readonly("directory", &Attributable::MyPath::directory)
+        .def_readonly("series_name", &Attributable::MyPath::seriesName)
+        .def_readonly(
+            "series_extension", &Attributable::MyPath::seriesExtension)
+        .def_readonly("group", &Attributable::MyPath::group)
+        .def_property_readonly("file_path", &Attributable::MyPath::filePath);
+
     py::class_<Attributable>(m, "Attributable")
         .def(py::init<Attributable const &>())
 
@@ -491,7 +499,8 @@ void init_Attributable(py::module &m)
         .def_property(
             "comment", &Attributable::comment, &Attributable::setComment)
         // TODO remove in future versions (deprecated)
-        .def("set_comment", &Attributable::setComment);
+        .def("set_comment", &Attributable::setComment)
+        .def("my_path", &Attributable::myPath);
 
     py::bind_vector<PyAttributeKeys>(m, "Attribute_Keys");
 }


### PR DESCRIPTION
This is somewhat available through `.__getstate__()` already, but not for all types and it should not be treated as a stable API.
Having this is very useful for debugging purposes.