### PR TITLE
CI: Doxygen 1.9.7 Broken

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -41,7 +41,7 @@ jobs:
         update-conda: true
         conda-channels: conda-forge
     - name: Install
-      run: conda install -c conda-forge doxygen
+      run: conda install -c conda-forge doxygen=1.9.6
     - name: Doxygen
       run: .github/workflows/source/buildDoxygen
 


### PR DESCRIPTION
Markdown support for main file broken in 1.9.7.
Go back to previous patch release. Upstream already fixed.

Note: backports can be skipped if https://github.com/conda-forge/doxygen-feedstock/pull/45 was merged.

X-ref:
- https://github.com/doxygen/doxygen/issues/10110
- https://github.com/doxygen/doxygen/pull/10112
- https://github.com/conda-forge/doxygen-feedstock/issues/44
- https://github.com/conda-forge/doxygen-feedstock/pull/45