### PR TITLE
HDF5: Handle unknown datatypes in datasets

### DIFF
--- a/share/openPMD/download_samples.ps1
+++ b/share/openPMD/download_samples.ps1
@@ -15,18 +15,23 @@ New-item -ItemType directory -Name samples\git-sample\3d-bp4\
 Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/f3b73e43511db96217a153dc3ab3cb2e8f81f7db/example-3d.tar.gz -OutFile example-3d.tar.gz
 Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/f3b73e43511db96217a153dc3ab3cb2e8f81f7db/example-thetaMode.tar.gz -OutFile example-thetaMode.tar.gz
 Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/f3b73e43511db96217a153dc3ab3cb2e8f81f7db/example-3d-bp4.tar.gz -OutFile example-3d-bp4.tar.gz
+Invoke-WebRequest https://github.com/openPMD/openPMD-example-datasets/raw/566b356030df38f56049484941baacafef331163/legacy_datasets.tar.gz -OutFile legacy_datasets.tar.gz
 7z.exe x -r example-3d.tar.gz
 7z.exe x -r example-3d.tar
 7z.exe x -r example-thetaMode.tar.gz
 7z.exe x -r example-thetaMode.tar
 7z.exe x -r example-3d-bp4.tar.gz
 7z.exe x -r example-3d-bp4.tar
+7z.exe x -r legacy_datasets.tar.gz
+7z.exe x -r legacy_datasets.tar
 Move-Item -Path example-3d\hdf5\* samples\git-sample\
 Move-Item -Path example-thetaMode\hdf5\* samples\git-sample\thetaMode\
 Move-Item -Path example-3d-bp4\* samples\git-sample\3d-bp4\
+Move-Item -Path legacy_datasets\* samples\git-sample\legacy\
 Remove-Item -Recurse -Force example-3d*
 Remove-Item -Recurse -Force example-thetaMode*
 Remove-Item -Recurse -Force example-3d-bp4*
+Remove-Item -Recurse -Force legacy_datasets*
 
 # Ref.: https://github.com/yt-project/yt/pull/1645
 New-item -ItemType directory -Name samples\issue-sample\

--- a/share/openPMD/download_samples.sh
+++ b/share/openPMD/download_samples.sh
@@ -15,14 +15,17 @@ mkdir -p samples/git-sample/3d-bp4
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/f3b73e43511db96217a153dc3ab3cb2e8f81f7db/example-3d.tar.gz
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/f3b73e43511db96217a153dc3ab3cb2e8f81f7db/example-thetaMode.tar.gz
 curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/f3b73e43511db96217a153dc3ab3cb2e8f81f7db/example-3d-bp4.tar.gz
+curl -sOL https://github.com/openPMD/openPMD-example-datasets/raw/566b356030df38f56049484941baacafef331163/legacy_datasets.tar.gz
 tar -xzf example-3d.tar.gz
 tar -xzf example-thetaMode.tar.gz
 tar -xzf example-3d-bp4.tar.gz
+tar -xzf legacy_datasets.tar.gz
 mv example-3d/hdf5/* samples/git-sample/
 mv example-thetaMode/hdf5/* samples/git-sample/thetaMode/
 mv example-3d-bp4/* samples/git-sample/3d-bp4
+mv legacy_datasets/* samples/git-sample/legacy
 chmod 777 samples/
-rm -rf example-3d.* example-3d example-thetaMode.* example-thetaMode example-3d-bp4 example-3d-bp4.*
+rm -rf example-3d.* example-3d example-thetaMode.* example-thetaMode example-3d-bp4 example-3d-bp4.* legacy_datasets legacy_datasets.*
 
 # Ref.: https://github.com/yt-project/yt/pull/1645
 mkdir -p samples/issue-sample/

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2837,19 +2837,6 @@ struct LoadDataset
     {
         auto chunk = rc.loadChunk<T>();
         rc.seriesFlush();
-        // std::cout << "Successfully loaded mask" << std::endl;
-        // for (size_t i = 0; i < rc.getExtent()[0]; ++i)
-        // {
-        //     if constexpr (std::is_convertible_v<T, int>)
-        //     {
-        //         std::cout << int(chunk.get()[i]) << ", ";
-        //     }
-        //     else
-        //     {
-        //         std::cout << chunk.get()[i] << ", ";
-        //     }
-        // }
-        // std::cout << std::endl;
     }
 
     static constexpr char const *errorMsg = "LoadDataset";

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2828,6 +2828,98 @@ TEST_CASE("git_hdf5_sample_structure_test", "[serial][hdf5]")
 #endif
 }
 
+namespace
+{
+struct LoadDataset
+{
+    template <typename T>
+    static void call(RecordComponent &rc)
+    {
+        auto chunk = rc.loadChunk<T>();
+        rc.seriesFlush();
+        // std::cout << "Successfully loaded mask" << std::endl;
+        // for (size_t i = 0; i < rc.getExtent()[0]; ++i)
+        // {
+        //     if constexpr (std::is_convertible_v<T, int>)
+        //     {
+        //         std::cout << int(chunk.get()[i]) << ", ";
+        //     }
+        //     else
+        //     {
+        //         std::cout << chunk.get()[i] << ", ";
+        //     }
+        // }
+        // std::cout << std::endl;
+    }
+
+    static constexpr char const *errorMsg = "LoadDataset";
+};
+} // namespace
+
+TEST_CASE("git_hdf5_legacy_picongpu", "[serial][hdf5]")
+{
+    try
+    {
+        Series o = Series(
+            "../samples/git-sample/legacy/simData_%T.h5", Access::READ_ONLY);
+
+        /*
+         * That dataset was written directly via HDF5 (not the openPMD-api)
+         * and had two issues:
+         *
+         * 1) No unitSI defined for numParticles and numParticlesOffset.
+         *    unitSI does not really make sense there, but the openPMD-standard
+         *    is not quite clear if it is required, so the API writes it and
+         *    also required it. We will keep writing it, but we don't require
+         *    it any longer.
+         * 2) A custom enum was used for writing a boolean dataset.
+         *    At the least, the dataset should be skipped in parsing instead
+         *    of failing the entire procedure. Ideally, the custom datatype
+         *    should be upcasted to char type and treated as such.
+         */
+
+        auto radiationMask =
+            o.iterations[200]
+                .particles["e"]["radiationMask"][RecordComponent::SCALAR];
+        switchNonVectorType<LoadDataset>(
+            radiationMask.getDatatype(), radiationMask);
+
+        auto particlePatches = o.iterations[200].particles["e"].particlePatches;
+        REQUIRE(particlePatches.size() == 4);
+        for (auto key : {"extent", "offset"})
+        {
+            REQUIRE(particlePatches.contains(key));
+            REQUIRE(particlePatches.at(key).size() == 3);
+            for (auto subkey : {"x", "y", "z"})
+            {
+                REQUIRE(particlePatches.at(key).contains(subkey));
+                // unitSI is present in those records
+                particlePatches.at(key).at(subkey).unitSI();
+            }
+        }
+        for (auto key : {"numParticles", "numParticlesOffset"})
+        {
+            REQUIRE(particlePatches.contains(key));
+            REQUIRE(particlePatches.at(key).contains(RecordComponent::SCALAR));
+            // unitSI is not present in those records
+            REQUIRE_THROWS_AS(
+                particlePatches.at(key).at(RecordComponent::SCALAR).unitSI(),
+                no_such_attribute_error);
+        }
+
+        helper::listSeries(o, true, std::cout);
+    }
+    catch (error::ReadError &e)
+    {
+        if (e.reason == error::Reason::Inaccessible)
+        {
+            std::cerr << "git sample not accessible. (" << e.what() << ")\n";
+            return;
+        }
+        throw;
+    }
+}
+
 TEST_CASE("git_hdf5_sample_attribute_test", "[serial][hdf5]")
 {
     try


### PR DESCRIPTION
**First commit:** Throw `error::ReadError` in `HDF5IOHandlerImpl::openDataset()`. Upon encountering an error, the middle-end will know that something has gone wrong that it can then recover from, skipping the dataset.

**Second commit:** Sometimes, datasets use custom datatypes based on a native type. This can be supported by checking the parent datatypes if the actual datatypes is not recognized. See [here](https://github.com/ComputationalRadiationPhysics/picongpu/issues/4568#issuecomment-1613501627) for an example that uses enums to emulate booleans.

- [x] Merge first: #1482