### PR TITLE
Don't require unitSI when reading a patch record component

### DIFF
--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -143,24 +143,26 @@ void PatchRecordComponent::flush(
 
 void PatchRecordComponent::read()
 {
-    Parameter<Operation::READ_ATT> aRead;
-
-    aRead.name = "unitSI";
-    IOHandler()->enqueue(IOTask(this, aRead));
-    IOHandler()->flush(internal::defaultFlushParams);
-    if (auto val = Attribute(*aRead.resource).getOptional<double>();
-        val.has_value())
-        setUnitSI(val.value());
-    else
-        throw error::ReadError(
-            error::AffectedObject::Attribute,
-            error::Reason::UnexpectedContent,
-            {},
-            "Unexpected Attribute datatype for 'unitSI' (expected double, "
-            "found " +
-                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
-
     readAttributes(ReadMode::FullyReread); // this will set dirty() = false
+
+    if (containsAttribute("unitSI"))
+    {
+        if (auto val = getAttribute("unitSI").getOptional<double>();
+            val.has_value())
+        {
+            setUnitSI(val.value());
+        }
+        else
+        {
+            throw error::ReadError(
+                error::AffectedObject::Attribute,
+                error::Reason::UnexpectedContent,
+                {},
+                "Unexpected Attribute datatype for 'unitSI' (expected double, "
+                "found " +
+                    datatypeToString(getAttribute("unitSI").dtype) + ")");
+        }
+    }
 }
 
 bool PatchRecordComponent::dirtyRecursive() const


### PR DESCRIPTION
The openPMD standard is not quite clear if `unitSI` is required for patch record components. At least for `numParticles` and `numParticlesOffset`, they don't really make sense.
The openPMD-api currently requires that these attributes are set and will fail at reading time if they are not (and subsequently skip the components). 

With this PR, the openPMD-api ignores if they are not present, but still writes them to maintain compatibility with versions of the openPMD-api that are not so lenient.