### PR TITLE
Better handling for file extensions

### DIFF
--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -40,6 +40,7 @@ namespace openPMD
  * @param   comm        MPI communicator used for IO.
  * @param   options     JSON-formatted option string, to be interpreted by
  *                      the backend.
+ * @param   pathAsItWasSpecifiedInTheConstructor For error messages.
  * @tparam  JSON        Substitute for nlohmann::json. Templated to avoid
                         including nlohmann::json in a .hpp file.
  * @return  Smart pointer to created IOHandler.
@@ -51,7 +52,8 @@ std::unique_ptr<AbstractIOHandler> createIOHandler(
     Format format,
     std::string originalExtension,
     MPI_Comm comm,
-    JSON options);
+    JSON options,
+    std::string const &pathAsItWasSpecifiedInTheConstructor);
 #endif
 
 /** Construct an appropriate specific IOHandler for the desired IO mode.
@@ -65,6 +67,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler(
  *                            specified by the user.
  * @param   options     JSON-formatted option string, to be interpreted by
  *                      the backend.
+ * @param   pathAsItWasSpecifiedInTheConstructor For error messages.
  * @tparam  JSON        Substitute for nlohmann::json. Templated to avoid
                         including nlohmann::json in a .hpp file.
  * @return  Smart pointer to created IOHandler.
@@ -75,7 +78,8 @@ std::unique_ptr<AbstractIOHandler> createIOHandler(
     Access access,
     Format format,
     std::string originalExtension,
-    JSON options = JSON());
+    JSON options,
+    std::string const &pathAsItWasSpecifiedInTheConstructor);
 
 // version without configuration to use in AuxiliaryTest
 std::unique_ptr<AbstractIOHandler> createIOHandler(

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -71,7 +71,8 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     std::string originalExtension,
 
     MPI_Comm comm,
-    json::TracingJSON options)
+    json::TracingJSON options,
+    std::string const &pathAsItWasSpecifiedInTheConstructor)
 {
     (void)options;
     switch (format)
@@ -124,9 +125,14 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
             std::move(options),
             "ssc",
             std::move(originalExtension));
+    case Format::JSON:
+        throw error::WrongAPIUsage(
+            "JSON backend not available in parallel openPMD.");
     default:
-        throw std::runtime_error(
-            "Unknown file format! Did you specify a file ending?");
+        throw error::WrongAPIUsage(
+            "Unknown file format! Did you specify a file ending? Specified "
+            "file name was '" +
+            pathAsItWasSpecifiedInTheConstructor + "'.");
     }
 }
 #endif
@@ -137,7 +143,8 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
     Access access,
     Format format,
     std::string originalExtension,
-    json::TracingJSON options)
+    json::TracingJSON options,
+    std::string const &pathAsItWasSpecifiedInTheConstructor)
 {
     (void)options;
     switch (format)
@@ -190,7 +197,9 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
             "JSON", path, access);
     default:
         throw std::runtime_error(
-            "Unknown file format! Did you specify a file ending?");
+            "Unknown file format! Did you specify a file ending? Specified "
+            "file name was '" +
+            pathAsItWasSpecifiedInTheConstructor + "'.");
     }
 }
 
@@ -205,6 +214,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler(
         access,
         format,
         std::move(originalExtension),
-        json::TracingJSON(json::ParsedConfig{}));
+        json::TracingJSON(json::ParsedConfig{}),
+        "");
 }
 } // namespace openPMD

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -2313,7 +2313,8 @@ Series::Series(
         input->format,
         input->filenameExtension,
         comm,
-        optionsJson);
+        optionsJson,
+        filepath);
     init(std::move(handler), std::move(input));
     json::warnGlobalUnusedOptions(optionsJson);
 }
@@ -2330,7 +2331,12 @@ Series::Series(
     auto input = parseInput(filepath);
     parseJsonOptions(optionsJson, *input);
     auto handler = createIOHandler(
-        input->path, at, input->format, input->filenameExtension, optionsJson);
+        input->path,
+        at,
+        input->format,
+        input->filenameExtension,
+        optionsJson,
+        filepath);
     init(std::move(handler), std::move(input));
     json::warnGlobalUnusedOptions(optionsJson);
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -424,6 +424,11 @@ std::unique_ptr<Series::ParsedInput> Series::parseInput(std::string filepath)
         filepath = auxiliary::replace_all(filepath, "\\", "/");
     }
 #endif
+    if (auxiliary::ends_with(filepath, auxiliary::directory_separator))
+    {
+        filepath = auxiliary::replace_last(
+            filepath, std::string(&auxiliary::directory_separator, 1), "");
+    }
     auto const pos = filepath.find_last_of(auxiliary::directory_separator);
     if (std::string::npos == pos)
     {

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1035,13 +1035,16 @@ TEST_CASE("no_file_ending", "[core]")
 {
     REQUIRE_THROWS_WITH(
         Series("./new_openpmd_output", Access::CREATE),
-        Catch::Equals("Unknown file format! Did you specify a file ending?"));
+        Catch::Equals("Unknown file format! Did you specify a file ending? "
+                      "Specified file name was './new_openpmd_output'."));
     REQUIRE_THROWS_WITH(
         Series("./new_openpmd_output_%T", Access::CREATE),
-        Catch::Equals("Unknown file format! Did you specify a file ending?"));
+        Catch::Equals("Unknown file format! Did you specify a file ending? "
+                      "Specified file name was './new_openpmd_output_%T'."));
     REQUIRE_THROWS_WITH(
         Series("./new_openpmd_output_%05T", Access::CREATE),
-        Catch::Equals("Unknown file format! Did you specify a file ending?"));
+        Catch::Equals("Unknown file format! Did you specify a file ending? "
+                      "Specified file name was './new_openpmd_output_%05T'."));
     {
         Series(
             "../samples/no_extension_specified",


### PR DESCRIPTION
Close #1471 

This also takes the chance to support filenames with a trailing slash, this kept annoying me. (BP files generally create folders and Bash completion will add a trailing slash)