### PR TITLE
Parallel JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1370,7 +1370,7 @@ if(openPMD_BUILD_TESTING)
                             --outfile                                              \
                                 ../samples/git-sample/thetaMode/data_%T.bp &&      \
                                                                                    \
-                        ${Python_EXECUTABLE}                                       \
+                        ${MPI_TEST_EXE} ${Python_EXECUTABLE}                       \
                             ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe       \
                             --infile ../samples/git-sample/thetaMode/data_%T.bp    \
                             --outfile ../samples/git-sample/thetaMode/data%T.json  \

--- a/include/openPMD/IO/JSON/JSONIOHandler.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandler.hpp
@@ -24,17 +24,30 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/JSON/JSONIOHandlerImpl.hpp"
 
+#if openPMD_HAVE_MPI
+#include <mpi.h>
+#endif
+
 namespace openPMD
 {
 class JSONIOHandler : public AbstractIOHandler
 {
 public:
     JSONIOHandler(
-        std::string const &path,
+        std::string path,
         Access at,
         openPMD::json::TracingJSON config,
         JSONIOHandlerImpl::FileFormat,
         std::string originalExtension);
+#if openPMD_HAVE_MPI
+    JSONIOHandler(
+        std::string path,
+        Access at,
+        MPI_Comm,
+        openPMD::json::TracingJSON config,
+        JSONIOHandlerImpl::FileFormat,
+        std::string originalExtension);
+#endif
 
     ~JSONIOHandler() override;
 

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -73,6 +73,7 @@ struct File
 
         std::string name;
         bool valid = true;
+        bool printedReadmeWarningAlready = false;
     };
 
     std::shared_ptr<FileState> fileState;

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -339,7 +339,8 @@ private:
 
     // write to disk the json contents associated with the file
     // remove from m_dirty if unsetDirty == true
-    void putJsonContents(File const &, bool unsetDirty = true);
+    auto putJsonContents(File const &, bool unsetDirty = true)
+        -> decltype(m_jsonVals)::iterator;
 
     // figure out the file position of the writable
     // (preferring the parent's file position) and extend it

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -31,6 +31,9 @@
 
 #include <istream>
 #include <nlohmann/json.hpp>
+#if openPMD_HAVE_MPI
+#include <mpi.h>
+#endif
 
 #include <complex>
 #include <fstream>
@@ -167,6 +170,15 @@ public:
         FileFormat,
         std::string originalExtension);
 
+#if openPMD_HAVE_MPI
+    JSONIOHandlerImpl(
+        AbstractIOHandler *,
+        MPI_Comm,
+        openPMD::json::TracingJSON config,
+        FileFormat,
+        std::string originalExtension);
+#endif
+
     ~JSONIOHandlerImpl() override;
 
     void
@@ -230,6 +242,10 @@ public:
     std::future<void> flush();
 
 private:
+#if openPMD_HAVE_MPI
+    std::optional<MPI_Comm> m_communicator;
+#endif
+
     using FILEHANDLE = std::fstream;
 
     // map each Writable to its associated file

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -125,8 +125,23 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
             "ssc",
             std::move(originalExtension));
     case Format::JSON:
-        throw error::WrongAPIUsage(
-            "JSON backend not available in parallel openPMD.");
+        return constructIOHandler<JSONIOHandler, openPMD_HAVE_JSON>(
+            "JSON",
+            path,
+            access,
+            comm,
+            std::move(options),
+            JSONIOHandlerImpl::FileFormat::Json,
+            std::move(originalExtension));
+    case Format::TOML:
+        return constructIOHandler<JSONIOHandler, openPMD_HAVE_JSON>(
+            "JSON",
+            path,
+            access,
+            comm,
+            std::move(options),
+            JSONIOHandlerImpl::FileFormat::Toml,
+            std::move(originalExtension));
     default:
         throw error::WrongAPIUsage(
             "Unknown file format! Did you specify a file ending? Specified "

--- a/src/IO/JSON/JSONIOHandler.cpp
+++ b/src/IO/JSON/JSONIOHandler.cpp
@@ -26,14 +26,28 @@ namespace openPMD
 JSONIOHandler::~JSONIOHandler() = default;
 
 JSONIOHandler::JSONIOHandler(
-    std::string const &path,
+    std::string path,
     Access at,
     openPMD::json::TracingJSON jsonCfg,
     JSONIOHandlerImpl::FileFormat format,
     std::string originalExtension)
-    : AbstractIOHandler{path, at}
+    : AbstractIOHandler{std::move(path), at}
     , m_impl{this, std::move(jsonCfg), format, std::move(originalExtension)}
 {}
+
+#if openPMD_HAVE_MPI
+JSONIOHandler::JSONIOHandler(
+    std::string path,
+    Access at,
+    MPI_Comm comm,
+    openPMD::json::TracingJSON jsonCfg,
+    JSONIOHandlerImpl::FileFormat format,
+    std::string originalExtension)
+    : AbstractIOHandler{std::move(path), at}
+    , m_impl{JSONIOHandlerImpl{
+          this, comm, std::move(jsonCfg), format, std::move(originalExtension)}}
+{}
+#endif
 
 std::future<void> JSONIOHandler::flush(internal::ParsedFlushParams &)
 {

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1406,7 +1406,8 @@ auto JSONIOHandlerImpl::putJsonContents(
             MPI_Comm_rank(comm, &rank);
             MPI_Comm_size(comm, &size);
             std::stringstream subfilePath;
-            subfilePath << dirpath << "/mpi_rank_"
+            // writeSingleFile will prepend the base dir
+            subfilePath << *filename << ".parallel/mpi_rank_"
                         << std::setw(num_digits(size - 1)) << std::setfill('0')
                         << rank << ".json";
             writeSingleFile(subfilePath.str());

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1409,7 +1409,16 @@ auto JSONIOHandlerImpl::putJsonContents(
             // writeSingleFile will prepend the base dir
             subfilePath << *filename << ".parallel/mpi_rank_"
                         << std::setw(num_digits(size - 1)) << std::setfill('0')
-                        << rank << ".json";
+                        << rank << [&]() {
+                               switch (m_fileFormat)
+                               {
+                               case FileFormat::Json:
+                                   return ".json";
+                               case FileFormat::Toml:
+                                   return ".toml";
+                               }
+                               throw std::runtime_error("Unreachable!");
+                           }();
             writeSingleFile(subfilePath.str());
             if (rank == 0)
             {

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -23,6 +23,8 @@
 #include "openPMD/Datatype.hpp"
 #include "openPMD/DatatypeHelpers.hpp"
 #include "openPMD/Error.hpp"
+#include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
@@ -132,6 +134,21 @@ JSONIOHandlerImpl::JSONIOHandlerImpl(
     , m_fileFormat{format}
     , m_originalExtension{std::move(originalExtension)}
 {}
+
+#if openPMD_HAVE_MPI
+JSONIOHandlerImpl::JSONIOHandlerImpl(
+    AbstractIOHandler *handler,
+    MPI_Comm comm,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    [[maybe_unused]] openPMD::json::TracingJSON config,
+    FileFormat format,
+    std::string originalExtension)
+    : AbstractIOHandlerImpl(handler)
+    , m_communicator{comm}
+    , m_fileFormat{format}
+    , m_originalExtension{std::move(originalExtension)}
+{}
+#endif
 
 JSONIOHandlerImpl::~JSONIOHandlerImpl() = default;
 

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -195,7 +195,8 @@ std::string collective_file_read(std::string const &path, MPI_Comm comm)
         if (!handle.good())
         {
             throw std::runtime_error(
-                "Failed reading JSON config from file " + path + ".");
+                "[collective_file_read] Failed acessing file '" + path +
+                "' on MPI rank 0.");
         }
         stringLength = res.size() + 1;
     }


### PR DESCRIPTION
Close #1472 

TODO:

- [x] Merge #1436 first
- [x] openpmd-pipe seems to not work in parallel as it tries reading at some point
- [x] test with picongpu
- [x] Documentation

Idea: When using in parallel, just create files `simData.json.parallel/rank_0.json, simData.json.parallel/rank_1.json, ...` and so on. No direct support for reading, users need to either manually pick one of the JSON files or find some adequate tooling for merging them.


