### PR TITLE
Update __repr__ method of major objects in openPMD hierarchy

### DIFF
--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -223,6 +223,7 @@ public:
          * Notice that RecordComponent::SCALAR is included in this list, too.
          */
         std::vector<std::string> group;
+        Access access;
 
         /** Reconstructs a path that can be passed to a Series constructor */
         std::string filePath() const;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -203,6 +203,7 @@ auto Attributable::myPath() const -> MyPath
     res.seriesName = series.name();
     res.seriesExtension = suffix(seriesData.m_format);
     res.directory = IOHandler()->directory;
+    res.access = IOHandler()->m_backendAccess;
     return res;
 }
 

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -368,6 +368,7 @@ void init_Attributable(py::module &m)
         .def_readonly(
             "series_extension", &Attributable::MyPath::seriesExtension)
         .def_readonly("group", &Attributable::MyPath::group)
+        .def_readonly("access", &Attributable::MyPath::access)
         .def_property_readonly("file_path", &Attributable::MyPath::filePath);
 
     py::class_<Attributable>(m, "Attributable")
@@ -377,7 +378,7 @@ void init_Attributable(py::module &m)
             "__repr__",
             [](Attributable const &attr) {
                 return "<openPMD.Attributable with '" +
-                    std::to_string(attr.numAttributes()) + "' attributes>";
+                    std::to_string(attr.numAttributes()) + "' attribute(s)>";
             })
         .def(
             "series_flush",

--- a/src/binding/python/Container.cpp
+++ b/src/binding/python/Container.cpp
@@ -41,7 +41,9 @@
 #include "openPMD/backend/PatchRecord.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"
 
+#include <cstddef>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -99,6 +101,22 @@ bind_container(py::handle scope, std::string const &name, Args &&...args)
         [](Map &m) { return py::make_key_iterator(m.begin(), m.end()); },
         // keep container alive while iterator exists
         py::keep_alive<0, 1>());
+
+    cl.def("__repr__", [name](Map const &m) {
+        std::stringstream stream;
+        stream << "<openPMD." << name << " with ";
+        if (size_t num_entries = m.size(); num_entries == 1)
+        {
+            stream << "1 entry and ";
+        }
+        else
+        {
+            stream << num_entries << " entries and ";
+        }
+
+        stream << m.numAttributes() << " attribute(s)>";
+        return stream.str();
+    });
 
     cl.def(
         "items",

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -59,8 +59,24 @@ void init_Dataset(py::module &m)
         .def(
             "__repr__",
             [](const Dataset &d) {
-                return "<openPMD.Dataset of rank '" + std::to_string(d.rank) +
-                    "'>";
+                std::stringstream stream;
+                stream << "<openPMD.Dataset of type '" << d.dtype
+                       << "' and with extent ";
+                if (d.extent.empty())
+                {
+                    stream << "[]>";
+                }
+                else
+                {
+                    auto begin = d.extent.begin();
+                    stream << '[' << *begin++;
+                    for (; begin != d.extent.end(); ++begin)
+                    {
+                        stream << ", " << *begin;
+                    }
+                    stream << "]>";
+                }
+                return stream.str();
             })
 
         .def_readonly("extent", &Dataset::extent)

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -40,7 +40,9 @@ void init_Iteration(py::module &m)
             [](Iteration const &it) {
                 std::stringstream ss;
                 ss << "<openPMD.Iteration at t = '" << std::scientific
-                   << it.template time<double>() * it.timeUnitSI() << " s'>";
+                   << it.template time<double>() * it.timeUnitSI()
+                   << " s' with " << std::to_string(it.numAttributes())
+                   << " attributes>";
                 return ss.str();
             })
 

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -42,7 +42,8 @@ void init_Mesh(py::module &m)
             "__repr__",
             [](Mesh const &mesh) {
                 return "<openPMD.Mesh record with '" +
-                    std::to_string(mesh.size()) + "' record components>";
+                    std::to_string(mesh.size()) + "' record component(s) and " +
+                    std::to_string(mesh.numAttributes()) + " attributes>";
             })
 
         .def_property(

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -38,9 +38,25 @@ void init_MeshRecordComponent(py::module &m)
         m, "Mesh_Record_Component");
     cl.def(
           "__repr__",
-          [](MeshRecordComponent const &rc) {
-              return "<openPMD.Mesh_Record_Component of dimensionality '" +
-                  std::to_string(rc.getDimensionality()) + "'>";
+          [](RecordComponent const &rc) {
+              std::stringstream stream;
+              stream << "<openPMD.Record_Component of type '"
+                     << rc.getDatatype() << "' and with extent ";
+              if (auto extent = rc.getExtent(); extent.empty())
+              {
+                  stream << "[]>";
+              }
+              else
+              {
+                  auto begin = extent.begin();
+                  stream << '[' << *begin++;
+                  for (; begin != extent.end(); ++begin)
+                  {
+                      stream << ", " << *begin;
+                  }
+                  stream << "]>";
+              }
+              return stream.str();
           })
 
         .def_property(

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -36,8 +36,11 @@ void init_ParticlePatches(py::module &m)
         .def(
             "__repr__",
             [](ParticlePatches const &pp) {
-                return "<openPMD.Particle_Patches of size '" +
-                    std::to_string(pp.numPatches()) + "'>";
+                std::stringstream stream;
+                stream << "<openPMD.Particle_Patches with " << pp.size()
+                       << " records and " << pp.numAttributes()
+                       << " attribute(s)>";
+                return stream.str();
             })
 
         .def_property_readonly("num_patches", &ParticlePatches::numPatches);

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -27,6 +27,7 @@
 #include "openPMD/backend/Container.hpp"
 #include "openPMD/binding/python/Pickle.hpp"
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,13 @@ void init_ParticleSpecies(py::module &m)
     py::class_<ParticleSpecies, Container<Record> > cl(m, "ParticleSpecies");
     cl.def(
           "__repr__",
-          [](ParticleSpecies const &) { return "<openPMD.ParticleSpecies>"; })
+          [](ParticleSpecies const &p) {
+              std::stringstream stream;
+              stream << "<openPMD.ParticleSpecies with " << p.size()
+                     << " record(s) and " << p.numAttributes()
+                     << " attribute(s)>";
+              return stream.str();
+          })
 
         .def_readwrite("particle_patches", &ParticleSpecies::particlePatches);
     add_pickle(

--- a/src/binding/python/PatchRecordComponent.cpp
+++ b/src/binding/python/PatchRecordComponent.cpp
@@ -52,6 +52,29 @@ void init_PatchRecordComponent(py::module &m)
             &BaseRecordComponent::unitSI,
             &PatchRecordComponent::setUnitSI)
 
+        .def(
+            "__repr__",
+            [](PatchRecordComponent const &rc) {
+                std::stringstream stream;
+                stream << "<openPMD.Patch_Record_Component of type '"
+                       << rc.getDatatype() << "' and with extent ";
+                if (auto extent = rc.getExtent(); extent.empty())
+                {
+                    stream << "[]>";
+                }
+                else
+                {
+                    auto begin = extent.begin();
+                    stream << '[' << *begin++;
+                    for (; begin != extent.end(); ++begin)
+                    {
+                        stream << ", " << *begin;
+                    }
+                    stream << "]>";
+                }
+                return stream.str();
+            })
+
         .def("reset_dataset", &PatchRecordComponent::resetDataset)
         .def_property_readonly(
             "ndims", &PatchRecordComponent::getDimensionality)

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -38,7 +38,13 @@ void init_Record(py::module &m)
     py::class_<Record, BaseRecord<RecordComponent> > cl(m, "Record");
     cl.def(py::init<Record const &>())
 
-        .def("__repr__", [](Record const &) { return "<openPMD.Record>"; })
+        .def(
+            "__repr__",
+            [](Record const &r) {
+                return "<openPMD.Record of " + std::to_string(r.size()) +
+                    " component(s) and " + std::to_string(r.numAttributes()) +
+                    " attribute(s)>";
+            })
 
         .def_property(
             "unit_dimension",

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -766,8 +766,24 @@ void init_RecordComponent(py::module &m)
     cl.def(
           "__repr__",
           [](RecordComponent const &rc) {
-              return "<openPMD.Record_Component of dimensionality '" +
-                  std::to_string(rc.getDimensionality()) + "'>";
+              std::stringstream stream;
+              stream << "<openPMD.Record_Component of type '"
+                     << rc.getDatatype() << "' and with extent ";
+              if (auto extent = rc.getExtent(); extent.empty())
+              {
+                  stream << "[]>";
+              }
+              else
+              {
+                  auto begin = extent.begin();
+                  stream << '[' << *begin++;
+                  for (; begin != extent.end(); ++begin)
+                  {
+                      stream << ", " << *begin;
+                  }
+                  stream << "]>";
+              }
+              return stream.str();
           })
 
         .def_property(

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -22,6 +22,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "openPMD/IO/Access.hpp"
+#include "openPMD/IterationEncoding.hpp"
 #include "openPMD/Series.hpp"
 #include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/config.hpp"
@@ -32,6 +34,7 @@
 #include <mpi.h>
 #endif
 
+#include <sstream>
 #include <string>
 
 namespace py = pybind11;
@@ -250,6 +253,20 @@ not possible once it has been closed.
             py::arg("options") = "{}")
 #endif
         .def("__bool__", &Series::operator bool)
+        .def(
+            "__repr__",
+            [](Series const &s) {
+                std::stringstream stream;
+                auto myPath = s.myPath();
+                stream << "<openPMD.Series at '" << myPath.filePath()
+                       << "' with " << s.iterations.size() << " iteration(s)";
+                if (myPath.access == Access::READ_LINEAR)
+                {
+                    stream << " (currently parsed)";
+                }
+                stream << " and " << s.numAttributes() << " attributes>";
+                return stream.str();
+            })
         .def("close", &Series::close, R"(
 Closes the Series and release the data storage/transport backends.
 


### PR DESCRIPTION
With this PR:

```python
>>> import openpmd_api as io
>>> s = io.Series("simData_%T.bp5", io.Access.read_only)
>>> s
<openPMD.Series at './simData_%T.bp5' with 6 iteration(s) and 12 attributes>
>>> s.iterations
<openPMD.Iteration_Container with 6 entries and 0 attribute(s)>
>>> s.iterations[100]
<openPMD.Iteration at t = '6.400000e-15 s' with 20 attributes>
>>> s.iterations[100].meshes
<openPMD.Mesh_Container with 5 entries and 5 attribute(s)>
>>> s.iterations[100].meshes["E"]
<openPMD.Mesh record with '3' record component(s) and 9 attributes>
>>> s.iterations[100].meshes["E"]["x"]
<openPMD.Record_Component of type 'FLOAT' and with extent [128, 3072, 128]>
>>> s.iterations[100].particles
<openPMD.Particle_Container with 1 entry and 0 attribute(s).>
>>> s.iterations[100].particles["e"]
<openPMD.ParticleSpecies with 8 record(s) and 5 attribute(s)>
>>> s.iterations[100].particles["e"]["position"]
<openPMD.Record of 3 component(s) and 4 attribute(s)>
>>> s.iterations[100].particles["e"]["position"]["x"]
<openPMD.Record_Component of type 'FLOAT' and with extent [91611546]>
>>> s.iterations[100].particles["e"].particle_patches
<openPMD.Particle_Patches with 4 records and 0 attribute(s)>
>>> s.iterations[100].particles["e"].particle_patches["offset"]
<openPMD.Patch_Record_Component_Container with 3 entries and 1 attribute(s)>
>>> s.iterations[100].particles["e"].particle_patches["offset"]["x"]
<openPMD.Patch_Record_Component of type 'ULONG' and with extent [1]>
```

(Plural (s) is not in parentheses where the openPMD standard requires more than one entry)

This fixes the UX bug last seen [here](https://github.com/bwheelz36/ParticlePhaseSpace/issues/156#issuecomment-1625044306).