### PR TITLE
CI: oneAPI 2023.2.0

### DIFF
--- a/.github/workflows/dependencies/install_icc
+++ b/.github/workflows/dependencies/install_icc
@@ -7,9 +7,14 @@ sudo apt-get -qqq update
 sudo apt-get install g++
 #                    libopenmpi-dev
 sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
-sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+# download the key to system keyring
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+| gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+# add signed entry to apt sources and configure the APT client to use Intel repository
+echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
 sudo apt-get update
 sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 #                       intel-oneapi-python

--- a/.github/workflows/dependencies/install_icx
+++ b/.github/workflows/dependencies/install_icx
@@ -5,17 +5,20 @@ set -eu -o pipefail
 
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
-wget -q -O - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
-  | sudo apt-key add -
-echo "deb https://apt.repos.intel.com/oneapi all main" \
-  | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+# download the key to system keyring
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+| gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+# add signed entry to apt sources and configure the APT client to use Intel repository
+echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \
     build-essential \
     cmake           \
-    intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
+    intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel \
     g++ gfortran
 #    libopenmpi-dev
 #    openmpi-bin


### PR DESCRIPTION
Update CI to breaking `apt` changes in the latest oneAPI release.