### PR TITLE
CI: macOS 11.0+

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,10 +28,11 @@ jobs:
         python3 -m pip install -U mpi4py numpy pandas
         set -e
     - name: Build
-      env: {CXXFLAGS: -Werror, MACOSX_DEPLOYMENT_TARGET: 10.15}
+      env: {CXXFLAGS: -Werror, MACOSX_DEPLOYMENT_TARGET: 11.0}
       # 10.14+ due to std::visit
       # 10.15+ due to std::filesystem in toml11
       #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
+      # 11.0+ for arm64/aarch64 (M1/M2) builds
       run: |
         share/openPMD/download_samples.sh build
         cmake -S . -B build \
@@ -49,16 +50,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install
-      env: {MACOSX_DEPLOYMENT_TARGET: 10.14}
+      env: {MACOSX_DEPLOYMENT_TARGET: 11.0}
       run: |
         set +e
         python3 -m pip install -U numpy pandas
         set -e
     - name: Build
-      env: {CXXFLAGS: -Werror -DTOML11_DISABLE_STD_FILESYSTEM, MACOSX_DEPLOYMENT_TARGET: 10.14}
+      env: {CXXFLAGS: -Werror, MACOSX_DEPLOYMENT_TARGET: 11.0}
       # 10.14+ due to std::visit
-      # std::filesystem in toml11 needs macOS 10.15
+      # 10.15+ due to std::filesystem in toml11
       #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
+      # 11.0+ for arm64/aarch64 (M1/M2) builds
       run: |
         share/openPMD/download_samples.sh build
         cmake -S . -B build \


### PR DESCRIPTION
We do not have the runners anymore to deploy and test macOS 10.15, so we bump our tests to 11.0+, too.

Technically, we could build & deploy a bit longer on GH actions `macos-11` for `10.15` (Catalina), but since it is unmaintained by Apple/end-of-life already and macOS-11 is the oldest still maintained OS by Apple, we do also stop support for it. Also, we cannot do runtime tests anymore with it, since we have no GH 10.15 runner images anymore.

At the time of writing, old and maintained are:
- macOS 11, Big Sur
- macOS 12, Monterey

latest is: macOS 13, Ventura - and in preview is macOS 14, Sonoma.

This also unifies our arm64/aarch64 (M1/M2) requirements, which are macOS 11.0+ as well.