### PR TITLE
CI fix: type comparison in openpmd-pipe

### DIFF
--- a/src/binding/python/openpmd_api/pipe/__main__.py
+++ b/src/binding/python/openpmd_api/pipe/__main__.py
@@ -234,7 +234,7 @@ class pipe:
         Copies data from src to dest. May represent any point in the openPMD
         hierarchy, but src and dest must both represent the same layer.
         """
-        if (type(src) != type(dest)
+        if (type(src) is not type(dest)
                 and not isinstance(src, io.IndexedIteration)
                 and not isinstance(dest, io.Iteration)):
             raise RuntimeError(


### PR DESCRIPTION
"Source / style" CI runner seems to be picking this up recently