### PR TITLE
ADIOS2: Ensure that a step is always active at write time

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2560,7 +2560,9 @@ namespace detail
             // might have been closed previously
             if (engine)
             {
-                if (streamStatus == StreamStatus::DuringStep)
+                if (streamStatus == StreamStatus::DuringStep ||
+                    (streamStatus == StreamStatus::NoStream &&
+                     m_mode == adios2::Mode::Write))
                 {
                     engine.EndStep();
                 }
@@ -3114,6 +3116,11 @@ namespace detail
                 // the streaming API was used.
                 m_engine = std::make_optional(
                     adios2::Engine(m_IO.Open(m_file, tempMode)));
+                if (streamStatus == StreamStatus::NoStream)
+                {
+                    // Write everything into one big step
+                    m_engine->BeginStep();
+                }
                 break;
             }
 #if HAS_ADIOS_2_8

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4328,7 +4328,8 @@ TEST_CASE("adios2_bp5_flush", "[serial][adios2]")
 [adios2]
 
 [adios2.engine]
-usesteps = true
+# Check that BP5 can also be used without steps
+usesteps = false
 type = "bp5"
 preferred_flush_target = "disk"
 


### PR DESCRIPTION
Even when not using steps, dump everything into a single large step. BP5 will fail otherwise. The PR modifies a BP5 test in a way that would fail before this PR.