### PR TITLE
Warn on BP5+Blosc in ADIOS2 v2.9 up to patch level 1

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -440,6 +440,12 @@ private:
         Extent const &extent,
         adios2::IO &IO,
         std::string const &var);
+
+    struct
+    {
+        bool noGroupBased = false;
+        bool blosc2bp5 = false;
+    } printedWarningsAlready;
 }; // ADIOS2IOHandlerImpl
 
 /*

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -669,8 +669,9 @@ void ADIOS2IOHandlerImpl::createDataset(
                 if (operatorType == "blosc")
                 {
                     std::cerr << &R"(
-[Warning] Use BP5+Blosc with care in ADIOS2 v2.9.0 or v2.9.1.
-Unreadable data might be created, for further details see
+[Warning] Use BP5+Blosc with care in ADIOS2 v2.9.0 and v2.9.1.
+Unreadable data might be created, to mitigate either deactivate Blosc or use BP4+Blosc.
+For further details see
 https://github.com/ornladios/ADIOS2/issues/3504.
                     )"[1] << std::endl;
                     printedWarningsAlready.blosc2bp5 = true;

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -80,7 +80,9 @@ std::vector<std::string> testedFileExtensions()
 {
     auto allExtensions = getFileExtensions();
     auto newEnd = std::remove_if(
-        allExtensions.begin(), allExtensions.end(), [](std::string const &ext) {
+        allExtensions.begin(),
+        allExtensions.end(),
+        []([[maybe_unused]] std::string const &ext) {
 #if openPMD_HAVE_ADIOS2
 #define HAS_ADIOS_2_9 (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 209)
 #if HAS_ADIOS_2_9
@@ -94,7 +96,7 @@ std::vector<std::string> testedFileExtensions()
 #endif
 #undef HAS_ADIOS_2_9
 #else
-    return false;
+            return false;
 #endif
         });
     return {allExtensions.begin(), newEnd};

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -81,9 +81,21 @@ std::vector<std::string> testedFileExtensions()
     auto allExtensions = getFileExtensions();
     auto newEnd = std::remove_if(
         allExtensions.begin(), allExtensions.end(), [](std::string const &ext) {
+#if openPMD_HAVE_ADIOS2
+#define HAS_ADIOS_2_9 (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 209)
+#if HAS_ADIOS_2_9
+            // sst and ssc need a receiver for testing
+            // bp5 is already tested via bp
+            return ext == "sst" || ext == "ssc" || ext == "bp5";
+#else
             // sst and ssc need a receiver for testing
             // bp4 is already tested via bp
             return ext == "sst" || ext == "ssc" || ext == "bp4";
+#endif
+#undef HAS_ADIOS_2_9
+#else
+    return false;
+#endif
         });
     return {allExtensions.begin(), newEnd};
 }


### PR DESCRIPTION
Since we are about to ship ADIOS2 v2.9 with our Python Wheel, we should maybe try to avoid that users fall into [this trap](https://github.com/ornladios/ADIOS2/issues/3504).
I will add a second PR based on this that will warn on groupBased encoding. That second PR should probably not go into the current release cycle since the alternative (variableBased encoding) is not stable yet.