### PR TITLE
Pandas DataFrames: Add Row Column Name

### DIFF
--- a/src/binding/python/openpmd_api/DaskDataFrame.py
+++ b/src/binding/python/openpmd_api/DaskDataFrame.py
@@ -87,4 +87,11 @@ def particles_to_daskdataframe(particle_species):
     ]
     df = dd.from_delayed(dfs)
 
+    # set a header for the first column (row index)
+    #   note: this is NOT the particle id
+    # TODO both these do not work:
+    #   https://github.com/dask/dask/issues/10440
+    # df.index.name = "row"
+    # df.index = df.index.rename("row")
+
     return df

--- a/src/binding/python/openpmd_api/DataFrame.py
+++ b/src/binding/python/openpmd_api/DataFrame.py
@@ -67,4 +67,10 @@ def particles_to_dataframe(particle_species, slice=None):
                 columns[column_name] = np.multiply(
                     columns[column_name], rc.unit_SI)
 
-    return pd.DataFrame(columns)
+    df = pd.DataFrame(columns)
+
+    # set a header for the first column (row index)
+    #   note: this is NOT the particle id
+    df.index.name = "row"
+
+    return df


### PR DESCRIPTION
By default, the row index (!= particle index) in a pandas dataframe has no name. This can be a bit cumbersome for exports, e.g., to CSV (#1444) - where this header field would just be empty. (First seen and reported by @cemitch99.)

This PR names the index now "row", because it is not a (macro) particle id property.

Close #1480


Additional info:
- Dask DataFrames do not yet support naming the index column: https://github.com/dask/dask/issues/10440