### PR TITLE
ADIOS 2.9: Avoid Unused Param Warning

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1824,6 +1824,7 @@ namespace detail
         auto defineAttribute =
             [&IO, &fullName, &modifiable, &impl](auto const &...args) {
 #if openPMD_HAS_ADIOS_2_9
+                (void)impl;
                 auto attr = IO.DefineAttribute(
                     fullName,
                     args...,


### PR DESCRIPTION
Fix a warning introduced in #1310.