### PR TITLE
Streaming examples: Set WAN as default transport

### DIFF
--- a/examples/10_streaming_read.cpp
+++ b/examples/10_streaming_read.cpp
@@ -19,7 +19,16 @@ int main()
         return 0;
     }
 
-    Series series = Series("electrons.sst", Access::READ_LINEAR);
+    Series series = Series("electrons.sst", Access::READ_LINEAR, R"(
+{
+  "adios2": {
+    "engine": {
+      "parameters": {
+        "DataTransport": "WAN"
+      }
+    }
+  }
+})");
 
     // `Series::writeIterations()` and `Series::readIterations()` are
     // intentionally restricted APIs that ensure a workflow which also works

--- a/examples/10_streaming_read.py
+++ b/examples/10_streaming_read.py
@@ -7,7 +7,8 @@ import openpmd_api as io
 # pass-through for ADIOS2 engine parameters
 # https://adios2.readthedocs.io/en/latest/engines/engines.html
 config = {'adios2': {'engine': {}, 'dataset': {}}}
-config['adios2']['engine'] = {'parameters': {'Threads': '4'}}
+config['adios2']['engine'] = {'parameters':
+                              {'Threads': '4', 'DataTransport': 'WAN'}}
 config['adios2']['dataset'] = {'operators': [{'type': 'bzip2'}]}
 
 if __name__ == "__main__":

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -20,7 +20,16 @@ int main()
     }
 
     // open file for writing
-    Series series = Series("electrons.sst", Access::CREATE);
+    Series series = Series("electrons.sst", Access::CREATE, R"(
+{
+  "adios2": {
+    "engine": {
+      "parameters": {
+        "DataTransport": "WAN"
+      }
+    }
+  }
+})");
 
     Datatype datatype = determineDatatype<position_t>();
     constexpr unsigned long length = 10ul;

--- a/examples/10_streaming_write.py
+++ b/examples/10_streaming_write.py
@@ -8,7 +8,8 @@ import openpmd_api as io
 # pass-through for ADIOS2 engine parameters
 # https://adios2.readthedocs.io/en/latest/engines/engines.html
 config = {'adios2': {'engine': {}, 'dataset': {}}}
-config['adios2']['engine'] = {'parameters': {'Threads': '4'}}
+config['adios2']['engine'] = {'parameters':
+                              {'Threads': '4', 'DataTransport': 'WAN'}}
 config['adios2']['dataset'] = {'operators': [{'type': 'bzip2'}]}
 
 if __name__ == "__main__":


### PR DESCRIPTION
If ADIOS2 v2.9 is built against MPICH, it will pick MPI as its default streaming transport. This might break the CI on containers where MPICH does not actually support that.