### PR TITLE
Wheels: 0.15.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'src'
-        ref: '0.15.1'
+        ref: '0.15.2'
 
     - uses: actions/checkout@v2
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.15.1"
+    - OPENPMD_GIT_REF="0.15.2"
 
     - CIBW_PROJECT_REQUIRES_PYTHON=">=3.8"
     # Install dependencies on Linux and OSX

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -88,11 +88,11 @@ exit /b 0
 :build_blosc2
   if exist blosc2-stamp exit /b 0
 
-  curl -sLo blosc2-2.10.1.zip ^
-    https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.10.1.zip
-  powershell Expand-Archive blosc2-2.10.1.zip -DestinationPath dep-blosc2
+  curl -sLo blosc2-2.10.2.zip ^
+    https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.10.2.zip
+  powershell Expand-Archive blosc2-2.10.2.zip -DestinationPath dep-blosc2
 
-  cmake -S dep-blosc2/c-blosc2-2.10.1 -B build-blosc2 ^
+  cmake -S dep-blosc2/c-blosc2-2.10.2 -B build-blosc2 ^
     -DCMAKE_BUILD_TYPE=Release  ^
     -DBUILD_SHARED=OFF          ^
     -DBUILD_STATIC=ON           ^
@@ -100,9 +100,9 @@ exit /b 0
     -DBUILD_EXAMPLES=OFF        ^
     -DBUILD_FUZZERS=OFF         ^
     -DBUILD_PLUGINS=OFF         ^
-    -DBUILD_TESTS=OFF
-::    -DPREFER_EXTERNAL_ZLIB=ON
-::    -DZLIB_USE_STATIC_LIBS=ON
+    -DBUILD_TESTS=OFF           ^
+    -DPREFER_EXTERNAL_ZLIB=ON   ^
+    -DZLIB_USE_STATIC_LIBS=ON
   if errorlevel 1 exit 1
 
   cmake --build build-blosc2 --parallel %CPU_COUNT%

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -16,11 +16,13 @@ exit /b 0
 
 :build_adios2
   if exist adios2-stamp exit /b 0
+  ::curl -sLo adios2-2.9.1.zip ^
+  ::  https://github.com/ornladios/ADIOS2/archive/v2.9.1.zip
   curl -sLo adios2-2.9.1.zip ^
-    https://github.com/ornladios/ADIOS2/archive/v2.9.1.zip
+    https://github.com/ax3l/ADIOS2/archive/refs/heads/release-2.9.1-bp-wheels.zip
   powershell Expand-Archive adios2-2.9.1.zip -DestinationPath dep-adios2
 
-  cmake -S dep-adios2/ADIOS2-2.9.1 -B build-adios2 ^
+  cmake -S dep-adios2/ADIOS2-release-2.9.1-bp-wheels -B build-adios2 ^
     -DCMAKE_BUILD_TYPE=Release  ^
     -DBUILD_SHARED_LIBS=OFF     ^
     -DBUILD_TESTING=OFF         ^

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -73,7 +73,10 @@ exit /b 0
     -DBUILD_EXAMPLES=OFF        ^
     -DBUILD_FUZZERS=OFF         ^
     -DBUILD_PLUGINS=OFF         ^
-    -DBUILD_TESTS=OFF
+    -DBUILD_TESTS=OFF           ^
+    -DPIGZ_ENABLE_TESTS=OFF     ^
+    -DZLIB_ENABLE_TESTS=OFF     ^
+    -DZLIBNG_ENABLE_TESTS=OFF
 ::    -DPREFER_EXTERNAL_ZLIB=ON   ^
 ::    -DZLIB_USE_STATIC_LIBS=ON
   if errorlevel 1 exit 1

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -11,6 +11,7 @@ goto:main
 
 :install_buildessentials
   python -m pip install --upgrade pip setuptools wheel
+  python -m pip install --upgrade cmake
   python -m pip install --upgrade "patch==1.*"
 exit /b 0
 

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -57,36 +57,6 @@ exit /b 0
   if errorlevel 1 exit 1
 exit /b 0
 
-:build_blosc
-  if exist blosc-stamp exit /b 0
-
-  curl -sLo blosc-1.21.0.zip ^
-    https://github.com/Blosc/c-blosc/archive/v1.21.0.zip
-  powershell Expand-Archive blosc-1.21.0.zip -DestinationPath dep-blosc
-
-  cmake -S dep-blosc/c-blosc-1.21.0 -B build-blosc ^
-    -DCMAKE_BUILD_TYPE=Release  ^
-    -DBUILD_BENCHMARKS=OFF      ^
-    -DBUILD_SHARED=OFF          ^
-    -DBUILD_STATIC=ON           ^
-    -DBUILD_TESTS=OFF           ^
-    -DZLIB_USE_STATIC_LIBS=ON   ^
-    -DDEACTIVATE_SNAPPY=ON
-  if errorlevel 1 exit 1
-
-  cmake --build build-blosc --parallel %CPU_COUNT%
-  if errorlevel 1 exit 1
-
-  cmake --build build-blosc --target install --config Release
-  if errorlevel 1 exit 1
-
-  rmdir /s /q build-blosc
-  if errorlevel 1 exit 1
-
-  break > blosc-stamp
-  if errorlevel 1 exit 1
-exit /b 0
-
 :build_blosc2
   if exist blosc2-stamp exit /b 0
 

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -73,9 +73,9 @@ exit /b 0
     -DBUILD_EXAMPLES=OFF        ^
     -DBUILD_FUZZERS=OFF         ^
     -DBUILD_PLUGINS=OFF         ^
-    -DBUILD_TESTS=OFF           ^
-    -DPREFER_EXTERNAL_ZLIB=ON   ^
-    -DZLIB_USE_STATIC_LIBS=ON
+    -DBUILD_TESTS=OFF
+::    -DPREFER_EXTERNAL_ZLIB=ON   ^
+::    -DZLIB_USE_STATIC_LIBS=ON
   if errorlevel 1 exit 1
 
   cmake --build build-blosc2 --parallel %CPU_COUNT%

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -65,6 +65,13 @@ exit /b 0
     https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.10.2.zip
   powershell Expand-Archive blosc2-2.10.2.zip -DestinationPath dep-blosc2
 
+  :: Fix Threads search in Blosc2Config.cmake
+  :: https://github.com/Blosc/c-blosc2/pull/549
+  curl -sLo blosc2-threads.patch ^
+    https://github.com/Blosc/c-blosc2/pull/549.patch
+  python -m patch -p 1 -d dep-blosc2/c-blosc2-2.10.2 blosc2-threads.patch
+  if errorlevel 1 exit 1
+
   cmake -S dep-blosc2/c-blosc2-2.10.2 -B build-blosc2 ^
     -DCMAKE_BUILD_TYPE=Release  ^
     -DBUILD_SHARED=OFF          ^

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -103,10 +103,10 @@ function build_adios1 {
 function build_adios2 {
     if [ -e adios2-stamp ]; then return; fi
 
-    #curl -sLo adios2-2.9.0.tar.gz \
-    #    https://github.com/ornladios/ADIOS2/archive/v2.9.0.tar.gz
-    curl -sLo adios2-fix-blosc2-findpackage.tar.gz \
-        https://github.com/ax3l/ADIOS2/archive/refs/heads/fix-blosc2-findpackage.tar.gz
+    #curl -sLo adios2-2.9.1.tar.gz \
+    #    https://github.com/ornladios/ADIOS2/archive/v2.9.1.tar.gz
+    curl -sLo adios2-2.9.1.tar.gz \
+        https://github.com/ax3l/ADIOS2/archive/refs/heads/release-2.9.1-bp-wheels.tar.gz
     file adios2*.tar.gz
     tar -xzf adios2*.tar.gz
     rm adios2*.tar.gz

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -200,8 +200,8 @@ function build_blosc {
 function build_blosc2 {
     if [ -e blosc-stamp2 ]; then return; fi
 
-    curl -sLo blosc2-v2.10.1.tar.gz \
-        https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.10.1.tar.gz
+    curl -sLo blosc2-v2.10.2.tar.gz \
+        https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.10.2.tar.gz
     file blosc2*.tar.gz
     tar -xzf blosc2*.tar.gz
     rm blosc2*.tar.gz


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.15.2 release.

Also includes this ADIOS2 patch for 2.9.1:
- https://github.com/ornladios/ADIOS2/pull/3769 / https://github.com/openPMD/openPMD-api/pull/1387#issuecomment-1684193022

Updates Blosc2 to 2.10.2 and [patches a thread propagation issue on Windows](https://github.com/Blosc/c-blosc2/pull/549).