### PR TITLE
CI: Linux aarch64/arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,52 @@
+version: 2
+
+jobs:
+  linux-aarch64:
+    working_directory: ~/linux-aarch64-wheels
+    machine:
+      image: ubuntu-2004:2022.04.1
+    # resource_class is what tells CircleCI to use an ARM worker for native arm builds
+    # https://circleci.com/product/features/resource-classes/
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - dependencies:
+          name: Install build dpendencies
+          command: |
+            sudo apt update
+            sudo apt install g++ gfortran libopenmpi-dev python3 python3-setuptools
+            sudo .github/workflows/dependencies/install_spack
+            python3 -m pip install -U pip
+            python3 -m pip install -U packaging setuptools wheel
+            python3 -m pip install -U numpy
+            python3 -m pip install -U mpi4py
+            python3 -m pip install -U pandas
+            python3 -m pip install -U dask
+            python3 -m pip install -U pyarrow
+
+            eval $(spack env activate --sh .github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/)
+            spack install
+
+            share/openPMD/download_samples.sh build
+      - build:
+          name: Build openPMD-api
+          command: |
+            eval $(spack env activate --sh .github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/)
+            cmake -S . -B build \
+              -DopenPMD_USE_PYTHON=ON \
+              -DopenPMD_USE_MPI=ON    \
+              -DopenPMD_USE_HDF5=ON   \
+              -DopenPMD_USE_ADIOS2=ON \
+              -DopenPMD_USE_INVASIVE_TESTS=ON
+            cmake --build build --parallel 2
+      - test:
+          name: Test openPMD-api
+          command: |
+            eval $(spack env activate --sh .github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/)
+            ctest --test-dir build --output-on-failure
+
+workflows:
+  version: 2
+  all-tests:
+    jobs:
+      - linux-aarch64

--- a/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
+++ b/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
@@ -1,0 +1,60 @@
+# This is a Spack environment file.
+#
+# Activating and installing this environment will provide all dependencies
+# that are needed for full-feature development.
+#   https//spack.readthedocs.io/en/latest/environments.html#anonymous-environments
+#
+spack:
+  specs:
+  - adios2
+  - hdf5
+  - openmpi
+
+  packages:
+    adios2:
+      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
+    cmake:
+      externals:
+      - spec: cmake@3.23.0
+        prefix: /usr
+      buildable: False
+    openmpi:
+      externals:
+      - spec: openmpi@2.1.1
+        prefix: /usr
+      buildable: False
+    perl:
+      externals:
+      - spec: perl@5.26.1
+        prefix: /usr
+      buildable: False
+    python:
+      externals:
+      - spec: python@3.8.10
+        prefix: /usr
+      buildable: False
+    all:
+      target: [aarch64]
+      variants: ~fortran
+      compiler: [gcc@9.0.0]
+
+  compilers:
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      modules: []
+      operating_system: ubuntu20.04
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      spec: gcc@9.0.0
+      target: aarch64
+
+  config:
+    build_jobs: 2
+
+  mirrors:
+    E4S: https://cache.e4s.io


### PR DESCRIPTION
Add native Linux aarch64/arm64 runners with CircleCI.

Adding CI here first before adding an entry to `wheels` for building Python (Pip) Wheels.
Note: We already successfully build this architecture on conda-forge.