### PR TITLE
Fix CMake: HDF5 Libs are PUBLIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,8 +576,9 @@ target_include_directories(openPMD SYSTEM PRIVATE
     $<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # HDF5 Backend
+#   TODO: Once we require CMake 3.20+, simply link hdf5::hdf5 C lib target
 if(openPMD_HAVE_HDF5)
-    target_link_libraries(openPMD PRIVATE ${HDF5_LIBRARIES})
+    target_link_libraries(openPMD PUBLIC ${HDF5_LIBRARIES})
     target_include_directories(openPMD SYSTEM PRIVATE ${HDF5_INCLUDE_DIRS})
     target_compile_definitions(openPMD PRIVATE ${HDF5_DEFINITIONS})
 endif()


### PR DESCRIPTION
We do not yet use `FindHDF5.cmake` CMake targets and thus need to ensure the libs are propagated properly (they are not consumed necessarily as private)

First seen when building with `-Wl,--disable-new-dtags` for RPATH over newer RUNPATH.

`FindHDF5.cmake` introduced targets in 3.19 but changed them again in 3.20+:
- https://cmake.org/cmake/help/v3.19/module/FindHDF5.html
- https://cmake.org/cmake/help/v3.20/module/FindHDF5.html