### PR TITLE
Bug fix: Linear read mode cannot directly access specific file of file-based Series

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1356,17 +1356,22 @@ if(openPMD_BUILD_TESTING)
                 add_test(NAME CLI.pipe.py
                     COMMAND sh -c
                         "${MPI_TEST_EXE} ${Python_EXECUTABLE}                      \
-                            ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
+                            ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe       \
                             --infile ../samples/git-sample/data%T.h5               \
                             --outfile ../samples/git-sample/data%T.bp &&           \
                                                                                    \
                         ${MPI_TEST_EXE} ${Python_EXECUTABLE}                       \
-                            ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
+                            ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe       \
+                            --infile ../samples/git-sample/data00000100.h5         \
+                            --outfile ../samples/git-sample/single_iteration.bp && \
+                                                                                   \
+                        ${MPI_TEST_EXE} ${Python_EXECUTABLE}                       \
+                            ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe       \
                             --infile ../samples/git-sample/thetaMode/data%T.h5     \
                             --outfile ../samples/git-sample/thetaMode/data.bp &&   \
                                                                                    \
                         ${Python_EXECUTABLE}                                       \
-                            ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe         \
+                            ${openPMD_RUNTIME_OUTPUT_DIRECTORY}/openpmd-pipe       \
                             --infile ../samples/git-sample/thetaMode/data.bp       \
                             --outfile ../samples/git-sample/thetaMode/data%T.json  \
                         "

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -88,7 +88,20 @@ void SeriesIterator::initSeriesInLinearReadMode()
             case PP::UpFront:
                 series.readGorVBased(
                     /* do_always_throw_errors = */ false, /* init = */ true);
-                series.advance(AdvanceMode::BEGINSTEP);
+                /*
+                 * In linear read mode (where no parsing at all is done upon
+                 * constructing the Series), it might turn out after parsing
+                 * that what we expected to be a group-based Series was in fact
+                 * a single file of a file-based Series.
+                 * (E.g. when opening "data00000100.h5" directly instead of
+                 * "data%T.h5")
+                 * So we need to check the current value of
+                 * `iterationEncoding()` once more.
+                 */
+                if (series.iterationEncoding() != IterationEncoding::fileBased)
+                {
+                    series.advance(AdvanceMode::BEGINSTEP);
+                }
                 break;
             }
             data.parsePreference = *fOpen.out_parsePreference;


### PR DESCRIPTION
Not a frequent use case, since linear read mode is not really necessary for single-iteration files anyway, but it can happen e.g. when using openpmd-pipe as in `openpmd-pipe --infile simData_000100.bp --outfile ...`. 
Since linear read mode does no parsing at construction time at all, it cannot initially know that the file is indeed file-based and needs to add a later check.