### PR TITLE
Fix double mesh.read() call in parsing procedures

### DIFF
--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -592,7 +592,6 @@ void Iteration::readMeshes(std::string const &meshesPath)
             IOHandler()->flush(internal::defaultFlushParams);
             mrc.get().m_isConstant = true;
         }
-        m.read();
         try
         {
             m.read();


### PR DESCRIPTION
First call was outside try{}, so errors would not be caught