### PR TITLE
Sphinx: Limit <7.2, RTD Default Theme Changed

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.15
 pygments
 recommonmark
 scipy
-sphinx>=5.3
+sphinx>=5.3,<7.2
 sphinx-copybutton
 sphinx-design
 sphinx_rtd_theme>=1.1.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 
 from recommonmark.parser import CommonMarkParser
+import sphinx_rtd_theme
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
@@ -58,8 +59,6 @@ subprocess.call('cd ..; doxygen;'
                 shell=True)
 
 if not on_rtd:
-    import sphinx_rtd_theme
-    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -117,7 +116,9 @@ html_logo = 'openPMD.png'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
+
+numfig = True
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The RTD default theme changed and was not their own anymore. This fixes this.

Limit the upper version of Sphinx, the RTD theme seems not ready yet.