### PR TITLE
Add visit-like pattern for RecordComponent

### DIFF
--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -75,20 +75,25 @@ int main()
 
     Offset chunk_offset = {1, 1, 1};
     Extent chunk_extent = {2, 2, 1};
-    auto chunk_data = E_x.loadChunk<double>(chunk_offset, chunk_extent);
+    // Loading without explicit datatype here
+    auto chunk_data = E_x.loadChunkVariant(chunk_offset, chunk_extent);
     cout << "Queued the loading of a single chunk from disk, "
             "ready to execute\n";
     series.flush();
     cout << "Chunk has been read from disk\n"
          << "Read chunk contains:\n";
-    for (size_t row = 0; row < chunk_extent[0]; ++row)
-    {
-        for (size_t col = 0; col < chunk_extent[1]; ++col)
-            cout << "\t" << '(' << row + chunk_offset[0] << '|'
-                 << col + chunk_offset[1] << '|' << 1 << ")\t"
-                 << chunk_data.get()[row * chunk_extent[1] + col];
-        cout << '\n';
-    }
+    std::visit(
+        [&chunk_offset, &chunk_extent](auto &shared_ptr) {
+            for (size_t row = 0; row < chunk_extent[0]; ++row)
+            {
+                for (size_t col = 0; col < chunk_extent[1]; ++col)
+                    cout << "\t" << '(' << row + chunk_offset[0] << '|'
+                         << col + chunk_offset[1] << '|' << 1 << ")\t"
+                         << shared_ptr.get()[row * chunk_extent[1] + col];
+                cout << '\n';
+            }
+        },
+        chunk_data);
 
     auto all_data = E_x.loadChunk<double>();
 

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -814,6 +814,25 @@ template <typename Action, typename... Args>
 constexpr auto switchNonVectorType(Datatype dt, Args &&...args)
     -> decltype(Action::template call<char>(std::forward<Args>(args)...));
 
+/**
+ * Generalizes switching over an openPMD datatype.
+ *
+ * Will call the function template found at Action::call< T >(), instantiating T
+ * with the C++ internal datatype corresponding to the openPMD datatype.
+ * Specializes only on those types that can occur in a dataset.
+ *
+ * @tparam ReturnType The function template's return type.
+ * @tparam Action The struct containing the function template.
+ * @tparam Args The function template's argument types.
+ * @param dt The openPMD datatype.
+ * @param args The function template's arguments.
+ * @return Passes on the result of invoking the function template with the given
+ *     arguments and with the template parameter specified by dt.
+ */
+template <typename Action, typename... Args>
+constexpr auto switchDatasetType(Datatype dt, Args &&...args)
+    -> decltype(Action::template call<char>(std::forward<Args>(args)...));
+
 } // namespace openPMD
 
 #if !defined(_MSC_VER)

--- a/include/openPMD/Datatype.tpp
+++ b/include/openPMD/Datatype.tpp
@@ -22,6 +22,10 @@
 
 #include "openPMD/Datatype.hpp"
 
+// comment to prevent clang-format from moving this #include up
+// datatype macros may be included and un-included in other headers
+#include "openPMD/DatatypeMacros.hpp"
+
 #include <string>
 #include <type_traits> // std::void_t
 #include <utility> // std::forward
@@ -83,6 +87,10 @@ namespace detail
     };
 } // namespace detail
 
+#define OPENPMD_SWITCHTYPE_IMPL(type)                                          \
+    case determineDatatype<type>():                                            \
+        return Action::template call<type>(std::forward<Args>(args)...);
+
 /**
  * Generalizes switching over an openPMD datatype.
  *
@@ -105,108 +113,7 @@ constexpr auto switchType(Datatype dt, Args &&...args)
         decltype(Action::template call<char>(std::forward<Args>(args)...));
     switch (dt)
     {
-    case Datatype::CHAR:
-        return Action::template call<char>(std::forward<Args>(args)...);
-    case Datatype::UCHAR:
-        return Action::template call<unsigned char>(
-            std::forward<Args>(args)...);
-    case Datatype::SCHAR:
-        return Action::template call<signed char>(std::forward<Args>(args)...);
-    case Datatype::SHORT:
-        return Action::template call<short>(std::forward<Args>(args)...);
-    case Datatype::INT:
-        return Action::template call<int>(std::forward<Args>(args)...);
-    case Datatype::LONG:
-        return Action::template call<long>(std::forward<Args>(args)...);
-    case Datatype::LONGLONG:
-        return Action::template call<long long>(std::forward<Args>(args)...);
-    case Datatype::USHORT:
-        return Action::template call<unsigned short>(
-            std::forward<Args>(args)...);
-    case Datatype::UINT:
-        return Action::template call<unsigned int>(std::forward<Args>(args)...);
-    case Datatype::ULONG:
-        return Action::template call<unsigned long>(
-            std::forward<Args>(args)...);
-    case Datatype::ULONGLONG:
-        return Action::template call<unsigned long long>(
-            std::forward<Args>(args)...);
-    case Datatype::FLOAT:
-        return Action::template call<float>(std::forward<Args>(args)...);
-    case Datatype::DOUBLE:
-        return Action::template call<double>(std::forward<Args>(args)...);
-    case Datatype::LONG_DOUBLE:
-        return Action::template call<long double>(std::forward<Args>(args)...);
-    case Datatype::CFLOAT:
-        return Action::template call<std::complex<float>>(
-            std::forward<Args>(args)...);
-    case Datatype::CDOUBLE:
-        return Action::template call<std::complex<double>>(
-            std::forward<Args>(args)...);
-    case Datatype::CLONG_DOUBLE:
-        return Action::template call<std::complex<long double>>(
-            std::forward<Args>(args)...);
-    case Datatype::STRING:
-        return Action::template call<std::string>(std::forward<Args>(args)...);
-    case Datatype::VEC_CHAR:
-        return Action::template call<std::vector<char>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_SHORT:
-        return Action::template call<std::vector<short>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_INT:
-        return Action::template call<std::vector<int>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_LONG:
-        return Action::template call<std::vector<long>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_LONGLONG:
-        return Action::template call<std::vector<long long>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_UCHAR:
-        return Action::template call<std::vector<unsigned char>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_SCHAR:
-        return Action::template call<std::vector<signed char>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_USHORT:
-        return Action::template call<std::vector<unsigned short>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_UINT:
-        return Action::template call<std::vector<unsigned int>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_ULONG:
-        return Action::template call<std::vector<unsigned long>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_ULONGLONG:
-        return Action::template call<std::vector<unsigned long long>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_FLOAT:
-        return Action::template call<std::vector<float>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_DOUBLE:
-        return Action::template call<std::vector<double>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_LONG_DOUBLE:
-        return Action::template call<std::vector<long double>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_CFLOAT:
-        return Action::template call<std::vector<std::complex<float>>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_CDOUBLE:
-        return Action::template call<std::vector<std::complex<double>>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_CLONG_DOUBLE:
-        return Action::template call<std::vector<std::complex<long double>>>(
-            std::forward<Args>(args)...);
-    case Datatype::VEC_STRING:
-        return Action::template call<std::vector<std::string>>(
-            std::forward<Args>(args)...);
-    case Datatype::ARR_DBL_7:
-        return Action::template call<std::array<double, 7>>(
-            std::forward<Args>(args)...);
-    case Datatype::BOOL:
-        return Action::template call<bool>(std::forward<Args>(args)...);
+        OPENPMD_FOREACH_DATATYPE(OPENPMD_SWITCHTYPE_IMPL)
     case Datatype::UNDEFINED:
         return detail::
             CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
@@ -241,51 +148,7 @@ constexpr auto switchNonVectorType(Datatype dt, Args &&...args)
         decltype(Action::template call<char>(std::forward<Args>(args)...));
     switch (dt)
     {
-    case Datatype::CHAR:
-        return Action::template call<char>(std::forward<Args>(args)...);
-    case Datatype::UCHAR:
-        return Action::template call<unsigned char>(
-            std::forward<Args>(args)...);
-    case Datatype::SCHAR:
-        return Action::template call<signed char>(std::forward<Args>(args)...);
-    case Datatype::SHORT:
-        return Action::template call<short>(std::forward<Args>(args)...);
-    case Datatype::INT:
-        return Action::template call<int>(std::forward<Args>(args)...);
-    case Datatype::LONG:
-        return Action::template call<long>(std::forward<Args>(args)...);
-    case Datatype::LONGLONG:
-        return Action::template call<long long>(std::forward<Args>(args)...);
-    case Datatype::USHORT:
-        return Action::template call<unsigned short>(
-            std::forward<Args>(args)...);
-    case Datatype::UINT:
-        return Action::template call<unsigned int>(std::forward<Args>(args)...);
-    case Datatype::ULONG:
-        return Action::template call<unsigned long>(
-            std::forward<Args>(args)...);
-    case Datatype::ULONGLONG:
-        return Action::template call<unsigned long long>(
-            std::forward<Args>(args)...);
-    case Datatype::FLOAT:
-        return Action::template call<float>(std::forward<Args>(args)...);
-    case Datatype::DOUBLE:
-        return Action::template call<double>(std::forward<Args>(args)...);
-    case Datatype::LONG_DOUBLE:
-        return Action::template call<long double>(std::forward<Args>(args)...);
-    case Datatype::CFLOAT:
-        return Action::template call<std::complex<float>>(
-            std::forward<Args>(args)...);
-    case Datatype::CDOUBLE:
-        return Action::template call<std::complex<double>>(
-            std::forward<Args>(args)...);
-    case Datatype::CLONG_DOUBLE:
-        return Action::template call<std::complex<long double>>(
-            std::forward<Args>(args)...);
-    case Datatype::STRING:
-        return Action::template call<std::string>(std::forward<Args>(args)...);
-    case Datatype::BOOL:
-        return Action::template call<bool>(std::forward<Args>(args)...);
+        OPENPMD_FOREACH_NONVECTOR_DATATYPE(OPENPMD_SWITCHTYPE_IMPL)
     case Datatype::UNDEFINED:
         return detail::
             CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
@@ -296,6 +159,43 @@ constexpr auto switchNonVectorType(Datatype dt, Args &&...args)
             std::to_string(static_cast<int>(dt)));
     }
 }
+
+/**
+ * Generalizes switching over an openPMD datatype.
+ *
+ * Will call the function template found at Action::call< T >(), instantiating T
+ * with the C++ internal datatype corresponding to the openPMD datatype.
+ * Specializes only on those types that can occur in a dataset.
+ *
+ * @tparam ReturnType The function template's return type.
+ * @tparam Action The struct containing the function template.
+ * @tparam Args The function template's argument types.
+ * @param dt The openPMD datatype.
+ * @param args The function template's arguments.
+ * @return Passes on the result of invoking the function template with the given
+ *     arguments and with the template parameter specified by dt.
+ */
+template <typename Action, typename... Args>
+constexpr auto switchDatasetType(Datatype dt, Args &&...args)
+    -> decltype(Action::template call<char>(std::forward<Args>(args)...))
+{
+    using ReturnType =
+        decltype(Action::template call<char>(std::forward<Args>(args)...));
+    switch (dt)
+    {
+        OPENPMD_FOREACH_DATASET_DATATYPE(OPENPMD_SWITCHTYPE_IMPL)
+    case Datatype::UNDEFINED:
+        return detail::
+            CallUndefinedDatatype<0, ReturnType, Action, Args &&...>::call(
+                std::forward<Args>(args)...);
+    default:
+        throw std::runtime_error(
+            "Internal error: Encountered unknown datatype (switchType) ->" +
+            std::to_string(static_cast<int>(dt)));
+    }
+}
+
+#undef OPENPMD_SWITCHTYPE_IMPL
 
 namespace detail
 {
@@ -354,3 +254,5 @@ constexpr inline bool isSameChar(Datatype d)
     return switchType<detail::IsSameChar<T_Char>>(d);
 }
 } // namespace openPMD
+
+#include "openPMD/UndefDatatypeMacros.hpp"

--- a/include/openPMD/DatatypeMacros.hpp
+++ b/include/openPMD/DatatypeMacros.hpp
@@ -18,7 +18,11 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#pragma once
+
+// sic!
+// no #pragma once
+// Since the macros can be un-defined with UndefDatatypeMacros.hpp, this header
+// may be included multiple times into one translation unit
 
 #include <array>
 #include <complex>
@@ -89,7 +93,6 @@ using openpmd_array_double_7 = std::array<double, 7>;
     MACRO(std::complex<double>)                                                \
     MACRO(std::complex<long double>)                                           \
     MACRO(std::string)                                                         \
-    MACRO(array_double_7)                                                      \
     MACRO(bool)
 
 #define OPENPMD_FOREACH_DATASET_DATATYPE(MACRO)                                \
@@ -109,5 +112,4 @@ using openpmd_array_double_7 = std::array<double, 7>;
     MACRO(long double)                                                         \
     MACRO(std::complex<float>)                                                 \
     MACRO(std::complex<double>)                                                \
-    MACRO(std::complex<long double>)                                           \
-    MACRO(std::array<double, 7>)
+    MACRO(std::complex<long double>)

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/Dataset.hpp"
+#include "openPMD/Datatype.hpp"
 #include "openPMD/auxiliary/ShareRaw.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/auxiliary/UniquePtr.hpp"
@@ -35,6 +36,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 // expose private and protected members for invasive testing
@@ -197,6 +199,21 @@ public:
      */
     template <typename T>
     std::shared_ptr<T> loadChunk(Offset = {0u}, Extent = {-1u});
+
+    using shared_ptr_dataset_types = auxiliary::detail::
+        map_variant<auxiliary::detail::as_shared_pointer, dataset_types>::type;
+
+    /** std::variant-based version of allocating loadChunk<T>(Offset, Extent)
+     *
+     * @return The same result that loadChunk() would return, but
+     *         as a std::variant of all possible return types, instantiated
+     *         with the actual type of this RecordComponent.
+     *
+     * Note: shared_ptr_dataset_types resolves to:
+     * std::variant<std::shared_ptr<char>, std::shared_ptr<unsigned char>,
+     *     ..., std::shared_ptr<std::complex<long double>>>
+     */
+    shared_ptr_dataset_types loadChunkVariant(Offset = {0u}, Extent = {-1u});
 
     /** Load a chunk of data into pre-allocated memory.
      *
@@ -403,6 +420,41 @@ public:
      */
     template <typename T>
     DynamicMemoryView<T> storeChunk(Offset, Extent);
+
+    /**
+     * @brief Run a template functor on the type of the record component,
+     *        similar to std::visit().
+     *
+     * Note that unlike std::visit(), this template cannot "switch" over
+     * a single existing value, meaning that the interface needs to work
+     * a bit different.
+     * The functor is given as a struct/class with a call() operation.
+     *
+     * (Ideally, this can be harmonized by using template lambdas once we
+     * support C++20)
+     *
+     * @tparam Visitor A struct type that has a static template method:
+     *         Visitor::template call<T>(RecordComponent &, ...)
+     *         In here, T will be instantiated with this RecordComponent's type
+     *         and a reference to this RecordComponent will be passed as first
+     *         argument.
+     *
+     * @tparam Args Types of optional further arguments.
+     * @param args Optional further arguments that will be forwarded to
+     *        Visitor::template call()
+     * @return Whatever Visitor::template call() returned.
+     *         Take special note that the return types must match (i.e. cannot
+     *         be different across instantiations
+     *         of T for Visitor::template call<T>()).
+     *         Formally, the return type is that of
+     *         Visitor::template call<char>(RecordComponent &, Args&&...)
+     *         and returned values from other template instantiations might then
+     *         be implicitly converted.
+     */
+    template <typename Visitor, typename... Args>
+    constexpr auto visit(Args &&...args)
+        -> decltype(Visitor::template call<char>(
+            std::declval<RecordComponent &>(), std::forward<Args>(args)...));
 
     static constexpr char const *const SCALAR = "\vScalar";
 

--- a/include/openPMD/auxiliary/Variant.hpp
+++ b/include/openPMD/auxiliary/Variant.hpp
@@ -35,7 +35,7 @@ namespace auxiliary
      * @tparam T        Varaidic template argument list of datatypes to be
      * stored.
      */
-    template <class T_DTYPES, typename... T>
+    template <class T_DTYPES, typename std_variant>
     class Variant
     {
         static_assert(
@@ -43,7 +43,7 @@ namespace auxiliary
             "Datatypes to Variant must be supplied as enum.");
 
     public:
-        using resource = std::variant<T...>;
+        using resource = std_variant;
         /** Construct a lightweight wrapper around a generic object that
          * indicates the concrete datatype of the specific object stored.
          *

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -21,9 +21,12 @@
 #pragma once
 
 #include "openPMD/Datatype.hpp"
-#include "openPMD/DatatypeMacros.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
+
+// comment to prevent clang-format from moving this #include up
+// datatype macros may be included and un-included in other headers
+#include "openPMD/DatatypeMacros.hpp"
 
 #include <algorithm>
 #include <array>
@@ -46,53 +49,10 @@ namespace openPMD
 // At the moment the dirty check is done at Attributable level,
 // resulting in all of an Attributables Attributes being written to disk even if
 // only one changes
-/** Varidic datatype supporting at least all formats for attributes specified in
+/** Variant datatype supporting at least all formats for attributes specified in
  * the openPMD standard.
- *
- * @note Extending and/or modifying the available formats requires identical
- *       modifications to Datatype.
  */
-class Attribute
-    : public auxiliary::Variant<
-          Datatype,
-          char,
-          unsigned char,
-          signed char,
-          short,
-          int,
-          long,
-          long long,
-          unsigned short,
-          unsigned int,
-          unsigned long,
-          unsigned long long,
-          float,
-          double,
-          long double,
-          std::complex<float>,
-          std::complex<double>,
-          std::complex<long double>,
-          std::string,
-          std::vector<char>,
-          std::vector<short>,
-          std::vector<int>,
-          std::vector<long>,
-          std::vector<long long>,
-          std::vector<unsigned char>,
-          std::vector<unsigned short>,
-          std::vector<unsigned int>,
-          std::vector<unsigned long>,
-          std::vector<unsigned long long>,
-          std::vector<float>,
-          std::vector<double>,
-          std::vector<long double>,
-          std::vector<std::complex<float>>,
-          std::vector<std::complex<double>>,
-          std::vector<std::complex<long double>>,
-          std::vector<signed char>,
-          std::vector<std::string>,
-          std::array<double, 7>,
-          bool>
+class Attribute : public auxiliary::Variant<Datatype, attribute_types>
 {
 public:
     Attribute(resource r) : Variant(std::move(r))

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -480,4 +480,23 @@ void RecordComponent::storeChunk(
     auto &rc = get();
     rc.m_chunks.push(IOTask(this, std::move(dWrite)));
 }
+
+namespace
+{
+    struct LoadChunkVariant
+    {
+        template <typename T>
+        static RecordComponent::shared_ptr_dataset_types
+        call(RecordComponent &rc, Offset o, Extent e)
+        {
+            return rc.loadChunk<T>(std::move(o), std::move(e));
+        }
+    };
+} // namespace
+
+auto RecordComponent::loadChunkVariant(Offset o, Extent e)
+    -> shared_ptr_dataset_types
+{
+    return visit<LoadChunkVariant>(std::move(o), std::move(e));
+}
 } // namespace openPMD


### PR DESCRIPTION
Close #1372 

TODO:

- [x] Once we agree on a design, add some further examples

This adds:

1. `std::variant<...>` aliases for openPMD datatypes
2. A `RecordComponent::visit(...)` call that instantiates the passed Functor Template Object with the current type of the `RecordComponent`
3. Using 1. and 2., a `RecordComponent::loadChunkVariant()` call that returns a `std::variant<...>` of `shared_ptr` types