### PR TITLE
Doc: Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM       quay.io/pypa/manylinux2010_x86_64 as build-env
 # FROM       quay.io/pypa/manylinux1_x86_64 as build-env
 ENV        DEBIAN_FRONTEND noninteractive
 
-# Python 3.8-3.11 via "38 39 311"
-ARG        PY_VERSIONS="38 39 310 311"
+# Python 3.8-3.12 via "38 39 311 312"
+ARG        PY_VERSIONS="38 39 310 311 312"
 
 # static libs need relocatable symbols for linking to shared python lib
 ENV        CFLAGS="-fPIC ${CFLAGS}"
@@ -162,7 +162,7 @@ FROM       debian:bullseye
 ENV        DEBIAN_FRONTEND noninteractive
 COPY --from=build-env /wheelhouse/openPMD_api-*-cp311-cp311-manylinux2010_x86_64.whl .
 RUN        apt-get update \
-           && apt-get install -y --no-install-recommends python3.10 python3-distutils ca-certificates curl \
+           && apt-get install -y --no-install-recommends python3.11 python3-distutils ca-certificates curl \
            && rm -rf /var/lib/apt/lists/*
 RUN        python3.11 --version \
            && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
@@ -170,6 +170,21 @@ RUN        python3.11 --version \
            && python3.11 -m pip install openPMD_api-*-cp311-cp311-manylinux2010_x86_64.whl
 RUN        python3.11 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
 RUN        python3.11 -m openpmd_api.ls --help
+RUN        openpmd-ls --help
+
+# test in fresh env: Debian:Bullseye + Python 3.12
+FROM       debian:bullseye
+ENV        DEBIAN_FRONTEND noninteractive
+COPY --from=build-env /wheelhouse/openPMD_api-*-cp312-cp312-manylinux2010_x86_64.whl .
+RUN        apt-get update \
+           && apt-get install -y --no-install-recommends python3.12 python3-distutils ca-certificates curl \
+           && rm -rf /var/lib/apt/lists/*
+RUN        python3.12 --version \
+           && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+           && python3.12 get-pip.py \
+           && python3.12 -m pip install openPMD_api-*-cp312-cp312-manylinux2010_x86_64.whl
+RUN        python3.12 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
+RUN        python3.12 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
 # copy binary artifacts (wheels)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.8 - 3.11
+  * Python 3.8 - 3.12
   * pybind11 2.11.1+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -39,7 +39,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.8 - 3.11
+  * Python 3.8 - 3.12
   * pybind11 2.11.1+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         ('License :: OSI Approved :: '
          'GNU Lesser General Public License v3 or later (LGPLv3+)'),
     ],

--- a/share/openPMD/thirdParty/pybind11/tools/pybind11Tools.cmake
+++ b/share/openPMD/thirdParty/pybind11/tools/pybind11Tools.cmake
@@ -43,7 +43,7 @@ endif()
 
 # A user can set versions manually too
 set(Python_ADDITIONAL_VERSIONS
-    "3.11;3.10;3.9;3.8;3.7;3.6"
+    "3.12;3.11;3.10;3.9;3.8"
     CACHE INTERNAL "")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
Document that we support Python 3.12.

Follow-up to #1193 

Conda-Forge and PyPI wheels packages are already passing and published for `0.15.2`.