### PR TITLE
Fix `unique_ptr<T, Del>` constructor of UniquePtrWithLambda

### DIFF
--- a/include/openPMD/auxiliary/UniquePtr.hpp
+++ b/include/openPMD/auxiliary/UniquePtr.hpp
@@ -30,15 +30,6 @@ namespace auxiliary
     public:
         using deleter_type = std::function<void(T_decayed *)>;
 
-        deleter_type const &get_deleter() const
-        {
-            return *this;
-        }
-        deleter_type &get_deleter()
-        {
-            return *this;
-        }
-
         /*
          * Default constructor: Use std::default_delete<T>.
          * This ensures correct destruction of arrays by using delete[].
@@ -148,7 +139,7 @@ UniquePtrWithLambda<T>::UniquePtrWithLambda(std::unique_ptr<T, Del> ptr)
           ptr.release(),
           auxiliary::CustomDelete<T>{
               [deleter = std::move(ptr.get_deleter())](T_decayed *del_ptr) {
-                  deleter.get_deleter()(del_ptr);
+                  deleter(del_ptr);
               }}}
 {}
 
@@ -170,7 +161,7 @@ UniquePtrWithLambda<U> UniquePtrWithLambda<T>::static_cast_() &&
     return UniquePtrWithLambda<U>{
         static_cast<other_type *>(this->release()),
         [deleter = std::move(this->get_deleter())](other_type *ptr) {
-            deleter.get_deleter()(static_cast<T_decayed *>(ptr));
+            deleter(static_cast<T_decayed *>(ptr));
         }};
 }
 } // namespace openPMD

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -984,7 +984,7 @@ inline void constant_scalar(std::string file_ending)
             s.iterations[1]
                 .meshes["rho"][MeshRecordComponent::SCALAR]
                 .getAttribute("shape")
-                .get<std::vector<uint64_t> >() == Extent{1, 2, 3});
+                .get<std::vector<uint64_t>>() == Extent{1, 2, 3});
         REQUIRE(s.iterations[1]
                     .meshes["rho"][MeshRecordComponent::SCALAR]
                     .containsAttribute("value"));
@@ -1006,7 +1006,7 @@ inline void constant_scalar(std::string file_ending)
             s.iterations[1]
                 .meshes["E"]["x"]
                 .getAttribute("shape")
-                .get<std::vector<uint64_t> >() == Extent{1, 2, 3});
+                .get<std::vector<uint64_t>>() == Extent{1, 2, 3});
         REQUIRE(s.iterations[1].meshes["E"]["x"].containsAttribute("value"));
         REQUIRE(
             s.iterations[1]
@@ -1034,7 +1034,7 @@ inline void constant_scalar(std::string file_ending)
             s.iterations[1]
                 .particles["e"]["position"][RecordComponent::SCALAR]
                 .getAttribute("shape")
-                .get<std::vector<uint64_t> >() == Extent{3, 2, 1});
+                .get<std::vector<uint64_t>>() == Extent{3, 2, 1});
         REQUIRE(s.iterations[1]
                     .particles["e"]["position"][RecordComponent::SCALAR]
                     .containsAttribute("value"));
@@ -1058,7 +1058,7 @@ inline void constant_scalar(std::string file_ending)
             s.iterations[1]
                 .particles["e"]["positionOffset"][RecordComponent::SCALAR]
                 .getAttribute("shape")
-                .get<std::vector<uint64_t> >() == Extent{3, 2, 1});
+                .get<std::vector<uint64_t>>() == Extent{3, 2, 1});
         REQUIRE(s.iterations[1]
                     .particles["e"]["positionOffset"][RecordComponent::SCALAR]
                     .containsAttribute("value"));
@@ -1080,7 +1080,7 @@ inline void constant_scalar(std::string file_ending)
             s.iterations[1]
                 .particles["e"]["velocity"]["x"]
                 .getAttribute("shape")
-                .get<std::vector<uint64_t> >() == Extent{3, 2, 1});
+                .get<std::vector<uint64_t>>() == Extent{3, 2, 1});
         REQUIRE(
             s.iterations[1].particles["e"]["velocity"]["x"].containsAttribute(
                 "value"));
@@ -1432,55 +1432,55 @@ inline void dtype_test(const std::string &backend)
         REQUIRE(s.getAttribute("emptyString").get<std::string>().empty());
     }
     REQUIRE(
-        s.getAttribute("vecChar").get<std::vector<char> >() ==
+        s.getAttribute("vecChar").get<std::vector<char>>() ==
         std::vector<char>({'c', 'h', 'a', 'r'}));
     REQUIRE(
-        s.getAttribute("vecInt16").get<std::vector<int16_t> >() ==
+        s.getAttribute("vecInt16").get<std::vector<int16_t>>() ==
         std::vector<int16_t>({32766, 32767}));
     REQUIRE(
-        s.getAttribute("vecInt32").get<std::vector<int32_t> >() ==
+        s.getAttribute("vecInt32").get<std::vector<int32_t>>() ==
         std::vector<int32_t>({2147483646, 2147483647}));
     REQUIRE(
-        s.getAttribute("vecInt64").get<std::vector<int64_t> >() ==
+        s.getAttribute("vecInt64").get<std::vector<int64_t>>() ==
         std::vector<int64_t>({9223372036854775806, 9223372036854775807}));
     REQUIRE(
-        s.getAttribute("vecUchar").get<std::vector<unsigned char> >() ==
+        s.getAttribute("vecUchar").get<std::vector<unsigned char>>() ==
         std::vector<unsigned char>({'u', 'c', 'h', 'a', 'r'}));
     REQUIRE(
-        s.getAttribute("vecSchar").get<std::vector<signed char> >() ==
+        s.getAttribute("vecSchar").get<std::vector<signed char>>() ==
         std::vector<signed char>({'s', 'c', 'h', 'a', 'r'}));
     REQUIRE(
-        s.getAttribute("vecUint16").get<std::vector<uint16_t> >() ==
+        s.getAttribute("vecUint16").get<std::vector<uint16_t>>() ==
         std::vector<uint16_t>({65534u, 65535u}));
     REQUIRE(
-        s.getAttribute("vecUint32").get<std::vector<uint32_t> >() ==
+        s.getAttribute("vecUint32").get<std::vector<uint32_t>>() ==
         std::vector<uint32_t>({4294967294u, 4294967295u}));
     REQUIRE(
-        s.getAttribute("vecUint64").get<std::vector<uint64_t> >() ==
+        s.getAttribute("vecUint64").get<std::vector<uint64_t>>() ==
         std::vector<uint64_t>({18446744073709551614u, 18446744073709551615u}));
     REQUIRE(
-        s.getAttribute("vecFloat").get<std::vector<float> >() ==
+        s.getAttribute("vecFloat").get<std::vector<float>>() ==
         std::vector<float>({0.f, 3.40282e+38f}));
     REQUIRE(
-        s.getAttribute("vecDouble").get<std::vector<double> >() ==
+        s.getAttribute("vecDouble").get<std::vector<double>>() ==
         std::vector<double>({0., 1.79769e+308}));
     if (test_long_double)
     {
         REQUIRE(
-            s.getAttribute("vecLongdouble").get<std::vector<long double> >() ==
+            s.getAttribute("vecLongdouble").get<std::vector<long double>>() ==
             std::vector<long double>(
                 {0.L, std::numeric_limits<long double>::max()}));
     }
     REQUIRE(
-        s.getAttribute("vecString").get<std::vector<std::string> >() ==
+        s.getAttribute("vecString").get<std::vector<std::string>>() ==
         std::vector<std::string>({"vector", "of", "strings"}));
     if (!adios1)
     {
         REQUIRE(
-            s.getAttribute("vecEmptyString").get<std::vector<std::string> >() ==
+            s.getAttribute("vecEmptyString").get<std::vector<std::string>>() ==
             std::vector<std::string>({"", "", ""}));
         REQUIRE(
-            s.getAttribute("vecMixedString").get<std::vector<std::string> >() ==
+            s.getAttribute("vecMixedString").get<std::vector<std::string>>() ==
             std::vector<std::string>({"hi", "", "ho"}));
     }
     REQUIRE(s.getAttribute("bool").get<bool>() == true);
@@ -1692,7 +1692,7 @@ void test_complex(const std::string &backend)
                 "longDoublesYouSay", std::complex<long double>(5.5, -4.55));
 
         auto Cflt = o.iterations[0].meshes["Cflt"][RecordComponent::SCALAR];
-        std::vector<std::complex<float> > cfloats(3);
+        std::vector<std::complex<float>> cfloats(3);
         cfloats.at(0) = {1., 2.};
         cfloats.at(1) = {-3., 4.};
         cfloats.at(2) = {5., -6.};
@@ -1700,14 +1700,14 @@ void test_complex(const std::string &backend)
         Cflt.storeChunk(cfloats, {0});
 
         auto Cdbl = o.iterations[0].meshes["Cdbl"][RecordComponent::SCALAR];
-        std::vector<std::complex<double> > cdoubles(3);
+        std::vector<std::complex<double>> cdoubles(3);
         cdoubles.at(0) = {2., 1.};
         cdoubles.at(1) = {-4., 3.};
         cdoubles.at(2) = {6., -5.};
         Cdbl.resetDataset(Dataset(Datatype::CDOUBLE, {cdoubles.size()}));
         Cdbl.storeChunk(cdoubles, {0});
 
-        std::vector<std::complex<long double> > cldoubles(3);
+        std::vector<std::complex<long double>> cldoubles(3);
         if (o.backend() != "ADIOS2" && o.backend() != "ADIOS1" &&
             o.backend() != "MPI_ADIOS1")
         {
@@ -1728,26 +1728,26 @@ void test_complex(const std::string &backend)
         Series i = Series(
             "../samples/serial_write_complex." + backend, Access::READ_ONLY);
         REQUIRE(
-            i.getAttribute("lifeIsComplex").get<std::complex<double> >() ==
+            i.getAttribute("lifeIsComplex").get<std::complex<double>>() ==
             std::complex<double>(4.56, 7.89));
         REQUIRE(
-            i.getAttribute("butComplexFloats").get<std::complex<float> >() ==
+            i.getAttribute("butComplexFloats").get<std::complex<float>>() ==
             std::complex<float>(42.3, -99.3));
         if (i.backend() != "ADIOS2" && i.backend() != "ADIOS1" &&
             i.backend() != "MPI_ADIOS1")
         {
             REQUIRE(
                 i.getAttribute("longDoublesYouSay")
-                    .get<std::complex<long double> >() ==
+                    .get<std::complex<long double>>() ==
                 std::complex<long double>(5.5, -4.55));
         }
 
         auto rcflt = i.iterations[0]
                          .meshes["Cflt"][RecordComponent::SCALAR]
-                         .loadChunk<std::complex<float> >();
+                         .loadChunk<std::complex<float>>();
         auto rcdbl = i.iterations[0]
                          .meshes["Cdbl"][RecordComponent::SCALAR]
-                         .loadChunk<std::complex<double> >();
+                         .loadChunk<std::complex<double>>();
         i.flush();
 
         REQUIRE(rcflt.get()[1] == std::complex<float>(-3., 4.));
@@ -1758,7 +1758,7 @@ void test_complex(const std::string &backend)
         {
             auto rcldbl = i.iterations[0]
                               .meshes["Cldbl"][RecordComponent::SCALAR]
-                              .loadChunk<std::complex<long double> >();
+                              .loadChunk<std::complex<long double>>();
             i.flush();
             REQUIRE(rcldbl.get()[2] == std::complex<long double>(7., -6.));
         }
@@ -5001,7 +5001,7 @@ void bp4_steps(
         auto E_x = E["x"];
         REQUIRE(
             E.getAttribute("vector_of_string")
-                .get<std::vector<std::string> >() ==
+                .get<std::vector<std::string>>() ==
             std::vector<std::string>{"vector", "of", "string"});
         REQUIRE(E_x.getDimensionality() == 1);
         REQUIRE(E_x.getExtent()[0] == 10);
@@ -5235,7 +5235,7 @@ struct AreEqual
 };
 
 template <typename T>
-struct AreEqual<std::vector<T> >
+struct AreEqual<std::vector<T>>
 {
     static bool areEqual(std::vector<T> v1, std::vector<T> v2)
     {


### PR DESCRIPTION
I forgot adding tests for that constructor and it turns out it is broken. It's the most generic conversion constructor that the class has (there is a specialization for `std::unique_ptr<T>`), so this is not used very often. There are two problems:

1. The implementation calls `get_deleter()` twice. This PR removes the second invocation.
2. `std::function` needs a copyable lambda, but `Del` might be non-copyable. Add a custom path for that case.

This PR adds two tests for each case. Without this PRs, the compile time errors are as follows:

**1**:
```
In file included from /.../openPMD-api/include/openPMD/auxiliary/TypeTraits.hpp:24,                                                
                 from /.../openPMD-api/include/openPMD/Datatype.hpp:23,                                                            
                 from /.../openPMD-api/test/SerialIOTest.cpp:2:                                                                    
/.../openPMD-api/include/openPMD/auxiliary/UniquePtr.hpp: In instantiation of 'openPMD::UniquePtrWithLambda<T>::UniquePtrWithLambda(std::unique_ptr<T, Del>) [with Del = detail::CopyableDeleter<int>; T = int]':
/.../openPMD-api/test/SerialIOTest.cpp:705:71:   required from here
/.../openPMD-api/include/openPMD/auxiliary/UniquePtr.hpp:151:27: error: 'const struct detail::CopyableDeleter<int>' has no member named 'get_deleter'
  151 |                   deleter.get_deleter()(del_ptr);

```

**2**:
```
In file included from /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/functional:59,
                 from /.../openPMD-api/include/openPMD/auxiliary/UniquePtr.hpp:3,
                 from /.../openPMD-api/include/openPMD/auxiliary/TypeTraits.hpp:24,
                 from /.../openPMD-api/include/openPMD/Datatype.hpp:23,
                 from /.../openPMD-api/test/SerialIOTest.cpp:2:
/nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h: In instantiation of 'std::function<_Res(_ArgTypes ...)>::function(_Functor&&) [with _Functor = openPMD::UniquePtrWithLambda<int>::UniquePtrWithLambda<detail::NonCopyableDeleter<int> >(std::unique_ptr<int, detail::NonCopyableDeleter<int> >)::<lambda(openPMD::UniquePtrWithLambda<int>::T_decayed*)>; _Constraints = void; _Res = void; _ArgTypes = {int*}]':
/.../openPMD-api/include/openPMD/auxiliary/UniquePtr.hpp:143:17:   required from 'openPMD::UniquePtrWithLambda<T>::UniquePtrWithLambda(std::unique_ptr<T, Del>) [with Del = detail::NonCopyableDeleter<int>; T = int]'
/.../openPMD-api/test/SerialIOTest.cpp:728:74:   required from here
/nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h:439:69: error: static assertion failed: std::function target must be copy-constructible
  439 |           static_assert(is_copy_constructible<__decay_t<_Functor>>::value,
```