### PR TITLE
Workaround for current CI issues with clang14 on MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,8 @@ jobs:
           -DopenPMD_USE_MPI=ON    \
           -DopenPMD_USE_HDF5=ON   \
           -DopenPMD_USE_ADIOS2=ON \
-          -DopenPMD_USE_INVASIVE_TESTS=ON
+          -DopenPMD_USE_INVASIVE_TESTS=ON \
+          -DMPIEXEC_EXECUTABLE=".github/workflows/mpirun_workaround.sh"
         cmake --build build --parallel 3
         ctest --test-dir build --verbose
 

--- a/.github/workflows/mpirun_workaround.sh
+++ b/.github/workflows/mpirun_workaround.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# mpiexec currently seems to have a bug where it tries to parse parameters
+# of the launched application when they start with a dash, e.g.
+# `mpiexec python ./openpmd-pipe --infile in.bp --outfile out.bp`
+# leads to:
+# >  An unrecognized option was included on the mpiexec command line:
+# >
+# >    Option: --infile
+# >
+# >  Please use the "mpiexec --help" command to obtain a list of all
+# >  supported options.
+#
+# This script provides a workaround by putting the called sub-command into
+# a script in a temporary file.
+
+mpirun_args=()
+
+script_file="$(mktemp)"
+
+cleanup() {
+    rm "$script_file"
+}
+trap cleanup EXIT
+
+while true; do
+    case "$1" in
+        -c | -np | --np | -n | --n )
+            mpirun_args+=("$1" "$2")
+            shift
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+echo -e '#!/usr/bin/env bash\n' > "$script_file"
+for item in "$@"; do
+    echo -n "'$item' " >> "$script_file"
+done
+
+chmod +x "$script_file"
+
+mpirun "${mpirun_args[@]}" "$script_file"

--- a/.github/workflows/mpirun_workaround.sh
+++ b/.github/workflows/mpirun_workaround.sh
@@ -14,6 +14,11 @@
 # This script provides a workaround by putting the called sub-command into
 # a script in a temporary file.
 
+mpiexec -n 1 ls --all \
+    && echo "MPIRUN WORKING AGAIN, PLEASE REMOVE WORKAROUND" >&2 \
+    && exit 1 \
+    || true
+
 mpirun_args=()
 
 script_file="$(mktemp)"


### PR DESCRIPTION
All CI runs for appleclang14_py_mpi_h5_ad2 are currently failing and this looks like a bug in `mpiexec` to me.
 This tries a workaround.

The error:

```
...

2023-11-28T10:53:38.1264050Z 27: --------------------------------------------------------------------------
2023-11-28T10:53:38.1265160Z 27: An unrecognized option was included on the mpiexec command line:
2023-11-28T10:53:38.1265740Z 27: 
2023-11-28T10:53:38.1266110Z 27:   Option: --infile
2023-11-28T10:53:38.1266410Z 27: 
2023-11-28T10:53:38.1266940Z 27: Please use the "mpiexec --help" command to obtain a list of all
2023-11-28T10:53:38.1267520Z 27: supported options.
2023-11-28T10:53:38.1268080Z 27: --------------------------------------------------------------------------
2023-11-28T10:53:38.1271700Z 27/40 Test #27: CLI.pipe.py .................................***Failed    0.03 sec

...

2023-11-28T10:53:39.7926460Z 33: --------------------------------------------------------------------------
2023-11-28T10:53:39.7927270Z 33: An unrecognized option was included on the mpiexec command line:
2023-11-28T10:53:39.7927830Z 33: 
2023-11-28T10:53:39.7928140Z 33:   Option: -m
2023-11-28T10:53:39.7928420Z 33: 
2023-11-28T10:53:39.7928970Z 33: Please use the "mpiexec --help" command to obtain a list of all
2023-11-28T10:53:39.7929540Z 33: supported options.
2023-11-28T10:53:39.7930100Z 33: --------------------------------------------------------------------------
2023-11-28T10:53:39.7930850Z 33/40 Test #33: Example.py.4_read_parallel ..................***Failed    0.02 sec

...

2023-11-28T10:53:39.8126700Z 34: --------------------------------------------------------------------------
2023-11-28T10:53:39.8127470Z 34: An unrecognized option was included on the mpiexec command line:
2023-11-28T10:53:39.8128040Z 34: 
2023-11-28T10:53:39.8128360Z 34:   Option: -m
2023-11-28T10:53:39.8128640Z 34: 
2023-11-28T10:53:39.8129180Z 34: Please use the "mpiexec --help" command to obtain a list of all
2023-11-28T10:53:39.8129760Z 34: supported options.
2023-11-28T10:53:39.8130740Z 34: --------------------------------------------------------------------------
2023-11-28T10:53:39.8131570Z 34/40 Test #34: Example.py.5_write_parallel .................***Failed    0.02 sec

...

2023-11-28T10:53:45.0888290Z The following tests FAILED:
2023-11-28T10:53:45.0890320Z 	 27 - CLI.pipe.py (Failed)
2023-11-28T10:53:45.0891220Z 	 33 - Example.py.4_read_parallel (Failed)
2023-11-28T10:53:45.0892090Z 	 34 - Example.py.5_write_parallel (Failed)
```

Happens always when the subcommand that is launched via mpiexec contains an argument starting with a dash, so this is probably a parser error in mipexec.