### PR TITLE
Docs: Research Groups of Maintainers

### DIFF
--- a/.rodare.json
+++ b/.rodare.json
@@ -19,8 +19,76 @@
       "name": "Gu, Junmin",
       "affiliation": "Lawrence Berkeley National Laboratory",
       "orcid": "0000-0002-1521-8534"
+    },
+    {
+      "affiliations": [
+        {
+          "name": "Center for Advanced Systems Understanding"
+        },
+        {
+          "name": "Helmholtz-Zentrum Dresden-Rossendorf"
+        }
+      ],
+      "person_or_org": {
+        "family_name": "Bussmann",
+        "given_name": "Michael",
+        "identifiers": [
+          {
+            "identifier": "0000-0002-8258-3881",
+            "scheme": "orcid"
+          }
+        ],
+        "name": "Michael Bussmann (Leader of the Computational Radiation Physics Research Team at CASUS/HZDR)",
+        "type": "personal"
+      },
+      "role": {
+        "id": "researchgroup"
+      }
+    },
+    {
+      "affiliations": [
+        {
+          "name": "Lawrence Berkeley National Laboratory"
+        }
+      ],
+      "person_or_org": {
+        "family_name": "Vay",
+        "given_name": "Jean-Luc",
+        "identifiers": [
+          {
+            "identifier": "0000-0002-0040-799X",
+            "scheme": "orcid"
+          }
+        ],
+        "name": "Jean-Luc Vay (Head of the Accelerator Modeling Program at LBNL)",
+        "type": "personal"
+      },
+      "role": {
+        "id": "researchgroup"
+      }
+    },
+    {
+      "affiliations": [
+        {
+          "name": "Lawrence Berkeley National Laboratory"
+        }
+      ],
+      "person_or_org": {
+        "family_name": "Wu",
+        "given_name": "Kesheng (John)",
+        "identifiers": [
+          {
+            "identifier": "0000-0002-6907-3393",
+            "scheme": "orcid"
+          }
+        ],
+        "name": "Kesheng (John) Wu (Head of the Scientific Data Management research group at LBNL)",
+        "type": "personal"
+      },
+      "role": {
+        "id": "researchgroup"
+      }
     }
-
   ],
   "contributors": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If you use this software, please cite it as below."
 authors:
 - family-names: Huebl
   given-names: Axel
-  affiliation: Lawrence Berkeley National Laboratory
+  affiliation: Lawrence Berkeley National Laboratory (LBNL)
   orcid: https://orcid.org/0000-0003-1943-7141
   email: axelhuebl@lbl.gov
 - family-names: Poeschel
@@ -12,16 +12,28 @@ authors:
   orcid: https://orcid.org/0000-0001-7042-5088
 - family-names: Koller
   given-names: Fabian
-  affiliation: Helmholtz-Zentrum Dresden-Rossendorf
+  affiliation: Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
   orcid: https://orcid.org/0000-0001-8704-1769
 - family-names: Gu
   given-names: Junmin
-  affiliation: Lawrence Berkeley National Laboratory
+  affiliation: Lawrence Berkeley National Laboratory (LBNL)
   orcid: https://orcid.org/0000-0002-1521-8534
+- family-names: Bussmann
+  given-names: Michael
+  affiliation: Center for Advanced Systems Understanding (CASUS) and Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+  orcid: https://orcid.org/0000-0002-8258-3881
+- family-names: Vay
+  given-names: Jean-Luc
+  affiliation: Lawrence Berkeley National Laboratory (LBNL)
+  orcid: https://orcid.org/0000-0002-0040-799X
+- family-names: Wu
+  given-names: Kesheng (John)
+  affiliation: Lawrence Berkeley National Laboratory (LBNL)
+  orcid: https://orcid.org/0000-0002-6907-3393
 contact:
 - family-names: Huebl
   given-names: Axel
-  affiliation: Lawrence Berkeley National Laboratory
+  affiliation: Lawrence Berkeley National Laboratory (LBNL)
   orcid: https://orcid.org/0000-0003-1943-7141
   email: axelhuebl@lbl.gov
 title: "openPMD-api: C++ & Python API for Scientific I/O with openPMD"

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ openPMD-api is developed by many people.
 It was initially started by the [Computational Radiation Physics Group](https://hzdr.de/crp) at [HZDR](https://www.hzdr.de/) as successor to [libSplash](https://github.com/ComputationalRadiationPhysics/libSplash/), generalizing the [successful HDF5 & ADIOS1 implementations](https://arxiv.org/abs/1706.00522) in [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu).
 The following people and institutions [contributed](https://github.com/openPMD/openPMD-api/graphs/contributors) to openPMD-api:
 
-* [Axel Huebl (HZDR, now LBNL)](https://github.com/ax3l):
+* [Axel Huebl (LBNL, previously HZDR)](https://github.com/ax3l):
   project lead, releases, documentation, automated CI/CD, Python bindings, Dask, installation & packaging, prior reference implementations
 * [Franz Poeschel (CASUS)](https://github.com/franzpoeschel):
   JSON & ADIOS2 backend, data staging/streaming, reworked class design
@@ -380,6 +380,12 @@ The following people and institutions [contributed](https://github.com/openPMD/o
   initial library design and implementation with HDF5 & ADIOS1 backend
 * [Junmin Gu (LBNL)](https://github.com/guj):
   non-collective parallel I/O fixes, ADIOS improvements, benchmarks
+
+Maintained by the following research groups:
+
+* [Computational Radiation Physics (CRD)](https://www.casus.science/casus/team/) at CASUS/HZDR, led by [Michael Bussmann](https://github.com/bussmann)
+* [Accelerator Modeling Program (AMP)](https://atap.lbl.gov/accelerator-modeling-program/) at LBNL, led by [Jean-Luc Vay](https://github.com/jlvay)
+* [Scientific Data Management (SDM)](https://crd.lbl.gov/divisions/scidata/sdm/) at LBNL, led by [Kesheng (John) Wu](https://github.com/john18)
 
 Further thanks go to improvements and contributions from:
 

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -67,7 +67,7 @@ As a software citation, you almost always want to refer to a *specific version* 
 
 .. tip::
 
-   Axel Huebl, Franz Poeschel, Fabian Koller, and Junmin Gu.
+   Axel Huebl, Franz Poeschel, Fabian Koller, Junmin Gu, Michael Bussmann, Jean-Luc Vay and Kesheng Wu.
    *"openPMD-api 0.14.3: C++ & Python API for Scientific I/O with openPMD,"*
    `DOI:10.14278/rodare.1234 <https://doi.org/10.14278/rodare.1234>`_ (2021)
 
@@ -77,7 +77,7 @@ We also provide a DOI that refers to all releases of openPMD-api:
 
 .. note::
 
-   Axel Huebl, Franz Poeschel, Fabian Koller, and Junmin Gu.
+   Axel Huebl, Franz Poeschel, Fabian Koller, Junmin Gu, Michael Bussmann, Jean-Luc Vay and Kesheng Wu.
    *"openPMD-api: C++ & Python API for Scientific I/O with openPMD"*
    `DOI:10.14278/rodare.27 <https://doi.org/10.14278/rodare.27>`_ (2018)
 
@@ -89,7 +89,10 @@ The equivalent BibTeX code is:
      author       = {Huebl, Axel and
                      Poeschel, Franz and
                      Koller, Fabian and
-                     Gu, Junmin},
+                     Gu, Junmin and
+                     Bussmann, Michael and
+                     Vay, Jean-Luc and
+                     Wu, Kesheng},
      title        = {{openPMD-api: C++ \& Python API for Scientific I/O with openPMD}},
      month        = june,
      year         = 2018,


### PR DESCRIPTION
Add research group leads as co-authors for Axel, Franz, Junmin, and Jean Luca.