### PR TITLE
Partially revert #1368

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1212,18 +1212,14 @@ void Series::readOneIterationFileBased(std::string const &filePath)
             series.m_iterationEncoding = IterationEncoding::fileBased;
         else if (encoding == "groupBased")
         {
-            series.m_iterationEncoding = IterationEncoding::groupBased;
-            /*
-             * Opening a single file of a file-based Series is a valid workflow,
-             * warnings are not necessary here.
-             * Leaving the old warning as a comment, because we might want to
-             * add this back in again if we add some kind of verbosity level
-             * specification or logging.
-             */
-            // std::cerr << "Series constructor called with iteration "
-            //              "regex '%T' suggests loading a "
-            //           << "time series with fileBased iteration "
-            //              "encoding. Loaded file is groupBased.\n";
+            series.m_iterationEncoding = IterationEncoding::fileBased;
+            std::cerr
+                << "Series constructor called with iteration regex '%T' "
+                   "suggests loading a time series with fileBased iteration "
+                   "encoding. Loaded file is groupBased. Will ignore the "
+                   "encoding stated in the file and continue treating this as "
+                   "file-based. Depending on what data the opened files "
+                   "actually contain, this might not yield correct results.\n";
         }
         else if (encoding == "variableBased")
         {


### PR DESCRIPTION
That PR removed one warning that should have stayed, as it checks for the exact other direction: Opening a group-based file that uses file-based file names.

Also, treat those files as file-based despite the file-encoded claimed by the `/iterationEncoding` attribute. Either option is wrong anyway since the entire situation is undefined behavior, but with this change, the file is consistently treated as file-based, instead of switching to group-based midway.