### PR TITLE
Update for OPENPMD_VERBOSE logging

### DIFF
--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -30,6 +30,7 @@
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/ParsePreference.hpp"
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>
@@ -680,15 +681,23 @@ template <>
 struct OPENPMDAPI_EXPORT Parameter<Operation::DEREGISTER>
     : public AbstractParameter
 {
-    Parameter() = default;
-    Parameter(Parameter const &) : AbstractParameter()
+    Parameter(void const *ptr_in) : former_parent(ptr_in)
     {}
+
+    Parameter(Parameter const &) = default;
+    Parameter(Parameter &&) = default;
+
+    Parameter &operator=(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
 
     std::unique_ptr<AbstractParameter> to_heap() && override
     {
         return std::make_unique<Parameter<Operation::DEREGISTER>>(
             std::move(*this));
     }
+
+    // Just for verbose logging.
+    void const *former_parent = nullptr;
 };
 
 /** @brief Self-contained description of a single IO operation.

--- a/src/IO/AbstractIOHandlerImpl.cpp
+++ b/src/IO/AbstractIOHandlerImpl.cpp
@@ -358,7 +358,11 @@ std::future<void> AbstractIOHandlerImpl::flush()
                 auto &parameter = deref_dynamic_cast<Parameter<O::DEREGISTER>>(
                     i.parameter.get());
                 writeToStderr(
-                    "[", i.writable->parent, "->", i.writable, "] DEREGISTER");
+                    "[",
+                    parameter.former_parent,
+                    "->",
+                    i.writable,
+                    "] DEREGISTER");
                 deregister(i.writable, parameter);
                 break;
             }

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -39,7 +39,7 @@ Writable::~Writable()
      * remove references to this object from internal data structures.
      */
     IOHandler->value()->enqueue(
-        IOTask(this, Parameter<Operation::DEREGISTER>()));
+        IOTask(this, Parameter<Operation::DEREGISTER>(parent)));
 }
 
 void Writable::seriesFlush(std::string backendConfig)


### PR DESCRIPTION
Sometimes, applications will swallow exceptions, making it hard to get to the bottom of an error. An example is seen in #1572 where the line `[AbstractIOHandlerImpl] IO Task AVAILABLE_CHUNKS failed with exception. Clearing IO queue and passing on the exception.` is printed by the openPMD-api, but the openPMD-viewer swallows the exception that is passed further up.

With this PR, the verbose logging will also print the original error.

Also, fix an issue with undefined behavior in verbose logging.