### PR TITLE
Remove constexpr from RecordComponent::visit()

### DIFF
--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -476,9 +476,8 @@ public:
      *         be implicitly converted.
      */
     template <typename Visitor, typename... Args>
-    constexpr auto visit(Args &&...args)
-        -> decltype(Visitor::template call<char>(
-            std::declval<RecordComponent &>(), std::forward<Args>(args)...));
+    auto visit(Args &&...args) -> decltype(Visitor::template call<char>(
+        std::declval<RecordComponent &>(), std::forward<Args>(args)...));
 
     static constexpr char const *const SCALAR = "\vScalar";
 

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -397,7 +397,7 @@ namespace detail
 } // namespace detail
 
 template <typename Visitor, typename... Args>
-constexpr auto RecordComponent::visit(Args &&...args)
+auto RecordComponent::visit(Args &&...args)
     -> decltype(Visitor::template call<char>(
         std::declval<RecordComponent &>(), std::forward<Args>(args)...))
 {


### PR DESCRIPTION
RecordComponent has a virtual base class, so it cannot be `constexpr`