### PR TITLE
Filename extensions: Allow specifying wildcards

### DIFF
--- a/docs/source/usage/firstread.rst
+++ b/docs/source/usage/firstread.rst
@@ -86,7 +86,7 @@ C++17
 .. code-block:: cpp
 
    auto series = io::Series(
-       "data%T.h5",
+       "data_%T.h5",
        io::Access::READ_ONLY);
 
 
@@ -96,8 +96,19 @@ Python
 .. code-block:: python3
 
    series = io.Series(
-       "data%T.h5",
+       "data_%T.h5",
        io.Access.read_only)
+
+.. tip::
+
+   Replace the file ending ``.h5`` with a wildcard ``.%E`` to let openPMD autodetect the ending from the file system.
+   Use the wildcard ``%T`` to match filename encoded iterations.
+
+.. tip::
+
+   More detailed options can be passed via JSON or TOML as a further constructor parameter.
+   Try ``{"defer_iteration_parsing": true}`` to speed up the first access.
+   (Remember to explicitly ``it.open()`` iterations in that case.)
 
 Iteration
 ---------

--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -100,7 +100,7 @@ Python
 Iteration
 ---------
 
-Grouping by an arbitrary, positive integer number ``<N>`` in a series:
+Grouping by an arbitrary, nonnegative integer number ``<N>`` in a series:
 
 C++17
 ^^^^^

--- a/examples/2a_read_thetaMode_serial.cpp
+++ b/examples/2a_read_thetaMode_serial.cpp
@@ -29,6 +29,8 @@ using namespace openPMD;
 
 int main()
 {
+    /* The pattern %E instructs the openPMD-api to determine the file ending
+     * automatically. It can also be given explicitly, e.g. `data%T.h5`. */
     Series series =
         Series("../samples/git-sample/thetaMode/data%T.h5", Access::READ_ONLY);
 

--- a/examples/2a_read_thetaMode_serial.py
+++ b/examples/2a_read_thetaMode_serial.py
@@ -9,6 +9,8 @@ License: LGPLv3+
 import openpmd_api as io
 
 if __name__ == "__main__":
+    # The pattern %E instructs the openPMD-api to determine the file ending
+    # automatically. It can also be given explicitly, e.g. `data%T.h5`.
     series = io.Series("../samples/git-sample/thetaMode/data%T.h5",
                        io.Access.read_only)
 

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -218,6 +218,12 @@ public:
     {}
     virtual ~AbstractIOHandler() = default;
 
+    AbstractIOHandler(AbstractIOHandler const &) = default;
+    AbstractIOHandler(AbstractIOHandler &&) = default;
+
+    AbstractIOHandler &operator=(AbstractIOHandler const &) = default;
+    AbstractIOHandler &operator=(AbstractIOHandler &&) = default;
+
     /** Add provided task to queue according to FIFO.
      *
      * @param   iotask  Task to be executed after all previously enqueued
@@ -245,7 +251,7 @@ public:
     /** The currently used backend */
     virtual std::string backendName() const = 0;
 
-    std::string const directory;
+    std::string directory;
     /*
      * Originally, the reason for distinguishing these two was that during
      * parsing in reading access modes, the access type would be temporarily
@@ -261,8 +267,8 @@ public:
      * which is entirely implemented by the frontend, which internally uses
      * the backend in CREATE mode.
      */
-    Access const m_backendAccess;
-    Access const m_frontendAccess;
+    Access m_backendAccess;
+    Access m_frontendAccess;
     internal::SeriesStatus m_seriesStatus = internal::SeriesStatus::Default;
     std::queue<IOTask> m_work;
     /**

--- a/include/openPMD/IO/DummyIOHandler.hpp
+++ b/include/openPMD/IO/DummyIOHandler.hpp
@@ -45,5 +45,6 @@ public:
      * without IO.
      */
     std::future<void> flush(internal::ParsedFlushParams &) override;
+    std::string backendName() const override;
 }; // DummyIOHandler
 } // namespace openPMD

--- a/include/openPMD/IO/Format.hpp
+++ b/include/openPMD/IO/Format.hpp
@@ -36,6 +36,7 @@ enum class Format
     ADIOS2_SSC,
     JSON,
     TOML,
+    GENERIC,
     DUMMY
 };
 

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -689,19 +689,10 @@ public:
         , parameter{std::move(p).to_heap()}
     {}
 
-    explicit IOTask(IOTask const &other)
-        : writable{other.writable}
-        , operation{other.operation}
-        , parameter{other.parameter}
-    {}
-
-    IOTask &operator=(IOTask const &other)
-    {
-        writable = other.writable;
-        operation = other.operation;
-        parameter = other.parameter;
-        return *this;
-    }
+    IOTask(IOTask const &other);
+    IOTask(IOTask &&other) noexcept;
+    IOTask &operator=(IOTask const &other);
+    IOTask &operator=(IOTask &&other) noexcept;
 
     Writable *writable;
     Operation operation;

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -831,22 +831,8 @@ OPENPMD_private
 
     AbstractIOHandler *runDeferredInitialization();
 
-    AbstractIOHandler *IOHandler()
-    {
-        auto res = Attributable::IOHandler();
-        if (res && //  res->backendName() == "Dummy" &&
-            m_series->m_deferred_initialization.has_value())
-        {
-            res = runDeferredInitialization();
-        }
-        return res;
-    }
-    AbstractIOHandler const *IOHandler() const
-    {
-        auto res = Attributable::IOHandler();
-        // std::cout << "Returning " << debug(res) << std::endl;
-        return res;
-    }
+    AbstractIOHandler *IOHandler();
+    AbstractIOHandler const *IOHandler() const;
 }; // Series
 } // namespace openPMD
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -195,7 +195,7 @@ namespace internal
          */
         std::optional<ParsePreference> m_parsePreference;
 
-        std::optional<std::function<AbstractIOHandler *()>>
+        std::optional<std::function<AbstractIOHandler *(Series &)>>
             m_deferred_initialization = std::nullopt;
 
         void close();
@@ -792,7 +792,7 @@ OPENPMD_private
         {
             auto functor = std::move(*m_series->m_deferred_initialization);
             m_series->m_deferred_initialization = std::nullopt;
-            res = functor();
+            res = functor(*this);
         }
         return res;
     }

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -227,6 +227,18 @@ public:
     explicit Series();
 
 #if openPMD_HAVE_MPI
+    /**
+     * @brief Construct a new Series
+     *
+     * For further details, refer to the documentation of the non-MPI overload.
+     *
+     * @param filepath The file path.
+     * @param at Access mode.
+     * @param comm The MPI communicator.
+     * @param options Advanced backend configuration via JSON.
+     *      May be specified as a JSON-formatted string directly, or as a path
+     *      to a JSON textfile, prepended by an at sign '@'.
+     */
     Series(
         std::string const &filepath,
         Access at,
@@ -235,13 +247,50 @@ public:
 #endif
 
     /**
-     * @brief Construct a new Series
+     * @brief Construct a new Series.
      *
-     * @param filepath The backend will be determined by the filepath extension.
+     * For details on access modes, JSON/TOML configuration and iteration
+     * encoding, refer to:
+     *
+     * * https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#access-modes
+     * * https://openpmd-api.readthedocs.io/en/latest/details/backendconfig.html
+     * * https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html#iteration-and-series
+     *
+     * In case of file-based iteration encoding, the file names for each
+     * iteration are determined by an expansion pattern that must be specified.
+     * It takes one out of two possible forms:
+     *
+     * 1. Simple form: %T is replaced with the iteration index, e.g.
+     *    `simData_%T.bp` becomes `simData_50.bp`.
+     * 2. Padded form: e.g. %06T is replaced with the iteration index padded to
+     *    at least six digits. `simData_%06T.bp` becomes `simData_000050.bp`.
+     *
+     * The backend is determined:
+     *
+     * 1. Explicitly via the JSON/TOML parameter `backend`, e.g. `{"backend":
+     *    "adios2"}`.
+     * 2. Otherwise implicitly from the filename extension, e.g.
+     *    `simData_%T.h5`.
+     *
+     * The filename extension can be replaced with a globbing pattern %E.
+     * It will be replaced with an automatically determined file name extension:
+     *
+     * 1. In CREATE mode: The extension is set to a backend-specific default
+     *    extension. This requires that the backend is specified via JSON/TOML.
+     * 2. In READ_ONLY, READ_WRITE and READ_LINEAR modes: These modes require
+     *    that files already exist on disk. The disk will be scanned for files
+     *    that match the pattern and the resulting file extension will be used.
+     *    If the result is ambiguous or no such file is found, an error is
+     *    raised.
+     * 3. In APPEND mode: Like (2.), except if no matching file is found. In
+     *    that case, the procedure of (1.) is used, owing to the fact that
+     *    APPEND mode can be used to create new datasets.
+     *
+     * @param filepath The file path.
      * @param at Access mode.
      * @param options Advanced backend configuration via JSON.
-     *      May be specified as a JSON-formatted string directly, or as a path
-     *      to a JSON textfile, prepended by an at sign '@'.
+     *      May be specified as a JSON/TOML-formatted string directly, or as a
+     *      path to a JSON/TOML textfile, prepended by an at sign '@'.
      */
     Series(
         std::string const &filepath,

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -648,21 +648,17 @@ OPENPMD_private
     bool hasExpansionPattern(std::string filenameWithExtension);
     bool reparseExpansionPattern(std::string filenameWithExtension);
     template <typename... MPI_Communicator>
-    AbstractIOHandler *init(
+    void init(
         std::string const &filepath,
         Access at,
         std::string const &options,
         MPI_Communicator &&...);
-    template <typename TracingJSON, typename BuildIOHandler>
-    std::tuple<
-        std::unique_ptr<AbstractIOHandler>,
-        std::unique_ptr<ParsedInput>,
-        TracingJSON>
-    initIOHandler(
+    template <typename TracingJSON>
+    std::tuple<std::unique_ptr<ParsedInput>, TracingJSON> initIOHandler(
         std::string const &filepath,
         std::string const &options,
         Access at,
-        BuildIOHandler &&buildIOHandler);
+        bool resolve_generic_extension);
     void initSeries(
         std::unique_ptr<AbstractIOHandler>, std::unique_ptr<ParsedInput>);
     void initDefaults(IterationEncoding, bool initAll = false);

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -645,6 +645,7 @@ OPENPMD_private
     initIOHandler(
         std::string const &filepath,
         std::string const &options,
+        Access at,
         BuildIOHandler &&buildIOHandler);
     void initSeries(
         std::unique_ptr<AbstractIOHandler>, std::unique_ptr<ParsedInput>);

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -600,10 +600,6 @@ OPENPMD_private
     {
         if (m_series)
         {
-            if (m_series->m_deferred_initialization.has_value())
-            {
-                return *m_series;
-            }
             return *m_series;
         }
         else
@@ -784,15 +780,15 @@ OPENPMD_private
      */
     std::optional<std::vector<IterationIndex_t>> currentSnapshot() const;
 
+    AbstractIOHandler *runDeferredInitialization();
+
     AbstractIOHandler *IOHandler()
     {
         auto res = Attributable::IOHandler();
         if (res && //  res->backendName() == "Dummy" &&
             m_series->m_deferred_initialization.has_value())
         {
-            auto functor = std::move(*m_series->m_deferred_initialization);
-            m_series->m_deferred_initialization = std::nullopt;
-            res = functor(*this);
+            res = runDeferredInitialization();
         }
         return res;
     }

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -788,28 +788,16 @@ OPENPMD_private
      */
     std::optional<std::vector<IterationIndex_t>> currentSnapshot() const;
 
-    static std::string debug(AbstractIOHandler const *ptr)
-    {
-        std::stringstream res;
-        res << ptr;
-        if (ptr)
-            res << '(' << ptr->directory << ')';
-        return res.str();
-    }
-
     AbstractIOHandler *IOHandler()
     {
         auto res = Attributable::IOHandler();
-        if ((!res || res->backendName() == "Dummy") &&
+        if (res && //  res->backendName() == "Dummy" &&
             m_series->m_deferred_initialization.has_value())
         {
-            decltype(m_series->m_deferred_initialization) steal_the_goods =
-                std::nullopt;
-            m_series->m_deferred_initialization.swap(steal_the_goods);
-            steal_the_goods->operator()();
-            res = Attributable::IOHandler();
+            auto functor = std::move(*m_series->m_deferred_initialization);
+            m_series->m_deferred_initialization = std::nullopt;
+            res = functor();
         }
-        // std::cout << "Returning " << debug(res) << std::endl;
         return res;
     }
     AbstractIOHandler const *IOHandler() const

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -33,6 +33,7 @@
 #include "openPMD/backend/ParsePreference.hpp"
 #include "openPMD/config.hpp"
 #include "openPMD/version.hpp"
+#include <memory>
 
 #if openPMD_HAVE_MPI
 #include <mpi.h>
@@ -636,7 +637,17 @@ OPENPMD_private
     void parseJsonOptions(TracingJSON &options, ParsedInput &);
     bool hasExpansionPattern(std::string filenameWithExtension);
     bool reparseExpansionPattern(std::string filenameWithExtension);
-    void init(std::unique_ptr<AbstractIOHandler>, std::unique_ptr<ParsedInput>);
+    template <typename TracingJSON, typename BuildIOHandler>
+    std::tuple<
+        std::unique_ptr<AbstractIOHandler>,
+        std::unique_ptr<ParsedInput>,
+        TracingJSON>
+    initIOHandler(
+        std::string const &filepath,
+        std::string const &options,
+        BuildIOHandler &&buildIOHandler);
+    void initSeries(
+        std::unique_ptr<AbstractIOHandler>, std::unique_ptr<ParsedInput>);
     void initDefaults(IterationEncoding, bool initAll = false);
     /**
      * @brief Internal call for flushing a Series.
@@ -688,7 +699,7 @@ OPENPMD_private
      * ReadIterations since those methods should be aware when the current step
      * is broken).
      */
-    std::optional<std::deque<IterationIndex_t> > readGorVBased(
+    std::optional<std::deque<IterationIndex_t>> readGorVBased(
         bool do_always_throw_errors,
         bool init,
         std::set<IterationIndex_t> const &ignoreIterations = {});
@@ -758,7 +769,7 @@ OPENPMD_private
      * Returns the current content of the /data/snapshot attribute.
      * (We could also add this to the public API some time)
      */
-    std::optional<std::vector<IterationIndex_t> > currentSnapshot() const;
+    std::optional<std::vector<IterationIndex_t>> currentSnapshot() const;
 }; // Series
 } // namespace openPMD
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -41,12 +41,14 @@
 
 #include <cstdint> // uint64_t
 #include <deque>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 
 // expose private and protected members for invasive testing
 #ifndef OPENPMD_private

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -34,8 +34,6 @@
 #include "openPMD/backend/ParsePreference.hpp"
 #include "openPMD/config.hpp"
 #include "openPMD/version.hpp"
-#include <memory>
-#include <stdexcept>
 
 #if openPMD_HAVE_MPI
 #include <mpi.h>
@@ -44,8 +42,10 @@
 #include <cstdint> // uint64_t
 #include <deque>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
+#include <stdexcept>
 #include <string>
 
 // expose private and protected members for invasive testing

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -45,6 +45,8 @@ Format determineFormat(std::string const &filename)
         return Format::JSON;
     if (auxiliary::ends_with(filename, ".toml"))
         return Format::TOML;
+    if (auxiliary::ends_with(filename, ".%E"))
+        return Format::GENERIC;
 
     // Format might still be specified via JSON
     return Format::DUMMY;
@@ -70,6 +72,8 @@ std::string suffix(Format f)
         return ".json";
     case Format::TOML:
         return ".toml";
+    case Format::GENERIC:
+        return ".%E";
     default:
         return "";
     }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -354,17 +354,32 @@ std::string ADIOS2IOHandlerImpl::fileSuffix(bool verbose) const
 {
     // SST engine adds its suffix unconditionally
     // so we don't add it
+#if defined(ADIOS2_HAVE_BP5) && openPMD_HAS_ADIOS_2_9
+    constexpr char const *const default_file_ending = ".bp5";
+#else
+    constexpr char const *const default_file_ending = ".bp4";
+#endif
+
     static std::map<std::string, AcceptedEndingsForEngine> const endings{
-        {"sst", {{"", ""}, {".sst", ""}}},
-        {"staging", {{"", ""}, {".sst", ""}}},
-        {"filestream", {{".bp", ".bp"}, {".bp4", ".bp4"}, {".bp5", ".bp5"}}},
-        {"bp4", {{".bp4", ".bp4"}, {".bp", ".bp"}}},
-        {"bp5", {{".bp5", ".bp5"}, {".bp", ".bp"}}},
-        {"bp3", {{".bp", ".bp"}}},
-        {"file", {{".bp", ".bp"}, {".bp4", ".bp4"}, {".bp5", ".bp5"}}},
-        {"hdf5", {{".h5", ".h5"}}},
-        {"nullcore", {{".nullcore", ".nullcore"}, {".bp", ".bp"}}},
-        {"ssc", {{".ssc", ".ssc"}}}};
+        {"sst", {{"", ""}, {".sst", ""}, {".%E", ""}}},
+        {"staging", {{"", ""}, {".sst", ""}, {".%E", ""}}},
+        {"filestream",
+         {{".bp", ".bp"},
+          {".bp4", ".bp4"},
+          {".bp5", ".bp5"},
+          {".%E", default_file_ending}}},
+        {"bp4", {{".bp4", ".bp4"}, {".bp", ".bp"}, {".%E", ".bp4"}}},
+        {"bp5", {{".bp5", ".bp5"}, {".bp", ".bp"}, {".%E", ".bp5"}}},
+        {"bp3", {{".bp", ".bp"}, {".%E", ".bp"}}},
+        {"file",
+         {{".bp", ".bp"},
+          {".bp4", ".bp4"},
+          {".bp5", ".bp5"},
+          {".%E", default_file_ending}}},
+        {"hdf5", {{".h5", ".h5"}, {".%E", ".h5"}}},
+        {"nullcore",
+         {{".nullcore", ".nullcore"}, {".bp", ".bp"}, {".%E", ".nullcore"}}},
+        {"ssc", {{".ssc", ".ssc"}, {".%E", ".ssc"}}}};
 
     if (auto engine = endings.find(m_engineType); engine != endings.end())
     {

--- a/src/IO/DummyIOHandler.cpp
+++ b/src/IO/DummyIOHandler.cpp
@@ -36,4 +36,9 @@ std::future<void> DummyIOHandler::flush(internal::ParsedFlushParams &)
 {
     return std::future<void>();
 }
+
+std::string DummyIOHandler::backendName() const
+{
+    return "Dummy";
+}
 } // namespace openPMD

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -154,4 +154,10 @@ namespace internal
         }
     }
 } // namespace internal
+
+IOTask::IOTask(IOTask const &) = default;
+IOTask::IOTask(IOTask &&) noexcept = default;
+
+IOTask &IOTask::operator=(IOTask const &) = default;
+IOTask &IOTask::operator=(IOTask &&) noexcept = default;
 } // namespace openPMD

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -875,6 +875,11 @@ Given file pattern: ')END"
                 series.m_filenamePrefix,
                 series.m_filenamePadding,
                 series.m_filenamePostfix,
+                /*
+                 * This might still be ".%E" if the backend is ADIOS2 and no
+                 * files are yet on disk.
+                 * In that case, this will just not find anything.
+                 */
                 series.m_filenameExtension),
             IOHandler()->directory);
         switch (padding)
@@ -884,8 +889,10 @@ Given file pattern: ')END"
                 "Cannot write to a series with inconsistent iteration padding. "
                 "Please specify '%0<N>T' or open as read-only.");
         case -1:
-            std::cerr << "No matching iterations found: " << name()
-                      << std::endl;
+            /*
+             * No matching iterations found. No problem, Append mode is also
+             * fine for creating new datasets.
+             */
             break;
         default:
             series.m_filenamePadding = padding;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -738,6 +738,12 @@ auto Series::initIOHandler(
                 "Unable to automatically determine filename extension. Please "
                 "specify in some way.");
         }
+        else if (input->format == Format::ADIOS2_BP)
+        {
+            // Since ADIOS2 has multiple extensions depending on the engine,
+            // we need to pass this job on to the backend
+            input->filenameExtension = ".%E";
+        }
         else
         {
             input->filenameExtension = suffix(input->format);

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -22,6 +22,7 @@
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerHelper.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/IO/Format.hpp"
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/ReadIterations.hpp"
@@ -559,6 +560,7 @@ template <typename TracingJSON, typename BuildIOHandler>
 auto Series::initIOHandler(
     std::string const &filepath,
     std::string const &options,
+    Access at,
     BuildIOHandler &&buildIOHandler)
     -> std::tuple<
         std::unique_ptr<AbstractIOHandler>,
@@ -568,7 +570,7 @@ auto Series::initIOHandler(
     json::TracingJSON optionsJson =
         json::parseOptions(options, /* considerFiles = */ true);
     auto input = parseInput(filepath);
-    if (input->format == Format::GENERIC)
+    if (input->format == Format::GENERIC && access::read(at))
     {
         auto isPartOfSeries =
             input->iterationEncoding == IterationEncoding::fileBased
@@ -2409,6 +2411,7 @@ Series::Series(
         initIOHandler<json::TracingJSON>(
             filepath,
             options,
+            at,
             [at, comm](
                 ParsedInput const &input,
                 json::TracingJSON optionsJson,
@@ -2436,6 +2439,7 @@ Series::Series(
         initIOHandler<json::TracingJSON>(
             filepath,
             options,
+            at,
             [at](
                 ParsedInput const &input,
                 json::TracingJSON optionsJson,

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -547,8 +547,6 @@ namespace
         {
             for (auto const &entry : auxiliary::list_directory(directory))
             {
-                // std::tie(isContained, padding, iterationIndex) =
-                // auto [isContained, padding, iterationIndex, extension] =
                 Match match = isPartOfSeries(entry);
                 if (match.isContained)
                 {
@@ -764,7 +762,6 @@ auto Series::initIOHandler(
             input->filenameExtension = suffix(input->format);
         }
     }
-    // auto handler = buildIOHandler(*input, optionsJson, filepath);
     return std::make_tuple(std::move(input), std::move(optionsJson));
 }
 
@@ -2693,6 +2690,22 @@ AbstractIOHandler *Series::runDeferredInitialization()
     {
         return nullptr;
     }
+}
+
+AbstractIOHandler *Series::IOHandler()
+{
+    auto res = Attributable::IOHandler();
+    if (res && //  res->backendName() == "Dummy" &&
+        m_series->m_deferred_initialization.has_value())
+    {
+        res = runDeferredInitialization();
+    }
+    return res;
+}
+AbstractIOHandler const *Series::IOHandler() const
+{
+    auto res = Attributable::IOHandler();
+    return res;
 }
 
 namespace

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -683,7 +683,7 @@ auto Series::initIOHandler(
         json::parseOptions(options, /* considerFiles = */ true);
     auto input = parseInput(filepath);
     if (resolve_generic_extension && input->format == Format::GENERIC &&
-        access::read(at))
+        at != Access::CREATE)
     {
         auto isPartOfSeries =
             input->iterationEncoding == IterationEncoding::fileBased
@@ -717,6 +717,14 @@ auto Series::initIOHandler(
         {
             input->filenameExtension = *extension;
             input->format = determineFormat(*extension);
+        }
+        else if (access::read(at))
+        {
+            throw error::ReadError(
+                error::AffectedObject::File,
+                error::Reason::NotFound,
+                std::nullopt,
+                "No file found that matches given pattern '" + filepath + "'.");
         }
     }
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -2415,7 +2415,7 @@ Series::Series(
             [at, comm](
                 ParsedInput const &input,
                 json::TracingJSON optionsJson,
-                std::string const &filepath) {
+                std::string const &filepath_lambda) {
                 return createIOHandler(
                     input.path,
                     at,
@@ -2423,7 +2423,7 @@ Series::Series(
                     input.filenameExtension.value_or(std::string()),
                     comm,
                     std::move(optionsJson),
-                    filepath);
+                    filepath_lambda);
             });
     initSeries(std::move(io_handler), std::move(parsed_input));
     json::warnGlobalUnusedOptions(options_json);
@@ -2443,14 +2443,14 @@ Series::Series(
             [at](
                 ParsedInput const &input,
                 json::TracingJSON optionsJson,
-                std::string const &filepath) {
+                std::string const &filepath_lambda) {
                 return createIOHandler(
                     input.path,
                     at,
                     input.format,
                     input.filenameExtension.value_or(std::string()),
                     std::move(optionsJson),
-                    filepath);
+                    filepath_lambda);
             });
     initSeries(std::move(io_handler), std::move(parsed_input));
     json::warnGlobalUnusedOptions(options_json);

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -718,7 +718,7 @@ auto Series::initIOHandler(
             input->filenameExtension = *extension;
             input->format = determineFormat(*extension);
         }
-        else if (access::read(at))
+        else if (access::readOnly(at))
         {
             throw error::ReadError(
                 error::AffectedObject::File,

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -733,7 +733,7 @@ auto Series::initIOHandler(
             input->filenameExtension = *extension;
             input->format = determineFormat(*extension);
         }
-        else if (access::readOnly(at))
+        else if (access::read(at))
         {
             throw error::ReadError(
                 error::AffectedObject::File,

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -539,9 +539,6 @@ namespace
         std::string const &directory,
         MappingFunction &&mappingFunction)
     {
-        // bool isContained;
-        // int padding;
-        // Series::IterationIndex_t iterationIndex;
         std::set<int> paddings;
         if (auxiliary::directory_exists(directory))
         {

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -713,7 +713,7 @@ auto Series::initIOHandler(
             if (!additional_extensions.empty())
             {
                 std::stringstream error;
-                error << "Found inconsistent filename extensions on disk: ";
+                error << "Found ambiguous filename extensions on disk: ";
                 auto it = additional_extensions.begin();
                 auto end = additional_extensions.end();
                 error << '\'' << *it++ << '\'';

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -317,7 +317,8 @@ this method.
         .def_property("name", &Series::name, &Series::setName)
         .def("flush", &Series::flush, py::arg("backend_config") = "{}")
 
-        .def_property_readonly("backend", &Series::backend)
+        .def_property_readonly(
+            "backend", static_cast<std::string (Series::*)()>(&Series::backend))
 
         // TODO remove in future versions (deprecated)
         .def("set_openPMD", &Series::setOpenPMD)

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -176,7 +176,53 @@ not possible once it has been closed.
             }),
             py::arg("filepath"),
             py::arg("access"),
-            py::arg("options") = "{}")
+            py::arg("options") = "{}",
+            R"END(
+Construct a new Series. Parameters:
+
+* filepath: The file path.
+* at: Access mode.
+* options: Advanced backend configuration via JSON.
+    May be specified as a JSON-formatted string directly, or as a path
+    to a JSON textfile, prepended by an at sign '@'.
+
+For details on access modes, JSON/TOML configuration and iteration encoding,
+refer to:
+
+* https://openpmd-api.readthedocs.io/en/latest/usage/workflow.html#access-modes
+* https://openpmd-api.readthedocs.io/en/latest/details/backendconfig.html
+* https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html#iteration-and-series
+
+In case of file-based iteration encoding, the file names for each
+iteration are determined by an expansion pattern that must be specified.
+It takes one out of two possible forms:
+
+1. Simple form: %T is replaced with the iteration index, e.g.
+   `simData_%T.bp` becomes `simData_50.bp`.
+2. Padded form: e.g. %06T is replaced with the iteration index padded to
+   at least six digits. `simData_%06T.bp` becomes `simData_000050.bp`.
+
+The backend is determined:
+
+1. Explicitly via the JSON/TOML parameter `backend`, e.g. `{"backend":
+   "adios2"}`.
+2. Otherwise implicitly from the filename extension, e.g.
+   `simData_%T.h5`.
+
+The filename extension can be replaced with a globbing pattern %E.
+It will be replaced with an automatically determined file name extension:
+
+1. In CREATE mode: The extension is set to a backend-specific default
+   extension. This requires that the backend is specified via JSON/TOML.
+2. In READ_ONLY, READ_WRITE and READ_LINEAR modes: These modes require
+   that files already exist on disk. The disk will be scanned for files
+   that match the pattern and the resulting file extension will be used.
+   If the result is ambiguous or no such file is found, an error is
+   raised.
+3. In APPEND mode: Like (2.), except if no matching file is found. In
+   that case, the procedure of (1.) is used, owing to the fact that
+   APPEND mode can be used to create new datasets.
+            )END")
 #if openPMD_HAVE_MPI
         .def(
             py::init([](std::string const &filepath,
@@ -246,7 +292,19 @@ not possible once it has been closed.
             py::arg("filepath"),
             py::arg("access"),
             py::arg("mpi_communicator"),
-            py::arg("options") = "{}")
+            py::arg("options") = "{}",
+            R"END(
+Construct a new Series. Parameters:
+
+* filepath: The file path.
+* at: Access mode.
+* options: Advanced backend configuration via JSON.
+    May be specified as a JSON-formatted string directly, or as a path
+    to a JSON textfile, prepended by an at sign '@'.
+* mpi_communicator: The MPI communicator
+
+For further details, refer to the non-MPI overload.
+            )END")
 #endif
         .def("__bool__", &Series::operator bool)
         .def(

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1226,7 +1226,7 @@ TEST_CASE("wildcard_extension", "[core]")
             read.close();
         }
     };
-#if openPMD_HAS_ADIOS_2_9
+#if openPMD_HAVE_ADIOS2
 #ifdef ADIOS2_HAVE_BP5
     run_test(
         R"({"adios2": {"engine": {"type": "bp5"}}, "backend": "adios2"})",

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4436,6 +4436,7 @@ TEST_CASE("adios2_engines_and_file_endings")
                 filesystemExt.empty() ? name : basename + filesystemExt;
             {
                 Series write(name, Access::CREATE, jsonCfg);
+                write.close();
             }
             if (directory)
             {
@@ -5020,9 +5021,6 @@ void variableBasedSingleIteration(std::string const &file)
             file,
             Access::CREATE,
             R"({"iteration_encoding": "variable_based"})");
-        REQUIRE(
-            writeSeries.iterationEncoding() ==
-            IterationEncoding::variableBased);
         auto iterations = writeSeries.writeIterations();
         auto iteration = iterations[0];
         auto E_x = iteration.meshes["E"]["x"];
@@ -5031,6 +5029,9 @@ void variableBasedSingleIteration(std::string const &file)
         std::iota(data.begin(), data.end(), 0);
         E_x.storeChunk(data, {0}, {1000});
         writeSeries.flush();
+        REQUIRE(
+            writeSeries.iterationEncoding() ==
+            IterationEncoding::variableBased);
     }
 
     {


### PR DESCRIPTION
Close #1561

- [x] Merge #1557 first

Diff: https://github.com/franzpoeschel/openPMD-api/compare/refactor-extract-bufferedactions..topic-wildcard-extension

Usage idea:

```
> bin/openpmd-pipe --infile ../samples/git-sample/3d-bp4/example-3d-bp4_%T.%E --outfile out.%E                                                              
Opening data source                                                                                                                                         
Opening data sink                                                                                                                                           
Traceback (most recent call last):                                                                                                                          
  File "/home/franzpoeschel/build/nbuild/bin/openpmd-pipe", line 17, in <module>                                                                            
    pipe.main()                                                                                                                                             
  File "/home/franzpoeschel/build/nbuild/lib/python3.11/site-packages/openpmd_api/pipe/__main__.py", line 366, in main                                      
    run_pipe.run()                                                                                                                                          
  File "/home/franzpoeschel/build/nbuild/lib/python3.11/site-packages/openpmd_api/pipe/__main__.py", line 211, in run                                       
    outseries = io.Series(self.outfile, io.Access.create,                                                                                                   
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                   
openpmd_api.openpmd_api_cxx.ErrorWrongAPIUsage: Wrong API usage: Unable to automatically determine filename extension. Please specify in some way.          
[~Series] An error occurred: fileBased output can not be written with no iterations.


> bin/openpmd-pipe --infile ../samples/git-sample/3d-bp4/example-3d-bp4_%T.%E --outfile out.%E --outconfig 'backend = "hdf5"'
Opening data source
Opening data sink
Opened input and output
Iteration 550 contains 9 meshes:
         B
         E
         e_all_chargeDensity
         e_all_energyDensity
         e_all_particleMomentumComponent
         i_all_chargeDensity
         i_all_energyDensity
         i_all_particleMomentumComponent
         picongpu_idProvider

Iteration 550 contains 2 particle species:
[…]


> ls 
out.h5


> bin/openpmd-ls out.%E                                  
openPMD series: out
openPMD standard: 1.1.0
openPMD extensions: 0

data author: unknown
data created: 2021-07-15 13:51:27 +0000 
data backend: HDF5
generating machine: unknown
generating software: PIConGPU (version: 0.6.0-dev)
generating software dependencies: unknown

number of iterations: 2 (groupBased)
  all iterations: 550 600 

number of meshes: 0 # this is a bug

number of particle species: 2
  all particle species:
    e
    i



> bin/openpmd-pipe --infile ../samples/git-sample/3d-bp4/example-3d-bp4_%T.%E --outfile out.%E --outconfig 'backend = "adios2"'
Opening data source
Opening data sink
Opened input and output
Iteration 550 contains 9 meshes:
         B
         E
         e_all_chargeDensity
         e_all_energyDensity
         e_all_particleMomentumComponent
         i_all_chargeDensity
         i_all_energyDensity
         i_all_particleMomentumComponent
         picongpu_idProvider

Iteration 550 contains 2 particle species:



> ls 
out.bp
out.h5



> bin/openpmd-ls out.%E            
An error occurred while opening the specified openPMD series!
Read Error in frontend 
Object type:    File
Error type:     Other
Further description:    Found ambiguous filename extensions on disk: '.h5' and '.bp'.
```

Todo:

- [x] Testing
- [x] Documentation
- [x] (Maybe) Adapt for Linear and Append access types
- [x] Fix (probably unrelated) bug found in openpmd-pipe