### PR TITLE
Fix: Strings with a single char in Python

### DIFF
--- a/include/openPMD/auxiliary/TypeTraits.hpp
+++ b/include/openPMD/auxiliary/TypeTraits.hpp
@@ -103,6 +103,27 @@ namespace detail
         constexpr static bool value = true;
         using type = T;
     };
+
+    template <typename>
+    struct IsChar
+    {
+        constexpr static bool value = false;
+    };
+    template <>
+    struct IsChar<char>
+    {
+        constexpr static bool value = true;
+    };
+    template <>
+    struct IsChar<signed char>
+    {
+        constexpr static bool value = true;
+    };
+    template <>
+    struct IsChar<unsigned char>
+    {
+        constexpr static bool value = true;
+    };
 } // namespace detail
 
 template <typename T>
@@ -116,6 +137,9 @@ inline constexpr bool IsPointer_v = detail::IsPointer<T>::value;
 
 template <typename T>
 using IsPointer_t = typename detail::IsPointer<T>::type;
+
+template <typename C>
+inline constexpr bool IsChar_v = detail::IsChar<C>::value;
 
 /** Emulate in the C++ concept ContiguousContainer
  *

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -139,7 +139,7 @@ Mesh &Mesh::setDataOrder(Mesh::DataOrder dor)
 
 std::vector<std::string> Mesh::axisLabels() const
 {
-    return getAttribute("axisLabels").get<std::vector<std::string> >();
+    return getAttribute("axisLabels").get<std::vector<std::string>>();
 }
 
 Mesh &Mesh::setAxisLabels(std::vector<std::string> const &als)
@@ -165,7 +165,7 @@ template Mesh &Mesh::setGridSpacing(std::vector<long double> const &gs);
 
 std::vector<double> Mesh::gridGlobalOffset() const
 {
-    return getAttribute("gridGlobalOffset").get<std::vector<double> >();
+    return getAttribute("gridGlobalOffset").get<std::vector<double>>();
 }
 
 Mesh &Mesh::setGridGlobalOffset(std::vector<double> const &ggo)
@@ -331,9 +331,9 @@ void Mesh::read()
     aRead.name = "axisLabels";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    if (*aRead.dtype == DT::VEC_STRING || *aRead.dtype == DT::STRING)
-        setAxisLabels(
-            Attribute(*aRead.resource).get<std::vector<std::string> >());
+    Attribute a = Attribute(*aRead.resource);
+    if (auto val = a.getOptional<std::vector<std::string>>(); val.has_value())
+        setAxisLabels(*val);
     else
         throw error::ReadError(
             error::AffectedObject::Attribute,
@@ -346,16 +346,16 @@ void Mesh::read()
     aRead.name = "gridSpacing";
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
-    Attribute a = Attribute(*aRead.resource);
+    a = Attribute(*aRead.resource);
     if (*aRead.dtype == DT::VEC_FLOAT || *aRead.dtype == DT::FLOAT)
-        setGridSpacing(a.get<std::vector<float> >());
+        setGridSpacing(a.get<std::vector<float>>());
     else if (*aRead.dtype == DT::VEC_DOUBLE || *aRead.dtype == DT::DOUBLE)
-        setGridSpacing(a.get<std::vector<double> >());
+        setGridSpacing(a.get<std::vector<double>>());
     else if (
         *aRead.dtype == DT::VEC_LONG_DOUBLE || *aRead.dtype == DT::LONG_DOUBLE)
-        setGridSpacing(a.get<std::vector<long double> >());
+        setGridSpacing(a.get<std::vector<long double>>());
     // conversion cast if a backend reports an integer type
-    else if (auto val = a.getOptional<std::vector<double> >(); val.has_value())
+    else if (auto val = a.getOptional<std::vector<double>>(); val.has_value())
         setGridSpacing(val.value());
     else
         throw error::ReadError(
@@ -370,7 +370,7 @@ void Mesh::read()
     IOHandler()->enqueue(IOTask(this, aRead));
     IOHandler()->flush(internal::defaultFlushParams);
     if (auto val =
-            Attribute(*aRead.resource).getOptional<std::vector<double> >();
+            Attribute(*aRead.resource).getOptional<std::vector<double>>();
         val.has_value())
         setGridGlobalOffset(val.value());
     else

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <map>
 #include <optional>
+#include <pybind11/pytypes.h>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -336,6 +337,16 @@ struct char_to_explicit_char<false>
 template <typename TargetType>
 std::optional<TargetType> tryCast(py::object const &obj)
 {
+    // Do a check to avoid throwing exceptions
+    if constexpr (std::is_default_constructible_v<TargetType>)
+    {
+        TargetType val{};
+        auto python_val = py::cast(std::move(val));
+        if (!py::isinstance(obj, python_val.get_type()))
+        {
+            return std::nullopt;
+        }
+    }
     try
     {
         return obj.cast<TargetType>();


### PR DESCRIPTION
Follow-up to #1517

Problem: In `pipe/__main__.py`, `dest.set_attribute(key, attr, attr_type)` cannot distinguish strings with size 1 from chars (except for explicit char types `signed char` and `unsigned char`). 

Before #1517, that call converted chars up to string, now it converts strings down to chars.

Old behavior:
```
  string    /data/600/fields/i_all_energyDensity/axisLabels                         attr   = {"z", "y", "x"}                                                                                                                                                                                                               
```

New behavior
```
  char      /data/600/fields/e_all_energyDensity/axisLabels                         attr   = {z, y, x}
```

Since values such as `axisLabels = ["x", "y", "z"]` are very frequent, the old behavior was less intrusive.

This PR:

1. Switches back to the old behavior (i.e. cancels out the attempts to cast to `char`, but keeps the attempts to cast to explicit `signed` or `unsigned char`)
2. Makes `Attribute::getOptional<>()` more flexible in such conversions (Currently `openpmd-pipe` creates unreadable files)

