### PR TITLE
Don't allow Container insertion in READ_LINEAR

### DIFF
--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/Error.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/backend/Attributable.hpp"
 
 #include <initializer_list>
@@ -289,7 +290,7 @@ public:
         {
             if (IOHandler()->m_seriesStatus !=
                     internal::SeriesStatus::Parsing &&
-                Access::READ_ONLY == IOHandler()->m_frontendAccess)
+                access::readOnly(IOHandler()->m_frontendAccess))
             {
                 auxiliary::OutOfRangeMsg const out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));
@@ -330,7 +331,7 @@ public:
         {
             if (IOHandler()->m_seriesStatus !=
                     internal::SeriesStatus::Parsing &&
-                Access::READ_ONLY == IOHandler()->m_frontendAccess)
+                access::readOnly(IOHandler()->m_frontendAccess))
             {
                 auxiliary::OutOfRangeMsg out_of_range_msg;
                 throw std::out_of_range(out_of_range_msg(key));

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -737,7 +737,12 @@ std::future<void> Series::flush_impl(
     }
     catch (...)
     {
-        IOHandler()->m_lastFlushSuccessful = false;
+        auto handler = IOHandler();
+        handler->m_lastFlushSuccessful = false;
+        while (!handler->m_work.empty())
+        {
+            handler->m_work.pop();
+        }
         throw;
     }
 }


### PR DESCRIPTION
`Container<T>::operator[]()` currently only checks if the access type is `READ_ONLY`, but insertion should also be disallowed in `READ_LINEAR` mode.

While debugging this, I noticed that the IO queue was not cleared when encountering exceptions. In order to allow clean destruction, this PR also drains the IO queue in such a case.
Potential future todo: Don't modify the data structures until a flush was successful, so the operation can be repeated. For now, this allows clean destruction and avoids segfaults.