### PR TITLE
CI: Fix CircleCI "six"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             sudo .github/workflows/dependencies/install_spack
             python3 -m pip install -U pip
             python3 -m pip install -U packaging setuptools wheel
+            python3 -m pip install -U six
             python3 -m pip install -U numpy
             python3 -m pip install -U mpi4py
             python3 -m pip install -U pandas


### PR DESCRIPTION
```
...
  File "/opt/spack/lib/spack/llnl/util/tty/__init__.py", line 20, in <module>
    from six.moves import input
ModuleNotFoundError: No module named 'six.moves'
```