### PR TITLE
CI: Spack v0.23.0

### DIFF
--- a/.github/ci/spack-envs/clang14_py311_nompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clang14_py311_nompi_h5_ad2/spack.yaml
@@ -17,7 +17,7 @@ spack:
     cmake:
       externals:
       - spec: cmake@3.22.1
-        prefix: /usr
+        prefix: /usr/local
       buildable: False
     perl:
       externals:

--- a/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2/spack.yaml
@@ -16,7 +16,7 @@ spack:
     cmake:
       externals:
       - spec: cmake@3.23.0
-        prefix: /usr
+        prefix: /usr/local
       buildable: False
     openmpi:
       externals:

--- a/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2/spack.yaml
@@ -60,3 +60,6 @@ spack:
 
   mirrors:
     E4S: https://cache.e4s.io
+    local-buildcache:
+      url: oci://ghcr.io/openPMD/spack-buildcache
+      signed: false

--- a/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2/spack.yaml
@@ -12,7 +12,7 @@ spack:
 
   packages:
     adios2:
-      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2 ~blosc2
+      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2 ~mgard ~blosc2
     cmake:
       externals:
       - spec: cmake@3.23.0

--- a/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2_libcpp/spack.yaml
+++ b/.github/ci/spack-envs/clang7_nopy_ompi_h5_ad2_libcpp/spack.yaml
@@ -16,7 +16,7 @@ spack:
     cmake:
       externals:
       - spec: cmake@3.23.0
-        prefix: /usr
+        prefix: /usr/local
       buildable: False
     openmpi:
       externals:

--- a/.github/ci/spack-envs/clang8_py38_mpich_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clang8_py38_mpich_h5_ad2/spack.yaml
@@ -16,7 +16,7 @@ spack:
     cmake:
       externals:
       - spec: cmake@3.23.0
-        prefix: /usr
+        prefix: /usr/local
       buildable: False
     mpich:
       externals:

--- a/.github/ci/spack-envs/clang8_py38_mpich_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clang8_py38_mpich_h5_ad2/spack.yaml
@@ -12,7 +12,7 @@ spack:
 
   packages:
     adios2:
-      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2 ~blosc2
+      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2 ~mgard ~blosc2
     cmake:
       externals:
       - spec: cmake@3.23.0

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -12,7 +12,7 @@ spack:
 
   packages:
     adios2:
-      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
+      variants: ~mgard ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
     cmake:
       externals:
       - spec: cmake@3.23.0

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -16,7 +16,7 @@ spack:
     cmake:
       externals:
       - spec: cmake@3.23.0
-        prefix: /usr
+        prefix: /usr/local
       buildable: False
     openmpi:
       externals:

--- a/.github/ci/spack-envs/gcc7_py36_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/gcc7_py36_ompi_h5_ad2/spack.yaml
@@ -12,7 +12,7 @@ spack:
 
   packages:
     adios2:
-      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
+      variants: ~mgard ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
     cmake:
       externals:
       - spec: cmake@3.23.0

--- a/.github/ci/spack-envs/gcc7_py36_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/gcc7_py36_ompi_h5_ad2/spack.yaml
@@ -16,7 +16,7 @@ spack:
     cmake:
       externals:
       - spec: cmake@3.23.0
-        prefix: /usr
+        prefix: /usr/local
       buildable: False
     openmpi:
       externals:

--- a/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
+++ b/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
@@ -12,7 +12,7 @@ spack:
 
   packages:
     adios2:
-      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
+      variants: ~mgard ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
     cmake:
       externals:
       - spec: cmake@3.22.1

--- a/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
+++ b/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
@@ -16,7 +16,7 @@ spack:
     cmake:
       externals:
       - spec: cmake@3.22.1
-        prefix: /usr
+        prefix: /usr/local
       buildable: False
     libfabric:
       externals:

--- a/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
+++ b/.github/ci/spack-envs/gcc_py_ompi_h5_ad2_arm64/spack.yaml
@@ -6,7 +6,7 @@
 #
 spack:
   specs:
-  - adios2
+  - adios2@2.10
   - hdf5
   - openmpi
 

--- a/.github/workflows/dependencies/install_spack
+++ b/.github/workflows/dependencies/install_spack
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-spack_ver="0.21.1"
+spack_ver="0.21.2"
 
 cd /opt
 if [[ -d spack && ! -f spack_${spack_ver} ]]

--- a/.github/workflows/dependencies/install_spack
+++ b/.github/workflows/dependencies/install_spack
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-spack_ver="0.22.1"
+spack_ver="0.22.2"
 
 cd /opt
 if [[ -d spack && ! -f spack_${spack_ver} ]]

--- a/.github/workflows/dependencies/install_spack
+++ b/.github/workflows/dependencies/install_spack
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-spack_ver="0.21.2"
+spack_ver="0.22.0"
 
 cd /opt
 if [[ -d spack && ! -f spack_${spack_ver} ]]

--- a/.github/workflows/dependencies/install_spack
+++ b/.github/workflows/dependencies/install_spack
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-spack_ver="0.22.0"
+spack_ver="0.22.1"
 
 cd /opt
 if [[ -d spack && ! -f spack_${spack_ver} ]]

--- a/.github/workflows/dependencies/install_spack
+++ b/.github/workflows/dependencies/install_spack
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-spack_ver="0.22.3"
+spack_ver="0.21.1"
 
 cd /opt
 if [[ -d spack && ! -f spack_${spack_ver} ]]

--- a/.github/workflows/dependencies/install_spack
+++ b/.github/workflows/dependencies/install_spack
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-spack_ver="0.22.2"
+spack_ver="0.23.0"
 
 cd /opt
 if [[ -d spack && ! -f spack_${spack_ver} ]]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -86,6 +86,8 @@ jobs:
 
   clang7_nopy_ompi_h5_ad2:
     runs-on: ubuntu-20.04
+    permissions:
+      packages: write
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4
@@ -96,13 +98,20 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install clang-7 gfortran libopenmpi-dev python3
-        sudo .github/workflows/dependencies/install_spack
+    - name: Set up Spack
+      uses: spack/setup-spack@v2
+      with:
+        ref: 187b8adb4faa7ad8e5de0baab9a610d158772823
+        buildcache: true
+        color: true
+        path: /opt/spack
     - name: Build
       env: {CC: clang-7, CXX: clang++-7, CXXFLAGS: -Werror}
+      shell: spack-bash {0}
       run: |
         sudo ln -s "$(which cmake)" /usr/bin/cmake
         eval $(spack env activate --sh .github/ci/spack-envs/clang7_nopy_ompi_h5_ad2/)
-        spack install
+        spack install --no-check-signature
 
         share/openPMD/download_samples.sh build
         cmake -S . -B build \
@@ -115,6 +124,12 @@ jobs:
         cmake --build build --parallel 2
         cd build
         ctest --output-on-failure
+
+    - name: Push packages and update index
+      run: |
+        spack -e . mirror set --push --oci-username ${{ github.actor }} --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
+        spack -e . buildcache push --base-image ubuntu:20.04 --update-index local-buildcache
+      if: ${{ !cancelled() }}
 
 # TODO
 #  clang7_py36_nompi_h5_ad2_libstdc++

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Spack
       uses: spack/setup-spack@v2
       with:
-        ref: 187b8adb4faa7ad8e5de0baab9a610d158772823
+        ref: v0.22.0
         buildcache: true
         color: true
         path: opt/spack

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Spack
       uses: spack/setup-spack@v2
       with:
-        ref: v0.22.1
+        ref: v0.22.2
         buildcache: true
         color: true
         path: opt/spack

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -104,7 +104,7 @@ jobs:
         ref: 187b8adb4faa7ad8e5de0baab9a610d158772823
         buildcache: true
         color: true
-        path: /opt/spack
+        path: opt/spack
     - name: Build
       env: {CC: clang-7, CXX: clang++-7, CXXFLAGS: -Werror}
       shell: spack-bash {0}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Spack
       uses: spack/setup-spack@v2
       with:
-        ref: v0.22.0
+        ref: v0.22.1
         buildcache: true
         color: true
         path: opt/spack

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Spack
       uses: spack/setup-spack@v2
       with:
-        ref: v0.22.2
+        ref: v0.23.0
         buildcache: true
         color: true
         path: opt/spack

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -20,6 +20,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install clang clang-tidy gfortran libopenmpi-dev python
+
+        which cmake
+
         sudo .github/workflows/dependencies/install_spack
     - name: Build
       env: {CC: clang, CXX: clang++}


### PR DESCRIPTION
Update Spack in CI to the latest stable release.

- [ ] consistently use E4S and local build caches
- [ ] enable blosc2 (and maybe mgard) again from #1711

Will need:
- [x] Spack 0.22.0: https://github.com/spack/spack/pull/42881

As a follow up
- [x] We could use the GH action of spack, which includes caching by default 
https://github.com/spack/setup-spack