### PR TITLE
Fix hdf5 dataset specific config

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -494,17 +494,20 @@ void HDF5IOHandlerImpl::createDataset(
                     *m_buffered_dataset_config,
                     nlohmann::json::parse(mask_for_global_conf));
             }
+            auto const &buffered_config = *m_buffered_dataset_config;
             auto parsed_config = json::parseOptions(
                 parameters.options, /* considerFiles = */ false);
             if (auto hdf5_config_it = parsed_config.config.find("hdf5");
                 hdf5_config_it != parsed_config.config.end())
             {
-                hdf5_config_it.value() = json::merge(
-                    *m_buffered_dataset_config, hdf5_config_it.value());
+                auto copy = buffered_config;
+                json::merge(copy, hdf5_config_it.value());
+                copy = nlohmann::json{{"hdf5", std::move(copy)}};
+                parsed_config.config = std::move(copy);
             }
             else
             {
-                parsed_config.config["hdf5"] = *m_buffered_dataset_config;
+                parsed_config.config["hdf5"] = buffered_config;
             }
             return parsed_config;
         }();

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -336,6 +336,13 @@ TEST_CASE("hdf5_write_test", "[parallel][hdf5]")
         "hdf5.dataset.chunks = [" + std::to_string(mpi_size) + "]"));
     e["positionOffset"]["x"].storeChunk(positionOffset_local, {mpi_rank}, {1});
 
+    // Test that chunking settings are not carried over to other datasets.
+    // Just declare a dataset smaller than the previously chunks size to trigger
+    // a failure in case the chunking is erroneously carried over.
+    e["positionOffset"]["y"].resetDataset({Datatype::FLOAT, {1}});
+    e["positionOffset"]["y"].storeChunk(
+        std::make_unique<float>(3.141592654), {0}, {1});
+
     o.flush();
 }
 


### PR DESCRIPTION
Follow-up to #1591 

That PR has a bug (concerning only the newly added behavior). The global dataset config is buffered in the HDF5 backend, but I accidentally manipulated it upon reading, meaning that the chunking configs can leak into other dataset.

This fixes that.