### PR TITLE
ADIOS2 variable shape LocalValue

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -223,6 +223,17 @@ Explanation of the single keys:
 
   * ``type`` supported ADIOS operator type, e.g. zfp, sz
   * ``parameters`` is an associative map of string parameters for the operator (e.g. compression levels)
+* ``adios2.dataset.shape`` (advanced): Specify the `dataset shape <https://adios2.readthedocs.io/en/v2.10.0/components/components.html#shapes>`_ for the ADIOS2 variable.
+  Note that variable shapes will generally imply a different way of interacting with a variable, and some variable shapes (such as *joined arrays*) may not be accessible via this parameter, but via different API calls instead.
+  This parameter's purpose to select different implementations for the same used API call.
+  Supported values by this parameter are:
+
+  * ``"global_array"`` (default): The variable is a (n-dimensional) array with a globally defined size. Local blocks, subsets of the global region, are written by parallel writers.
+  * ``"local_value"``: Each parallel writer contributes one single value to the dataset, joined into a 1-dimensional array.
+    Since there (currently) exists no dedicated API call for this shape in the openPMD-api, this setting is only useful as an optimization since "local value" variables participate in ADIOS2 metadata aggregation.
+    Can only be applied if the global shape (1-dimensional array the same length as number of parallel instances) and the local blocks (a single data item) are specified correctly.
+    Use global or joined arrays otherwise.
+
 * ``adios2.use_span_based_put``: The openPMD-api exposes the `span-based Put() API <https://adios2.readthedocs.io/en/latest/components/components.html#put-modes-and-memory-contracts>`_ of ADIOS2 via an overload of ``RecordComponent::storeChunk()``.
   This API is incompatible with compression operators as described above.
   The openPMD-api will automatically use a fallback implementation for the span-based Put() API if any operator is added to a dataset.

--- a/examples/10_streaming_read.cpp
+++ b/examples/10_streaming_read.cpp
@@ -87,7 +87,8 @@ int main()
                 for (auto const &chunk : rc.second.availableChunks())
                 {
                     std::cout << "\n\tRank " << chunk.sourceID << "\t"
-                              << auxiliary::vec_as_string(chunk.offset) << "\t– "
+                              << auxiliary::vec_as_string(chunk.offset)
+                              << "\t– "
                               << auxiliary::vec_as_string(chunk.extent);
                 }
                 std::cout << std::endl;

--- a/examples/10_streaming_read.cpp
+++ b/examples/10_streaming_read.cpp
@@ -87,8 +87,8 @@ int main()
                 for (auto const &chunk : rc.second.availableChunks())
                 {
                     std::cout << "\n\tRank " << chunk.sourceID << "\t"
-                              << auxiliary::format_vec(chunk.offset) << "\t– "
-                              << auxiliary::format_vec(chunk.extent);
+                              << auxiliary::vec_as_string(chunk.offset) << "\t– "
+                              << auxiliary::vec_as_string(chunk.extent);
                 }
                 std::cout << std::endl;
             }

--- a/examples/10_streaming_read.cpp
+++ b/examples/10_streaming_read.cpp
@@ -18,8 +18,8 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#include <openPMD/openPMD.hpp>
 #include <openPMD/auxiliary/StringManip.hpp>
+#include <openPMD/openPMD.hpp>
 
 #include <algorithm>
 #include <array>

--- a/examples/10_streaming_read.cpp
+++ b/examples/10_streaming_read.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <openPMD/openPMD.hpp>
+#include <openPMD/auxiliary/StringManip.hpp>
 
 #include <algorithm>
 #include <array>
@@ -73,6 +74,24 @@ int main()
             loadedChunks[i] = rc.loadChunkVariant(
                 Offset(rc.getDimensionality(), 0), rc.getExtent());
             extents[i] = rc.getExtent();
+        }
+
+        auto e_patches = iteration.particles["e"].particlePatches;
+        for (auto key :
+             {"numParticles", "numParticlesOffset", "offset", "extent"})
+        {
+            for (auto &rc : e_patches[key])
+            {
+                std::cout << "Chunks for '" << rc.second.myPath().openPMDPath()
+                          << "':";
+                for (auto const &chunk : rc.second.availableChunks())
+                {
+                    std::cout << "\n\tRank " << chunk.sourceID << "\t"
+                              << auxiliary::format_vec(chunk.offset) << "\t– "
+                              << auxiliary::format_vec(chunk.extent);
+                }
+                std::cout << std::endl;
+            }
         }
 
         // The iteration can be closed in order to help free up resources.

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -26,6 +26,10 @@
 #include <memory>
 #include <numeric> // std::iota
 
+#if openPMD_HAVE_MPI
+#include <mpi.h>
+#endif
+
 using std::cout;
 using namespace openPMD;
 

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -19,7 +19,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <openPMD/openPMD.hpp>
-#include <mpi.h>
 
 #include <algorithm>
 #include <iostream>

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -112,6 +112,7 @@ int main()
         // fully interconnected communication meshes for data that needs to be
         // read by each reader. A local value dataset can only contain a single
         // item per MPI rank, forming an array of length equal to the MPI size.
+        // https://adios2.readthedocs.io/en/v2.9.2/components/components.html#shapes
 
         auto e_patches = iteration.particles["e"].particlePatches;
         auto numParticles = e_patches["numParticles"];

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -18,9 +18,8 @@
  * and the GNU Lesser General Public License along with openPMD-api.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#include "openPMD/Series.hpp"
-#include "openPMD/snapshots/Snapshots.hpp"
 #include <openPMD/openPMD.hpp>
+#include <mpi.h>
 
 #include <algorithm>
 #include <iostream>
@@ -41,6 +40,14 @@ int main()
         return 0;
     }
 
+    int mpi_rank{0}, mpi_size{1};
+
+#if openPMD_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+#endif
+
     // open file for writing
     // use QueueFullPolicy = Discard in order to create a situation where from
     // the reader's perspective steps are skipped. This tests the bug reported
@@ -50,7 +57,13 @@ int main()
     // Iterations can be accessed independently from one another. This more
     // restricted mode enables performance optimizations in the backends, and
     // more importantly is compatible with streaming I/O.
-    Series series = Series("electrons.sst", Access::CREATE_LINEAR, R"(
+    Series series = Series(
+        "electrons.sst",
+        Access::CREATE_LINEAR,
+#if openPMD_HAVE_MPI
+        MPI_COMM_WORLD,
+#endif
+        R"(
 {
   "adios2": {
     "engine": {
@@ -60,11 +73,13 @@ int main()
       }
     }
   }
-})");
+})"
+
+    );
 
     Datatype datatype = determineDatatype<position_t>();
     constexpr unsigned long length = 10ul;
-    Extent global_extent = {length};
+    Extent global_extent = {mpi_size * length};
     Dataset dataset = Dataset(datatype, global_extent);
     std::shared_ptr<position_t> local_data(
         new position_t[length], [](position_t const *ptr) { delete[] ptr; });
@@ -75,13 +90,66 @@ int main()
         Iteration iteration = iterations[i];
         Record electronPositions = iteration.particles["e"]["position"];
 
-        std::iota(local_data.get(), local_data.get() + length, i * length);
+        std::iota(
+            local_data.get(),
+            local_data.get() + length,
+            i * length * mpi_size + mpi_rank * length);
         for (auto const &dim : {"x", "y", "z"})
         {
             RecordComponent pos = electronPositions[dim];
             pos.resetDataset(dataset);
-            pos.storeChunk(local_data, Offset{0}, global_extent);
+            pos.storeChunk(local_data, Offset{length * mpi_rank}, {length});
         }
+
+        // Use the `local_value` ADIOS2 dataset shape to send a dataset not via
+        // the data plane, but the control plane of ADIOS2 SST. This is
+        // advisable for datasets where each rank contributes only a single item
+        // since the control plane performs data aggregation, thus avoiding
+        // fully interconnected communication meshes for data that needs to be
+        // read by each reader. A local value dataset can only contain a single
+        // item per MPI rank, forming an array of length equal to the MPI size.
+
+        auto e_patches = iteration.particles["e"].particlePatches;
+        auto numParticles = e_patches["numParticles"];
+        auto numParticlesOffset = e_patches["numParticlesOffset"];
+        for (auto rc : {&numParticles, &numParticlesOffset})
+        {
+            rc->resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type(mpi_size)},
+                 R"(adios2.dataset.shape = "local_value")"});
+        }
+        numParticles.storeChunk(
+            std::make_unique<unsigned long>(10), {size_t(mpi_rank)}, {1});
+        numParticlesOffset.storeChunk(
+            std::make_unique<unsigned long>(10 * ((unsigned long)mpi_rank)),
+            {size_t(mpi_rank)},
+            {1});
+        auto offset = e_patches["offset"];
+        for (auto const &dim : {"x", "y", "z"})
+        {
+            auto rc = offset[dim];
+            rc.resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type(mpi_size)},
+                 R"(adios2.dataset.shape = "local_value")"});
+            rc.storeChunk(
+                std::make_unique<unsigned long>((unsigned long)mpi_rank),
+                {size_t(mpi_rank)},
+                {1});
+        }
+        auto extent = e_patches["extent"];
+        for (auto const &dim : {"x", "y", "z"})
+        {
+            auto rc = extent[dim];
+            rc.resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type(mpi_size)},
+                 R"(adios2.dataset.shape = "local_value")"});
+            rc.storeChunk(
+                std::make_unique<unsigned long>(1), {size_t(mpi_rank)}, {1});
+        }
+
         iteration.close();
     }
 
@@ -92,6 +160,10 @@ int main()
      * calling the destructor, including the release of file handles.
      */
     series.close();
+
+#if openPMD_HAVE_MPI
+    MPI_Finalize();
+#endif
 
     return 0;
 #else

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -40,7 +40,6 @@
 #include "openPMD/backend/Variant_internal.hpp"
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/config.hpp"
-#include <stdexcept>
 
 #if openPMD_HAVE_ADIOS2
 #include <adios2.h>
@@ -350,12 +349,19 @@ private:
     // use m_config
     std::optional<std::vector<ParameterizedOperator>> getOperators();
 
+    enum class Shape
+    {
+        GlobalArray,
+        LocalValue
+    };
+
     template <typename Parameter>
-    std::vector<ParameterizedOperator> getDatasetOperators(
+    auto parseDatasetConfig(
         Parameter const &,
         Writable *,
         std::string const &varName,
-        std::vector<ParameterizedOperator> default_operators = {});
+        std::vector<ParameterizedOperator> default_operators = {})
+        -> std::tuple<std::vector<ParameterizedOperator>, Shape>;
 
     std::string fileSuffix(bool verbose = true) const;
 
@@ -554,6 +560,10 @@ private:
         }
         // TODO leave this check to ADIOS?
         adios2::Dims shape = var.Shape();
+        if (shape == adios2::Dims{adios2::LocalValueDim})
+        {
+            return var;
+        }
         auto actualDim = shape.size();
         {
             auto requiredDim = extent.size();

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -306,9 +306,12 @@ private:
         adios2::Params params;
     };
 
-    std::vector<ParameterizedOperator> defaultOperators;
+    // read operators can (currently) not be specified per dataset, so parse
+    // them once and then buffer them
+    std::vector<ParameterizedOperator> readOperators;
 
     json::TracingJSON m_config;
+    std::optional<nlohmann::json> m_buffered_dataset_config;
     static json::TracingJSON nullvalue;
 
     template <typename Callback>
@@ -349,7 +352,10 @@ private:
 
     template <typename Parameter>
     std::vector<ParameterizedOperator> getDatasetOperators(
-        Parameter const &, Writable *, std::string const &varName);
+        Parameter const &,
+        Writable *,
+        std::string const &varName,
+        std::vector<ParameterizedOperator> default_operators = {});
 
     std::string fileSuffix(bool verbose = true) const;
 

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -243,6 +243,14 @@ namespace auxiliary
         return std::forward<S>(s);
     }
 
+    /** Write a string representation of a vector or another iterable
+     *  container to a stream.
+     *
+     * @param s The stream to write to.
+     * @param vec The vector or other iterable container.
+     * @return The modified stream. Each item is
+     *         formatted using the default definition for operator<<().
+     */
     template <typename Stream, typename Vec>
     auto write_vec_to_stream(Stream &&s, Vec const &vec) -> Stream &&
     {
@@ -265,6 +273,13 @@ namespace auxiliary
         return std::forward<Stream>(s);
     }
 
+    /** Create a string representation of a vector or another iterable
+     *  container.
+     *
+     * @param vec The vector or other iterable container.
+     * @return A string that shows the items of the container. Each item is
+     *         formatted using the default definition for operator<<().
+     */
     template <typename Vec>
     auto vec_as_string(Vec const &vec) -> std::string
     {

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -112,14 +112,16 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
                     std::nullopt,
                     ba.variables());
 
-                if (var.Shape() == adios2::Dims{adios2::LocalValue})
+                if (var.Shape() == adios2::Dims{adios2::LocalValueDim})
                 {
                     if (bp.param.extent != Extent{1})
                     {
                         throw error::OperationUnsupportedInBackend(
                             "ADIOS2",
                             "Can only write a single element to LocalValue "
-                            "variables (extent == Extent{1}).");
+                            "variables (extent == Extent{1}, but extent of '" +
+                                bp.name + " was " +
+                                auxiliary::format_vec(bp.param.extent) + "').");
                     }
                     engine.Put(var, *ptr);
                 }
@@ -189,14 +191,16 @@ struct RunUniquePtrPut
             bufferedPut.name,
             std::nullopt,
             ba.variables());
-        if (var.Shape() == adios2::Dims{adios2::LocalValue})
+        if (var.Shape() == adios2::Dims{adios2::LocalValueDim})
         {
             if (bufferedPut.extent != Extent{1})
             {
                 throw error::OperationUnsupportedInBackend(
                     "ADIOS2",
                     "Can only write a single element to LocalValue "
-                    "variables (extent == Extent{1}).");
+                    "variables (extent == Extent{1}, but extent of '" +
+                        bufferedPut.name + " was " +
+                        auxiliary::format_vec(bufferedPut.extent) + "').");
             }
             engine.Put(var, *ptr);
         }

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -112,7 +112,21 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
                     std::nullopt,
                     ba.variables());
 
-                engine.Put(var, ptr);
+                if (var.Shape() == adios2::Dims{adios2::LocalValue})
+                {
+                    if (bp.param.extent != Extent{1})
+                    {
+                        throw error::OperationUnsupportedInBackend(
+                            "ADIOS2",
+                            "Can only write a single element to LocalValue "
+                            "variables (extent == Extent{1}).");
+                    }
+                    engine.Put(var, *ptr);
+                }
+                else
+                {
+                    engine.Put(var, ptr);
+                }
             }
             else if constexpr (
                 std::is_same_v<
@@ -175,7 +189,21 @@ struct RunUniquePtrPut
             bufferedPut.name,
             std::nullopt,
             ba.variables());
-        engine.Put(var, ptr);
+        if (var.Shape() == adios2::Dims{adios2::LocalValue})
+        {
+            if (bufferedPut.extent != Extent{1})
+            {
+                throw error::OperationUnsupportedInBackend(
+                    "ADIOS2",
+                    "Can only write a single element to LocalValue "
+                    "variables (extent == Extent{1}).");
+            }
+            engine.Put(var, *ptr);
+        }
+        else
+        {
+            engine.Put(var, ptr);
+        }
     }
 
     static constexpr char const *errorMsg = "RunUniquePtrPut";

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -122,7 +122,8 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
                             "Can only write a single element to LocalValue "
                             "variables (extent == Extent{1}, but extent of '" +
                                 bp.name + " was " +
-                                auxiliary::format_vec(bp.param.extent) + "').");
+                                auxiliary::vec_as_string(bp.param.extent) +
+                                "').");
                     }
                     engine.Put(var, *ptr);
                 }
@@ -202,7 +203,7 @@ struct RunUniquePtrPut
                     "Can only write a single element to LocalValue "
                     "variables (extent == Extent{1}, but extent of '" +
                         bufferedPut.name + " was " +
-                        auxiliary::format_vec(bufferedPut.extent) + "').");
+                        auxiliary::vec_as_string(bufferedPut.extent) + "').");
             }
             engine.Put(var, *ptr);
         }

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -112,6 +112,7 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
                     std::nullopt,
                     ba.variables());
 
+                // https://adios2.readthedocs.io/en/v2.9.2/components/components.html#shapes
                 if (var.Shape() == adios2::Dims{adios2::LocalValueDim})
                 {
                     if (bp.param.extent != Extent{1})
@@ -191,6 +192,7 @@ struct RunUniquePtrPut
             bufferedPut.name,
             std::nullopt,
             ba.variables());
+        // https://adios2.readthedocs.io/en/v2.9.2/components/components.html#shapes
         if (var.Shape() == adios2::Dims{adios2::LocalValueDim})
         {
             if (bufferedPut.extent != Extent{1})

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1282,7 +1282,7 @@ void ADIOS2IOHandlerImpl::openDataset(
      * here.
      */
     [[maybe_unused]] auto [operators, _] =
-        parseDatasetConfig(parameters, writable, varName);
+        parseDatasetConfig(parameters, writable, varName, readOperators);
     switchAdios2VariableType<detail::DatasetOpener>(
         *parameters.dtype,
         this,

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -36,6 +36,7 @@
 #include "openPMD/ThrowError.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
+#include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/auxiliary/JSONMatcher.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/auxiliary/Mpi.hpp"
@@ -234,6 +235,19 @@ void ADIOS2IOHandlerImpl::init(
             groupTableViaEnv == 0 ? UseGroupTable::No : UseGroupTable::Yes;
     }
 
+    {
+        constexpr char const *const init_json_shadow_str = R"(
+        {
+          "adios2": {
+            "dataset": {
+              "operators": null
+            }
+          }
+        })";
+        auto init_json_shadow = nlohmann::json::parse(init_json_shadow_str);
+        json::merge(cfg.getShadow(), init_json_shadow);
+    }
+
     if (cfg.json().contains("adios2"))
     {
         m_config = cfg["adios2"];
@@ -310,7 +324,7 @@ void ADIOS2IOHandlerImpl::init(
         auto operators = getOperators();
         if (operators)
         {
-            defaultOperators = std::move(operators.value());
+            readOperators = std::move(operators.value());
         }
     }
 }
@@ -410,27 +424,55 @@ ADIOS2IOHandlerImpl::getOperators()
 
 template <typename Parameter>
 auto ADIOS2IOHandlerImpl::getDatasetOperators(
-    Parameter const &parameters, Writable *writable, std::string const &varName)
+    Parameter const &parameters,
+    Writable *writable,
+    std::string const &varName,
+    std::vector<ParameterizedOperator> operators)
     -> std::vector<ParameterizedOperator>
 {
-    std::vector<ParameterizedOperator> operators;
-    json::TracingJSON options =
-        parameters.template compileJSONConfig<json::ParsedConfig>(
-            writable, *m_handler->jsonMatcher, "adios2");
-    if (options.json().contains("adios2"))
-    {
-        json::TracingJSON datasetConfig(options["adios2"]);
-        auto datasetOperators = getOperators(datasetConfig);
+    json::TracingJSON config = [&]() {
+        if (!m_buffered_dataset_config.has_value())
+        {
+            // we are only interested in these values from the global config
+            constexpr char const *const mask_for_global_conf = R"(
+                {
+                "dataset": {
+                    "operators": null,
+                    "shape": null
+                }
+                })";
+            m_buffered_dataset_config = m_config.json();
+            json::filterByTemplate(
+                *m_buffered_dataset_config,
+                nlohmann::json::parse(mask_for_global_conf));
+        }
+        auto parsed_config =
+            parameters.template compileJSONConfig<json::ParsedConfig>(
+                writable, *m_handler->jsonMatcher, "adios2");
+        if (auto adios2_config_it = parsed_config.config.find("adios2");
+            adios2_config_it != parsed_config.config.end())
+        {
+            adios2_config_it.value() = json::merge(
+                *m_buffered_dataset_config, adios2_config_it.value());
+        }
+        else
+        {
+            parsed_config.config["adios2"] = *m_buffered_dataset_config;
+        }
+        return parsed_config;
+    }();
 
-        operators = datasetOperators ? std::move(datasetOperators.value())
-                                     : defaultOperators;
-    }
-    else
+    if (config.json().contains("adios2"))
     {
-        operators = defaultOperators;
+        json::TracingJSON datasetConfig(config["adios2"]);
+        auto maybe_operators = getOperators(datasetConfig);
+        if (maybe_operators)
+        {
+            operators = std::move(*maybe_operators);
+        }
     }
     parameters.warnUnusedParameters(
-        options,
+        config,
         "adios2",
         "Warning: parts of the backend configuration for ADIOS2 dataset '" +
             varName + "' remain unused:\n");

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -993,7 +993,7 @@ void ADIOS2IOHandlerImpl::createDataset(
                         "Shape for local value array must be a 1D array "
                         "equivalent to the MPI size ('" +
                             varName + "' has shape " +
-                            auxiliary::format_vec(parameters.extent) +
+                            auxiliary::vec_as_string(parameters.extent) +
                             ", but should have shape [" +
                             std::to_string(required_size) + "]).");
                 }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -431,7 +431,7 @@ auto ADIOS2IOHandlerImpl::parseDatasetConfig(
     std::vector<ParameterizedOperator> operators)
     -> std::tuple<std::vector<ParameterizedOperator>, Shape>
 {
-    json::TracingJSON config = [&]() {
+    json::TracingJSON config = [&]() -> json::ParsedConfig {
         if (!m_buffered_dataset_config.has_value())
         {
             // we are only interested in these values from the global config
@@ -447,18 +447,21 @@ auto ADIOS2IOHandlerImpl::parseDatasetConfig(
                 *m_buffered_dataset_config,
                 nlohmann::json::parse(mask_for_global_conf));
         }
+        auto const &buffered_config = *m_buffered_dataset_config;
         auto parsed_config =
             parameters.template compileJSONConfig<json::ParsedConfig>(
                 writable, *m_handler->jsonMatcher, "adios2");
         if (auto adios2_config_it = parsed_config.config.find("adios2");
             adios2_config_it != parsed_config.config.end())
         {
-            adios2_config_it.value() = json::merge(
-                *m_buffered_dataset_config, adios2_config_it.value());
+            auto copy = buffered_config;
+            json::merge(copy, adios2_config_it.value());
+            copy = nlohmann::json{{"adios2", std::move(copy)}};
+            parsed_config.config = std::move(copy);
         }
         else
         {
-            parsed_config.config["adios2"] = *m_buffered_dataset_config;
+            parsed_config.config["adios2"] = buffered_config;
         }
         return parsed_config;
     }();
@@ -978,7 +981,11 @@ void ADIOS2IOHandlerImpl::createDataset(
                     throw error::OperationUnsupportedInBackend(
                         "ADIOS2",
                         "Shape for local value array must be a 1D array "
-                        "equivalent to the MPI size.");
+                        "equivalent to the MPI size ('" +
+                            varName + "' has shape " +
+                            auxiliary::format_vec(parameters.extent) +
+                            ", but should have shape [" +
+                            std::to_string(required_size) + "]).");
                 }
                 return adios2::Dims{adios2::LocalValueDim};
             }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -246,7 +246,11 @@ void ADIOS2IOHandlerImpl::init(
           }
         })";
         auto init_json_shadow = nlohmann::json::parse(init_json_shadow_str);
-        json::merge(cfg.getShadow(), init_json_shadow);
+        std::cout << "Will merge:\n"
+                  << init_json_shadow << "\ninto:\n"
+                  << cfg.getShadow() << std::endl;
+        json::merge_internal(
+            cfg.getShadow(), init_json_shadow, /* do_prune = */ false);
     }
 
     if (cfg.json().contains("adios2"))
@@ -455,7 +459,8 @@ auto ADIOS2IOHandlerImpl::parseDatasetConfig(
             adios2_config_it != parsed_config.config.end())
         {
             auto copy = buffered_config;
-            json::merge(copy, adios2_config_it.value());
+            json::merge_internal(
+                copy, adios2_config_it.value(), /* do_prune = */ false);
             copy = nlohmann::json{{"adios2", std::move(copy)}};
             parsed_config.config = std::move(copy);
         }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -240,7 +240,8 @@ void ADIOS2IOHandlerImpl::init(
         {
           "adios2": {
             "dataset": {
-              "operators": null
+              "operators": null,
+              "shape": null
             }
           }
         })";
@@ -423,12 +424,12 @@ ADIOS2IOHandlerImpl::getOperators()
 }
 
 template <typename Parameter>
-auto ADIOS2IOHandlerImpl::getDatasetOperators(
+auto ADIOS2IOHandlerImpl::parseDatasetConfig(
     Parameter const &parameters,
     Writable *writable,
     std::string const &varName,
     std::vector<ParameterizedOperator> operators)
-    -> std::vector<ParameterizedOperator>
+    -> std::tuple<std::vector<ParameterizedOperator>, Shape>
 {
     json::TracingJSON config = [&]() {
         if (!m_buffered_dataset_config.has_value())
@@ -462,21 +463,58 @@ auto ADIOS2IOHandlerImpl::getDatasetOperators(
         return parsed_config;
     }();
 
-    if (config.json().contains("adios2"))
-    {
-        json::TracingJSON datasetConfig(config["adios2"]);
-        auto maybe_operators = getOperators(datasetConfig);
-        if (maybe_operators)
+    Shape arrayShape = Shape::GlobalArray;
+    [&]() {
+        if (!config.json().contains("adios2"))
         {
-            operators = std::move(*maybe_operators);
+            return;
+        };
+        json::TracingJSON adios2Config(config["adios2"]);
+        auto datasetOperators = getOperators(adios2Config);
+        if (datasetOperators.has_value())
+        {
+            operators = std::move(*datasetOperators);
         }
-    }
+        if (!adios2Config.json().contains("dataset"))
+        {
+            return;
+        }
+        auto datasetConfig = adios2Config["dataset"];
+        if (!datasetConfig.json().contains("shape"))
+        {
+            return;
+        }
+        auto maybe_shape =
+            json::asLowerCaseStringDynamic(datasetConfig["shape"].json());
+        if (!maybe_shape.has_value())
+        {
+            throw error::BackendConfigSchema(
+                {"adios2", "dataset", "shape"},
+                "Must be convertible to string type.");
+        }
+        auto const &shape = *maybe_shape;
+        if (shape == "global_array")
+        {
+            arrayShape = Shape::GlobalArray;
+        }
+        else if (shape == "local_value")
+        {
+            arrayShape = Shape::LocalValue;
+        }
+        else
+        {
+            throw error::BackendConfigSchema(
+                {"adios2", "dataset", "shape"},
+                "Unknown value: '" + shape + "'.");
+        }
+    }();
+
     parameters.warnUnusedParameters(
         config,
         "adios2",
         "Warning: parts of the backend configuration for ADIOS2 dataset '" +
             varName + "' remain unused:\n");
-    return operators;
+    return {std::move(operators), arrayShape};
 }
 
 using AcceptedEndingsForEngine = std::map<std::string, std::string>;
@@ -906,15 +944,47 @@ void ADIOS2IOHandlerImpl::createDataset(
         filePos->gd = GroupOrDataset::DATASET;
         auto const varName = nameOfVariable(writable);
 
-        std::vector<ParameterizedOperator> operators =
-            getDatasetOperators(parameters, writable, varName);
+        // Captured structured bindings are a C++20 extension...
+        std::vector<ParameterizedOperator> operators;
+        Shape arrayShape;
+        std::tie(operators, arrayShape) =
+            parseDatasetConfig(parameters, writable, varName);
 
-        // cast from openPMD::Extent to adios2::Dims
-        adios2::Dims shape(parameters.extent.begin(), parameters.extent.end());
-        if (auto jd = parameters.joinedDimension; jd.has_value())
-        {
-            shape[jd.value()] = adios2::JoinedDim;
-        }
+        adios2::Dims shape = [&, arrayShape = arrayShape]() {
+            switch (arrayShape)
+            {
+
+            case Shape::GlobalArray: {
+                // cast from openPMD::Extent to adios2::Dims
+                adios2::Dims res(
+                    parameters.extent.begin(), parameters.extent.end());
+                if (auto jd = parameters.joinedDimension; jd.has_value())
+                {
+                    res[jd.value()] = adios2::JoinedDim;
+                }
+                return res;
+            }
+            case Shape::LocalValue: {
+                int required_size = 1;
+#if openPMD_HAVE_MPI
+                if (m_communicator.has_value())
+                {
+                    MPI_Comm_size(*m_communicator, &required_size);
+                }
+#endif
+                if (parameters.extent !=
+                    Extent{Extent::value_type(required_size)})
+                {
+                    throw error::OperationUnsupportedInBackend(
+                        "ADIOS2",
+                        "Shape for local value array must be a 1D array "
+                        "equivalent to the MPI size.");
+                }
+                return adios2::Dims{adios2::LocalValueDim};
+            }
+            }
+            throw std::runtime_error("Unreachable!");
+        }();
 
         auto &fileData = getFileData(file, IfFileNotOpen::ThrowError);
 
@@ -1189,8 +1259,8 @@ void ADIOS2IOHandlerImpl::openDataset(
      * reading, so the dataset-specific configuration should still be explored
      * here.
      */
-    std::vector<ParameterizedOperator> operators =
-        getDatasetOperators(parameters, writable, varName);
+    [[maybe_unused]] auto [operators, _] =
+        parseDatasetConfig(parameters, writable, varName);
     switchAdios2VariableType<detail::DatasetOpener>(
         *parameters.dtype,
         this,
@@ -1294,6 +1364,11 @@ namespace detail
                 varName,
                 std::nullopt,
                 ba.variables());
+            if (variable.Shape() == adios2::Dims{adios2::LocalValueDim})
+            {
+                params.out->backendManagedBuffer = false;
+                return;
+            }
             adios2::Dims offset(params.offset.begin(), params.offset.end());
             adios2::Dims extent(params.extent.begin(), params.extent.end());
             variable.SetSelection({std::move(offset), std::move(extent)});

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2661,7 +2661,23 @@ namespace detail
         }
         else
         {
-            var.SetShape(shape);
+            auto const &old_shape = var.Shape();
+            bool shape_changed = old_shape.size() != shape.size();
+            if (!shape_changed)
+            {
+                for (size_t i = 0; i < old_shape.size(); ++i)
+                {
+                    if (old_shape[i] != shape[i])
+                    {
+                        shape_changed = true;
+                        break;
+                    }
+                }
+            }
+            if (shape_changed)
+            {
+                var.SetShape(shape);
+            }
             if (count.size() > 0)
             {
                 var.SetSelection({start, count});

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -431,7 +431,7 @@ auto ADIOS2IOHandlerImpl::parseDatasetConfig(
     std::vector<ParameterizedOperator> operators)
     -> std::tuple<std::vector<ParameterizedOperator>, Shape>
 {
-    json::TracingJSON config = [&]() -> json::ParsedConfig {
+    json::TracingJSON parsedConfig = [&]() -> json::ParsedConfig {
         if (!m_buffered_dataset_config.has_value())
         {
             // we are only interested in these values from the global config
@@ -468,11 +468,11 @@ auto ADIOS2IOHandlerImpl::parseDatasetConfig(
 
     Shape arrayShape = Shape::GlobalArray;
     [&]() {
-        if (!config.json().contains("adios2"))
+        if (!parsedConfig.json().contains("adios2"))
         {
             return;
         };
-        json::TracingJSON adios2Config(config["adios2"]);
+        json::TracingJSON adios2Config(parsedConfig["adios2"]);
         auto datasetOperators = getOperators(adios2Config);
         if (datasetOperators.has_value())
         {
@@ -512,11 +512,21 @@ auto ADIOS2IOHandlerImpl::parseDatasetConfig(
         }
     }();
 
+#if 0
+        std::cout << "Operations for '" << varName << "':";
+        for(auto const & op: operators)
+        {
+            std::cout << " '" << op.op.Type() << "'";
+        }
+        std::cout << std::endl;
+#endif
+
     parameters.warnUnusedParameters(
-        config,
+        parsedConfig,
         "adios2",
         "Warning: parts of the backend configuration for ADIOS2 dataset '" +
             varName + "' remain unused:\n");
+
     return {std::move(operators), arrayShape};
 }
 
@@ -953,7 +963,7 @@ void ADIOS2IOHandlerImpl::createDataset(
         std::tie(operators, arrayShape) =
             parseDatasetConfig(parameters, writable, varName);
 
-        adios2::Dims shape = [&, arrayShape = arrayShape]() {
+        adios2::Dims shape = [&]() {
             switch (arrayShape)
             {
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -480,6 +480,48 @@ void available_chunks_test(std::string const &file_ending)
         auto E_x = it0.meshes["E"]["x"];
         E_x.resetDataset({Datatype::INT, {mpi_size, 4}});
         E_x.storeChunk(data, {mpi_rank, 0}, {1, 4});
+
+        auto electrons = it0.particles["e"].particlePatches;
+        auto numParticles = electrons["numParticles"];
+        auto numParticlesOffset = electrons["numParticlesOffset"];
+        for (auto rc : {&numParticles, &numParticlesOffset})
+        {
+            rc->resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type{mpi_size}},
+                 R"(adios2.dataset.shape = "local_value")"});
+        }
+        numParticles.storeChunk(
+            std::make_unique<unsigned long>(10), {size_t(mpi_rank)}, {1});
+        numParticlesOffset.storeChunk(
+            std::make_unique<unsigned long>(10 * ((unsigned long)mpi_rank)),
+            {size_t(mpi_rank)},
+            {1});
+        auto offset = electrons["offset"];
+        for (auto const &dim : {"x", "y", "z"})
+        {
+            auto rc = offset[dim];
+            rc.resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type{mpi_size}},
+                 R"(adios2.dataset.shape = "local_value")"});
+            rc.storeChunk(
+                std::make_unique<unsigned long>((unsigned long)mpi_rank),
+                {size_t(mpi_rank)},
+                {1});
+        }
+        auto extent = electrons["extent"];
+        for (auto const &dim : {"x", "y", "z"})
+        {
+            auto rc = extent[dim];
+            rc.resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type{mpi_size}},
+                 R"(adios2.dataset.shape = "local_value")"});
+            rc.storeChunk(
+                std::make_unique<unsigned long>(1), {size_t(mpi_rank)}, {1});
+        }
+
         it0.close();
     }
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -30,6 +30,7 @@
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/Mpi.hpp"
+#include "openPMD/backend/PatchRecordComponent.hpp"
 #include "openPMD/openPMD.hpp"
 // @todo change includes
 #include "openPMD/auxiliary/OneDimensionalBlockSlicer.hpp"
@@ -447,7 +448,7 @@ void available_chunks_test(std::string const &file_ending)
     MPI_Comm_size(MPI_COMM_WORLD, &r_mpi_size);
     unsigned mpi_rank{static_cast<unsigned>(r_mpi_rank)},
         mpi_size{static_cast<unsigned>(r_mpi_size)};
-    std::string name = "../samples/available_chunks." + file_ending;
+    std::string name = "../samples/parallel_available_chunks." + file_ending;
 
     /*
      * ADIOS2 assigns writerIDs to blocks in a BP file by id of the substream
@@ -460,7 +461,6 @@ void available_chunks_test(std::string const &file_ending)
     {
         "engine":
         {
-            "type": "bp4",
             "parameters":
             {
                 "NumAggregators":)END"
@@ -480,6 +480,14 @@ void available_chunks_test(std::string const &file_ending)
         auto E_x = it0.meshes["E"]["x"];
         E_x.resetDataset({Datatype::INT, {mpi_size, 4}});
         E_x.storeChunk(data, {mpi_rank, 0}, {1, 4});
+
+        /*
+         * Verify that block decomposition also works in "local value" variable
+         * shape. That shape instructs the data to participate in ADIOS2
+         * metadata aggregation, hence there is only one "real" written block,
+         * the aggregated one. We still need the original logical blocks to be
+         * present in reading.
+         */
 
         auto electrons = it0.particles["e"].particlePatches;
         auto numParticles = electrons["numParticles"];
@@ -553,12 +561,40 @@ void available_chunks_test(std::string const &file_ending)
         {
             REQUIRE(ranks[i] == i);
         }
+
+        auto electrons = it0.particles["e"].particlePatches;
+        for (PatchRecordComponent *prc :
+             {static_cast<PatchRecordComponent *>(&electrons["numParticles"]),
+              static_cast<PatchRecordComponent *>(
+                  &electrons["numParticlesOffset"]),
+              &electrons["offset"]["x"],
+              &electrons["offset"]["y"],
+              &electrons["extent"]["z"],
+              &electrons["offset"]["x"],
+              &electrons["extent"]["y"],
+              &electrons["extent"]["z"]})
+        {
+            auto available_chunks = prc->availableChunks();
+            REQUIRE(size_t(r_mpi_size) == available_chunks.size());
+            for (size_t i = 0; i < available_chunks.size(); ++i)
+            {
+                auto const &chunk = available_chunks[i];
+                REQUIRE(chunk.extent == Extent{1});
+                REQUIRE(chunk.offset == Offset{i});
+                REQUIRE(chunk.sourceID == i);
+            }
+        }
     }
 }
 
 PARALLEL_TEST_CASE(available_chunks_test, "[parallel][adios]")
 {
+#if HAS_ADIOS_2_9
+    available_chunks_test("bp4");
+    available_chunks_test("bp5");
+#else
     available_chunks_test("bp");
+#endif
 }
 #endif
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -30,6 +30,7 @@
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/Mpi.hpp"
+#include "openPMD/backend/PatchRecordComponent.hpp"
 #include "openPMD/openPMD.hpp"
 // @todo change includes
 #include "openPMD/auxiliary/OneDimensionalBlockSlicer.hpp"
@@ -428,7 +429,7 @@ void available_chunks_test(std::string const &file_ending)
     MPI_Comm_size(MPI_COMM_WORLD, &r_mpi_size);
     unsigned mpi_rank{static_cast<unsigned>(r_mpi_rank)},
         mpi_size{static_cast<unsigned>(r_mpi_size)};
-    std::string name = "../samples/available_chunks." + file_ending;
+    std::string name = "../samples/parallel_available_chunks." + file_ending;
 
     /*
      * ADIOS2 assigns writerIDs to blocks in a BP file by id of the substream
@@ -441,7 +442,6 @@ void available_chunks_test(std::string const &file_ending)
     {
         "engine":
         {
-            "type": "bp4",
             "parameters":
             {
                 "NumAggregators":)END"
@@ -461,6 +461,14 @@ void available_chunks_test(std::string const &file_ending)
         auto E_x = it0.meshes["E"]["x"];
         E_x.resetDataset({Datatype::INT, {mpi_size, 4}});
         E_x.storeChunk(data, {mpi_rank, 0}, {1, 4});
+
+        /*
+         * Verify that block decomposition also works in "local value" variable
+         * shape. That shape instructs the data to participate in ADIOS2
+         * metadata aggregation, hence there is only one "real" written block,
+         * the aggregated one. We still need the original logical blocks to be
+         * present in reading.
+         */
 
         auto electrons = it0.particles["e"].particlePatches;
         auto numParticles = electrons["numParticles"];
@@ -534,12 +542,40 @@ void available_chunks_test(std::string const &file_ending)
         {
             REQUIRE(ranks[i] == i);
         }
+
+        auto electrons = it0.particles["e"].particlePatches;
+        for (PatchRecordComponent *prc :
+             {static_cast<PatchRecordComponent *>(&electrons["numParticles"]),
+              static_cast<PatchRecordComponent *>(
+                  &electrons["numParticlesOffset"]),
+              &electrons["offset"]["x"],
+              &electrons["offset"]["y"],
+              &electrons["extent"]["z"],
+              &electrons["offset"]["x"],
+              &electrons["extent"]["y"],
+              &electrons["extent"]["z"]})
+        {
+            auto available_chunks = prc->availableChunks();
+            REQUIRE(size_t(r_mpi_size) == available_chunks.size());
+            for (size_t i = 0; i < available_chunks.size(); ++i)
+            {
+                auto const &chunk = available_chunks[i];
+                REQUIRE(chunk.extent == Extent{1});
+                REQUIRE(chunk.offset == Offset{i});
+                REQUIRE(chunk.sourceID == i);
+            }
+        }
     }
 }
 
 TEST_CASE("available_chunks_test", "[parallel][adios]")
 {
+#if HAS_ADIOS_2_9
+    available_chunks_test("bp4");
+    available_chunks_test("bp5");
+#else
     available_chunks_test("bp");
+#endif
 }
 #endif
 

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -461,6 +461,48 @@ void available_chunks_test(std::string const &file_ending)
         auto E_x = it0.meshes["E"]["x"];
         E_x.resetDataset({Datatype::INT, {mpi_size, 4}});
         E_x.storeChunk(data, {mpi_rank, 0}, {1, 4});
+
+        auto electrons = it0.particles["e"].particlePatches;
+        auto numParticles = electrons["numParticles"];
+        auto numParticlesOffset = electrons["numParticlesOffset"];
+        for (auto rc : {&numParticles, &numParticlesOffset})
+        {
+            rc->resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type{mpi_size}},
+                 R"(adios2.dataset.shape = "local_value")"});
+        }
+        numParticles.storeChunk(
+            std::make_unique<unsigned long>(10), {size_t(mpi_rank)}, {1});
+        numParticlesOffset.storeChunk(
+            std::make_unique<unsigned long>(10 * ((unsigned long)mpi_rank)),
+            {size_t(mpi_rank)},
+            {1});
+        auto offset = electrons["offset"];
+        for (auto const &dim : {"x", "y", "z"})
+        {
+            auto rc = offset[dim];
+            rc.resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type{mpi_size}},
+                 R"(adios2.dataset.shape = "local_value")"});
+            rc.storeChunk(
+                std::make_unique<unsigned long>((unsigned long)mpi_rank),
+                {size_t(mpi_rank)},
+                {1});
+        }
+        auto extent = electrons["extent"];
+        for (auto const &dim : {"x", "y", "z"})
+        {
+            auto rc = extent[dim];
+            rc.resetDataset(
+                {Datatype::ULONG,
+                 {Extent::value_type{mpi_size}},
+                 R"(adios2.dataset.shape = "local_value")"});
+            rc.storeChunk(
+                std::make_unique<unsigned long>(1), {size_t(mpi_rank)}, {1});
+        }
+
         it0.close();
     }
 


### PR DESCRIPTION
Ref https://adios2.readthedocs.io/en/v2.9.2/components/components.html#shapes

This PR considers LocalValues in ADIOS2 merely an implementation detail, without actually exposing an API analogous to to how LocalValues work in ADIOS2.

The reasoning is:

1. LocalValues are useful not only for their API, but also since they give a hint to ADIOS2 that the variable should be handled as metadata and take part e.g. in metadata aggregation. With this PR, datasets such as the particlePatches in PIConGPU (one single value per MPI rank) can be given to the metadata system without changing a single line of code in PIConGPU. This can be crucial in streaming setups: When each reading rank loads the entire dataset naively (without this setting), the data plane of SST will open a connection between every writer and reader for just a single value each. Better to aggregate.
2. If needed at some point, a LocalValue-like API can still be exposed on top of this.

TODO

- [x] Documentation
- [ ] Check usage of `readOperators, m_operators`