### PR TITLE
[Do not merge yet] Fix: Read `ParticlePatches` Attr

### DIFF
--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -60,24 +60,6 @@ void PatchRecord::flush_impl(
 
 void PatchRecord::read()
 {
-    Parameter<Operation::READ_ATT> aRead;
-    aRead.name = "unitDimension";
-    IOHandler()->enqueue(IOTask(this, aRead));
-    IOHandler()->flush(internal::defaultFlushParams);
-
-    if (auto val =
-            Attribute(*aRead.resource).getOptional<std::array<double, 7> >();
-        val.has_value())
-        this->setAttribute("unitDimension", val.value());
-    else
-        throw error::ReadError(
-            error::AffectedObject::Attribute,
-            error::Reason::UnexpectedContent,
-            {},
-            "Unexpected Attribute datatype for 'unitDimension' (expected an "
-            "array of seven floating point numbers, found " +
-                datatypeToString(Attribute(*aRead.resource).dtype) + ")");
-
     Parameter<Operation::LIST_DATASETS> dList;
     IOHandler()->enqueue(IOTask(this, dList));
     IOHandler()->flush(internal::defaultFlushParams);


### PR DESCRIPTION
`ParticlePatches` are no openPMD records but a special group. It does not need required record components such as `unitDimension`.

Ref.: https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#sub-group-for-each-particle-species

Fix #1609

Update: oh, but we write
> If the particlePatches sub-group exists, **the following records** within it are required and the entries in each record are stored in a per particle patch order:

## Action Items

- either clarify standard or
- update [openPMD-validator](https://github.com/openPMD/openPMD-validator/blob/1.1.X/openpmd_validator/createExamples_h5.py#L515-L527) and [openPMD-example data set](https://github.com/openPMD/openPMD-example-datasets/pull/22)

I will probably to the latter.