### PR TITLE
Add define for ADIOS2_HAVE_BP5

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -95,39 +95,6 @@ namespace detail
     // we represent booleans as unsigned chars
     using bool_representation = unsigned char;
 
-    template <typename T>
-    struct ToDatatypeHelper
-    {
-        static std::string type();
-    };
-
-    template <typename T>
-    struct ToDatatypeHelper<std::vector<T>>
-    {
-        static std::string type();
-    };
-
-    template <typename T, size_t n>
-    struct ToDatatypeHelper<std::array<T, n>>
-    {
-        static std::string type();
-    };
-
-    template <>
-    struct ToDatatypeHelper<bool>
-    {
-        static std::string type();
-    };
-
-    struct ToDatatype
-    {
-        template <typename T>
-        std::string operator()();
-
-        template <int n>
-        std::string operator()();
-    };
-
     /**
      * @brief Convert ADIOS2 datatype to openPMD type.
      * @param dt
@@ -210,6 +177,9 @@ namespace detail
         }
         throw error::Internal("Control flow error: No ADIOS2 open mode.");
     }
+
+    std::string
+    normalizingVariableType(adios2::IO const &, std::string const &name);
 } // namespace detail
 
 /**

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -409,10 +409,9 @@ private:
             {
                 std::stringstream errorMessage;
                 errorMessage << "Trying to access a dataset with wrong type "
-                                "(trying to access dataset with type "
-                             << determineDatatype<T>() << ", but has type "
-                             << detail::fromADIOS2Type(actualType, false)
-                             << ")";
+                                "(trying to access dataset with type '"
+                             << requiredType << "', but has type '"
+                             << actualType << "')";
                 throw error::ReadError(
                     error::AffectedObject::Dataset,
                     error::Reason::UnexpectedContent,

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -403,7 +403,7 @@ private:
     {
         {
             auto requiredType = adios2::GetType<T>();
-            auto actualType = IO.VariableType(varName);
+            auto actualType = detail::normalizingVariableType(IO, varName);
 
             if (requiredType != actualType)
             {

--- a/include/openPMD/IO/ADIOS/macros.hpp
+++ b/include/openPMD/IO/ADIOS/macros.hpp
@@ -19,11 +19,6 @@
 #define openPMD_HAS_ADIOS_2_9                                                  \
     (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 209)
 
-#if !defined(ADIOS2_HAVE_BP5) && openPMD_HAS_ADIOS_2_9
-// ADIOS2 v2.10 no longer defines this
-#define ADIOS2_HAVE_BP5
-#endif
-
 #else
 
 #define openPMD_HAS_ADIOS_2_8 0

--- a/include/openPMD/IO/ADIOS/macros.hpp
+++ b/include/openPMD/IO/ADIOS/macros.hpp
@@ -19,6 +19,11 @@
 #define openPMD_HAS_ADIOS_2_9                                                  \
     (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 209)
 
+#if !defined(ADIOS2_HAVE_BP5) && openPMD_HAS_ADIOS_2_9
+// ADIOS2 v2.10 no longer defines this
+#define ADIOS2_HAVE_BP5
+#endif
+
 #else
 
 #define openPMD_HAS_ADIOS_2_8 0

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/config.hpp"
 #if openPMD_HAVE_ADIOS2
 #include "openPMD/Datatype.hpp"
@@ -61,45 +62,6 @@ FlushTarget flushTargetFromString(std::string const &str)
 
 namespace openPMD::detail
 {
-template <typename T>
-std::string ToDatatypeHelper<T>::type()
-{
-    return adios2::GetType<T>();
-}
-
-template <typename T>
-std::string ToDatatypeHelper<std::vector<T>>::type()
-{
-    return
-
-        adios2::GetType<T>();
-}
-
-template <typename T, size_t n>
-std::string ToDatatypeHelper<std::array<T, n>>::type()
-{
-    return
-
-        adios2::GetType<T>();
-}
-
-std::string ToDatatypeHelper<bool>::type()
-{
-    return ToDatatypeHelper<bool_representation>::type();
-}
-
-template <typename T>
-std::string ToDatatype::operator()()
-{
-    return ToDatatypeHelper<T>::type();
-}
-
-template <int n>
-std::string ToDatatype::operator()()
-{
-    return "";
-}
-
 Datatype fromADIOS2Type(std::string const &dt, bool verbose)
 {
     static std::map<std::string, Datatype> map{
@@ -271,6 +233,44 @@ Datatype attributeInfo(
         }
         throw std::runtime_error("Unreachable!");
     }
+}
+
+namespace
+{
+    struct ToDatatype
+    {
+        template <typename T>
+        static std::string call()
+        {
+            if constexpr (std::is_same_v<T, bool>)
+            {
+                return ToDatatype::call<bool_representation>();
+            }
+            else if constexpr (
+                auxiliary::IsVector_v<T> || auxiliary::IsArray_v<T>)
+            {
+                return ToDatatype::call<typename T::value_type>();
+            }
+            else
+            {
+                return adios2::GetType<T>();
+            }
+        }
+
+        template <int>
+        static std::string call()
+        {
+            return {};
+        }
+    };
+} // namespace
+
+std::string
+normalizingVariableType(const adios2::IO &IO, const std::string &name)
+{
+    auto const &unsanitized_result = IO.VariableType(name);
+    auto openpmd_type = fromADIOS2Type(unsanitized_result);
+    return switchAdios2VariableType<ToDatatype>(openpmd_type);
 }
 } // namespace openPMD::detail
 #endif

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -270,7 +270,10 @@ normalizingVariableType(const adios2::IO &IO, const std::string &name)
 {
     auto const &unsanitized_result = IO.VariableType(name);
     auto openpmd_type = fromADIOS2Type(unsanitized_result);
-    return switchAdios2VariableType<ToDatatype>(openpmd_type);
+    auto res = switchAdios2VariableType<ToDatatype>(openpmd_type);
+    std::cout << "[normalizingVariableType] for '" << name << "' " << res
+              << " (non-normalized: " << unsanitized_result << ")" << std::endl;
+    return res;
 }
 } // namespace openPMD::detail
 #endif

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -166,7 +166,7 @@ Datatype attributeInfo(
         type = IO.AttributeType(attributeName);
         break;
     case VariableOrAttribute::Variable:
-        type = IO.VariableType(attributeName);
+        type = normalizingVariableType(IO, attributeName);
         break;
     }
     if (type.empty())

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -965,6 +965,8 @@ void ADIOS2IOHandlerImpl::openDataset(
     auto &fileData = getFileData(file, IfFileNotOpen::ThrowError);
     *parameters.dtype = detail::fromADIOS2Type(
         detail::normalizingVariableType(fileData.m_IO, varName));
+    std::cout << "[openDataset] opened '" << varName << "'as "
+              << *parameters.dtype << std::endl;
     switchAdios2VariableType<detail::DatasetOpener>(
         *parameters.dtype, this, file, varName, parameters);
     writable->written = true;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -865,7 +865,8 @@ void ADIOS2IOHandlerImpl::extendDataset(
     auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
     std::string name = nameOfVariable(writable);
     auto &filedata = getFileData(file, IfFileNotOpen::ThrowError);
-    Datatype dt = detail::fromADIOS2Type(filedata.m_IO.VariableType(name));
+    Datatype dt = detail::fromADIOS2Type(
+        detail::normalizingVariableType(filedata.m_IO, name));
     switchAdios2VariableType<detail::DatasetExtender>(
         dt, filedata.m_IO, name, parameters.extent);
 }
@@ -962,8 +963,8 @@ void ADIOS2IOHandlerImpl::openDataset(
     auto file = refreshFileFromParent(writable, /* preferParentFile = */ true);
     auto varName = nameOfVariable(writable);
     auto &fileData = getFileData(file, IfFileNotOpen::ThrowError);
-    *parameters.dtype =
-        detail::fromADIOS2Type(fileData.m_IO.VariableType(varName));
+    *parameters.dtype = detail::fromADIOS2Type(
+        detail::normalizingVariableType(fileData.m_IO, varName));
     switchAdios2VariableType<detail::DatasetOpener>(
         *parameters.dtype, this, file, varName, parameters);
     writable->written = true;
@@ -1464,7 +1465,8 @@ void ADIOS2IOHandlerImpl::availableChunks(
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
     std::string varName = nameOfVariable(writable);
     auto engine = ba.getEngine(); // make sure that data are present
-    auto datatype = detail::fromADIOS2Type(ba.m_IO.VariableType(varName));
+    auto datatype = detail::fromADIOS2Type(
+        detail::normalizingVariableType(ba.m_IO, varName));
     bool allSteps = ba.m_mode != adios2::Mode::Read &&
         ba.streamStatus == detail::ADIOS2File::StreamStatus::ReadWithoutStream;
     switchAdios2VariableType<detail::RetrieveBlocksInfo>(

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,6 +22,7 @@
 #include "openPMD/version.hpp"
 
 #if openPMD_HAVE_ADIOS2
+#include "openPMD/IO/ADIOS/macros.hpp"
 #include <adios2.h>
 #endif
 #include <map>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,7 +22,6 @@
 #include "openPMD/version.hpp"
 
 #if openPMD_HAVE_ADIOS2
-#include "openPMD/IO/ADIOS/macros.hpp"
 #include <adios2.h>
 #endif
 #include <map>


### PR DESCRIPTION
This was removed from ADIOS2 v2.9 to v2.10, causing test failures in #1613 since openPMD thinks that BP5 does not exist, but ADIOS2 creates BP5 files.