### PR TITLE
Regexes: Sanitize user input

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3053,7 +3053,9 @@ namespace
     {
         auto sanitize_regex(std::string const &input) -> std::string
         {
+             // need to escape special characters reserved for regexes, see https://stackoverflow.com/questions/40195412/c11-regex-search-for-exact-string-escape
             std::regex specialChars{R"([-[\]{}()*+?.,\^$|#\s])"};
+            // `$&` is the matched substring, see https://en.cppreference.com/w/cpp/regex/regex_replace
             return std::regex_replace(input, specialChars, R"(\$&)");
         }
     } // namespace

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3053,9 +3053,11 @@ namespace
     {
         auto sanitize_regex(std::string const &input) -> std::string
         {
-             // need to escape special characters reserved for regexes, see https://stackoverflow.com/questions/40195412/c11-regex-search-for-exact-string-escape
+            // need to escape special characters reserved for regexes, see
+            // https://stackoverflow.com/questions/40195412/c11-regex-search-for-exact-string-escape
             std::regex specialChars{R"([-[\]{}()*+?.,\^$|#\s])"};
-            // `$&` is the matched substring, see https://en.cppreference.com/w/cpp/regex/regex_replace
+            // `$&` is the matched substring, see
+            // https://en.cppreference.com/w/cpp/regex/regex_replace
             return std::regex_replace(input, specialChars, R"(\$&)");
         }
     } // namespace

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3055,7 +3055,8 @@ namespace
         {
             // need to escape special characters reserved for regexes, see
             // https://stackoverflow.com/questions/40195412/c11-regex-search-for-exact-string-escape
-            std::regex specialChars{R"([-[\]{}()*+?.,\^$|#\s])"};
+            // https://regex101.com/r/GDPK7E/3
+            std::regex specialChars{R"([-[\]{}()*+?.,\^$|#\s\\])"};
             // `$&` is the matched substring, see
             // https://en.cppreference.com/w/cpp/regex/regex_replace
             return std::regex_replace(input, specialChars, R"(\$&)");

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5076,8 +5076,16 @@ TEST_CASE("serial_iterator", "[serial][adios2]")
 {
     for (auto const &t : testedFileExtensions())
     {
+#ifdef _WIN32
         serial_iterator("../samples/serial_iterator_filebased_%T." + t);
         serial_iterator("../samples/serial_iterator_groupbased." + t);
+#else
+        // Add some regex characters into the file names to see that we can deal
+        // with that. Don't do that on Windows because Windows does not like
+        // those characters within file paths.
+        serial_iterator("../samples/serial_iterator_filebased_+?_%T." + t);
+        serial_iterator("../samples/serial_iterator_groupbased_+?." + t);
+#endif
     }
 }
 


### PR DESCRIPTION
For detecting files of file-based encoding, we use Regexes and emplace user input into them. This might lead to Regex injection when the file name contains a special character, e.g. `openpmd-ls simData_+10_1_%T.bp5`. Fix that.
