### PR TITLE
Fix particle patches flush api

### DIFF
--- a/examples/12_span_write.cpp
+++ b/examples/12_span_write.cpp
@@ -28,8 +28,28 @@ void span_write(std::string const &filename)
     for (size_t i = 0; i < 10; ++i)
     {
         Iteration iteration = iterations[i];
-        Record electronPositions = iteration.particles["e"]["position"];
+        auto patches = iteration.particles["e"].particlePatches;
 
+        for (auto record : {"offset", "extent"})
+        {
+            for (auto component : {"x", "y", "z"})
+            {
+                patches[record][component].resetDataset(
+                    {Datatype::DOUBLE, {1}});
+                *patches[record][component]
+                     .storeChunk<double>({0}, {1})
+                     .currentBuffer()
+                     .data() = 4.2;
+            }
+        }
+        for (auto record : {"numParticlesOffset", "numParticles"})
+        {
+            patches[record].resetDataset({Datatype::INT, {1}});
+            *patches[record].storeChunk<int>({0}, {1}).currentBuffer().data() =
+                42;
+        }
+
+        Record electronPositions = iteration.particles["e"]["position"];
         size_t j = 0;
         for (auto const &dim : {"x", "y", "z"})
         {

--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -28,6 +28,8 @@
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Writable.hpp"
 
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -200,6 +202,14 @@ AbstractIOHandlerImplCommon<FilePositionType>::refreshFileFromParent(
     Writable *writable, bool preferParentFile)
 {
     auto getFileFromParent = [writable, this]() {
+        auto file_it = m_files.find(writable->parent);
+        if (file_it == m_files.end())
+        {
+            std::stringstream s;
+            s << "Parent Writable " << writable->parent << " of Writable "
+              << writable << " has no associated file.";
+            throw std::runtime_error(s.str());
+        }
         auto file = m_files.find(writable->parent)->second;
         associateWithFile(writable, file);
         return file;

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -56,11 +56,6 @@ namespace traits
         void operator()(T &ret)
         {
             ret.particlePatches.linkHierarchy(ret.writable());
-
-            auto &np = ret.particlePatches["numParticles"];
-            np.resetDataset(Dataset(determineDatatype<uint64_t>(), {1}));
-            auto &npo = ret.particlePatches["numParticlesOffset"];
-            npo.resetDataset(Dataset(determineDatatype<uint64_t>(), {1}));
         }
     };
 } // namespace traits

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -148,10 +148,7 @@ namespace
 {
     bool flushParticlePatches(ParticlePatches const &particlePatches)
     {
-        return particlePatches.find("numParticles") != particlePatches.end() &&
-            particlePatches.find("numParticlesOffset") !=
-            particlePatches.end() &&
-            particlePatches.size() >= 3;
+        return !particlePatches.empty();
     }
 } // namespace
 

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -418,7 +418,7 @@ TEST_CASE("particleSpecies_modification_test", "[core]")
     species["positionOffset"][RecordComponent::SCALAR].resetDataset(dset);
     REQUIRE(1 == species.count("positionOffset"));
     auto &patches = species.particlePatches;
-    REQUIRE(2 == patches.size());
+    REQUIRE(0 == patches.size());
     REQUIRE(0 == patches.numAttributes());
     auto &offset = patches["offset"];
     REQUIRE(0 == offset.size());
@@ -720,10 +720,10 @@ TEST_CASE("structure_test", "[core]")
             .parent() == getWritable(&o.iterations[1].particles["P"]));
 
     REQUIRE(
-        1 ==
+        0 ==
         o.iterations[1].particles["P"].particlePatches.count("numParticles"));
     REQUIRE(
-        1 ==
+        0 ==
         o.iterations[1].particles["P"].particlePatches.count(
             "numParticlesOffset"));
 


### PR DESCRIPTION
I don't understand our current particle patches flushing logic and it has led to surprising situations in the past often enough. For some reason, we initialize "numParticles" and "numParticlesOffset" (but not "offset" and "extent"???) upon creation of `ParticleSpecies`, but then flush the patches only if there are 3 or more records in the patches (since with numParticles and numParticlesOffset there are 2 already).....

Since #1594, we have all regular `storeChunk()` API calls in `PatchRecordComponent`, including the Span API which breaks under this logic, since it requires flushing the structure to the backend immediately internally and cannot handle being skipped by this item count.

Additionally, as a further follow-up to #1594 this erases special patch handling from `openpmd-pipe` since we can now just use the regular API calls.