### PR TITLE
Fix broken mpiexec in Conda CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -316,7 +316,8 @@ jobs:
           -DopenPMD_USE_MPI=ON    \
           -DopenPMD_USE_HDF5=ON   \
           -DopenPMD_USE_ADIOS2=ON \
-          -DopenPMD_USE_INVASIVE_TESTS=ON
+          -DopenPMD_USE_INVASIVE_TESTS=ON \
+          -DMPIEXEC_EXECUTABLE=".github/workflows/mpirun_workaround.sh"
         cmake --build build --parallel 2
         cd build
         ctest --output-on-failure

--- a/.github/workflows/mpirun_workaround.sh
+++ b/.github/workflows/mpirun_workaround.sh
@@ -14,7 +14,8 @@
 # This script provides a workaround by putting the called sub-command into
 # a script in a temporary file.
 
-mpiexec -n 1 ls --all \
+ls="$(which ls)"
+mpiexec "$ls" -m \
     && echo "MPIRUN WORKING AGAIN, PLEASE REMOVE WORKAROUND" >&2 \
     && exit 1 \
     || true


### PR DESCRIPTION
Previously added for the MacOS CI in #1565, this bug has reached Conda now too
This is currently breaking all PRs