### PR TITLE
Flush target newstep

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -129,10 +129,11 @@ Explanation of the single keys:
 
   * If ``"disk"``, data will be moved to disk on every flush.
   * If ``"buffer"``, then only upon ending an IO step or closing an engine.
+  * If ``new_step``, then a new step will be created. This should be used in combination with the ADIOS2 option ``adios2.engine.parameters.FlattenSteps = "on"``.
 
   This behavior can be overridden on a per-flush basis by specifying this JSON/TOML key as an optional parameter to the ``Series::flush()`` or ``Attributable::seriesFlush()`` methods.
 
-  Additionally, specifying ``"disk_override"`` or ``"buffer_override"`` will take precedence over options specified without the ``_override`` suffix, allowing to invert the normal precedence order.
+  Additionally, specifying ``"disk_override"``, ``"buffer_override"`` or ``"new_step_override"`` will take precedence over options specified without the ``_override`` suffix, allowing to invert the normal precedence order.
   This way, a data producing code can hardcode the preferred flush target per ``flush()`` call, but users can e.g. still entirely deactivate flushing to disk in the ``Series`` constructor by specifying ``preferred_flush_target = buffer_override``.
   This is useful when applying the asynchronous IO capabilities of the BP5 engine.
 * ``adios2.dataset.operators``: This key contains a list of ADIOS2 `operators <https://adios2.readthedocs.io/en/latest/components/components.html#operator>`_, used to enable compression or dataset transformations.

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -53,7 +53,8 @@ namespace adios_defs
         Buffer,
         Buffer_Override,
         Disk,
-        Disk_Override
+        Disk_Override,
+        NewStep
     };
 
     using FlushTarget = adios_defs::FlushTarget;

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -54,7 +54,8 @@ namespace adios_defs
         Buffer_Override,
         Disk,
         Disk_Override,
-        NewStep
+        NewStep,
+        NewStep_Override
     };
 
     using FlushTarget = adios_defs::FlushTarget;

--- a/include/openPMD/IO/ADIOS/macros.hpp
+++ b/include/openPMD/IO/ADIOS/macros.hpp
@@ -22,6 +22,11 @@
 #define openPMD_HAS_ADIOS_2_10                                                 \
     (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 210)
 
+#define openPMD_HAS_ADIOS_2_10_1                                               \
+    (ADIOS2_VERSION_MAJOR * 1000 + ADIOS2_VERSION_MINOR * 10 +                 \
+         ADIOS2_VERSION_PATCH >=                                               \
+     2101)
+
 #if defined(ADIOS2_HAVE_BP5) || openPMD_HAS_ADIOS_2_10
 // ADIOS2 v2.10 no longer defines this
 #define openPMD_HAVE_ADIOS2_BP5 1

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -195,13 +195,28 @@ private:
     {
         /*
          * In file-based iteration encoding, the APPEND mode is handled entirely
-         * by the frontend, the backend should just treat it as CREATE mode
+         * by the frontend, the backend should just treat it as CREATE mode.
+         * Similar for READ_LINEAR which should be treated as READ_RANDOM_ACCESS
+         * in the backend.
          */
-        if (encoding == IterationEncoding::fileBased &&
-            m_backendAccess == Access::APPEND)
+        if (encoding == IterationEncoding::fileBased)
         {
-            // do we really want to have those as const members..?
-            *const_cast<Access *>(&m_backendAccess) = Access::CREATE;
+            switch (m_backendAccess)
+            {
+
+            case Access::READ_LINEAR:
+                // do we really want to have those as const members..?
+                *const_cast<Access *>(&m_backendAccess) =
+                    Access::READ_RANDOM_ACCESS;
+                break;
+            case Access::APPEND:
+                *const_cast<Access *>(&m_backendAccess) = Access::CREATE;
+                break;
+            case Access::READ_RANDOM_ACCESS:
+            case Access::READ_WRITE:
+            case Access::CREATE:
+                break;
+            }
         }
 
         m_encoding = encoding;

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -48,6 +48,10 @@ FlushTarget flushTargetFromString(std::string const &str)
     {
         return FlushTarget::Disk_Override;
     }
+    else if (str == "new_step")
+    {
+        return FlushTarget::NewStep;
+    }
     else
     {
         throw error::BackendConfigSchema(

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -52,11 +52,15 @@ FlushTarget flushTargetFromString(std::string const &str)
     {
         return FlushTarget::NewStep;
     }
+    else if (str == "new_step_override")
+    {
+        return FlushTarget::NewStep_Override;
+    }
     else
     {
         throw error::BackendConfigSchema(
             {"adios2", "engine", adios_defaults::str_flushtarget},
-            "Flush target must be either 'disk' or 'buffer', but "
+            "Flush target must be either 'disk', 'buffer' or 'new_step', but "
             "was " +
                 str + ".");
     }

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -22,6 +22,7 @@
 #include "openPMD/IO/ADIOS/ADIOS2File.hpp"
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
+#include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 
@@ -1067,6 +1068,7 @@ void ADIOS2File::flush_impl(ADIOS2FlushParams flushParams, bool writeLatePuts)
             target = CleanedFlushTarget::Buffer;
             break;
         case FlushTarget::NewStep:
+        case FlushTarget::NewStep_Override:
             target = CleanedFlushTarget::Step;
             break;
         }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -463,6 +463,7 @@ overrideFlushTarget(FlushTarget &inplace, FlushTarget new_val)
             return true;
         case FlushTarget::Buffer_Override:
         case FlushTarget::Disk_Override:
+        case FlushTarget::NewStep_Override:
             return false;
         }
         return true;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -459,6 +459,7 @@ overrideFlushTarget(FlushTarget &inplace, FlushTarget new_val)
         {
         case FlushTarget::Buffer:
         case FlushTarget::Disk:
+        case FlushTarget::NewStep:
             return true;
         case FlushTarget::Buffer_Override:
         case FlushTarget::Disk_Override:

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1550,6 +1550,13 @@ void Series::readFileBased()
     Parameter<Operation::OPEN_FILE> fOpen;
     Parameter<Operation::READ_ATT> aRead;
 
+    // Tell the backend that we are parsing file-based iteration encoding.
+    // This especially means that READ_RANDOM_ACCESS will be used instead of
+    // READ_LINEAR, as READ_LINEAR is implemented in the frontend for file-based
+    // encoding. Don't set the iteration encoding in the frontend yet, will be
+    // set after reading the iteration encoding attribute from the opened file.
+    IOHandler()->setIterationEncoding(IterationEncoding::fileBased);
+
     if (!auxiliary::directory_exists(IOHandler()->directory))
         throw error::ReadError(
             error::AffectedObject::File,

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4437,6 +4437,7 @@ BufferChunkSize = 2147483646 # 2^31 - 2
 }
 #endif
 
+#if openPMD_HAVE_ADIOS2_BP5
 TEST_CASE("adios2_flush_via_step")
 {
     Series write(
@@ -4475,6 +4476,7 @@ TEST_CASE("adios2_flush_via_step")
     }
 #endif
 }
+#endif
 
 TEST_CASE("adios2_engines_and_file_endings")
 {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2,7 +2,6 @@
 #include "openPMD/ChunkInfo_internal.hpp"
 #include "openPMD/Datatype.hpp"
 #include "openPMD/IO/Access.hpp"
-#include <adios2/cxx11/ADIOS.h>
 #if openPMD_USE_INVASIVE_TESTS
 #define OPENPMD_private public:
 #define OPENPMD_protected public:

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4462,9 +4462,7 @@ TEST_CASE("adios2_flush_via_step")
 #if openPMD_HAS_ADIOS_2_10_1
     for (auto access : {Access::READ_RANDOM_ACCESS, Access::READ_LINEAR})
     {
-        Series read(
-            "../samples/adios2_flush_via_step/simData_%T.bp5",
-            Access::READ_RANDOM_ACCESS);
+        Series read("../samples/adios2_flush_via_step/simData_%T.%E", access);
         std::vector<float> load_data(100);
         data.resize(100);
         for (auto iteration : read.readIterations())


### PR DESCRIPTION
- [x] merge #1619 first
- [x] documentation
- [x] reading logic, e.g. `adios2.engine.mode = "what's the name of the mode that we need here does it even exist yet help"`
    It seems this needs no explicit reading logic, just `io.SetParameters("FlattenSteps=on");` on the **writer** side?
- [x] ~~Automatically add that option in file-based encoding~~ Not possible without breaking other workflows

Introduces a new flush target `"new_step"` used for creating readable output in file-based iteration encoding while the Iteration is not yet fully defined yet.

Close #1629