### PR TITLE
ADIOS2: Override access mode

### DIFF
--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -122,6 +122,9 @@ Explanation of the single keys:
 
 * ``adios2.engine.type``: A string that is passed directly to ``adios2::IO:::SetEngine`` for choosing the ADIOS2 engine to be used.
   Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for a list of available engines.
+* ``adios2.engine.access_mode``: One of ``"Write", "Read", "Append", "ReadRandomAccess"``.
+  Only needed in specific use cases, the access mode is usually determined from the specified ``openPMD::Access``.
+  Useful for finetuning the backend-specific behavior of ADIOS2 when overwriting existing Iterations in file-based Append mode.
 * ``adios2.engine.parameters``: An associative array of string-formatted engine parameters, passed directly through to ``adios2::IO::SetParameters``.
   Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for the available engine parameters.
   The openPMD-api does not interpret these values and instead simply forwards them to ADIOS2.

--- a/docs/source/usage/workflow.rst
+++ b/docs/source/usage/workflow.rst
@@ -102,6 +102,8 @@ The openPMD-api distinguishes between a number of different access modes:
   We suggest to fully define iterations when using Append mode (i.e. as if using Create mode) to avoid implementation-specific behavior.
   Appending to an openPMD Series is only supported on a per-iteration level.
 
+  **Tip:** Use the ``adios2.engine.access_mode`` :ref:`backend key <backendconfig>` of the :ref:`ADIOS2 backend <backends-adios2>` to finetune the backend-specific behavior of Append mode for niche use cases.
+
   **Warning:** There is no reading involved in using Append mode.
   It is a user's responsibility to ensure that the appended dataset and the appended-to dataset are compatible with each other.
   The results of using incompatible backend configurations are undefined.

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1514,8 +1514,12 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(std::string const &fullPath)
         constexpr std::array<pair_t, 4> modeNames{
             pair_t{"write", adios2::Mode::Write},
             pair_t{"read", adios2::Mode::Read},
-            pair_t{"append", adios2::Mode::Append},
-            pair_t{"readrandomaccess", adios2::Mode::ReadRandomAccess}};
+            pair_t{"append", adios2::Mode::Append}
+#if openPMD_HAS_ADIOS_2_8
+            ,
+            pair_t{"readrandomaccess", adios2::Mode::ReadRandomAccess}
+#endif
+        };
         for (auto const &[name, mode] : modeNames)
         {
             if (name == access_mode_string)

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -30,6 +30,7 @@
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
+#include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/auxiliary/Mpi.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
@@ -40,6 +41,7 @@
 #include <iterator>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -1496,6 +1498,42 @@ void ADIOS2IOHandlerImpl::touch(
 
 adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(std::string const &fullPath)
 {
+    if (m_config.json().contains("engine") &&
+        m_config["engine"].json().contains("access_mode"))
+    {
+        auto const &access_mode_json = m_config["engine"]["access_mode"].json();
+        auto maybe_access_mode_string =
+            json::asLowerCaseStringDynamic(access_mode_json);
+        if (!maybe_access_mode_string.has_value())
+        {
+            throw error::BackendConfigSchema(
+                {"adios2", "engine", "access_mode"}, "Must be of string type.");
+        }
+        auto access_mode_string = *maybe_access_mode_string;
+        using pair_t = std::pair<char const *, adios2::Mode>;
+        constexpr std::array<pair_t, 4> modeNames{
+            pair_t{"write", adios2::Mode::Write},
+            pair_t{"read", adios2::Mode::Read},
+            pair_t{"append", adios2::Mode::Append},
+            pair_t{"readrandomaccess", adios2::Mode::ReadRandomAccess}};
+        for (auto const &[name, mode] : modeNames)
+        {
+            if (name == access_mode_string)
+            {
+                return mode;
+            }
+        }
+        std::stringstream error;
+        error << "Unsupported value '" << access_mode_string
+              << "'. Must be one of:";
+        for (auto const &pair : modeNames)
+        {
+            error << " '" << pair.first << "'";
+        }
+        error << '.';
+        throw error::BackendConfigSchema(
+            {"adios2", "engine", "access_mode"}, error.str());
+    }
     switch (m_handler->m_backendAccess)
     {
     case Access::CREATE:


### PR DESCRIPTION
Close #1630. See there as well as the documentation and testing in the [diff](https://github.com/franzpoeschel/openPMD-api/compare/flush_target_newstep...adios2-override-access-type).

- [x] Merge #1632 first
- [x] Add a parallel test too
