### PR TITLE
Performance: Flush IOHandler only once, not for each Iteration

### DIFF
--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -150,11 +150,13 @@ public:
      * extent of parameters.extent. If possible, the new dataset should be
      * extensible. If possible, the new dataset should be divided into chunks
      * with size parameters.chunkSize. If possible, the new dataset should be
-     * compressed according to parameters.compression. This may be
-     * format-specific. If possible, the new dataset should be transformed
-     * accoring to parameters.transform. This may be format-specific. The
-     * Writables file position should correspond to the newly created dataset.
-     * The Writable should be marked written when the operation completes
+     * compressed/transformed according to the backend-specific configuration in
+     * parameters.options. The Writables file position should correspond to the
+     * newly created dataset. Any pre-existing file position should be ignored,
+     * the new file position will be based upon the parent object and the newly
+     * created path. (The old file position might still contain data due to
+     * reuse of Writable objects across files in file-based encoding.) The
+     * Writable should be marked written when the operation completes
      * successfully.
      */
     virtual void

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -400,6 +400,9 @@ public:
     virtual void
     touch(Writable *, Parameter<Operation::TOUCH> const &param) = 0;
 
+    virtual void
+    setWritten(Writable *, Parameter<Operation::SET_WRITTEN> const &param);
+
     AbstractIOHandler *m_handler;
     bool m_verboseIOTasks = false;
 

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -77,7 +77,8 @@ OPENPMDAPI_EXPORT_ENUM_CLASS(Operation){
     ADVANCE,
     AVAILABLE_CHUNKS, //!< Query chunks that can be loaded in a dataset
     DEREGISTER, //!< Inform the backend that an object has been deleted.
-    TOUCH //!< tell the backend that the file is to be considered active
+    TOUCH, //!< tell the backend that the file is to be considered active
+    SET_WRITTEN //!< tell backend to consider a file written / not written
 }; // note: if you change the enum members here, please update
    // docs/source/dev/design.rst
 
@@ -689,6 +690,27 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::TOUCH> : public AbstractParameter
     {
         return std::make_unique<Parameter<Operation::TOUCH>>(std::move(*this));
     }
+};
+
+template <>
+struct OPENPMDAPI_EXPORT Parameter<Operation::SET_WRITTEN>
+    : public AbstractParameter
+{
+    explicit Parameter() = default;
+
+    Parameter(Parameter const &) = default;
+    Parameter(Parameter &&) = default;
+
+    Parameter &operator=(Parameter const &) = default;
+    Parameter &operator=(Parameter &&) = default;
+
+    std::unique_ptr<AbstractParameter> to_heap() && override
+    {
+        return std::make_unique<Parameter<Operation::SET_WRITTEN>>(
+            std::move(*this));
+    }
+
+    bool target_status = false;
 };
 
 /** @brief Self-contained description of a single IO operation.

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -481,11 +481,14 @@ OPENPMD_protected
     {
         return writable().written;
     }
-    void setWritten(bool val)
+    void setWritten(bool val, bool asynchronous)
     {
-        Parameter<Operation::SET_WRITTEN> param;
-        param.target_status = val;
-        IOHandler()->enqueue(IOTask(this, param));
+        if (asynchronous)
+        {
+            Parameter<Operation::SET_WRITTEN> param;
+            param.target_status = val;
+            IOHandler()->enqueue(IOTask(this, param));
+        }
         writable().written = val;
     }
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -481,16 +481,22 @@ OPENPMD_protected
     {
         return writable().written;
     }
-    void setWritten(bool val, bool asynchronous)
+    enum class EnqueueAsynchronously : bool
     {
-        if (asynchronous)
-        {
-            Parameter<Operation::SET_WRITTEN> param;
-            param.target_status = val;
-            IOHandler()->enqueue(IOTask(this, param));
-        }
-        writable().written = val;
-    }
+        Yes,
+        No
+    };
+    /*
+     * setWritten() will take effect immediately.
+     * But it might additionally be necessary in some situations to enqueue a
+     * SET_WRITTEN task to the backend:
+     * A single flush() operation might encompass different Iterations. In
+     * file-based Iteration encoding, some objects must be written to every
+     * single file, thus their `written` flag must be restored to `false` for
+     * each Iteration. When flushing multiple Iterations at once, this must
+     * happen as an asynchronous IO task.
+     */
+    void setWritten(bool val, EnqueueAsynchronously);
 
 private:
     /**

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -481,9 +481,12 @@ OPENPMD_protected
     {
         return writable().written;
     }
-    bool &written()
+    void setWritten(bool val)
     {
-        return writable().written;
+        Parameter<Operation::SET_WRITTEN> param;
+        param.target_status = val;
+        IOHandler()->enqueue(IOTask(this, param));
+        writable().written = val;
     }
 
 private:

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -645,7 +645,7 @@ auto BaseRecord<T_elem>::erase(key_type const &key) -> size_type
 
     if (keyScalar)
     {
-        this->written() = false;
+        this->setWritten(false);
         this->writable().abstractFilePosition.reset();
         this->get().m_datasetDefined = false;
     }

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -645,7 +645,7 @@ auto BaseRecord<T_elem>::erase(key_type const &key) -> size_type
 
     if (keyScalar)
     {
-        this->setWritten(false, false);
+        this->setWritten(false, Attributable::EnqueueAsynchronously::No);
         this->writable().abstractFilePosition.reset();
         this->get().m_datasetDefined = false;
     }

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -645,7 +645,7 @@ auto BaseRecord<T_elem>::erase(key_type const &key) -> size_type
 
     if (keyScalar)
     {
-        this->setWritten(false);
+        this->setWritten(false, false);
         this->writable().abstractFilePosition.reset();
         this->get().m_datasetDefined = false;
     }

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -1197,12 +1197,7 @@ AdvanceStatus ADIOS2File::advance(AdvanceMode mode)
 
 void ADIOS2File::drop()
 {
-    if (!m_buffer.empty())
-    {
-        throw error::Internal(
-            "ADIOS2 backend: File data for '" + m_file +
-            "' dropped, but there were enqueued operations.");
-    }
+    assert(m_buffer.empty());
 }
 
 static std::vector<std::string> availableAttributesOrVariablesPrefixed(

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -750,6 +750,7 @@ void ADIOS2IOHandlerImpl::createDataset(
 
         auto const file =
             refreshFileFromParent(writable, /* preferParentFile = */ true);
+        writable->abstractFilePosition.reset();
         auto filePos = setAndGetFilePosition(writable, name);
         filePos->gd = GroupOrDataset::DATASET;
         auto const varName = nameOfVariable(writable);

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -532,16 +532,17 @@ ADIOS2IOHandlerImpl::flush(internal::ParsedFlushParams &flushParams)
         }
     }
 
-    for (auto &p : m_fileData)
+    for (auto const &file : m_dirty)
     {
-        if (m_dirty.find(p.first) != m_dirty.end())
+        auto file_data = m_fileData.find(file);
+        if (file_data == m_fileData.end())
         {
-            p.second->flush(adios2FlushParams, /* writeLatePuts = */ false);
+            throw error::Internal(
+                "[ADIOS2 backend] No associated data found for file'" + *file +
+                "'.");
         }
-        else
-        {
-            p.second->drop();
-        }
+        file_data->second->flush(
+            adios2FlushParams, /* writeLatePuts = */ false);
     }
     m_dirty.clear();
     return res;

--- a/src/IO/AbstractIOHandlerImpl.cpp
+++ b/src/IO/AbstractIOHandlerImpl.cpp
@@ -425,8 +425,16 @@ std::future<void> AbstractIOHandlerImpl::flush()
                 auto &parameter =
                     deref_dynamic_cast<Parameter<O::TOUCH>>(i.parameter.get());
                 writeToStderr(
-                    "[", i.writable->parent, "->", i.writable, "] DEREGISTER");
+                    "[", i.writable->parent, "->", i.writable, "] TOUCH");
                 touch(i.writable, parameter);
+                break;
+            }
+            case O::SET_WRITTEN: {
+                auto &parameter = deref_dynamic_cast<Parameter<O::SET_WRITTEN>>(
+                    i.parameter.get());
+                writeToStderr(
+                    "[", i.writable->parent, "->", i.writable, "] SET_WRITTEN");
+                setWritten(i.writable, parameter);
                 break;
             }
             }
@@ -475,5 +483,11 @@ std::future<void> AbstractIOHandlerImpl::flush()
         (*m_handler).m_work.pop();
     }
     return std::future<void>();
+}
+
+void AbstractIOHandlerImpl::setWritten(
+    Writable *w, Parameter<Operation::SET_WRITTEN> const &param)
+{
+    w->written = param.target_status;
 }
 } // namespace openPMD

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -617,6 +617,7 @@ void HDF5IOHandlerImpl::createDataset(
         }
 #endif
 
+        writable->abstractFilePosition.reset();
         /* Open H5Object to write into */
         File file{};
         if (auto opt = getFile(writable->parent); opt.has_value())

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1346,8 +1346,12 @@ JSONIOHandlerImpl::obtainJsonContents(File const &file)
 nlohmann::json &JSONIOHandlerImpl::obtainJsonContents(Writable *writable)
 {
     auto file = refreshFileFromParent(writable);
+    std::cout << "Getting JSON contents from file '" << *file
+              << "':" << std::endl;
     auto filePosition = setAndGetFilePosition(writable, false);
-    return (*obtainJsonContents(file))[filePosition->id];
+    auto &res = (*obtainJsonContents(file))[filePosition->id];
+    std::cout << "\t" << res << std::endl;
+    return res;
 }
 
 auto JSONIOHandlerImpl::putJsonContents(

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -292,6 +292,7 @@ void JSONIOHandlerImpl::createDataset(
         std::string name = removeSlashes(parameter.name);
 
         auto file = refreshFileFromParent(writable);
+        writable->abstractFilePosition.reset();
         setAndGetFilePosition(writable);
         auto &jsonVal = obtainJsonContents(writable);
         // be sure to have a JSON object, not a list
@@ -1346,12 +1347,8 @@ JSONIOHandlerImpl::obtainJsonContents(File const &file)
 nlohmann::json &JSONIOHandlerImpl::obtainJsonContents(Writable *writable)
 {
     auto file = refreshFileFromParent(writable);
-    std::cout << "Getting JSON contents from file '" << *file
-              << "':" << std::endl;
     auto filePosition = setAndGetFilePosition(writable, false);
-    auto &res = (*obtainJsonContents(file))[filePosition->id];
-    std::cout << "\t" << res << std::endl;
-    return res;
+    return (*obtainJsonContents(file))[filePosition->id];
 }
 
 auto JSONIOHandlerImpl::putJsonContents(

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -214,7 +214,7 @@ void Iteration::flushFileBased(
          * If it was written before, then in the context of another iteration.
          */
         auto &attr = s.get().m_rankTable.m_attributable;
-        attr.setWritten(false, true);
+        attr.setWritten(false, Attributable::EnqueueAsynchronously::Yes);
         s.get()
             .m_rankTable.m_attributable.get()
             .m_writable.abstractFilePosition.reset();
@@ -631,9 +631,9 @@ void Iteration::readMeshes(std::string const &meshesPath)
         MeshRecordComponent &mrc = m;
         IOHandler()->enqueue(IOTask(&mrc, dOpen));
         IOHandler()->flush(internal::defaultFlushParams);
-        mrc.setWritten(false, false);
+        mrc.setWritten(false, Attributable::EnqueueAsynchronously::No);
         mrc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        mrc.setWritten(true, false);
+        mrc.setWritten(true, Attributable::EnqueueAsynchronously::No);
         try
         {
             m.read();
@@ -755,7 +755,8 @@ auto Iteration::beginStep(
         access::read(series.IOHandler()->m_frontendAccess))
     {
         bool previous = series.iterations.written();
-        series.iterations.setWritten(false, true);
+        series.iterations.setWritten(
+            false, Attributable::EnqueueAsynchronously::Yes);
         auto oldStatus = IOHandl->m_seriesStatus;
         IOHandl->m_seriesStatus = internal::SeriesStatus::Parsing;
         try
@@ -771,7 +772,8 @@ auto Iteration::beginStep(
             throw;
         }
         IOHandl->m_seriesStatus = oldStatus;
-        series.iterations.setWritten(previous, true);
+        series.iterations.setWritten(
+            previous, Attributable::EnqueueAsynchronously::Yes);
     }
 
     res.stepStatus = status;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -214,7 +214,7 @@ void Iteration::flushFileBased(
          * If it was written before, then in the context of another iteration.
          */
         auto &attr = s.get().m_rankTable.m_attributable;
-        attr.setWritten(false);
+        attr.setWritten(false, true);
         s.get()
             .m_rankTable.m_attributable.get()
             .m_writable.abstractFilePosition.reset();
@@ -631,9 +631,9 @@ void Iteration::readMeshes(std::string const &meshesPath)
         MeshRecordComponent &mrc = m;
         IOHandler()->enqueue(IOTask(&mrc, dOpen));
         IOHandler()->flush(internal::defaultFlushParams);
-        mrc.setWritten(false);
+        mrc.setWritten(false, false);
         mrc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        mrc.setWritten(true);
+        mrc.setWritten(true, false);
         try
         {
             m.read();
@@ -755,7 +755,7 @@ auto Iteration::beginStep(
         access::read(series.IOHandler()->m_frontendAccess))
     {
         bool previous = series.iterations.written();
-        series.iterations.setWritten(false);
+        series.iterations.setWritten(false, true);
         auto oldStatus = IOHandl->m_seriesStatus;
         IOHandl->m_seriesStatus = internal::SeriesStatus::Parsing;
         try
@@ -771,7 +771,7 @@ auto Iteration::beginStep(
             throw;
         }
         IOHandl->m_seriesStatus = oldStatus;
-        series.iterations.setWritten(previous);
+        series.iterations.setWritten(previous, true);
     }
 
     res.stepStatus = status;

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -213,7 +213,8 @@ void Iteration::flushFileBased(
         /*
          * If it was written before, then in the context of another iteration.
          */
-        s.get().m_rankTable.m_attributable.written() = false;
+        auto &attr = s.get().m_rankTable.m_attributable;
+        attr.setWritten(false);
         s.get()
             .m_rankTable.m_attributable.get()
             .m_writable.abstractFilePosition.reset();
@@ -630,9 +631,9 @@ void Iteration::readMeshes(std::string const &meshesPath)
         MeshRecordComponent &mrc = m;
         IOHandler()->enqueue(IOTask(&mrc, dOpen));
         IOHandler()->flush(internal::defaultFlushParams);
-        mrc.written() = false;
+        mrc.setWritten(false);
         mrc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        mrc.written() = true;
+        mrc.setWritten(true);
         try
         {
             m.read();
@@ -754,7 +755,7 @@ auto Iteration::beginStep(
         access::read(series.IOHandler()->m_frontendAccess))
     {
         bool previous = series.iterations.written();
-        series.iterations.written() = false;
+        series.iterations.setWritten(false);
         auto oldStatus = IOHandl->m_seriesStatus;
         IOHandl->m_seriesStatus = internal::SeriesStatus::Parsing;
         try
@@ -770,7 +771,7 @@ auto Iteration::beginStep(
             throw;
         }
         IOHandl->m_seriesStatus = oldStatus;
-        series.iterations.written() = previous;
+        series.iterations.setWritten(previous);
     }
 
     res.stepStatus = status;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -438,9 +438,9 @@ void Mesh::read()
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.written() = false;
+            rc.setWritten(false);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.written() = true;
+            rc.setWritten(true);
             try
             {
                 rc.read();

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -438,9 +438,9 @@ void Mesh::read()
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.setWritten(false, false);
+            rc.setWritten(false, Attributable::EnqueueAsynchronously::No);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.setWritten(true, false);
+            rc.setWritten(true, Attributable::EnqueueAsynchronously::No);
             try
             {
                 rc.read();

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -438,9 +438,9 @@ void Mesh::read()
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.setWritten(false);
+            rc.setWritten(false, false);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.setWritten(true);
+            rc.setWritten(true, false);
             try
             {
                 rc.read();

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -93,9 +93,9 @@ void ParticlePatches::read()
                     datatypeToString(*dOpen.dtype) + ")");
 
         /* allow all attributes to be set */
-        prc.setWritten(false);
+        prc.setWritten(false, false);
         prc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        prc.setWritten(true);
+        prc.setWritten(true, false);
 
         pr.setDirty(false);
         try

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -93,9 +93,9 @@ void ParticlePatches::read()
                     datatypeToString(*dOpen.dtype) + ")");
 
         /* allow all attributes to be set */
-        prc.setWritten(false, false);
+        prc.setWritten(false, Attributable::EnqueueAsynchronously::No);
         prc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        prc.setWritten(true, false);
+        prc.setWritten(true, Attributable::EnqueueAsynchronously::No);
 
         pr.setDirty(false);
         try

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -93,9 +93,9 @@ void ParticlePatches::read()
                     datatypeToString(*dOpen.dtype) + ")");
 
         /* allow all attributes to be set */
-        prc.written() = false;
+        prc.setWritten(false);
         prc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        prc.written() = true;
+        prc.setWritten(true);
 
         pr.setDirty(false);
         try

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -124,9 +124,9 @@ void ParticleSpecies::read()
             RecordComponent &rc = r;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.setWritten(false);
+            rc.setWritten(false, false);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.setWritten(true);
+            rc.setWritten(true, false);
             r.read();
         }
         catch (error::ReadError const &err)

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -124,9 +124,9 @@ void ParticleSpecies::read()
             RecordComponent &rc = r;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.setWritten(false, false);
+            rc.setWritten(false, Attributable::EnqueueAsynchronously::No);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.setWritten(true, false);
+            rc.setWritten(true, Attributable::EnqueueAsynchronously::No);
             r.read();
         }
         catch (error::ReadError const &err)

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -124,9 +124,9 @@ void ParticleSpecies::read()
             RecordComponent &rc = r;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.written() = false;
+            rc.setWritten(false);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.written() = true;
+            rc.setWritten(true);
             r.read();
         }
         catch (error::ReadError const &err)

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -150,9 +150,9 @@ void Record::read()
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.written() = false;
+            rc.setWritten(false);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.written() = true;
+            rc.setWritten(true);
             try
             {
                 rc.read(/* require_unit_si = */ true);

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -150,9 +150,9 @@ void Record::read()
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.setWritten(false);
+            rc.setWritten(false, false);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.setWritten(true);
+            rc.setWritten(true, false);
             try
             {
                 rc.read(/* require_unit_si = */ true);

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -150,9 +150,9 @@ void Record::read()
             dOpen.name = component;
             IOHandler()->enqueue(IOTask(&rc, dOpen));
             IOHandler()->flush(internal::defaultFlushParams);
-            rc.setWritten(false, false);
+            rc.setWritten(false, Attributable::EnqueueAsynchronously::No);
             rc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-            rc.setWritten(true, false);
+            rc.setWritten(true, Attributable::EnqueueAsynchronously::No);
             try
             {
                 rc.read(/* require_unit_si = */ true);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -399,9 +399,9 @@ void RecordComponent::readBase(bool require_unit_si)
 
         Attribute a(*aRead.resource);
         DT dtype = *aRead.dtype;
-        setWritten(false, false);
+        setWritten(false, Attributable::EnqueueAsynchronously::No);
         switchNonVectorType<MakeConstant>(dtype, *this, a);
-        setWritten(true, false);
+        setWritten(true, Attributable::EnqueueAsynchronously::No);
 
         aRead.name = "shape";
         IOHandler()->enqueue(IOTask(this, aRead));
@@ -426,9 +426,9 @@ void RecordComponent::readBase(bool require_unit_si)
                 oss.str());
         }
 
-        setWritten(false, false);
+        setWritten(false, Attributable::EnqueueAsynchronously::No);
         resetDataset(Dataset(dtype, e));
-        setWritten(true, false);
+        setWritten(true, Attributable::EnqueueAsynchronously::No);
     }
 
     readAttributes(ReadMode::FullyReread);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -399,9 +399,9 @@ void RecordComponent::readBase(bool require_unit_si)
 
         Attribute a(*aRead.resource);
         DT dtype = *aRead.dtype;
-        written() = false;
+        setWritten(false);
         switchNonVectorType<MakeConstant>(dtype, *this, a);
-        written() = true;
+        setWritten(true);
 
         aRead.name = "shape";
         IOHandler()->enqueue(IOTask(this, aRead));
@@ -426,9 +426,9 @@ void RecordComponent::readBase(bool require_unit_si)
                 oss.str());
         }
 
-        written() = false;
+        setWritten(false);
         resetDataset(Dataset(dtype, e));
-        written() = true;
+        setWritten(true);
     }
 
     readAttributes(ReadMode::FullyReread);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -399,9 +399,9 @@ void RecordComponent::readBase(bool require_unit_si)
 
         Attribute a(*aRead.resource);
         DT dtype = *aRead.dtype;
-        setWritten(false);
+        setWritten(false, false);
         switchNonVectorType<MakeConstant>(dtype, *this, a);
-        setWritten(true);
+        setWritten(true, false);
 
         aRead.name = "shape";
         IOHandler()->enqueue(IOTask(this, aRead));
@@ -426,9 +426,9 @@ void RecordComponent::readBase(bool require_unit_si)
                 oss.str());
         }
 
-        setWritten(false);
+        setWritten(false, false);
         resetDataset(Dataset(dtype, e));
-        setWritten(true);
+        setWritten(true, false);
     }
 
     readAttributes(ReadMode::FullyReread);

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1138,12 +1138,12 @@ Given file pattern: ')END"
             {
                 /* Access::READ_WRITE can be used to create a new Series
                  * allow setting attributes in that case */
-                setWritten(false);
+                setWritten(false, false);
 
                 initDefaults(input->iterationEncoding);
                 setIterationEncoding(input->iterationEncoding);
 
-                setWritten(true);
+                setWritten(true, false);
             }
         }
         catch (...)
@@ -1346,8 +1346,8 @@ void Series::flushFileBased(
                  * (to ensure that the Series gets reassociated with the
                  * current iteration by the backend)
                  */
-                this->setWritten(false);
-                series.iterations.setWritten(false);
+                this->setWritten(false, true);
+                series.iterations.setWritten(false, true);
 
                 setDirty(dirty() || it->second.dirty());
                 std::string filename = iterationFilename(it->first);
@@ -1798,9 +1798,9 @@ void Series::readOneIterationFileBased(std::string const &filePath)
     IOHandler()->flush(internal::defaultFlushParams);
     if (*aRead.dtype == DT::STRING)
     {
-        setWritten(false);
+        setWritten(false, false);
         setIterationFormat(Attribute(*aRead.resource).get<std::string>());
-        setWritten(true);
+        setWritten(true, false);
     }
     else
         throw error::ReadError(
@@ -1949,9 +1949,9 @@ creating new iterations.
         IOHandler()->flush(internal::defaultFlushParams);
         if (*aRead.dtype == DT::STRING)
         {
-            setWritten(false);
+            setWritten(false, false);
             setIterationFormat(Attribute(*aRead.resource).get<std::string>());
-            setWritten(true);
+            setWritten(true, false);
         }
         else
             throw error::ReadError(
@@ -2216,12 +2216,12 @@ void Series::readBase()
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
-                it.second.meshes.setWritten(false);
+                it.second.meshes.setWritten(false, false);
 
             setMeshesPath(val.value());
 
             for (auto &it : series.iterations)
-                it.second.meshes.setWritten(true);
+                it.second.meshes.setWritten(true, false);
         }
         else
             throw error::ReadError(
@@ -2246,12 +2246,12 @@ void Series::readBase()
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
-                it.second.particles.setWritten(false);
+                it.second.particles.setWritten(false, false);
 
             setParticlesPath(val.value());
 
             for (auto &it : series.iterations)
-                it.second.particles.setWritten(true);
+                it.second.particles.setWritten(true, false);
         }
         else
             throw error::ReadError(

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1321,12 +1321,12 @@ void Series::flushFileBased(
                 it->second.get().m_closed =
                     internal::CloseStatus::ClosedInBackend;
             }
+        }
 
-            // Phase 3
-            if (flushIOHandler)
-            {
-                IOHandler()->flush(flushParams);
-            }
+        // Phase 3
+        if (flushIOHandler)
+        {
+            IOHandler()->flush(flushParams);
         }
         break;
     case Access::READ_WRITE:
@@ -1379,18 +1379,18 @@ void Series::flushFileBased(
                 it->second.get().m_closed =
                     internal::CloseStatus::ClosedInBackend;
             }
-
-            // Phase 3
-            if (flushIOHandler)
-            {
-                IOHandler()->flush(flushParams);
-            }
             /* reset the dirty bit for every iteration (i.e. file)
              * otherwise only the first iteration will have updates attributes
              */
             setDirty(allDirty);
         }
         setDirty(false);
+
+        // Phase 3
+        if (flushIOHandler)
+        {
+            IOHandler()->flush(flushParams);
+        }
         break;
     }
     }
@@ -1431,14 +1431,14 @@ void Series::flushGorVBased(
                 it->second.get().m_closed =
                     internal::CloseStatus::ClosedInBackend;
             }
+        }
 
-            // Phase 3
-            Parameter<Operation::TOUCH> touch;
-            IOHandler()->enqueue(IOTask(&writable(), touch));
-            if (flushIOHandler)
-            {
-                IOHandler()->flush(flushParams);
-            }
+        // Phase 3
+        Parameter<Operation::TOUCH> touch;
+        IOHandler()->enqueue(IOTask(&writable(), touch));
+        if (flushIOHandler)
+        {
+            IOHandler()->flush(flushParams);
         }
     }
     else

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1344,10 +1344,16 @@ void Series::flushFileBased(
                  * emulate the file belonging to each iteration as not yet
                  * written, even if the iteration itself is already written
                  * (to ensure that the Series gets reassociated with the
-                 * current iteration)
+                 * current iteration by the backend)
                  */
-                written() = false;
-                series.iterations.written() = false;
+                Parameter<Operation::SET_WRITTEN> setWritten;
+                setWritten.target_status = false;
+                for (auto a :
+                     std::array<Attributable *, 2>{this, &series.iterations})
+                {
+                    a->writable().written = false;
+                    IOHandler()->enqueue(IOTask(a, setWritten));
+                }
 
                 setDirty(dirty() || it->second.dirty());
                 std::string filename = iterationFilename(it->first);

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1138,12 +1138,12 @@ Given file pattern: ')END"
             {
                 /* Access::READ_WRITE can be used to create a new Series
                  * allow setting attributes in that case */
-                setWritten(false, false);
+                setWritten(false, Attributable::EnqueueAsynchronously::No);
 
                 initDefaults(input->iterationEncoding);
                 setIterationEncoding(input->iterationEncoding);
 
-                setWritten(true, false);
+                setWritten(true, Attributable::EnqueueAsynchronously::No);
             }
         }
         catch (...)
@@ -1346,8 +1346,10 @@ void Series::flushFileBased(
                  * (to ensure that the Series gets reassociated with the
                  * current iteration by the backend)
                  */
-                this->setWritten(false, true);
-                series.iterations.setWritten(false, true);
+                this->setWritten(
+                    false, Attributable::EnqueueAsynchronously::Yes);
+                series.iterations.setWritten(
+                    false, Attributable::EnqueueAsynchronously::Yes);
 
                 setDirty(dirty() || it->second.dirty());
                 std::string filename = iterationFilename(it->first);
@@ -1798,9 +1800,9 @@ void Series::readOneIterationFileBased(std::string const &filePath)
     IOHandler()->flush(internal::defaultFlushParams);
     if (*aRead.dtype == DT::STRING)
     {
-        setWritten(false, false);
+        setWritten(false, Attributable::EnqueueAsynchronously::No);
         setIterationFormat(Attribute(*aRead.resource).get<std::string>());
-        setWritten(true, false);
+        setWritten(true, Attributable::EnqueueAsynchronously::No);
     }
     else
         throw error::ReadError(
@@ -1949,9 +1951,9 @@ creating new iterations.
         IOHandler()->flush(internal::defaultFlushParams);
         if (*aRead.dtype == DT::STRING)
         {
-            setWritten(false, false);
+            setWritten(false, Attributable::EnqueueAsynchronously::No);
             setIterationFormat(Attribute(*aRead.resource).get<std::string>());
-            setWritten(true, false);
+            setWritten(true, Attributable::EnqueueAsynchronously::No);
         }
         else
             throw error::ReadError(
@@ -2216,12 +2218,14 @@ void Series::readBase()
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
-                it.second.meshes.setWritten(false, false);
+                it.second.meshes.setWritten(
+                    false, Attributable::EnqueueAsynchronously::No);
 
             setMeshesPath(val.value());
 
             for (auto &it : series.iterations)
-                it.second.meshes.setWritten(true, false);
+                it.second.meshes.setWritten(
+                    true, Attributable::EnqueueAsynchronously::No);
         }
         else
             throw error::ReadError(
@@ -2246,12 +2250,14 @@ void Series::readBase()
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
-                it.second.particles.setWritten(false, false);
+                it.second.particles.setWritten(
+                    false, Attributable::EnqueueAsynchronously::No);
 
             setParticlesPath(val.value());
 
             for (auto &it : series.iterations)
-                it.second.particles.setWritten(true, false);
+                it.second.particles.setWritten(
+                    true, Attributable::EnqueueAsynchronously::No);
         }
         else
             throw error::ReadError(

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1138,12 +1138,12 @@ Given file pattern: ')END"
             {
                 /* Access::READ_WRITE can be used to create a new Series
                  * allow setting attributes in that case */
-                written() = false;
+                setWritten(false);
 
                 initDefaults(input->iterationEncoding);
                 setIterationEncoding(input->iterationEncoding);
 
-                written() = true;
+                setWritten(true);
             }
         }
         catch (...)
@@ -1346,14 +1346,8 @@ void Series::flushFileBased(
                  * (to ensure that the Series gets reassociated with the
                  * current iteration by the backend)
                  */
-                Parameter<Operation::SET_WRITTEN> setWritten;
-                setWritten.target_status = false;
-                for (auto a :
-                     std::array<Attributable *, 2>{this, &series.iterations})
-                {
-                    a->writable().written = false;
-                    IOHandler()->enqueue(IOTask(a, setWritten));
-                }
+                this->setWritten(false);
+                series.iterations.setWritten(false);
 
                 setDirty(dirty() || it->second.dirty());
                 std::string filename = iterationFilename(it->first);
@@ -1804,9 +1798,9 @@ void Series::readOneIterationFileBased(std::string const &filePath)
     IOHandler()->flush(internal::defaultFlushParams);
     if (*aRead.dtype == DT::STRING)
     {
-        written() = false;
+        setWritten(false);
         setIterationFormat(Attribute(*aRead.resource).get<std::string>());
-        written() = true;
+        setWritten(true);
     }
     else
         throw error::ReadError(
@@ -1955,9 +1949,9 @@ creating new iterations.
         IOHandler()->flush(internal::defaultFlushParams);
         if (*aRead.dtype == DT::STRING)
         {
-            written() = false;
+            setWritten(false);
             setIterationFormat(Attribute(*aRead.resource).get<std::string>());
-            written() = true;
+            setWritten(true);
         }
         else
             throw error::ReadError(
@@ -2222,12 +2216,12 @@ void Series::readBase()
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
-                it.second.meshes.written() = false;
+                it.second.meshes.setWritten(false);
 
             setMeshesPath(val.value());
 
             for (auto &it : series.iterations)
-                it.second.meshes.written() = true;
+                it.second.meshes.setWritten(true);
         }
         else
             throw error::ReadError(
@@ -2252,12 +2246,12 @@ void Series::readBase()
         {
             /* allow setting the meshes path after completed IO */
             for (auto &it : series.iterations)
-                it.second.particles.written() = false;
+                it.second.particles.setWritten(false);
 
             setParticlesPath(val.value());
 
             for (auto &it : series.iterations)
-                it.second.particles.written() = true;
+                it.second.particles.setWritten(true);
         }
         else
             throw error::ReadError(

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -26,6 +26,7 @@
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 
+#include <nlohmann/json.hpp>
 #include <queue>
 #include <toml.hpp>
 
@@ -293,9 +294,22 @@ namespace
 {
     ParsedConfig parseInlineOptions(std::string const &options)
     {
+        // speed up default options
+        ParsedConfig res;
+        if (options.empty())
+        {
+            res.originallySpecifiedAs = SupportedLanguages::TOML;
+            res.config = nlohmann::json::object();
+            return res;
+        }
+        else if (options == "{}")
+        {
+            res.originallySpecifiedAs = SupportedLanguages::JSON;
+            res.config = nlohmann::json::object();
+            return res;
+        }
         std::string trimmed =
             auxiliary::trim(options, [](char c) { return std::isspace(c); });
-        ParsedConfig res;
         if (trimmed.empty())
         {
             return res;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -481,6 +481,23 @@ void Attributable::readAttributes(ReadMode mode)
     setDirty(false);
 }
 
+void Attributable::setWritten(bool val, EnqueueAsynchronously ea)
+{
+    switch (ea)
+    {
+
+    case EnqueueAsynchronously::Yes: {
+        Parameter<Operation::SET_WRITTEN> param;
+        param.target_status = val;
+        IOHandler()->enqueue(IOTask(this, param));
+    }
+    break;
+    case EnqueueAsynchronously::No:
+        break;
+    }
+    writable().written = val;
+}
+
 void Attributable::linkHierarchy(Writable &w)
 {
     auto handler = w.IOHandler;

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -90,9 +90,9 @@ void PatchRecord::read()
         IOHandler()->enqueue(IOTask(&prc, dOpen));
         IOHandler()->flush(internal::defaultFlushParams);
         /* allow all attributes to be set */
-        prc.written() = false;
+        prc.setWritten(false);
         prc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        prc.written() = true;
+        prc.setWritten(true);
         try
         {
             prc.read(/* require_unit_si = */ false);

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -90,9 +90,9 @@ void PatchRecord::read()
         IOHandler()->enqueue(IOTask(&prc, dOpen));
         IOHandler()->flush(internal::defaultFlushParams);
         /* allow all attributes to be set */
-        prc.setWritten(false, false);
+        prc.setWritten(false, Attributable::EnqueueAsynchronously::No);
         prc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        prc.setWritten(true, false);
+        prc.setWritten(true, Attributable::EnqueueAsynchronously::No);
         try
         {
             prc.read(/* require_unit_si = */ false);

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -90,9 +90,9 @@ void PatchRecord::read()
         IOHandler()->enqueue(IOTask(&prc, dOpen));
         IOHandler()->flush(internal::defaultFlushParams);
         /* allow all attributes to be set */
-        prc.setWritten(false);
+        prc.setWritten(false, false);
         prc.resetDataset(Dataset(*dOpen.dtype, *dOpen.extent));
-        prc.setWritten(true);
+        prc.setWritten(true, false);
         try
         {
             prc.read(/* require_unit_si = */ false);

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -2071,6 +2071,7 @@ inline void fileBased_write_test(const std::string &backend)
             .makeConstant<double>(1.0);
 
         o.iterations[overlong_it].setTime(static_cast<double>(overlong_it));
+        o.flush();
         REQUIRE(o.iterations.size() == 7);
     }
     REQUIRE(


### PR DESCRIPTION
This might address a performance regression seen by @guj.

Until now, `Series::flushFileBased()` and `Series::flushGorVBased()` flushed the IOHandler for every iteration. Since flushing has a constant overhead, calling `Series::flush()` has a linear complexity along with the number of Iterations, even if only a single Iteration has modifications.

Fixing this was not entirely trivial, since in file-based encoding, some frontend object must unset the `written` flag, since they must be written anew for each file. Before this PR, this could easily be done synchronously in the frontend, but since all Iterations are now flushed at once, this must now be done asynchronously in the backend as a backend task.

Also speed up the common case of parsing flush options: No options at all.

- [x] Check if this addresses the performance regressions seen by @guj 
- [x] Check this against PIConGPU, the new `written` logic might behave weird in more complex setups