### PR TITLE
Release notes: 0.16

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -13,6 +13,10 @@ Please transition to ADIOS2.
 For reading legacy ADIOS1 BP3 files, either use an older version of openPMD-api or the BP3 backend in ADIOS2.
 Note that ADIOS2 does not support compression in BP3 files.
 
+For converting ADIOS1 BP3 files to ADIOS2, use a version of the openPMD-api that still supports ADIOS1 and run the conversion with ``openpmd-pipe``, e.g. ``openpmd-pipe --infile adios1_data_%T.bp --inconfig '{"backend": "adios1"}' --outfile adios2_data_%T.bp --outconfig '{"backend": "adios2"}'``.
+
+Group-Based encoding is deprecated in ADIOS2 due to performance considerations. As alternatives, consider file-based encoding for regular file I/O or variable-based encoding (currently restricted to streaming and streaming-like workflows).
+
 CMake 3.22.0 is now the minimally supported version for CMake.
 pybind11 2.13.0 is now the minimally supported version for Python support.
 Python 3.12 & 3.13 are now supported, Python 3.7 is removed.

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
 Use the following lines in your project's `CMakeLists.txt`:
 ```cmake
 # supports:                       COMPONENTS MPI NOMPI HDF5 ADIOS2
-find_package(openPMD 0.15.0 CONFIG)
+find_package(openPMD 0.16.0 CONFIG)
 
 if(openPMD_FOUND)
     target_link_libraries(YourTarget PRIVATE openPMD::openPMD)
@@ -332,7 +332,7 @@ set(openPMD_INSTALL OFF)            # or instead use:
 set(openPMD_USE_PYTHON OFF)
 FetchContent_Declare(openPMD
   GIT_REPOSITORY "https://github.com/openPMD/openPMD-api.git"
-  GIT_TAG        "0.15.0")
+  GIT_TAG        "0.16.0")
 FetchContent_MakeAvailable(openPMD)
 ```
 

--- a/docs/source/dev/linking.rst
+++ b/docs/source/dev/linking.rst
@@ -23,7 +23,7 @@ Use the following lines in your project's ``CMakeLists.txt``:
 .. code-block:: cmake
 
    # supports:                       COMPONENTS MPI NOMPI HDF5 ADIOS2
-   find_package(openPMD 0.15.0 CONFIG)
+   find_package(openPMD 0.16.0 CONFIG)
 
    if(openPMD_FOUND)
        target_link_libraries(YourTarget PRIVATE openPMD::openPMD)
@@ -53,7 +53,7 @@ Just replace the ``add_subdirectory`` call with:
    set(openPMD_USE_PYTHON OFF)
    FetchContent_Declare(openPMD
      GIT_REPOSITORY "https://github.com/openPMD/openPMD-api.git"
-     GIT_TAG        "0.15.0")
+     GIT_TAG        "0.16.0")
    FetchContent_MakeAvailable(openPMD)
 
 

--- a/include/openPMD/version.hpp
+++ b/include/openPMD/version.hpp
@@ -30,7 +30,7 @@
 #define OPENPMDAPI_VERSION_MAJOR 0
 #define OPENPMDAPI_VERSION_MINOR 16
 #define OPENPMDAPI_VERSION_PATCH 0
-#define OPENPMDAPI_VERSION_LABEL "dev"
+#define OPENPMDAPI_VERSION_LABEL ""
 /** @} */
 
 /** maximum supported version of the openPMD standard (read & write,


### PR DESCRIPTION
Does not yet contain PRs that are part of the milestone, but not yet merged:

https://github.com/openPMD/openPMD-api/pull/1645
https://github.com/openPMD/openPMD-api/pull/1638
https://github.com/openPMD/openPMD-api/pull/1634
https://github.com/openPMD/openPMD-api/pull/1633
https://github.com/openPMD/openPMD-api/pull/1632
https://github.com/openPMD/openPMD-api/pull/1583

## TODO

- [x] `Changelog`: Add breaking changes and deprecations
- [x] `NEWS.rst`: Add upgrade guide for breaking changes and deprecations
- [x] Update version to `0.16.0` in relevant places using script from #1467