### PR TITLE
Add missing openPMD_HAVE_MPI guard to ParallelIOTest

### DIFF
--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1150,7 +1150,7 @@ TEST_CASE("hipace_like_write", "[parallel]")
 }
 #endif
 
-#if openPMD_HAVE_ADIOS2 && openPMD_HAS_ADIOS_2_9
+#if openPMD_HAVE_ADIOS2 && openPMD_HAS_ADIOS_2_9 && openPMD_HAVE_MPI
 TEST_CASE("independent_write_with_collective_flush", "[parallel]")
 {
     Series write(


### PR DESCRIPTION
In non-MPI builds, the ParallelIOTest is not deactivated by CMake, but by ifdef checks inside the test. One of them was missing.