### PR TITLE
Opt-in support for unknown ADIOS2 engines

### DIFF
--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -48,6 +48,10 @@ Exceptions to this are the BP3 and SST engines which require their endings ``.bp
 
 For file engines, we currently leverage the default ADIOS2 transport parameters, i.e. ``POSIX`` on Unix systems and ``FStream`` on Windows.
 
+.. tip::
+
+  Use the ``adios2.engine.treat_unsupported_engine_as`` :ref:`JSON/TOML parameter <backendconfig-adios2>` for experimentally interacting with an unsupported ADIOS2 engine.
+
 Steps
 -----
 

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -50,7 +50,7 @@ For file engines, we currently leverage the default ADIOS2 transport parameters,
 
 .. tip::
 
-  Use the ``adios2.engine.treat_unsupported_engine_as`` :ref:`JSON/TOML parameter <backendconfig-adios2>` for experimentally interacting with an unsupported ADIOS2 engine.
+   Use the ``adios2.engine.treat_unsupported_engine_as`` :ref:`JSON/TOML parameter <backendconfig-adios2>` for experimentally interacting with an unsupported ADIOS2 engine.
 
 Steps
 -----

--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -85,6 +85,7 @@ environment variable                  default    description
 ``OPENPMD_ADIOS2_HAVE_METADATA_FILE`` ``1``      Online creation of the adios journal file (``1``: yes, ``0``: no).
 ``OPENPMD_ADIOS2_NUM_SUBSTREAMS``     ``0``      Number of files to be created, 0 indicates maximum number possible.
 ``OPENPMD_ADIOS2_ENGINE``             ``File``   `ADIOS2 engine <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_
+``OPENPMD_ADIOS2_PRETEND_ENGINE``     *empty*    Pretend that an (unknown) ADIOS2 engine is in fact another one (also see the ``adios2.pretend_engine`` :ref:`parameter <backendconfig-adios2>`).
 ``OPENPMD2_ADIOS2_USE_GROUP_TABLE``   ``0``      Use group table (see below)
 ``OPENPMD_ADIOS2_STATS_LEVEL``        ``0``      whether to generate statistics for variables in ADIOS2. (``1``: yes, ``0``: no).
 ``OPENPMD_ADIOS2_ASYNC_WRITE``        ``0``      ADIOS2 BP5 engine: 1 means setting "AsyncWrite" in ADIOS2 to "on". Flushes will go to the buffer by default (see ``preferred_flush_target``).

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -122,6 +122,14 @@ Explanation of the single keys:
 
 * ``adios2.engine.type``: A string that is passed directly to ``adios2::IO:::SetEngine`` for choosing the ADIOS2 engine to be used.
   Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for a list of available engines.
+* ``adios2.engine.treat_unsupported_engine_like``: May be used for experimentally testing an ADIOS2 engine that is not explicitly supported by the openPMD-api.
+  Specify the actual engine via ``adios2.engine.type`` and use ``adios2.engine.treat_unsupported_engine_like`` to make the ADIOS2 backend pretend that it is in fact using another engine that it knows.
+  Some advanced engine-specific features will be turned off indiscriminately:
+
+  * The Span API will use a fallback implementation
+  * ``PerformDataWrite()`` will not be used, even when specifying ``adios2.engine.preferred_flush_target = "disk"``.
+  * Engine-specific parameters such as ``QueueLimit`` will not be set by default.
+  * No engine-specific filename extension handling will be executed, the extension specified by the user is taken "as is".
 * ``adios2.engine.access_mode``: One of ``"Write", "Read", "Append", "ReadRandomAccess"``.
   Only needed in specific use cases, the access mode is usually determined from the specified ``openPMD::Access``.
   Useful for finetuning the backend-specific behavior of ADIOS2 when overwriting existing Iterations in file-based Append mode.

--- a/docs/source/details/backendconfig.rst
+++ b/docs/source/details/backendconfig.rst
@@ -122,8 +122,8 @@ Explanation of the single keys:
 
 * ``adios2.engine.type``: A string that is passed directly to ``adios2::IO:::SetEngine`` for choosing the ADIOS2 engine to be used.
   Please refer to the `official ADIOS2 documentation <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_ for a list of available engines.
-* ``adios2.engine.treat_unsupported_engine_like``: May be used for experimentally testing an ADIOS2 engine that is not explicitly supported by the openPMD-api.
-  Specify the actual engine via ``adios2.engine.type`` and use ``adios2.engine.treat_unsupported_engine_like`` to make the ADIOS2 backend pretend that it is in fact using another engine that it knows.
+* ``adios2.engine.pretend_engine``: May be used for experimentally testing an ADIOS2 engine that is not explicitly supported by the openPMD-api.
+  Specify the actual engine via ``adios2.engine.type`` and use ``adios2.engine.pretend_engine`` to make the ADIOS2 backend pretend that it is in fact using another engine that it knows.
   Some advanced engine-specific features will be turned off indiscriminately:
 
   * The Span API will use a fallback implementation

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -77,8 +77,7 @@ namespace adios_defaults
     using const_str = char const *const;
     constexpr const_str str_engine = "engine";
     constexpr const_str str_type = "type";
-    constexpr const_str str_treat_unsupported_engine_like =
-        "treat_unsupported_engine_like";
+    constexpr const_str str_treat_unsupported_engine_like = "pretend_engine";
     constexpr const_str str_params = "parameters";
     constexpr const_str str_usesteps = "usesteps";
     constexpr const_str str_flushtarget = "preferred_flush_target";

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -77,6 +77,8 @@ namespace adios_defaults
     using const_str = char const *const;
     constexpr const_str str_engine = "engine";
     constexpr const_str str_type = "type";
+    constexpr const_str str_treat_unsupported_engine_like =
+        "treat_unsupported_engine_like";
     constexpr const_str str_params = "parameters";
     constexpr const_str str_usesteps = "usesteps";
     constexpr const_str str_flushtarget = "preferred_flush_target";

--- a/include/openPMD/IO/ADIOS/ADIOS2File.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2File.hpp
@@ -413,10 +413,6 @@ public:
 private:
     ADIOS2IOHandlerImpl *m_impl;
     std::optional<adios2::Engine> m_engine; //! ADIOS engine
-    /**
-     * The ADIOS2 engine type, to be passed to adios2::IO::SetEngine
-     */
-    std::string m_engineType;
 
     /*
      * Not all engines support the CurrentStep() call, so we have to

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -238,6 +238,19 @@ private:
             return m_engineType;
         }
     }
+    inline std::string &realEngineType()
+    {
+        return const_cast<std::string &>(
+            static_cast<ADIOS2IOHandlerImpl const *>(this)->realEngineType());
+    }
+    inline void pretendEngine(std::string facade_engine)
+    {
+        if (!m_realEngineType.has_value())
+        {
+            m_realEngineType = std::move(m_engineType);
+        }
+        m_engineType = std::move(facade_engine);
+    }
     /*
      * The filename extension specified by the user.
      */

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -225,6 +225,19 @@ private:
      * The ADIOS2 engine type, to be passed to adios2::IO::SetEngine
      */
     std::string m_engineType;
+    std::optional<std::string> m_realEngineType;
+
+    inline std::string const &realEngineType() const
+    {
+        if (m_realEngineType.has_value())
+        {
+            return *m_realEngineType;
+        }
+        else
+        {
+            return m_engineType;
+        }
+    }
     /*
      * The filename extension specified by the user.
      */


### PR DESCRIPTION
The ADIOS2 backend has a set of known and supported ADIOS2 engines. The consequence is that new, unknown or unsupported engines cannot be used without changing the code of the ADIOS2 backend.
This PR adds the backend key `adios2.engine.treat_unsupported_engine_like` in order to allow users to try alternative backends at their own risk.

e.g.:

```toml
[adios2.engine]
type = "dataman"
treat_unsupported_engine_like = "sst"
```

TODO:
- [x] Documentation

Notes to myself for documenting advanced features not supported by this:
QueueLimit
filename extension handling: default extensions, mandatory extensions in BP3 and SST
Span API
PerformDataWrite