### PR TITLE
Pickle API: Cache unpickled Series to avoid repeated file access

### DIFF
--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -22,6 +22,7 @@
 
 #include "openPMD/IO/Access.hpp"
 #include "openPMD/Series.hpp"
+#include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Attributable.hpp"
 
 #include "Common.hpp"
@@ -75,7 +76,9 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
                 try
                 {
                     return !series.has_value() || !series->operator bool() ||
-                        series->myPath().filePath() != filename;
+                        auxiliary::replace_all(
+                            series->myPath().filePath(), "\\", "/") !=
+                        auxiliary::replace_all(filename, "\\", "/");
                 }
                 /*
                  * Better safe than sorry, if anything goes wrong because the

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -67,9 +67,38 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
             std::vector<std::string> const group =
                 t[1].cast<std::vector<std::string> >();
 
-            openPMD::Series series(
-                filename, Access::READ_ONLY, "defer_iteration_parsing = true");
-            return seriesAccessor(std::move(series), group);
+            /*
+             * Cache the Series per thread.
+             */
+            thread_local std::optional<openPMD::Series> series;
+            bool re_initialize = [&]() {
+                try
+                {
+                    return !series.has_value() || !series->operator bool() ||
+                        series->myPath().filePath() != filename;
+                }
+                /*
+                 * Better safe than sorry, if anything goes wrong because the
+                 * Series is in a weird state, just reinitialize it.
+                 */
+                catch (...)
+                {
+                    return true;
+                }
+            }();
+            if (re_initialize)
+            {
+                /*
+                 * Do NOT close the old Series, it might still be active in
+                 * terms of handed-out handles.
+                 */
+                series = std::make_optional<Series>(
+                    filename,
+                    Access::READ_ONLY,
+                    "defer_iteration_parsing = true");
+            }
+
+            return seriesAccessor(*series, group);
         }));
 }
 } // namespace openPMD

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -177,7 +177,9 @@ void write_and_read_many_iterations(
 
     {
         Series write(filename, Access::CREATE);
-        REQUIRE(write.myPath().filePath() == filename);
+        REQUIRE(
+            auxiliary::replace_all(write.myPath().filePath(), "\\", "/") ==
+            auxiliary::replace_all(filename, "\\", "/"));
         for (unsigned int i = 0; i < nIterations; ++i)
         {
             // std::cout << "Putting iteration " << i << std::endl;
@@ -1852,8 +1854,11 @@ inline void fileBased_write_test(const std::string &backend)
             Access::CREATE,
             jsonCfg);
         REQUIRE(
-            o.myPath().filePath() ==
-            ("../samples/subdir/serial_fileBased_write%03T." + backend));
+            auxiliary::replace_all(o.myPath().filePath(), "\\", "/") ==
+            auxiliary::replace_all(
+                "../samples/subdir/serial_fileBased_write%03T." + backend,
+                "\\",
+                "/"));
 
         ParticleSpecies &e_1 = o.iterations[1].particles["e"];
 

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -177,6 +177,7 @@ void write_and_read_many_iterations(
 
     {
         Series write(filename, Access::CREATE);
+        REQUIRE(write.myPath().filePath() == filename);
         for (unsigned int i = 0; i < nIterations; ++i)
         {
             // std::cout << "Putting iteration " << i << std::endl;
@@ -1850,6 +1851,9 @@ inline void fileBased_write_test(const std::string &backend)
             "../samples/subdir/serial_fileBased_write%03T." + backend,
             Access::CREATE,
             jsonCfg);
+        REQUIRE(
+            o.myPath().filePath() ==
+            ("../samples/subdir/serial_fileBased_write%03T." + backend));
 
         ParticleSpecies &e_1 = o.iterations[1].particles["e"];
 


### PR DESCRIPTION
Factored out of #1633

When unpickling multiple objects from the same Series in succession, this PR helps performance by opening the Series only once.

TODO:

- [x] Merge #1633 first