### PR TITLE
Fix used after free issue in SerialIOTests

### DIFF
--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4286,11 +4286,11 @@ void adios2_bp5_flush(std::string const &cfg, FlushDuringStep flushDuringStep)
             REQUIRE(currentSize <= 4096);
         }
 
-        bool has_been_deleted = false;
+        auto has_been_deleted = std::make_shared<bool>(false);
         UniquePtrWithLambda<int32_t> copied_as_unique(
-            new int[size], [&has_been_deleted](int const *ptr) {
+            new int[size], [has_been_deleted](int const *ptr) {
                 delete[] ptr;
-                has_been_deleted = true;
+                *has_been_deleted = true;
             });
         std::copy_n(data.data(), size, copied_as_unique.get());
         {
@@ -4308,13 +4308,13 @@ void adios2_bp5_flush(std::string const &cfg, FlushDuringStep flushDuringStep)
         {
             // should now be roughly within 1% of 16Mb
             REQUIRE(std::abs(1 - double(currentSize) / (16 * size)) <= 0.01);
-            REQUIRE(has_been_deleted);
+            REQUIRE(*has_been_deleted);
         }
         else
         {
             // should be roughly zero
             REQUIRE(currentSize <= 4096);
-            REQUIRE(!has_been_deleted);
+            REQUIRE(!*has_been_deleted);
         }
     }
     auto currentSize = getsize();


### PR DESCRIPTION
Destructor may run after the flag has been deleted. Not even Valgrind caught this, but the Clang Sanitizer does in #1597.
Factored out of there.