### PR TITLE
Python Series/Iteration: Fix Length

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -15,6 +15,9 @@ Note that ADIOS2 does not support compression in BP3 files.
 
 pybind11 2.12.0 is now the minimally supported version for Python support.
 
+The ``len(...)`` of many classes has been reworked for consistency and returns now the number of entries (iterations, record components, etc.).
+Previously, this sporadically returned the number of attributes, which is better queried via ``len(<object>.attributes)``.
+
 
 0.15.0
 ------

--- a/include/openPMD/binding/python/Container.H
+++ b/include/openPMD/binding/python/Container.H
@@ -85,6 +85,12 @@ declare_container(py::handle scope, std::string const &name)
         // keep container alive while iterator exists
         py::keep_alive<0, 1>());
 
+    // overwrite to avoid that the __len__ of Attributable is used
+    cl.def(
+        "__len__",
+        [](const Map &m) { return m.size(); },
+        "Number of elements in the container to iterate.");
+
     cl.def("__repr__", [name](Map const &m) {
         std::stringstream stream;
         stream << "<openPMD." << name << " with ";

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -629,8 +629,6 @@ void init_Attributable(py::module &m)
         .def("delete_attribute", &Attributable::deleteAttribute)
         .def("contains_attribute", &Attributable::containsAttribute)
 
-        .def("__len__", &Attributable::numAttributes)
-
         // @todo _ipython_key_completions_ if we find a way to add a []
         // interface
 

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -252,6 +252,7 @@ For further details, refer to the non-MPI overload.
             )END")
 #endif
         .def("__bool__", &Series::operator bool)
+        .def("__len__", [](Series const &s) { return s.iterations.size(); })
         .def(
             "__repr__",
             [](Series const &s) {


### PR DESCRIPTION
If the `len(...)` intrinsic for series and iterations.
Close #1375

```py
import openpmd_api as io

s = io.Series("build/samples/git-sample/3d-bp4/example-3d-bp4_%T.bp", io.Access.read_only)

s
# <openPMD.Series at 'build/samples/git-sample/3d-bp4/example-3d-bp4_%T.bp' with 2 iteration(s) and 10 attributes>

s.iterations
# <openPMD.Iteration_Container with 2 entries and 0 attribute(s)>

len(s)
# 2

len(s.iterations)
# 2
```