### PR TITLE
Independent writes: Make workaround more flexible

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -133,6 +133,7 @@ class Iteration : public Attributable
     friend class internal::AttributableData;
     template <typename T>
     friend T &internal::makeOwning(T &self, Series);
+    friend class Writable;
 
 public:
     Iteration(Iteration const &) = default;

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -294,7 +294,8 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
      * Flush the openPMD hierarchy to the backend without flushing any actual
      * data yet.
      */
-    seriesFlush</* flush_entire_series = */ false>({FlushLevel::SkeletonOnly});
+    seriesFlush_impl</* flush_entire_series = */ false>(
+        {FlushLevel::SkeletonOnly});
 
     size_t size = 1;
     for (auto ext : e)

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -294,7 +294,7 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
      * Flush the openPMD hierarchy to the backend without flushing any actual
      * data yet.
      */
-    seriesFlush({FlushLevel::SkeletonOnly});
+    seriesFlush({FlushLevel::SkeletonOnly}, /* flush_entire_series = */ false);
 
     size_t size = 1;
     for (auto ext : e)

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -294,7 +294,7 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
      * Flush the openPMD hierarchy to the backend without flushing any actual
      * data yet.
      */
-    seriesFlush({FlushLevel::SkeletonOnly}, /* flush_entire_series = */ false);
+    seriesFlush</* flush_entire_series = */ false>({FlushLevel::SkeletonOnly});
 
     size_t size = 1;
     for (auto ext : e)

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -28,6 +28,7 @@
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/Streaming.hpp"
 #include "openPMD/WriteIterations.hpp"
+#include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
@@ -691,6 +692,17 @@ public:
      * this method.
      */
     void close();
+
+    /**
+     * This overrides Attributable::iterationFlush() which will fail on Series.
+     */
+    template <typename X = void, typename... Args>
+    auto iterationFlush(Args &&...)
+    {
+        static_assert(
+            auxiliary::dependent_false_v<X>,
+            "Cannot call this on an instance of Series.");
+    }
 
     // clang-format off
 OPENPMD_private

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -314,6 +314,12 @@ public:
      */
     MyPath myPath() const;
 
+    /**
+     * @brief Sets the object dirty to make internal procedures think it has
+     *        been modified.
+     */
+    void touch();
+
     // clang-format off
 OPENPMD_protected
     // clang-format on

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -351,7 +351,7 @@ OPENPMD_protected
     /** @} */
 
     template <bool flush_entire_series>
-    void seriesFlush(internal::FlushParams const &);
+    void seriesFlush_impl(internal::FlushParams const &);
 
     void flushAttributes(internal::FlushParams const &);
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -270,8 +270,14 @@ public:
      *                      implement this flush call.
      *                      Must be provided in-line, configuration is not read
      *                      from files.
+     * @param flush_entire_series By default, this method is just a shortcut
+     *        for Series::flush() when you don't currently have a Series handle
+     *        at hand. If however the current object is an Iteration or
+     *        contained within an Iteration, flushing can be restricted to that
+     *        specific Iteration by setting this flag to false.
      */
-    void seriesFlush(std::string backendConfig = "{}");
+    void seriesFlush(
+        std::string backendConfig = "{}", bool flush_entire_series = true);
 
     /** String serialization to describe an Attributable
      *
@@ -330,7 +336,7 @@ OPENPMD_protected
                                    internal::SeriesData *>;
     /** @} */
 
-    void seriesFlush(internal::FlushParams const &);
+    void seriesFlush(internal::FlushParams const &, bool flush_entire_series);
 
     void flushAttributes(internal::FlushParams const &);
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -270,14 +270,22 @@ public:
      *                      implement this flush call.
      *                      Must be provided in-line, configuration is not read
      *                      from files.
-     * @param flush_entire_series By default, this method is just a shortcut
-     *        for Series::flush() when you don't currently have a Series handle
-     *        at hand. If however the current object is an Iteration or
-     *        contained within an Iteration, flushing can be restricted to that
-     *        specific Iteration by setting this flag to false.
      */
-    void seriesFlush(
-        std::string backendConfig = "{}", bool flush_entire_series = true);
+    void seriesFlush(std::string backendConfig = "{}");
+
+    /** Flush the containing Iteration.
+     *
+     * Writable connects all objects of an openPMD series through a linked list
+     * of parents. This method will walk up the parent list to find
+     * the containing Iteration.
+     * The Iteration will be flushed regardless if it is dirty.
+     *
+     * @param backendConfig Further backend-specific instructions on how to
+     *                      implement this flush call.
+     *                      Must be provided in-line, configuration is not read
+     *                      from files.
+     */
+    void iterationFlush(std::string backendConfig = "{}");
 
     /** String serialization to describe an Attributable
      *
@@ -342,7 +350,8 @@ OPENPMD_protected
                                    internal::SeriesData *>;
     /** @} */
 
-    void seriesFlush(internal::FlushParams const &, bool flush_entire_series);
+    template <bool flush_entire_series>
+    void seriesFlush(internal::FlushParams const &);
 
     void flushAttributes(internal::FlushParams const &);
 

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -120,14 +120,15 @@ public:
      * an object that has no parent, which is the Series object, and flush()-es
      * it.
      */
-    void seriesFlush(
-        std::string backendConfig = "{}", bool flush_entire_series = true);
+    template <bool flush_entire_series>
+    void seriesFlush(std::string backendConfig = "{}");
 
     // clang-format off
 OPENPMD_private
     // clang-format on
 
-    void seriesFlush(internal::FlushParams const &, bool flush_entire_series);
+    template <bool flush_entire_series>
+    void seriesFlush(internal::FlushParams const &);
     /*
      * These members need to be shared pointers since distinct instances of
      * Writable may share them.

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -120,13 +120,14 @@ public:
      * an object that has no parent, which is the Series object, and flush()-es
      * it.
      */
-    void seriesFlush(std::string backendConfig = "{}");
+    void seriesFlush(
+        std::string backendConfig = "{}", bool flush_entire_series = true);
 
     // clang-format off
 OPENPMD_private
     // clang-format on
 
-    void seriesFlush(internal::FlushParams const &);
+    void seriesFlush(internal::FlushParams const &, bool flush_entire_series);
     /*
      * These members need to be shared pointers since distinct instances of
      * Writable may share them.

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -253,14 +253,14 @@ void Attributable::touch()
 }
 
 template <bool flush_entire_series>
-void Attributable::seriesFlush(internal::FlushParams const &flushParams)
+void Attributable::seriesFlush_impl(internal::FlushParams const &flushParams)
 {
     writable().seriesFlush<flush_entire_series>(flushParams);
 }
 template void
-Attributable::seriesFlush<true>(internal::FlushParams const &flushParams);
+Attributable::seriesFlush_impl<true>(internal::FlushParams const &flushParams);
 template void
-Attributable::seriesFlush<false>(internal::FlushParams const &flushParams);
+Attributable::seriesFlush_impl<false>(internal::FlushParams const &flushParams);
 
 void Attributable::flushAttributes(internal::FlushParams const &flushParams)
 {

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -118,10 +118,16 @@ Attributable &Attributable::setComment(std::string const &c)
     return *this;
 }
 
-void Attributable::seriesFlush(
-    std::string backendConfig, bool flush_entire_series)
+void Attributable::seriesFlush(std::string backendConfig)
 {
-    writable().seriesFlush(std::move(backendConfig), flush_entire_series);
+    writable().seriesFlush</* flush_entire_series = */ true>(
+        std::move(backendConfig));
+}
+
+void Attributable::iterationFlush(std::string backendConfig)
+{
+    writable().seriesFlush</* flush_entire_series = */ false>(
+        std::move(backendConfig));
 }
 
 Series Attributable::retrieveSeries() const
@@ -246,11 +252,15 @@ void Attributable::touch()
     setDirtyRecursive(true);
 }
 
-void Attributable::seriesFlush(
-    internal::FlushParams const &flushParams, bool flush_entire_series)
+template <bool flush_entire_series>
+void Attributable::seriesFlush(internal::FlushParams const &flushParams)
 {
-    writable().seriesFlush(flushParams, flush_entire_series);
+    writable().seriesFlush<flush_entire_series>(flushParams);
 }
+template void
+Attributable::seriesFlush<true>(internal::FlushParams const &flushParams);
+template void
+Attributable::seriesFlush<false>(internal::FlushParams const &flushParams);
 
 void Attributable::flushAttributes(internal::FlushParams const &flushParams)
 {

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -241,6 +241,11 @@ auto Attributable::myPath() const -> MyPath
     return res;
 }
 
+void Attributable::touch()
+{
+    setDirtyRecursive(true);
+}
+
 void Attributable::seriesFlush(
     internal::FlushParams const &flushParams, bool flush_entire_series)
 {

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -118,9 +118,10 @@ Attributable &Attributable::setComment(std::string const &c)
     return *this;
 }
 
-void Attributable::seriesFlush(std::string backendConfig)
+void Attributable::seriesFlush(
+    std::string backendConfig, bool flush_entire_series)
 {
-    writable().seriesFlush(std::move(backendConfig));
+    writable().seriesFlush(std::move(backendConfig), flush_entire_series);
 }
 
 Series Attributable::retrieveSeries() const
@@ -240,9 +241,10 @@ auto Attributable::myPath() const -> MyPath
     return res;
 }
 
-void Attributable::seriesFlush(internal::FlushParams const &flushParams)
+void Attributable::seriesFlush(
+    internal::FlushParams const &flushParams, bool flush_entire_series)
 {
-    writable().seriesFlush(flushParams);
+    writable().seriesFlush(flushParams, flush_entire_series);
 }
 
 void Attributable::flushAttributes(internal::FlushParams const &flushParams)

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -49,7 +49,7 @@ template <bool flush_entire_series>
 void Writable::seriesFlush(std::string backendConfig)
 {
     seriesFlush<flush_entire_series>(
-        {FlushLevel::UserFlush, std::move(backendConfig)});
+        internal::FlushParams{FlushLevel::UserFlush, std::move(backendConfig)});
 }
 template void Writable::seriesFlush<true>(std::string backendConfig);
 template void Writable::seriesFlush<false>(std::string backendConfig);

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -58,9 +58,7 @@ void Writable::seriesFlush(
     auto [iteration_internal, series_internal] = impl.containingIteration();
     if (iteration_internal)
     {
-        (*iteration_internal)
-            ->asInternalCopyOf<Iteration>()
-            .setDirtyRecursive(true);
+        (*iteration_internal)->asInternalCopyOf<Iteration>().touch();
     }
     auto series = series_internal->asInternalCopyOf<Series>();
     auto [begin, end] = [&, &iteration_internal_lambda = iteration_internal]()

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -515,8 +515,9 @@ void init_Attributable(py::module &m)
             })
         .def(
             "series_flush",
-            py::overload_cast<std::string>(&Attributable::seriesFlush),
-            py::arg("backend_config") = "{}")
+            py::overload_cast<std::string, bool>(&Attributable::seriesFlush),
+            py::arg("backend_config") = "{}",
+            py::arg("flush_entire_series") = true)
 
         .def_property_readonly(
             "attributes",

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -515,9 +515,12 @@ void init_Attributable(py::module &m)
             })
         .def(
             "series_flush",
-            py::overload_cast<std::string, bool>(&Attributable::seriesFlush),
-            py::arg("backend_config") = "{}",
-            py::arg("flush_entire_series") = true)
+            py::overload_cast<std::string>(&Attributable::seriesFlush),
+            py::arg("backend_config") = "{}")
+        .def(
+            "iteration_flush",
+            py::overload_cast<std::string>(&Attributable::iterationFlush),
+            py::arg("backend_config") = "{}")
 
         .def_property_readonly(
             "attributes",

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1163,6 +1163,7 @@ TEST_CASE("independent_write_with_collective_flush", "[parallel]")
         Access::CREATE,
         MPI_COMM_WORLD,
         "adios2.engine.preferred_flush_target = \"buffer\"");
+    write.seriesFlush();
     int size, rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -1183,9 +1184,7 @@ TEST_CASE("independent_write_with_collective_flush", "[parallel]")
      * unless the flush in the next line really is collective.
      */
     MPI_Barrier(MPI_COMM_WORLD);
-    iteration.seriesFlush(
-        "adios2.engine.preferred_flush_target = \"disk\"",
-        /* flush_entire_series = */ false);
+    iteration.iterationFlush("adios2.engine.preferred_flush_target = \"disk\"");
     MPI_Barrier(MPI_COMM_WORLD);
 }
 #endif

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1182,11 +1182,11 @@ TEST_CASE("independent_write_with_collective_flush", "[parallel]")
      * conflict with the default buffer target that will run in the destructor,
      * unless the flush in the next line really is collective.
      */
-    std::cout << "ENTER" << std::endl;
     MPI_Barrier(MPI_COMM_WORLD);
-    iteration.seriesFlush("adios2.engine.preferred_flush_target = \"disk\"");
+    iteration.seriesFlush(
+        "adios2.engine.preferred_flush_target = \"disk\"",
+        /* flush_entire_series = */ false);
     MPI_Barrier(MPI_COMM_WORLD);
-    std::cout << "LEAVE" << std::endl;
 }
 #endif
 


### PR DESCRIPTION
Follow-up to #1619
This lets users decide to flush only the containing Iteration or everything with `Attributable::seriesFlush()`.

TODO:

- [x] ~~Maybe use `false` as a default even. Would be a breaking change, but I'd argue it's the more intuitive behavior and most usage is probably along that line.~~ They're two different functions now.