### PR TITLE
Pickle API: Fix memory leak

### DIFF
--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -110,7 +110,7 @@ void init_Iteration(py::module &m)
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto &res = series.iterations[n_it];
+            auto res = series.iterations[n_it];
             return internal::makeOwning(res, std::move(series));
         });
 

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -117,7 +117,7 @@ void init_Mesh(py::module &m)
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto &res = series.iterations[n_it].open().meshes[group.at(3)];
+            auto res = series.iterations[n_it].open().meshes[group.at(3)];
             return internal::makeOwning(res, std::move(series));
         });
 

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -84,7 +84,7 @@ void init_MeshRecordComponent(py::module &m)
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto &res =
+            auto res =
                 series.iterations[n_it]
                     .open()
                     .meshes[group.at(3)]

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -57,7 +57,7 @@ void init_ParticleSpecies(py::module &m)
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            ParticleSpecies &res =
+            ParticleSpecies res =
                 series.iterations[n_it].open().particles[group.at(3)];
             return internal::makeOwning(res, std::move(series));
         });

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -74,8 +74,8 @@ void init_Record(py::module &m)
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto &res = series.iterations[n_it].open().particles[group.at(3)]
-                                                                [group.at(4)];
+            auto res = series.iterations[n_it].open().particles[group.at(3)]
+                                                               [group.at(4)];
             return internal::makeOwning(res, std::move(series));
         });
 

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1124,12 +1124,11 @@ void init_RecordComponent(py::module &m)
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto &res =
-                series.iterations[n_it]
-                    .open()
-                    .particles[group.at(3)][group.at(4)]
-                              [group.size() < 6 ? RecordComponent::SCALAR
-                                                : group.at(5)];
+            auto res = series.iterations[n_it]
+                           .open()
+                           .particles[group.at(3)][group.at(4)]
+                                     [group.size() < 6 ? RecordComponent::SCALAR
+                                                       : group.at(5)];
             return internal::makeOwning(res, std::move(series));
         });
 


### PR DESCRIPTION
clang-sanitizer found this on #1432, but the bug affects the dev branch already.
Since the Pickle API returns handles that own the Series, they MUST be copies, we cannot turn the internal handles into owning handles as they again are owned by the Series, creating a reference cycle.