### PR TITLE
Drop Python 3.8 & 3.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,14 @@
 environment:
   matrix:
     - TARGET_ARCH: x64
-      CONDA_PY: 3.7
+      CONDA_PY: 3.9
       CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       SHARED: OFF
 
     - TARGET_ARCH: x86
-      CONDA_PY: 3.7
+      CONDA_PY: 3.9
       CONDA_INSTALL_LOCN: C:\\Miniconda37
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,14 @@
 environment:
   matrix:
     - TARGET_ARCH: x64
-      CONDA_PY: 3.9
+      CONDA_PY: 3.10
       CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       SHARED: OFF
 
     - TARGET_ARCH: x86
-      CONDA_PY: 3.9
+      CONDA_PY: 3.10
       CONDA_INSTALL_LOCN: C:\\Miniconda37
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,21 +34,25 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-python@v6
+      name: Install Python
+      with:
+        python-version: "3.10"
     - name: Build & Install
       run: |
-        python3.exe -m pip install --upgrade pip setuptools wheel
-        python3.exe -m pip install --upgrade cmake
-        python3.exe -m pip install --upgrade numpy
+        python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install --upgrade cmake
+        python3 -m pip install --upgrade numpy
 
-        python3.exe -m pip wheel .
+        python3 -m pip wheel .
         if(!$?) { Exit $LASTEXITCODE }
-        python3.exe -m pip install openPMD_api-0.17.0.dev0-cp39-cp39-win_amd64.whl
-        if(!$?) { Exit $LASTEXITCODE }
-
-        python3.exe -c "import openpmd_api as api; print(api.variants)"
+        python3 -m pip install --find-links=. openPMD_api
         if(!$?) { Exit $LASTEXITCODE }
 
-        python3.exe -m openpmd_api.ls --help
+        python3 -c "import openpmd_api as api; print(api.variants)"
+        if(!$?) { Exit $LASTEXITCODE }
+
+        python3 -m openpmd_api.ls --help
         if(!$?) { Exit $LASTEXITCODE }
 
   build_win_clang:

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,21 +112,6 @@ RUN         for whl in /opt/src/dist/*.whl; do \
             && du -hs /opt/src/dist/* \
             && du -hs /wheelhouse/*
 
-# test in fresh env: Debian:Sid + Python 3.8
-FROM       debian:sid
-ENV        DEBIAN_FRONTEND noninteractive
-COPY --from=build-env /wheelhouse/openPMD_api-*-cp38-cp38-manylinux2010_x86_64.whl .
-RUN        apt-get update \
-           && apt-get install -y --no-install-recommends python3.8 python3-distutils ca-certificates curl \
-           && rm -rf /var/lib/apt/lists/*
-RUN        python3.8 --version \
-           && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-           && python3.8 get-pip.py \
-           && python3.8 -m pip install openPMD_api-*-cp38-cp38-manylinux2010_x86_64.whl
-RUN        python3.8 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-RUN        python3.8 -m openpmd_api.ls --help
-RUN        openpmd-ls --help
-
 # test in fresh env: Debian:Bullseye + Python 3.9
 FROM       debian:bullseye
 ENV        DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,21 @@ RUN        python3.13 -c "import openpmd_api as io; print(io.__version__); print
 RUN        python3.13 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
+# test in fresh env: Debian:Bullseye + Python 3.14
+FROM       debian:bullseye
+ENV        DEBIAN_FRONTEND noninteractive
+COPY --from=build-env /wheelhouse/openPMD_api-*-cp314-cp314-manylinux2010_x86_64.whl .
+RUN        apt-get update \
+           && apt-get install -y --no-install-recommends python3.14 python3-distutils ca-certificates curl \
+           && rm -rf /var/lib/apt/lists/*
+RUN        python3.14 --version \
+           && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+           && python3.14 get-pip.py \
+           && python3.14 -m pip install openPMD_api-*-cp314-cp314-manylinux2010_x86_64.whl
+RUN        python3.14 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
+RUN        python3.14 -m openpmd_api.ls --help
+RUN        openpmd-ls --help
+
 # copy binary artifacts (wheels)
 FROM       quay.io/pypa/manylinux2010_x86_64
 MAINTAINER Axel Huebl <a.huebl@hzdr.de>

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,21 +112,6 @@ RUN         for whl in /opt/src/dist/*.whl; do \
             && du -hs /opt/src/dist/* \
             && du -hs /wheelhouse/*
 
-# test in fresh env: Debian:Bullseye + Python 3.9
-FROM       debian:bullseye
-ENV        DEBIAN_FRONTEND noninteractive
-COPY --from=build-env /wheelhouse/openPMD_api-*-cp39-cp39-manylinux2010_x86_64.whl .
-RUN        apt-get update \
-           && apt-get install -y --no-install-recommends python3.9 python3-distutils ca-certificates curl \
-           && rm -rf /var/lib/apt/lists/*
-RUN        python3.9 --version \
-           && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-           && python3.9 get-pip.py \
-           && python3.9 -m pip install openPMD_api-*-cp39-cp39-manylinux2010_x86_64.whl
-RUN        python3.9 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
-RUN        python3.9 -m openpmd_api.ls --help
-RUN        openpmd-ls --help
-
 # test in fresh env: Debian:Bullseye + Python 3.10
 FROM       debian:bullseye
 ENV        DEBIAN_FRONTEND noninteractive

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,7 @@ Upgrade Guide
 ADIOS 2.9.0 is now the minimally supported version for ADIOS2 support.
 
 Python 3.8 support is EOL and removed.
+Python 3.14 is now supported.
 
 
 0.16.0

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,7 +8,7 @@ Upgrade Guide
 
 ADIOS 2.9.0 is now the minimally supported version for ADIOS2 support.
 
-Python 3.8 support is EOL and removed.
+Python 3.8 and 3.9 support is EOL and removed.
 Python 3.14 is now supported.
 
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,6 +8,9 @@ Upgrade Guide
 
 ADIOS 2.9.0 is now the minimally supported version for ADIOS2 support.
 
+Python 3.8 support is EOL and removed.
+
+
 0.16.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.8 - 3.13
+  * Python 3.9 - 3.13
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.9 - 3.14
+  * Python 3.10 - 3.14
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.9 - 3.13
+  * Python 3.9 - 3.14
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/Singularity
+++ b/Singularity
@@ -42,7 +42,7 @@ Supported frontends are C++11 and Python3.
         -DopenPMD_USE_PYTHON=ON  \
         -DopenPMD_BUILD_TESTING=OFF       \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DCMAKE_INSTALL_PYTHONDIR=lib/python3.6/dist-packages
+        -DCMAKE_INSTALL_PYTHONDIR=lib/python3.12/dist-packages
     make
     # make test
     make install

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -83,9 +83,9 @@ set(openPMD_pybind11_branch "v2.13.6"
     "Repository branch for openPMD_pybind11_repo if(openPMD_USE_INTERNAL_PYBIND11)")
 
 if(openPMD_USE_PYTHON STREQUAL AUTO)
-    find_package(Python 3.7.0 COMPONENTS Interpreter Development.Module)
+    find_package(Python 3.9.0 COMPONENTS Interpreter Development.Module)
 elseif(openPMD_USE_PYTHON)
-    find_package(Python 3.7.0 COMPONENTS Interpreter Development.Module REQUIRED)
+    find_package(Python 3.9.0 COMPONENTS Interpreter Development.Module REQUIRED)
 else()
     set(openPMD_HAVE_PYTHON FALSE)
 endif()

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -83,9 +83,9 @@ set(openPMD_pybind11_branch "v2.13.6"
     "Repository branch for openPMD_pybind11_repo if(openPMD_USE_INTERNAL_PYBIND11)")
 
 if(openPMD_USE_PYTHON STREQUAL AUTO)
-    find_package(Python 3.9.0 COMPONENTS Interpreter Development.Module)
+    find_package(Python 3.10.0 COMPONENTS Interpreter Development.Module)
 elseif(openPMD_USE_PYTHON)
-    find_package(Python 3.9.0 COMPONENTS Interpreter Development.Module REQUIRED)
+    find_package(Python 3.10.0 COMPONENTS Interpreter Development.Module REQUIRED)
 else()
     set(openPMD_HAVE_PYTHON FALSE)
 endif()

--- a/conda.yml
+++ b/conda.yml
@@ -37,7 +37,7 @@ dependencies:
   - pre-commit
   - pyarrow  # for dask
 #  - pybind11  # shipped internally
-  - python>=3.9
+  - python>=3.10
 
 # just a note for later hackery, we could install pip packages inside the env, too:
 #  - pip:

--- a/conda.yml
+++ b/conda.yml
@@ -37,7 +37,7 @@ dependencies:
   - pre-commit
   - pyarrow  # for dask
 #  - pybind11  # shipped internally
-  - python>=3.8
+  - python>=3.9
 
 # just a note for later hackery, we could install pip packages inside the env, too:
 #  - pip:

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -38,7 +38,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.8 - 3.13
+  * Python 3.9 - 3.13
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -38,7 +38,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.9 - 3.13
+  * Python 3.9 - 3.14
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -38,7 +38,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.9 - 3.14
+  * Python 3.10 - 3.14
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -192,7 +192,7 @@ CMake will summarize the install paths for you before the build step.
    # Note that one some systems, /lib might need to be replaced with /lib64.
 
    #                change path to your python MAJOR.MINOR version
-   export PYTHONPATH=$HOME/somepath/lib/python3.8/site-packages:$PYTHONPATH
+   export PYTHONPATH=$HOME/somepath/lib/python3.12/site-packages:$PYTHONPATH
 
 Adding those lines to your ``$HOME/.bashrc`` and re-opening your terminal will set them permanently.
 

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
     cmdclass=dict(build_ext=CMakeBuild),
     # scripts=['openpmd-ls'],
     zip_safe=False,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     # tests_require=['pytest'],
     install_requires=install_requires,
     # see: src/bindings/python/cli
@@ -232,7 +232,6 @@ setup(
         'Topic :: Database :: Front-Ends',
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         ('License :: OSI Approved :: '
          'GNU Lesser General Public License v3 or later (LGPLv3+)'),
     ],

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
     cmdclass=dict(build_ext=CMakeBuild),
     # scripts=['openpmd-ls'],
     zip_safe=False,
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     # tests_require=['pytest'],
     install_requires=install_requires,
     # see: src/bindings/python/cli
@@ -232,7 +232,6 @@ setup(
         'Topic :: Database :: Front-Ends',
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
Python 3.8 is EOL as of October 2024.
Python 3.9 is EOL as of October 2025.

- [x] rebase after #1675