### PR TITLE
CMake Tar: TOML11 3.7.1

### DIFF
--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -64,10 +64,10 @@ set(openPMD_toml11_src ""
     "Local path to toml11 source directory (preferred if set)")
 
 # tarball fetcher
-set(openPMD_toml11_tar "https://github.com/ToruNiina/toml11/archive/refs/tags/v4.2.0.tar.gz"
+set(openPMD_toml11_tar "https://github.com/ToruNiina/toml11/archive/refs/tags/v3.7.1.tar.gz"
         CACHE STRING
         "Remote tarball link to pull and build toml11 from if(openPMD_USE_INTERNAL_TOML11)")
-set(openPMD_toml11_tar_hash "SHA256=9287971cd4a1a3992ef37e7b95a3972d1ae56410e7f8e3f300727ab1d6c79c2c"
+set(openPMD_toml11_tar_hash "SHA256=afeaa9aa0416d4b6b2cd3897ca55d9317084103077b32a852247d8efd4cf6068"
         CACHE STRING
         "Hash checksum of the tarball of toml11 if(openPMD_USE_INTERNAL_TOML11)")
 


### PR DESCRIPTION
Keep branch and tar to TOML11 v3.7.1 in sync.
We currently still see issues with, so let's not ship it by default in superbuilds.

From @franzpoeschel:
```
About to parse 'iteration_encoding = "variable_based"'
[fwk394:211086:0:211086] Caught signal 11 (Segmentation fault: Sent by the kernel at address (nil))
```

Follow-up to #1668 #1645