### PR TITLE
ADIOS2 Access Mode: Fix Dangling Ref

### DIFF
--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -81,8 +81,9 @@ namespace json
         /**
          * @brief Access the underlying JSON value
          *
-         * @param arg  See args, first arg, used to distinguish this overload.
-         * @param args Index to some sub-expression. Shortcut for
+         * See args, first arg, used to distinguish this overload.
+         *
+         * @param path Index to some sub-expression. Shortcut for
          *        `tracingJSON[arg1][arg2][arg3].json()`.
          * @return nlohmann::json&
          */

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -81,6 +81,30 @@ namespace json
             return *m_positionInOriginal;
         }
 
+        /**
+         * @brief Access the underlying JSON value
+         *
+         * @param arg  See args, first arg, used to distinguish this overload.
+         * @param args Index to some sub-expression. Shortcut for
+         *        `tracingJSON[arg1][arg2][arg3].json()`.
+         * @return nlohmann::json&
+         */
+        template <typename Arg, typename... Args>
+        inline nlohmann::json &json(Arg &&arg, Args &&...args)
+        {
+            [[maybe_unused]] auto do_trace =
+                [subhandle = this->operator[](arg)](auto const &key) mutable {
+                    subhandle = subhandle[key];
+                };
+            (do_trace(args), ...);
+            nlohmann::json *res = &m_positionInOriginal->operator[](arg);
+            [[maybe_unused]] auto get_res = [&res](auto const &key) {
+                res = &(*res)[key];
+            };
+            (get_res(args), ...);
+            return *res;
+        }
+
         template <typename Key>
         TracingJSON operator[](Key &&key);
 

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -76,10 +76,7 @@ namespace json
          *
          * @return nlohmann::json&
          */
-        inline nlohmann::json &json()
-        {
-            return *m_positionInOriginal;
-        }
+        nlohmann::json &json();
 
         /**
          * @brief Access the underlying JSON value
@@ -89,21 +86,7 @@ namespace json
          *        `tracingJSON[arg1][arg2][arg3].json()`.
          * @return nlohmann::json&
          */
-        template <typename Arg, typename... Args>
-        inline nlohmann::json &json(Arg &&arg, Args &&...args)
-        {
-            [[maybe_unused]] auto do_trace =
-                [subhandle = this->operator[](arg)](auto const &key) mutable {
-                    subhandle = subhandle[key];
-                };
-            (do_trace(args), ...);
-            nlohmann::json *res = &m_positionInOriginal->operator[](arg);
-            [[maybe_unused]] auto get_res = [&res](auto const &key) {
-                res = &(*res)[key];
-            };
-            (get_res(args), ...);
-            return *res;
-        }
+        nlohmann::json &json(std::vector<std::string> path);
 
         template <typename Key>
         TracingJSON operator[](Key &&key);

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1528,7 +1528,7 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(std::string const &fullPath)
     if (m_config.json().contains("engine") &&
         m_config["engine"].json().contains("access_mode"))
     {
-        auto const &access_mode_json = m_config.json("engine", "access_mode");
+        auto const &access_mode_json = m_config.json({"engine", "access_mode"});
         auto maybe_access_mode_string =
             json::asLowerCaseStringDynamic(access_mode_json);
         if (!maybe_access_mode_string.has_value())

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1528,7 +1528,7 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(std::string const &fullPath)
     if (m_config.json().contains("engine") &&
         m_config["engine"].json().contains("access_mode"))
     {
-        auto const access_mode_json = m_config["engine"]["access_mode"].json();
+        auto const &access_mode_json = m_config.json("engine", "access_mode");
         auto maybe_access_mode_string =
             json::asLowerCaseStringDynamic(access_mode_json);
         if (!maybe_access_mode_string.has_value())

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1528,7 +1528,7 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(std::string const &fullPath)
     if (m_config.json().contains("engine") &&
         m_config["engine"].json().contains("access_mode"))
     {
-        auto const &access_mode_json = m_config["engine"]["access_mode"].json();
+        auto const access_mode_json = m_config["engine"]["access_mode"].json();
         auto maybe_access_mode_string =
             json::asLowerCaseStringDynamic(access_mode_json);
         if (!maybe_access_mode_string.has_value())

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -231,7 +231,7 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
                     {
                         return std::nullopt;
                     }
-                    auto const &val = vfd_json_config.json(key);
+                    auto const &val = vfd_json_config.json({key});
                     if (val.is_number_integer())
                     {
                         return val.get<long long>();
@@ -250,7 +250,7 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
                     {
                         return std::nullopt;
                     }
-                    auto const &val = vfd_json_config.json(key);
+                    auto const &val = vfd_json_config.json({key});
                     if (auto str_val = json::asLowerCaseStringDynamic(val);
                         str_val.has_value())
                     {

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -231,7 +231,7 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
                     {
                         return std::nullopt;
                     }
-                    auto const &val = vfd_json_config[key].json();
+                    auto const &val = vfd_json_config.json(key);
                     if (val.is_number_integer())
                     {
                         return val.get<long long>();
@@ -250,7 +250,7 @@ ParallelHDF5IOHandlerImpl::ParallelHDF5IOHandlerImpl(
                     {
                         return std::nullopt;
                     }
-                    auto const &val = vfd_json_config[key].json();
+                    auto const &val = vfd_json_config.json(key);
                     if (auto str_val = json::asLowerCaseStringDynamic(val);
                         str_val.has_value())
                     {

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -60,6 +60,29 @@ TracingJSON::TracingJSON(ParsedConfig parsedConfig)
           std::move(parsedConfig.config), parsedConfig.originallySpecifiedAs}
 {}
 
+nlohmann::json &TracingJSON::json()
+{
+    return *m_positionInOriginal;
+}
+
+nlohmann::json &TracingJSON::json(std::vector<std::string> paths)
+{
+    if (paths.empty())
+    {
+        return json();
+    }
+    auto it = paths.begin();
+    auto end = paths.end();
+    nlohmann::json *res = &m_positionInOriginal->operator[](*it);
+    auto subhandle = this->operator[](*it);
+    for (++it; it != end; ++it)
+    {
+        subhandle = subhandle[*it];
+        res = &(*res)[*it];
+    }
+    return *res;
+}
+
 nlohmann::json const &TracingJSON::getShadow() const
 {
     return *m_positionInShadow;


### PR DESCRIPTION
Fix GCC 13.3 warning:
```
/home/runner/work/openPMD-api/openPMD-api/src/IO/ADIOS/ADIOS2IOHandler.cpp: In member function 'adios2::Mode openPMD::ADIOS2IOHandlerImpl::adios2AccessMode(const std::string&)':
/home/runner/work/openPMD-api/openPMD-api/src/IO/ADIOS/ADIOS2IOHandler.cpp:1531:21: warning: possibly dangling reference to a temporary [-Wdangling-reference]
 1531 |         auto const &access_mode_json = m_config["engine"]["access_mode"].json();
      |                     ^~~~~~~~~~~~~~~~
/home/runner/work/openPMD-api/openPMD-api/src/IO/ADIOS/ADIOS2IOHandler.cpp:1531:78: note: the temporary was destroyed at the end of the full expression 'openPMD::json::TracingJSON::operator[](Key&&) [with Key = const char (&)[12]]("access_mode").openPMD::json::TracingJSON::json()'
 1531 |         auto const &access_mode_json = m_config["engine"]["access_mode"].json();
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

First seen in #1672