### PR TITLE
Python 3.13, pybind11 2.13.0+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Changes to "0.15.0"
 Features
 """"""""
 
-- pybind11: require version 2.12.0+ #1220 #1322 #1637
+- pybind11: require version 2.13.0+ #1220 #1322 #1637 #1671
 
 Bug Fixes
 """""""""

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,21 @@ RUN        python3.12 -c "import openpmd_api as io; print(io.__version__); print
 RUN        python3.12 -m openpmd_api.ls --help
 RUN        openpmd-ls --help
 
+# test in fresh env: Debian:Bullseye + Python 3.13
+FROM       debian:bullseye
+ENV        DEBIAN_FRONTEND noninteractive
+COPY --from=build-env /wheelhouse/openPMD_api-*-cp313-cp313-manylinux2010_x86_64.whl .
+RUN        apt-get update \
+           && apt-get install -y --no-install-recommends python3.13 python3-distutils ca-certificates curl \
+           && rm -rf /var/lib/apt/lists/*
+RUN        python3.13 --version \
+           && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+           && python3.13 get-pip.py \
+           && python3.13 -m pip install openPMD_api-*-cp313-cp313-manylinux2010_x86_64.whl
+RUN        python3.13 -c "import openpmd_api as io; print(io.__version__); print(io.variants)"
+RUN        python3.13 -m openpmd_api.ls --help
+RUN        openpmd-ls --help
+
 # copy binary artifacts (wheels)
 FROM       quay.io/pypa/manylinux2010_x86_64
 MAINTAINER Axel Huebl <a.huebl@hzdr.de>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -14,7 +14,7 @@ For reading legacy ADIOS1 BP3 files, either use an older version of openPMD-api 
 Note that ADIOS2 does not support compression in BP3 files.
 
 CMake 3.22.0 is now the minimally supported version for CMake.
-pybind11 2.12.0 is now the minimally supported version for Python support.
+pybind11 2.13.0 is now the minimally supported version for Python support.
 
 The ``len(...)`` of many classes has been reworked for consistency and returns now the number of entries (iterations, record components, etc.).
 Previously, this sporadically returned the number of attributes, which is better queried via ``len(<object>.attributes)``.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -15,6 +15,7 @@ Note that ADIOS2 does not support compression in BP3 files.
 
 CMake 3.22.0 is now the minimally supported version for CMake.
 pybind11 2.13.0 is now the minimally supported version for Python support.
+Python 3.12 & 3.13 are now supported, Python 3.7 is removed.
 
 The ``len(...)`` of many classes has been reworked for consistency and returns now the number of entries (iterations, record components, etc.).
 Previously, this sporadically returned the number of attributes, which is better queried via ``len(<object>.attributes)``.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Required:
 
 Shipped internally in `share/openPMD/thirdParty/`:
 * [Catch2](https://github.com/catchorg/Catch2) 2.13.10+ ([BSL-1.0](https://github.com/catchorg/Catch2/blob/master/LICENSE.txt))
-* [pybind11](https://github.com/pybind/pybind11) 2.12.0+ ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
+* [pybind11](https://github.com/pybind/pybind11) 2.13.0+ ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
 * [NLohmann-JSON](https://github.com/nlohmann/json) 3.9.1+ ([MIT](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT))
 * [toml11](https://github.com/ToruNiina/toml11) 3.7.1+ ([MIT](https://github.com/ToruNiina/toml11/blob/master/LICENSE))
 
@@ -116,7 +116,7 @@ while those can be built either with or without:
 Optional language bindings:
 * Python:
   * Python 3.8 - 3.12
-  * pybind11 2.12.0+
+  * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)
   * pandas 1.0+ (optional, for dataframes)
@@ -265,7 +265,7 @@ CMake controls options with prefixed `-D`, e.g. `-DopenPMD_USE_MPI=OFF`:
 Additionally, the following libraries are downloaded via [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
 during the configuration of the project or, if the corresponding `<PACKAGENAME>_ROOT` variable is provided, can be provided externally:
 * [Catch2](https://github.com/catchorg/Catch2) (2.13.10+)
-* [PyBind11](https://github.com/pybind/pybind11) (2.12.0+)
+* [PyBind11](https://github.com/pybind/pybind11) (2.13.0+)
 * [NLohmann-JSON](https://github.com/nlohmann/json) (3.9.1+)
 * [toml11](https://github.com/ToruNiina/toml11) (3.7.1+)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ while those can be built either with or without:
 
 Optional language bindings:
 * Python:
-  * Python 3.8 - 3.12
+  * Python 3.8 - 3.13
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -46,9 +46,9 @@ function(find_pybind11)
         endif()
     elseif(NOT openPMD_USE_INTERNAL_PYBIND11)
         if(openPMD_USE_PYTHON STREQUAL AUTO)
-            find_package(pybind11 2.12.0 CONFIG)
+            find_package(pybind11 2.13.0 CONFIG)
         elseif(openPMD_USE_PYTHON)
-            find_package(pybind11 2.12.0 CONFIG REQUIRED)
+            find_package(pybind11 2.13.0 CONFIG REQUIRED)
         endif()
         if(TARGET pybind11::module)
             message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
@@ -62,10 +62,10 @@ set(openPMD_pybind11_src ""
     "Local path to pybind11 source directory (preferred if set)")
 
 # tarball fetcher
-set(openPMD_pybind11_tar "https://github.com/pybind/pybind11/archive/refs/tags/v2.12.0.tar.gz"
+set(openPMD_pybind11_tar "https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz"
         CACHE STRING
         "Remote tarball link to pull and build pybind11 from if(openPMD_USE_INTERNAL_PYBIND11)")
-set(openPMD_pybind11_tar_hash "SHA256=bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7"
+set(openPMD_pybind11_tar_hash "SHA256=e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20"
         CACHE STRING
         "Hash checksum of the tarball of pybind11 if(openPMD_USE_INTERNAL_PYBIND11)")
 
@@ -73,7 +73,7 @@ set(openPMD_pybind11_tar_hash "SHA256=bf8f242abd1abcd375d516a7067490fb71abd79519
 set(openPMD_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(openPMD_USE_INTERNAL_PYBIND11)")
-set(openPMD_pybind11_branch "v2.12.0"
+set(openPMD_pybind11_branch "v2.13.6"
     CACHE STRING
     "Repository branch for openPMD_pybind11_repo if(openPMD_USE_INTERNAL_PYBIND11)")
 

--- a/docs/source/dev/buildoptions.rst
+++ b/docs/source/dev/buildoptions.rst
@@ -69,7 +69,7 @@ CMake Option                      Values      Installs Library       Version
 ================================= =========== ======== ============= ========
 ``openPMD_SUPERBUILD``            **ON**/OFF
 ``openPMD_USE_INTERNAL_CATCH``    ON/OFF      No       Catch2        2.13.10+
-``openPMD_USE_INTERNAL_PYBIND11`` ON/OFF      No       pybind11       2.12.0+
+``openPMD_USE_INTERNAL_PYBIND11`` ON/OFF      No       pybind11       2.13.0+
 ``openPMD_USE_INTERNAL_JSON``     ON/OFF      No       NLohmann-JSON   3.9.1+
 ``openPMD_USE_INTERNAL_TOML11``   ON/OFF      No       toml11          3.7.1+
 ================================= =========== ======== ============= ========

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -18,7 +18,7 @@ Shipped internally
 The following libraries are shipped internally in ``share/openPMD/thirdParty/`` for convenience:
 
 * `Catch2 <https://github.com/catchorg/Catch2>`_ 2.13.10+ (`BSL-1.0 <https://github.com/catchorg/Catch2/blob/master/LICENSE.txt>`__)
-* `pybind11 <https://github.com/pybind/pybind11>`_ 2.12.0+ (`new BSD <https://github.com/pybind/pybind11/blob/master/LICENSE>`_)
+* `pybind11 <https://github.com/pybind/pybind11>`_ 2.13.0+ (`new BSD <https://github.com/pybind/pybind11/blob/master/LICENSE>`_)
 * `NLohmann-JSON <https://github.com/nlohmann/json>`_ 3.9.1+ (`MIT <https://github.com/nlohmann/json/blob/develop/LICENSE.MIT>`_)
 * `toml11 <https://github.com/ToruNiina/toml11>`_ 3.7.1+ (`MIT <https://github.com/ToruNiina/toml11/blob/master/LICENSE>`__)
 
@@ -39,7 +39,7 @@ Optional: language bindings
 * Python:
 
   * Python 3.8 - 3.12
-  * pybind11 2.12.0+
+  * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)
   * pandas 1.0+ (optional, for dataframes)

--- a/docs/source/dev/dependencies.rst
+++ b/docs/source/dev/dependencies.rst
@@ -38,7 +38,7 @@ Optional: language bindings
 
 * Python:
 
-  * Python 3.8 - 3.12
+  * Python 3.8 - 3.13
   * pybind11 2.13.0+
   * numpy 1.15+
   * mpi4py 2.1+ (optional, for MPI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ requires = [
     "wheel",
     "cmake>=3.22.0,<4.0.0",
     "packaging>=23",
-    "pybind11>=2.12.0,<3.0.0"
+    "pybind11>=2.13.0,<3.0.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         ('License :: OSI Approved :: '
          'GNU Lesser General Public License v3 or later (LGPLv3+)'),
     ],


### PR DESCRIPTION
Python 3.13 is released.

pybind11 2.13.0+ tests Python 3.13, so bump there.