### PR TITLE
Wheels: 0.16.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,19 +86,18 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install cibuildwheel==2.21.2
 
-    # Hack: cmake --trace-expand
-    #- name: Download Patch 2/2
-    #  uses: suisei-cn/actions-download-file@v1
-    #  id: setupversion
-    #  with:
-    #    url: "https://gist.githubusercontent.com/ax3l/9b15c5bc73d7f3c1c66784187a016474/raw/e31dd54498c9c8fc465a7cbb6f900f768b9d0c0b/0001-Hack-setup.py-CMake-trace-expand.patch"
-    #    target: src/.patch/
+    # Patch: Fix versioning
+    - name: Download Patch 1/1
+      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9  # 1.6.0
+      id: setupversion
+      with:
+        url: "https://github.com/openPMD/openPMD-api/pull/1680.patch"
+        target: src/.patch/
 
-    #- name: Apply Patches
-    #  run: |
-    #    python -m pip install patch
-    #    cd src
-    #    python -m patch .patch/0001-Hack-setup.py-CMake-trace-expand.patch
+    - name: Apply Patches
+      run: |
+        cd src
+        git apply --exclude=.github/workflows/windows.yml .patch/1680.patch
 
     - name: Build wheel
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: 'src'
-        ref: '0.15.2'
+        ref: '0.16.0'
 
     - uses: actions/checkout@v4
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,19 +144,14 @@ install:
   - python -m pip install patch
 
 # Download & Apply Patches
-#before_script:
-#  - mkdir -p src/.patch
-#  - cd src/.patch
-#  - curl -sOL https://github.com/ax3l/openPMD-api/commit/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
-#  - curl -sOL https://github.com/ax3l/openPMD-api/commit/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
-#  - curl -sOL https://github.com/ax3l/openPMD-api/commit/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch
-#  - curl -sOL https://gist.githubusercontent.com/ax3l/5e83edefe4b05cf6aa2a971649285fe0/raw/023cbd69e06715e5191ece741bb1de56560a9f96/0001-Bump-setup.py.patch
-#  - cd ..
-#  - python -m patch .patch/b622cc5ea770f866c1e373185a9e389c04bdb54c.patch
-#  - python -m patch .patch/a1aac530dbc8261656cf6a07900374bc6ac6fcab.patch
-#  - python -m patch .patch/43c4bf4327616e9cf7e7992d91d9b8ccd4ee3a83.patch
-#  - python -m patch .patch/0001-Bump-setup.py.patch
-#  - cd ..
+before_script:
+  - mkdir -p src/.patch
+  - cd src/.patch
+  - curl -sOL https://github.com/openPMD/openPMD-api/pull/1680.patch
+  - cd ..
+  - ls -hal .patch/
+  - git apply --exclude=.github/workflows/windows.yml .patch/1680.patch
+  - cd ..
 
 script:
   - cd src

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.15.2"
+    - OPENPMD_GIT_REF="0.16.0"
 
     - CIBW_PROJECT_REQUIRES_PYTHON=">=3.9"
     # Install dependencies on Linux and OSX


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.16.0 release.

- [x] patch in #1680 or wait for 0.16.1 #1676 because of botched `setup.py` #https://github.com/openPMD/openPMD-api/pull/1648#issuecomment-2398527616
- [x] rebase once ADIOS2 v2.10.1 is building #1554