### PR TITLE
Fix: CMake Internal Control

### DIFF
--- a/cmake/dependencies/catch.cmake
+++ b/cmake/dependencies/catch.cmake
@@ -1,49 +1,49 @@
 function(find_catch2)
     if(TARGET Catch2::Catch2)
         message(STATUS "Catch2::Catch2 target already imported")
-    elseif(openPMD_catch_src)
-        message(STATUS "Compiling local Catch2 ...")
-        message(STATUS "Catch2 source path: ${openPMD_catch_src}")
-        if(NOT IS_DIRECTORY ${openPMD_catch_src})
-            message(FATAL_ERROR "Specified directory openPMD_catch_src='${openPMD_catch_src}' does not exist!")
-        endif()
-    elseif(openPMD_catch_tar)
-        message(STATUS "Downloading Catch2 ...")
-        message(STATUS "Catch2 source: ${openPMD_catch_tar}")
     elseif(openPMD_USE_INTERNAL_CATCH)
-        message(STATUS "Downloading Catch2 ...")
-        message(STATUS "Catch2 repository: ${openPMD_catch_repo} (${openPMD_catch_branch})")
+        if(openPMD_catch_src)
+            message(STATUS "Compiling local Catch2 ...")
+            message(STATUS "Catch2 source path: ${openPMD_catch_src}")
+            if(NOT IS_DIRECTORY ${openPMD_catch_src})
+                message(FATAL_ERROR "Specified directory openPMD_catch_src='${openPMD_catch_src}' does not exist!")
+            endif()
+        elseif(openPMD_catch_tar)
+            message(STATUS "Downloading Catch2 ...")
+            message(STATUS "Catch2 source: ${openPMD_catch_tar}")
+        elseif(openPMD_catch_branch)
+            message(STATUS "Downloading Catch2 ...")
+            message(STATUS "Catch2 repository: ${openPMD_catch_repo} (${openPMD_catch_branch})")
+        endif()
     endif()
     if(TARGET Catch2::Catch2)
         # nothing to do, target already exists in the superbuild
-    elseif(openPMD_USE_INTERNAL_CATCH OR openPMD_catch_src OR openPMD_catch_tar)
-        if(openPMD_catch_src)
-            add_subdirectory(${openPMD_catch_src} _deps/localCatch2-build/)
+    elseif(openPMD_USE_INTERNAL_CATCH AND openPMD_catch_src)
+        add_subdirectory(${openPMD_catch_src} _deps/localCatch2-build/)
+    elseif(openPMD_USE_INTERNAL_CATCH AND (openPMD_catch_tar OR openPMD_catch_branch))
+        include(FetchContent)
+        if(openPMD_catch_tar)
+            FetchContent_Declare(fetchedCatch2
+                URL             ${openPMD_catch_tar}
+                URL_HASH        ${openPMD_catch_tar_hash}
+                BUILD_IN_SOURCE OFF
+            )
         else()
-            include(FetchContent)
-            if(openPMD_catch_tar)
-                FetchContent_Declare(fetchedCatch2
-                    URL             ${openPMD_catch_tar}
-                    URL_HASH        ${openPMD_catch_tar_hash}
-                    BUILD_IN_SOURCE OFF
-                )
-            else()
-                FetchContent_Declare(fetchedCatch2
-                    GIT_REPOSITORY ${openPMD_catch_repo}
-                    GIT_TAG        ${openPMD_catch_branch}
-                    BUILD_IN_SOURCE OFF
-                )
-            endif()
-            FetchContent_MakeAvailable(fetchedCatch2)
-
-            # advanced fetch options
-            mark_as_advanced(FETCHCONTENT_BASE_DIR)
-            mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-            mark_as_advanced(FETCHCONTENT_QUIET)
-            #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDCatch2)
-            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-            #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDCatch2)
+            FetchContent_Declare(fetchedCatch2
+                GIT_REPOSITORY ${openPMD_catch_repo}
+                GIT_TAG        ${openPMD_catch_branch}
+                BUILD_IN_SOURCE OFF
+            )
         endif()
+        FetchContent_MakeAvailable(fetchedCatch2)
+
+        # advanced fetch options
+        mark_as_advanced(FETCHCONTENT_BASE_DIR)
+        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+        mark_as_advanced(FETCHCONTENT_QUIET)
+        #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDCatch2)
+        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+        #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDCatch2)
     elseif(NOT openPMD_USE_INTERNAL_CATCH)
         find_package(Catch2 2.13.10 CONFIG REQUIRED)
         message(STATUS "Catch2: Found version '${Catch2_VERSION}'")

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -1,49 +1,49 @@
 function(find_json)
     if(TARGET nlohmann_json::nlohmann_json)
         message(STATUS "nlohmann_json::nlohmann_json target already imported")
-    elseif(openPMD_json_src)
-        message(STATUS "Compiling local nlohmann_json ...")
-        message(STATUS "nlohmann_json source path: ${openPMD_json_src}")
-        if(NOT IS_DIRECTORY ${openPMD_json_src})
-            message(FATAL_ERROR "Specified directory openPMD_json_src='${openPMD_json_src}' does not exist!")
-        endif()
-    elseif(openPMD_json_tar)
-        message(STATUS "Downloading nlohmann_json ...")
-        message(STATUS "nlohmann_json source: ${openPMD_json_tar}")
     elseif(openPMD_USE_INTERNAL_JSON)
-        message(STATUS "Downloading nlohmann_json ...")
-        message(STATUS "nlohmann_json repository: ${openPMD_json_repo} (${openPMD_json_branch})")
+        if(openPMD_json_src)
+            message(STATUS "Compiling local nlohmann_json ...")
+            message(STATUS "nlohmann_json source path: ${openPMD_json_src}")
+            if(NOT IS_DIRECTORY ${openPMD_json_src})
+                message(FATAL_ERROR "Specified directory openPMD_json_src='${openPMD_json_src}' does not exist!")
+            endif()
+        elseif(openPMD_json_tar)
+            message(STATUS "Downloading nlohmann_json ...")
+            message(STATUS "nlohmann_json source: ${openPMD_json_tar}")
+        elseif(openPMD_json_branch)
+            message(STATUS "Downloading nlohmann_json ...")
+            message(STATUS "nlohmann_json repository: ${openPMD_json_repo} (${openPMD_json_branch})")
+        endif()
     endif()
     if(TARGET nlohmann_json::nlohmann_json)
         # nothing to do, target already exists in the superbuild
-    elseif(openPMD_USE_INTERNAL_JSON OR openPMD_json_src OR openPMD_json_tar)
-        if(openPMD_json_src)
-            add_subdirectory(${openPMD_json_src} _deps/localnlohmann_json-build/)
+    elseif(openPMD_USE_INTERNAL_JSON AND openPMD_json_src)
+        add_subdirectory(${openPMD_json_src} _deps/localnlohmann_json-build/)
+    elseif(openPMD_USE_INTERNAL_JSON AND (openPMD_json_tar OR openPMD_json_branch))
+        include(FetchContent)
+        if(openPMD_json_tar)
+            FetchContent_Declare(fetchednlohmann_json
+                URL             ${openPMD_json_tar}
+                URL_HASH        ${openPMD_json_tar_hash}
+                BUILD_IN_SOURCE OFF
+            )
         else()
-            include(FetchContent)
-            if(openPMD_json_tar)
-                FetchContent_Declare(fetchednlohmann_json
-                    URL             ${openPMD_json_tar}
-                    URL_HASH        ${openPMD_json_tar_hash}
-                    BUILD_IN_SOURCE OFF
-                )
-            else()
-                FetchContent_Declare(fetchednlohmann_json
-                    GIT_REPOSITORY ${openPMD_json_repo}
-                    GIT_TAG        ${openPMD_json_branch}
-                    BUILD_IN_SOURCE OFF
-                )
-            endif()
-            FetchContent_MakeAvailable(fetchednlohmann_json)
-
-            # advanced fetch options
-            mark_as_advanced(FETCHCONTENT_BASE_DIR)
-            mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-            mark_as_advanced(FETCHCONTENT_QUIET)
-            #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDnlohmann_json)
-            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-            #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDnlohmann_json)
+            FetchContent_Declare(fetchednlohmann_json
+                GIT_REPOSITORY ${openPMD_json_repo}
+                GIT_TAG        ${openPMD_json_branch}
+                BUILD_IN_SOURCE OFF
+            )
         endif()
+        FetchContent_MakeAvailable(fetchednlohmann_json)
+
+        # advanced fetch options
+        mark_as_advanced(FETCHCONTENT_BASE_DIR)
+        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+        mark_as_advanced(FETCHCONTENT_QUIET)
+        #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDnlohmann_json)
+        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+        #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDnlohmann_json)
     elseif(NOT openPMD_USE_INTERNAL_JSON)
         find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)
         message(STATUS "nlohmann_json: Found version '${nlohmann_json_VERSION}'")

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -1,49 +1,49 @@
 function(find_pybind11)
     if(TARGET pybind11::module)
         message(STATUS "pybind11::module target already imported")
-    elseif(openPMD_pybind11_src)
-        message(STATUS "Compiling local pybind11 ...")
-        message(STATUS "pybind11 source path: ${openPMD_pybind11_src}")
-        if(NOT IS_DIRECTORY ${openPMD_pybind11_src})
-            message(FATAL_ERROR "Specified directory openPMD_pybind11_src='${openPMD_pybind11_src}' does not exist!")
-        endif()
-    elseif(openPMD_pybind11_tar)
-        message(STATUS "Downloading pybind11 ...")
-        message(STATUS "pybind11 source: ${openPMD_pybind11_tar}")
     elseif(openPMD_USE_INTERNAL_PYBIND11)
-        message(STATUS "Downloading pybind11 ...")
-        message(STATUS "pybind11 repository: ${openPMD_pybind11_repo} (${openPMD_pybind11_branch})")
+        if(openPMD_pybind11_src)
+            message(STATUS "Compiling local pybind11 ...")
+            message(STATUS "pybind11 source path: ${openPMD_pybind11_src}")
+            if(NOT IS_DIRECTORY ${openPMD_pybind11_src})
+                message(FATAL_ERROR "Specified directory openPMD_pybind11_src='${openPMD_pybind11_src}' does not exist!")
+            endif()
+        elseif(openPMD_pybind11_tar)
+            message(STATUS "Downloading pybind11 ...")
+            message(STATUS "pybind11 source: ${openPMD_pybind11_tar}")
+        elseif(openPMD_pybind11_branch)
+            message(STATUS "Downloading pybind11 ...")
+            message(STATUS "pybind11 repository: ${openPMD_pybind11_repo} (${openPMD_pybind11_branch})")
+        endif()
     endif()
     if(TARGET pybind11::module)
         # nothing to do, target already exists in the superbuild
-    elseif(openPMD_USE_INTERNAL_PYBIND11 OR openPMD_pybind11_src)
-        if(openPMD_pybind11_src)
-            add_subdirectory(${openPMD_pybind11_src} _deps/localpybind11-build/)
-        else()
-            include(FetchContent)
-            if(openPMD_pybind11_tar)
-                FetchContent_Declare(fetchedpybind11
-                        URL             ${openPMD_pybind11_tar}
-                        URL_HASH        ${openPMD_pybind11_tar_hash}
-                        BUILD_IN_SOURCE OFF
-                )
-            else()
-                FetchContent_Declare(fetchedpybind11
-                    GIT_REPOSITORY ${openPMD_pybind11_repo}
-                    GIT_TAG        ${openPMD_pybind11_branch}
+    elseif(openPMD_USE_INTERNAL_PYBIND11 AND openPMD_pybind11_src)
+        add_subdirectory(${openPMD_pybind11_src} _deps/localpybind11-build/)
+    elseif(openPMD_USE_INTERNAL_PYBIND11 AND (openPMD_pybind11_tar OR openPMD_pybind11_branch))
+        include(FetchContent)
+        if(openPMD_pybind11_tar)
+            FetchContent_Declare(fetchedpybind11
+                    URL             ${openPMD_pybind11_tar}
+                    URL_HASH        ${openPMD_pybind11_tar_hash}
                     BUILD_IN_SOURCE OFF
-                )
-            endif()
-            FetchContent_MakeAvailable(fetchedpybind11)
-
-            # advanced fetch options
-            mark_as_advanced(FETCHCONTENT_BASE_DIR)
-            mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-            mark_as_advanced(FETCHCONTENT_QUIET)
-            mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDpybind11)
-            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
+            )
+        else()
+            FetchContent_Declare(fetchedpybind11
+                GIT_REPOSITORY ${openPMD_pybind11_repo}
+                GIT_TAG        ${openPMD_pybind11_branch}
+                BUILD_IN_SOURCE OFF
+            )
         endif()
+        FetchContent_MakeAvailable(fetchedpybind11)
+
+        # advanced fetch options
+        mark_as_advanced(FETCHCONTENT_BASE_DIR)
+        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+        mark_as_advanced(FETCHCONTENT_QUIET)
+        mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDpybind11)
+        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
     elseif(NOT openPMD_USE_INTERNAL_PYBIND11)
         if(openPMD_USE_PYTHON STREQUAL AUTO)
             find_package(pybind11 2.13.0 CONFIG)

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -1,49 +1,49 @@
 function(find_toml11)
     if(TARGET toml11::toml11)
         message(STATUS "toml11::toml11 target already imported")
-    elseif(openPMD_toml11_src)
-        message(STATUS "Compiling local toml11 ...")
-        message(STATUS "toml11 source path: ${openPMD_toml11_src}")
-        if(NOT IS_DIRECTORY ${openPMD_toml11_src})
-            message(FATAL_ERROR "Specified directory openPMD_toml11_src='${openPMD_toml11_src}' does not exist!")
-        endif()
-    elseif(openPMD_toml11_tar)
-        message(STATUS "Downloading toml11 ...")
-        message(STATUS "toml11 source: ${openPMD_toml11_tar}")
     elseif(openPMD_USE_INTERNAL_TOML11)
-        message(STATUS "Downloading toml11 ...")
-        message(STATUS "toml11 repository: ${openPMD_toml11_repo} (${openPMD_toml11_branch})")
+        if(openPMD_toml11_src)
+            message(STATUS "Compiling local toml11 ...")
+            message(STATUS "toml11 source path: ${openPMD_toml11_src}")
+            if(NOT IS_DIRECTORY ${openPMD_toml11_src})
+                message(FATAL_ERROR "Specified directory openPMD_toml11_src='${openPMD_toml11_src}' does not exist!")
+            endif()
+        elseif(openPMD_toml11_tar)
+            message(STATUS "Downloading toml11 ...")
+            message(STATUS "toml11 source: ${openPMD_toml11_tar}")
+        elseif(openPMD_toml11_branch)
+            message(STATUS "Downloading toml11 ...")
+            message(STATUS "toml11 repository: ${openPMD_toml11_repo} (${openPMD_toml11_branch})")
+        endif()
     endif()
     if(TARGET toml11::toml11)
         # nothing to do, target already exists in the superbuild
-    elseif(openPMD_USE_INTERNAL_TOML11 OR openPMD_toml11_src)
-        if(openPMD_toml11_src)
-            add_subdirectory(${openPMD_toml11_src} _deps/localtoml11-build/)
-        else()
-            include(FetchContent)
-            if(openPMD_toml11_tar)
-                FetchContent_Declare(fetchedtoml11
-                        URL             ${openPMD_toml11_tar}
-                        URL_HASH        ${openPMD_toml11_tar_hash}
-                        BUILD_IN_SOURCE OFF
-                )
-            else()
-                FetchContent_Declare(fetchedtoml11
-                    GIT_REPOSITORY ${openPMD_toml11_repo}
-                    GIT_TAG        ${openPMD_toml11_branch}
+    elseif(openPMD_USE_INTERNAL_TOML11 AND openPMD_toml11_src)
+        add_subdirectory(${openPMD_toml11_src} _deps/localtoml11-build/)
+    elseif(openPMD_USE_INTERNAL_TOML11 AND (openPMD_toml11_tar OR openPMD_toml11_branch))
+        include(FetchContent)
+        if(openPMD_toml11_tar)
+            FetchContent_Declare(fetchedtoml11
+                    URL             ${openPMD_toml11_tar}
+                    URL_HASH        ${openPMD_toml11_tar_hash}
                     BUILD_IN_SOURCE OFF
-                )
-            endif()
-            FetchContent_MakeAvailable(fetchedtoml11)
-
-            # advanced fetch options
-            mark_as_advanced(FETCHCONTENT_BASE_DIR)
-            mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-            mark_as_advanced(FETCHCONTENT_QUIET)
-            #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDtoml11)
-            mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-            #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDtoml11)
+            )
+        else()
+            FetchContent_Declare(fetchedtoml11
+                GIT_REPOSITORY ${openPMD_toml11_repo}
+                GIT_TAG        ${openPMD_toml11_branch}
+                BUILD_IN_SOURCE OFF
+            )
         endif()
+        FetchContent_MakeAvailable(fetchedtoml11)
+
+        # advanced fetch options
+        mark_as_advanced(FETCHCONTENT_BASE_DIR)
+        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+        mark_as_advanced(FETCHCONTENT_QUIET)
+        #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDtoml11)
+        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+        #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDtoml11)
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake
         # logic: version 4.0 is not accepted by a call to find_package(toml11 3.7).


### PR DESCRIPTION
The `openPMD_USE_INTERNAL_*` options are for general internal/external control. They were accidentally overwritten by new tar flags and sometimes incomplete.

Follow-up to #1668 