### PR TITLE
Replace deprecated makeSuite with loadTestsFromTestCase

### DIFF
--- a/test/python/unittest/Test.py
+++ b/test/python/unittest/Test.py
@@ -16,8 +16,8 @@ from API.APITest import APITest
 # Define the test suite.
 def suite():
     suites = [
-               unittest.makeSuite(APITest),
-             ]
+        unittest.TestLoader().loadTestsFromTestCase(testCaseClass=APITest),
+    ]
 
     return unittest.TestSuite(suites)
 


### PR DESCRIPTION
Removed with Python 3.13
Relevant for 0.16 releases due to #1675

```python3
def makeSuite(testCaseClass, prefix='test', sortUsing=util.three_way_cmp,
              suiteClass=suite.TestSuite):
    import warnings
    warnings.warn(
        "unittest.makeSuite() is deprecated and will be removed in Python 3.13. "
        "Please use unittest.TestLoader.loadTestsFromTestCase() instead.",
        DeprecationWarning, stacklevel=2
    )
    return _makeLoader(prefix, sortUsing, suiteClass).loadTestsFromTestCase(
        testCaseClass)
```
