### PR TITLE
Fix Leftover ADIOS1 Mentions

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,7 +1,6 @@
 PROJECT_NAME      = "openPMD-api"
 XML_OUTPUT        = xml
 INPUT             = ../src ../include ../README.md
-#EXCLUDE_PATTERNS  = *CommonADIOS1IOHandler.cpp
 
 # TAGFILES += "cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 BUILTIN_STL_SUPPORT = YES

--- a/docs/source/maintenance/release_channels.rst
+++ b/docs/source/maintenance/release_channels.rst
@@ -39,7 +39,7 @@ Brew
 We maintain a `homebrew tap <https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap>`_ for `openPMD <https://github.com/openPMD/homebrew-openPMD>`_.
 Provides the C++ and Python API for users.
 Supports OSX and Linux.
-Its source-only Formula for the latest release includes (Open)MPI support and lacks the ADIOS1 backend.
+Its source-only Formula for the latest release includes (Open)MPI support.
 
 Example workflow for a new release:
 

--- a/examples/13_write_dynamic_configuration.cpp
+++ b/examples/13_write_dynamic_configuration.cpp
@@ -39,9 +39,6 @@ iteration_encoding = "group_based"
 # The following is only relevant in read mode
 defer_iteration_parsing = true
 
-[adios1.dataset]
-transform = "blosc:compressor=zlib,shuffle=bit,lvl=5;nometa"
-
 [adios2.engine]
 type = "bp4"
 

--- a/examples/13_write_dynamic_configuration.py
+++ b/examples/13_write_dynamic_configuration.py
@@ -25,9 +25,6 @@ iteration_encoding = "group_based"
 # The following is only relevant in read mode
 defer_iteration_parsing = true
 
-[adios1.dataset]
-transform = "blosc:compressor=zlib,shuffle=bit,lvl=5;nometa"
-
 [adios2.engine]
 type = "bp4"
 

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -107,11 +107,6 @@ int main()
         auto d = io::Dataset(dtype, io::Extent{2, 5});
         std::string datasetConfig = R"END(
 {
-  "adios1": {
-    "dataset": {
-      "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
-    }
-  },
   "adios2": {
     "dataset": {
       "operators": [

--- a/examples/7_extended_write_serial.py
+++ b/examples/7_extended_write_serial.py
@@ -106,11 +106,6 @@ if __name__ == "__main__":
     # written to disk
     d = Dataset(partial_mesh.dtype, extent=[2, 5])
     dataset_config = {
-        "adios1": {
-            "dataset": {
-                "transform": "blosc:compressor=zlib,shuffle=bit,lvl=1;nometa"
-            }
-        },
         "adios2": {
             "dataset": {
                 "operators": [{

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -772,7 +772,7 @@ void ADIOS2IOHandlerImpl::createDataset(
     if (parameters.joinedDimension.has_value())
     {
         error::throwOperationUnsupportedInBackend(
-            "ADIOS1", "Joined Arrays require ADIOS2 >= v2.9");
+            "ADIOS2", "Joined Arrays require ADIOS2 >= v2.9");
     }
 #endif
     if (!writable->written)

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -471,7 +471,7 @@ void HDF5IOHandlerImpl::createDataset(
     if (parameters.joinedDimension.has_value())
     {
         error::throwOperationUnsupportedInBackend(
-            "ADIOS1", "Joined Arrays currently only supported in ADIOS2");
+            "HDF5", "Joined Arrays currently only supported in ADIOS2");
     }
 
     if (!writable->written)

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -283,7 +283,7 @@ void JSONIOHandlerImpl::createDataset(
     if (parameter.joinedDimension.has_value())
     {
         error::throwOperationUnsupportedInBackend(
-            "ADIOS1", "Joined Arrays currently only supported in ADIOS2");
+            "JSON", "Joined Arrays currently only supported in ADIOS2");
     }
 
     if (!writable->written)


### PR DESCRIPTION
Leaves the doc page on ADIOS1 for now in, because it contains a migration guide on how to read legacy BP3 files.

Note: Examples 7 and 13 still mention adios1 options, which will need a separate PR to update.