### PR TITLE
`PYBIND11_FINDPYTHON=ON`

### DIFF
--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -16,6 +16,11 @@ function(find_pybind11)
             message(STATUS "pybind11 repository: ${openPMD_pybind11_repo} (${openPMD_pybind11_branch})")
         endif()
     endif()
+
+    # rely on our find_package(Python ...) call
+    # https://pybind11.readthedocs.io/en/stable/compiling.html#modules-with-cmake
+    set(PYBIND11_FINDPYTHON ON)
+
     if(TARGET pybind11::module)
         # nothing to do, target already exists in the superbuild
     elseif(openPMD_USE_INTERNAL_PYBIND11 AND openPMD_pybind11_src)

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,19 @@ class CMakeBuild(build_ext):
         if not extdir.endswith(os.path.sep):
             extdir += os.path.sep
 
+        pyv = sys.version_info
         cmake_args = [
+            # Python: use the calling interpreter in CMake
+            # https://cmake.org/cmake/help/latest/module/FindPython.html#hints
+            # https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-version-selection
+            '-DPython_ROOT_DIR=' + sys.prefix,
+            f'-DPython_FIND_VERSION={pyv.major}.{pyv.minor}.{pyv.micro}',
+            '-DPython_FIND_VERSION_EXACT=TRUE',
+            '-DPython_FIND_STRATEGY=LOCATION',
             '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' +
             os.path.join(extdir, "openpmd_api"),
             # '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=' + extdir,
             '-DopenPMD_PYTHON_OUTPUT_DIRECTORY=' + extdir,
-            '-DPython_EXECUTABLE=' + sys.executable,
             '-DopenPMD_USE_PYTHON:BOOL=ON',
             # variants
             '-DopenPMD_USE_MPI:BOOL=' + openPMD_USE_MPI,


### PR DESCRIPTION
Reuse our `find_package(Python ...)` call and use new CMake logic in pybind11.
https://pybind11.readthedocs.io/en/stable/compiling.html#modules-with-cmake
https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-version-selection

Fix https://github.com/openPMD/openPMD-api/pull/1677#issuecomment-2407743771