### PR TITLE
Fix icx CI run

### DIFF
--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -259,7 +259,7 @@ public:
 
     void swap(Container &other)
     {
-        container().swap(other.m_container);
+        container().swap(other.container());
     }
 
     mapped_type &at(key_type const &key)


### PR DESCRIPTION
Seen in the CI of https://github.com/openPMD/openPMD-api/pull/1551 and https://github.com/openPMD/openPMD-api/pull/1689:

```
/home/runner/work/openPMD-api/openPMD-api/include/openPMD/backend/Container.hpp:262:32: error: no member named 'm_container' in 'Container<T, T_key, T_container>'
  262 |         container().swap(other.m_container);
      |                          ~~~~~ ^
```

Adding to 0.16.1 milestone since the bug will occur there, too.