### PR TITLE
Take TOML out of Python testing

### DIFF
--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -25,8 +25,10 @@ except ImportError:
 from TestUtilities.TestUtilities import generateTestFilePath
 
 tested_file_extensions = [
-    ext for ext in io.file_extensions if ext != 'sst' and ext != 'ssc'
-]
+    ext for ext in io.file_extensions
+    # TOML is relatively slow and it's just an adaptor for the JSON backend,
+    # so it doesn't require full testing
+    if ext !='sst' and ext !='ssc' and ext !='toml']
 
 
 class APITest(unittest.TestCase):

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -28,7 +28,7 @@ tested_file_extensions = [
     ext for ext in io.file_extensions
     # TOML is relatively slow and it's just an adaptor for the JSON backend,
     # so it doesn't require full testing
-    if ext !='sst' and ext !='ssc' and ext !='toml']
+    if ext != 'sst' and ext != 'ssc' and ext != 'toml']
 
 
 class APITest(unittest.TestCase):


### PR DESCRIPTION
Especially the ASAN/UBSAN tests are currently running into timeouts due to TOML being slow.