### PR TITLE
Apply patch for #1684: PYBIND11_FINDPYTHON=ON

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,17 +87,26 @@ jobs:
         python -m pip install cibuildwheel==2.21.2
 
     # Patch: Fix versioning
-    - name: Download Patch 1/1
+    - name: Download Patch 1/2
       uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9  # 1.6.0
       id: setupversion
       with:
         url: "https://github.com/openPMD/openPMD-api/pull/1680.patch"
         target: src/.patch/
 
+    # Patch: PYBIND11_FINDPYTHON=ON
+    - name: Download Patch 2/2
+      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9  # 1.6.0
+      id: setupversion
+      with:
+        url: "https://github.com/openPMD/openPMD-api/pull/1684.patch"
+        target: src/.patch/
+
     - name: Apply Patches
       run: |
         cd src
         git apply --exclude=.github/workflows/windows.yml .patch/1680.patch
+        git apply .patch/1684.patch
 
     - name: Build wheel
       env:


### PR DESCRIPTION
Pre-built wheel installations for 0.16.0 currently may fail importing into a Python environment without this due to wrongly-detected Python paths:

```
> python
Python 3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import openpmd_api
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/franzpoeschel/git-repos-no-sync/env/lib/python3.10/site-packages/openpmd_api/__init__.py", line 1, in <module>
    from . import openpmd_api_cxx as cxx
ImportError: cannot import name 'openpmd_api_cxx' from partially initialized module 'openpmd_api' (most likely due to a circular import) (/home/franzpoeschel/git-repos-no-sync/env/lib/python3.1
0/site-packages/openpmd_api/__init__.py)
```