### PR TITLE
Specify LANGUAGES CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 cmake_minimum_required(VERSION 3.22.0)
 
-project(openPMD VERSION 0.17.0) # LANGUAGES CXX
+project(openPMD VERSION 0.17.0 LANGUAGES CXX)
 
 # the openPMD "markup"/"schema" standard version
 set(openPMD_STANDARD_VERSION 1.1.0)


### PR DESCRIPTION
CMake also includes C by default, we don't need it. This came up in https://github.com/spack/spack/pull/47662#discussion_r1848064385.
The previous form was apparently introduced in 2018 in https://github.com/openPMD/openPMD-api/commit/b17feeb09c0a02f5630b81a45f9fcad5b5057d35 and looks like a provisorium, so we should maybe change that now.