### PR TITLE
Conda: Pin HDF5 to 1.14.1 in CI workflow

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -23,7 +23,7 @@ dependencies:
   - dask
   - doxygen
   - git
-  - hdf5=*=mpi_openmpi_*
+  - hdf5=1.14.0=mpi_openmpi_*
   - mamba
   - make
   - mpi4py

--- a/conda.yml
+++ b/conda.yml
@@ -23,7 +23,7 @@ dependencies:
   - dask
   - doxygen
   - git
-  - hdf5=1.14.0=mpi_openmpi_*
+  - hdf5=1.14.1=mpi_openmpi_*
   - mamba
   - make
   - mpi4py


### PR DESCRIPTION
Version 1.14.4 has trouble: https://github.com/HDFGroup/hdf5/issues/5164
Until that is resolved, let's stick with a version that works.