### PR TITLE
Properly check for empty HDF5_VERSION in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,7 @@ endif()
 string(CONCAT openPMD_HDF5_STATUS "")
 # version: lower limit
 if(openPMD_HAVE_HDF5)
-    if(HDF5_VERSION STREQUAL "")
+    if("${HDF5_VERSION}" STREQUAL "")
         message(WARNING "HDF5_VERSION is empty. Now assuming it is 1.8.13 or newer.")
     else()
         if(HDF5_VERSION VERSION_LESS 1.8.13)

--- a/conda.yml
+++ b/conda.yml
@@ -23,7 +23,7 @@ dependencies:
   - dask
   - doxygen
   - git
-  - hdf5=1.14.1=mpi_openmpi_*
+  - hdf5=*=mpi_openmpi_*
   - mamba
   - make
   - mpi4py


### PR DESCRIPTION
The old test apparently invoked some weird CMake legacy behavior (and hence did not work). This should make the pinned HDF5 Conda version unnecessary (#1701) since the version with missing HDF5_VERSION is correctly dealt with.