### PR TITLE
Upgrade appleclang14 build to MacOS 13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,7 @@ jobs:
         ctest --test-dir build --verbose
 
   appleclang14_py:
-    runs-on: macos-12
+    runs-on: macos-13
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
> The macOS-12 environment is deprecated, consider switching to macOS-13,
macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721

We'll try keeping MacOS 12 tested for the 0.16 release (as long is the environment still is around), but let's switch to MacOS 13 otherwise. The MacOS 12 run keeps not being available.