### PR TITLE
TOUCH IOTask: Avoid setting files as dirty in non-write modes

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1522,7 +1522,15 @@ void ADIOS2IOHandlerImpl::touch(
     Writable *writable, Parameter<Operation::TOUCH> const &)
 {
     auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
-    m_dirty.emplace(std::move(file));
+    if (access::write(m_handler->m_backendAccess))
+    {
+        m_dirty.emplace(std::move(file));
+    }
+    else if (m_fileData.find(file) == m_fileData.end())
+    {
+        throw error::Internal(
+            "ADIOS2: Tried activating a file that is not open.");
+    }
 }
 
 adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -25,6 +25,7 @@
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
+#include "openPMD/IO/Access.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
 #include "openPMD/auxiliary/Memory.hpp"
@@ -158,6 +159,11 @@ JSONIOHandlerImpl::~JSONIOHandlerImpl() = default;
 std::future<void> JSONIOHandlerImpl::flush()
 {
     AbstractIOHandlerImpl::flush();
+    if (access::readOnly(m_handler->m_backendAccess) && !m_dirty.empty())
+    {
+        throw error::Internal(
+            "JSON backend: Cannot have dirty files in read-only modes.");
+    }
     for (auto const &file : m_dirty)
     {
         putJsonContents(file, false);

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1044,7 +1044,15 @@ void JSONIOHandlerImpl::touch(
     Writable *writable, Parameter<Operation::TOUCH> const &)
 {
     auto file = refreshFileFromParent(writable);
-    m_dirty.emplace(std::move(file));
+    if (access::write(m_handler->m_backendAccess))
+    {
+        m_dirty.emplace(std::move(file));
+    }
+    else if (m_jsonVals.find(file) == m_jsonVals.end())
+    {
+        throw error::Internal(
+            "ADIOS2: Tried activating a file that is not open.");
+    }
 }
 
 auto JSONIOHandlerImpl::getFilehandle(File const &fileName, Access access)


### PR DESCRIPTION
This caused unnecessary reprocessing of data files, including rewriting JSON files.