### PR TITLE
Wheels: 0.16.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
               CMAKE_GENERATOR: "Visual Studio 16 2019"
               CMAKE_GENERATOR_PLATFORM: "Win32"
 
-          - os: macos-12
+          - os: macos-13
             arch: "x86_64"
             env:
               MACOSX_DEPLOYMENT_TARGET: 11.0
@@ -48,7 +48,7 @@ jobs:
           # Apple Silicon M1/arm64/aarch64 builds:
           #   https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
           #   https://github.com/pypa/cibuildwheel/pull/704
-          - os: macos-12
+          - os: macos-13
             arch: "arm64"
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64"
@@ -60,7 +60,7 @@ jobs:
           #   https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
           # ADIOS1 tricky to build and HDF5 even with CMake as well (as of 1.12)
           # We could build them twice and use `lipo` to combine the lib artifacts.
-          #- os: macos-12
+          #- os: macos-13
           #  arch: "universal2"
           #  env:
           #    CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: 'src'
-        ref: '0.16.0'
+        ref: '0.16.1'
 
     - uses: actions/checkout@v4
       with:
@@ -86,29 +86,29 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install cibuildwheel==2.21.2
 
-    # Patch: Fix versioning
-    - name: Download Patch 1/2
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9  # 1.6.0
-      id: setupversion
-      with:
-        url: "https://github.com/openPMD/openPMD-api/pull/1680.patch"
-        target: src/.patch/
+#    # Patch: Fix versioning
+#    - name: Download Patch 1/2
+#      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9  # 1.6.0
+#      id: setupversion
+#      with:
+#        url: "https://github.com/openPMD/openPMD-api/pull/1680.patch"
+#        target: src/.patch/
 
-    # Patch: PYBIND11_FINDPYTHON=ON
-    - name: Download Patch 2/2
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9  # 1.6.0
-      id: setupfindpython
-      with:
-        url: "https://github.com/openPMD/openPMD-api/pull/1684.patch"
-        target: src/.patch/
+#    # Patch: PYBIND11_FINDPYTHON=ON
+#    - name: Download Patch 2/2
+#      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9  # 1.6.0
+#      id: setupfindpython
+#      with:
+#        url: "https://github.com/openPMD/openPMD-api/pull/1684.patch"
+#        target: src/.patch/
 
-    - name: Apply Patches
-      run: |
-        cd src
-        git apply --exclude=.github/workflows/windows.yml .patch/1680.patch
-        git apply --exclude=cmake/dependencies/pybind11.cmake .patch/1684.patch
-        git fetch
-        git apply --exclude=setup.py -3 .patch/1684.patch
+#    - name: Apply Patches
+#      run: |
+#        cd src
+#        git apply --exclude=.github/workflows/windows.yml .patch/1680.patch
+#        git apply --exclude=cmake/dependencies/pybind11.cmake .patch/1684.patch
+#        git fetch
+#        git apply --exclude=setup.py -3 .patch/1684.patch
 
     - name: Build wheel
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 
 env:
   global:
-    - OPENPMD_GIT_REF="0.16.0"
+    - OPENPMD_GIT_REF="0.16.1"
 
     - CIBW_PROJECT_REQUIRES_PYTHON=">=3.9"
     # Install dependencies on Linux and OSX
@@ -154,14 +154,14 @@ install:
   - python -m pip install patch
 
 # Download & Apply Patches
-before_script:
-  - mkdir -p src/.patch
-  - cd src/.patch
-  - curl -sOL https://github.com/openPMD/openPMD-api/pull/1680.patch
-  - cd ..
-  - ls -hal .patch/
-  - git apply --exclude=.github/workflows/windows.yml .patch/1680.patch
-  - cd ..
+#before_script:
+#  - mkdir -p src/.patch
+#  - cd src/.patch
+#  - curl -sOL https://github.com/openPMD/openPMD-api/pull/1680.patch
+#  - cd ..
+#  - ls -hal .patch/
+#  - git apply --exclude=.github/workflows/windows.yml .patch/1680.patch
+#  - cd ..
 
 script:
   - cd src

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -17,13 +17,13 @@ exit /b 0
 
 :build_adios2
   if exist adios2-stamp exit /b 0
-  curl -sLo adios2-2.10.1.zip ^
-    https://github.com/ornladios/ADIOS2/archive/v2.10.1.zip
-  powershell Expand-Archive adios2-2.10.1.zip -DestinationPath dep-adios2
+  curl -sLo adios2-2.10.2.zip ^
+    https://github.com/ornladios/ADIOS2/archive/v2.10.2.zip
+  powershell Expand-Archive adios2-2.10.2.zip -DestinationPath dep-adios2
 
   cmake --version
 
-  cmake -S dep-adios2/ADIOS2-2.10.1 -B build-adios2 ^
+  cmake -S dep-adios2/ADIOS2-2.10.2 -B build-adios2 ^
     -DCMAKE_BUILD_TYPE=Release  ^
     -DCMAKE_DISABLE_FIND_PACKAGE_LibFFI=TRUE  ^
     -DBUILD_SHARED_LIBS=OFF     ^

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -103,8 +103,8 @@ function build_adios1 {
 function build_adios2 {
     if [ -e adios2-stamp ]; then return; fi
 
-    curl -sLo adios2-2.10.1.tar.gz \
-        https://github.com/ornladios/ADIOS2/archive/v2.10.1.tar.gz
+    curl -sLo adios2-2.10.2.tar.gz \
+        https://github.com/ornladios/ADIOS2/archive/v2.10.2.tar.gz
     file adios2*.tar.gz
     tar -xzf adios2*.tar.gz
     rm adios2*.tar.gz


### PR DESCRIPTION
Update the cibuildwheel reference tracking to the 0.16.1 release.

Dependencies:
- ADIOS 2.10.1 -> 2.10.2
- macOS 12 -> 13