### PR TITLE
RTD: Sphinx Key

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,9 @@ python:
   install:
     - requirements: docs/requirements.txt
 
+sphinx:
+  configuration: docs/source/conf.py
+
 formats:
   - htmlzip
   - pdf


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/