### PR TITLE
Integrate openpmd-scipp into the main API

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -136,6 +136,7 @@ jobs:
         sudo apt install clang-15 cmake gfortran libhdf5-dev python3.11 python3.11-dev wget
         sudo .github/workflows/dependencies/install_spack
         python3.11 -m pip install numpy pandas
+        python -m pip install scipp plopp
         git clone -b v4.0.3 https://github.com/ToruNiina/toml11
         cmake -S toml11 -B build_toml11               \
           -DCMAKE_INSTALL_PREFIX=toml11_install \
@@ -246,6 +247,8 @@ jobs:
         python3 -m pip install -U pandas
         python3 -m pip install -U dask
         python3 -m pip install -U pyarrow
+        python3 -m pip install -U plopp
+        python3 -m pip install -U scipp
     - name: Build
       env: {CC: gcc-12, CXX: g++-12, CXXFLAGS: -Werror}
       run: |
@@ -319,7 +322,10 @@ jobs:
       run: |
         apk update
         apk add hdf5-dev
-        python3.10 -m pip install numpy h5py
+        python3.10 -m pip install numpy
+        python3.10 -m pip install h5py
+        python3.10 -m pip install scipp
+        python3.10 -m pip install plopp
     - name: Build
       env: {CXXFLAGS: "-Werror -Wno-error=maybe-uninitialized"}
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -324,8 +324,6 @@ jobs:
         apk add hdf5-dev
         python3.10 -m pip install numpy
         python3.10 -m pip install h5py
-        python3.10 -m pip install scipp
-        python3.10 -m pip install plopp
     - name: Build
       env: {CXXFLAGS: "-Werror -Wno-error=maybe-uninitialized"}
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,7 +690,7 @@ if(openPMD_HAVE_PYTHON)
         ls/__init__.py   ls/__main__.py
         pipe/__init__.py pipe/__main__.py
         scipp/__init__.py scipp/loader.py scipp/mesh_loader.py scipp/utils.py
-        ScippLazyInit.py
+        scipp/lazy_init.py
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,7 +690,7 @@ if(openPMD_HAVE_PYTHON)
         ls/__init__.py   ls/__main__.py
         pipe/__init__.py pipe/__main__.py
         scipp/__init__.py scipp/loader.py scipp/mesh_loader.py scipp/utils.py
-        scipp/lazy_init.py
+        ScippLazyInit.py
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,6 +689,8 @@ if(openPMD_HAVE_PYTHON)
         __init__.py DaskArray.py DaskDataFrame.py DataFrame.py
         ls/__init__.py   ls/__main__.py
         pipe/__init__.py pipe/__main__.py
+        scipp/__init__.py scipp/loader.py scipp/mesh_loader.py scipp/utils.py
+        ScippLazyInit.py
     )
 endif()
 
@@ -747,6 +749,7 @@ set(openPMD_PYTHON_EXAMPLE_NAMES
     12_span_write
     13_write_dynamic_configuration
     15_compression
+    16_scipp_loader
 )
 
 if(openPMD_USE_INVASIVE_TESTS)

--- a/docs/source/analysis/README_15_0.svg
+++ b/docs/source/analysis/README_15_0.svg
@@ -1,0 +1,856 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="422.265625pt" height="277.114687pt" viewBox="0 0 422.265625 277.114687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-01-27T16:07:28.783245</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 277.114687
+L 422.265625 277.114687
+L 422.265625 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 58.523438 239.558437
+L 365.679401 239.558437
+L 365.679401 17.798437
+L 58.523438 17.798437
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAasAAAE0CAYAAACSIRz7AAAWOklEQVR4nO3czZLj1pmg4UOQzMwqybIdMRMT0RG98qL7GubC5uLmRnrTi970ZmzZsssqVSUJcBY4HwmcJEjmj1SfSs+zYfEHhwAI1pfcvKv//X//z6GUUlarQwn90JVSSjkcVqV9jpM4P9ld+vxuPYZbroFraz3nOlpa65deY2kt3wn4ZXVfegcA4BrDCoD0DCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANLbRONssxqODx5WYwdtOLsJIc5d9kbgW+zfW7TxvnRr8ks1AXUF4fX8sgIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANIzrABIz7ACID3DCoD0DCsA0ttEE3DdnUqA+0OdYcmbd9mda8B9yY7gW+zPLWsMzf2ubnNLE29pre4ZPb2lY1pqE07Xjvd77hrP8ZI1lvbnNWtoFPJr4pcVAOkZVgCkZ1gBkJ5hBUB6hhUA6RlWAKRnWAGQnmEFQHqGFQDpGVYApGdYAZDeJvpgm0kbcDeMj/X1/nO6bK/VduV+jb5Uc+05Hb1rPb/wnK7frZ9drDl9fezP0hrx/peOrR+6i2tE/7I9pnPdvVvXOKftC7afyy3Hcq1RuNQ3PLffb9mjfIu+oEYhL+GXFQDpGVYApGdYAZCeYQVAeoYVAOkZVgCkZ1gBkJ5hBUB6hhUA6RlWAKRnWAGQ3ib+Me2UdeXLtbpu6aVl8ZbNtSWX+nXh2nm51F57aRNwuj+njt38NevuJS2882ss7c+583LrGnG/P9MofM1+XOschpes0Z7Dpfsv+a783H3BX+L7wtfLLysA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANIzrABIb3Mu6zKUeRYlW+boS1vKxlzKGj1Xu9b0/tL7L6WAXpLgaZNEbfZpmL64WXe1mq+x7obZWmHo1xfef2GNJgW2O5zWWDq+do31apgdSz/dpytrxO1mNTsDs/0IbbIpvlZL56N/xudzLft0LofVbrt0P7P22n/L7xy5+WUFQHqGFQDpGVYApGdYAZCeYQVAeoYVAOkZVgCkZ1gBkJ5hBUB6hhUA6RlWAKS3+fHxrpRSysfd3fHBX1Mr7Odyrjn2Fk3Aa6+91nwbn5y3/tYLHb/2c5zW6/qhq0ud78a1Hb12P/aHp3/nxHOx7bYbq3vbdT973b6+99Ctnmxbmibg/Xo/WyP2L9aY7sexgVgXifuxbax1aY3Wqun5La0x/byGYz9x/vnEGtEVbHuL5xqF0RdsW4ntZ/ySfudS9zEsXe+X1mr34zlrwCV+WQGQnmEFQHqGFQDpGVYApGdYAZCeYQVAeoYVAOkZVgCkZ1gBkJ5hBUB6hhUA6W1++Of7Ukop+8dTOe7dN5/H2/tdKeX2vtdzGnnP0ZXb1l09I0O21D+8dAztc+0aS02+m/anXO76TS114Da1PdctrDHd7tiva9aKNe5q1y/ux+uihfc4nK6XpTUeakcv1gqx7cf99vjYrmkQRs/v/WZ3do1P/aZcE23CWONhs5+vsR/XiE5iKaX0dd/jmt80XcGHpg34uBqPpT/TF4zPtO0tLrUSbxFrbZrzFU3FfuFznb10oT95vH9m21hvqV3Z7t9LWoVL9AUpxS8rAH4FDCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANIzrABIb7P7/qGUUsrdX0+tt4//Ora4tpuxYRZtrrbR9ZIW4LVtzvX9oqS21OIL3aF9/ula13p+1/p/pSx3/JaafJfWWNr2eFtfN5TlPlq8ZhM9v9qNi/tD7dbN2oBl3pCL97vrxvbdfTdv4IXHYezpfZ60+fZ1/Xjtu/XY4nvX7Zr9GN/rx/5+vN3fPVk3juWhrvHN5vNsf+JY/rGv1+36/rhGtP5CtADfrx9n+xXH/mH1MLt/zn2ssdAoLDU3GI3AUk7tvzjeaALeL7QSw244netjY6/MP59Y60lDsvYFz688X3Pp+nxJz+8lHczwc7VE+Tr5ZQVAeoYVAOkZVgCkZ1gBkJ5hBUB6hhUA6RlWAKRnWAGQnmEFQHqGFQDpGVYApLe5/39j0+y7/zp1uv7yu20ppZTh9+Ms2/e3zbRLra+207fU6Iu833St2Lbt2B3XOrb65mtP12gfa9t70Vy71Plre36bZpto8nWrZq3ydD/iNdum47duOn+XrI/v29e1xtuH2uSL9wi74dTOa3t4se193fZhFWuM77E7jNfJ52G8Nj7V2+lascb77nG21t1qP9vmwzA2+f5Z+36llPL5sJ0dy+/Wn2ZrxbHEfvxt9814u39/XOOnflv3Y3ztu9oE/HY99gW39ZzuhnGNu2P/8HSeotsXxx2NwriNRuH+cGoBjveffkeipRmtwIdoAzbtwDh/m8l+9KtxvXXTBFwfr5f5Z9teLdPrdqn595quH/zS/LICID3DCoD0DCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANLbPPxl/Mcf/+PH44N//9O3pZRJu6zeRutsqQG4OtMgO712vk300JYagdOWYNv1WzfdvtXqfN9vPWmttT2/TdPvW378VF2L56Ixd2ryzft+0cg77kc57ce2ec3T2/3s/rrp+5Uy6Rke+4LzbaPr127bT/p1Q/N3SrvttszfP7b9VBt+cTtd62H1WG/jGPb1+Mf9faw9vR+Gsef3YXh3XCOaf/H+0Tc8rTHUNca+4Z/X35VSSvlr/81xjegWtp3DuN82CqPzt55cmz9taouwPhZ9wW1cW2XeKDyeg8m1H9dJPBYtwFN3cHx+XxuF8fr1pPcX5z/W2DRNwLi2huY72d6O+1wWn7uVjiBfml9WAKRnWAGQnmEFQHqGFQDpGVYApGdYAZCeYQVAeoYVAOkZVgCkZ1gBkN7m4Yea7vnP/z49+PHfZi+KzFJUaY7327rSJMnyNLxUH69PtKmkUzLpaRKmzStFluaYVyrzx9t00uyx5rm7mtw5pZLOp5NKOSV37iNJ1J3P+rS3kfk5/5p55uiuzS3VY+smyaZTZqkeQ5nv+/aYebo9kbOtn8u2fnLb1fzvmKGutTt8LKWU8nh4uva6WWO9ml8Ffd3mQ13jw7A5PXdMNj1NIM3WqGt/130qpZTyh0luaVdTTMdEUz0PfZMB69ddfd3TpFWkmOKxbiETFvmpyB3120luqdvOtonrtl0r/lTc1LUiyzTdJtbvmu/Aknj+MH1ds82tazwNfV03nEmutV6SewK/rABIz7ACID3DCoD0DCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9DbrT2Ona//998cHu8fxdoiEV9sErFbxxPUc2KJTG3B+fz3phy01AderpvfXdv8mrbVN0/yLJmD09O6bRuB9N2/0Tf/9UFuAbRMw+n7RprtrXj99blv6+WtWbV+wHmM9x9tpK/H4WF2zafFty3o8bwuNvvG5rnlNN3v8mt1h/+Sx9er8tv2hVubqbryv2/6h6yeviZ5ftPdqi7BE3695r/WPpZTT+Rxf09U1hrqPYyvwx8Pd+WNYj8/3k2PeHcZzty7zNT4OdY36HqW5bt6tp5/x+NypIzjeDnXb/WF+nuL6vpucj+gIxhq3NPem25XuVPZrt11aq/1+TxuC195/6fm36ABqCVKKX1YA/AoYVgCkZ1gBkJ5hBUB6hhUA6RlWAKRnWAGQnmEFQHqGFQDpGVYApGdYAZDeJnptq8329OgrWn8ZdD9TSyyac0uGV5y4vm4bbb714WkjMcRfGOuF9+vLfJt1s/b473kTMAzl/DG2zcDtanP2daWcuoH70s8ePx5b7f/d1w5fKaUMzXHu6rafjl29ukY95OgjPkzagO3piK7fp2G8tqMBGN2/uI0uYyml3K3mzcNdv6lrrWdrrZvzNG1IrrvaM6w79Dhs6m1tAw7jWkuNwFJOncto7u1LbNvNHm+bfNHR6yanM9ZtO4NtC/CS9ju19P7wc/HLCoD0DCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANIzrABIb/P4bW3E/cv/Oj7YP4y3x+pX9AOb5txbNARPfbLD7H5/7sVDM1vr3UM/75TF7WY49duitbY5zPtsd93YgtvVx7d1m8/d2HO7706tuM+18RYduG13N79fb++73ez+3XBa47526O7qc13tDd4d1xhfe+rW7WePj/+et+2ik9f22+L54/5NPr+7VfQCR3GmoivYNx91vH573O704Ud7cFdX+XSI23nXb1v3b3vhutnV136o5/qH4V0ppZTH2uaLjl90GvtJXy8eiybg9/03pZRS/rz/rj6+ru8/v7r6M3+zxTX0oX4Z/r4f9yOugeN7tt+JM2vs6rX2qR+7go/9eva6+Nymn9+x59e099o1W3EOVpO12gbg4UrXL9770hpLj69e0eWMtV6zBl8vv6wASM+wAiA9wwqA9AwrANIzrABIz7ACID3DCoD0DCsA0jOsAEjPsAIgPcMKgPQ2n/849rg+/+nUBtyNSbVyH03A2uo6lMvtruekAqNL1k7Lfoj3PK12qO8X3bOhNt762gqM/VnXJt1umL++lFPv7NgIrM91q+3ZxzddP9tu+ty2PrdZzV9zagYOs+enLbrTa6IBGF24eedve2wCnltjfO5udbagODnmeXfwYfX4ZD/i/fro+9Vz+3iYN/Du6ns+HG93T94v1vgwjD29H4f7+ng324/3q89P9r87dgXHz+OH4X0ppZS/7r+d7ddD7S62jcXp8UYb8M/735VSSvnLbrz9aRhbjvG5HNfqTscS5+PTMO7H3/Z1Px7HL0X0/eK94pq4X5/ajV1dI3qTsc2n/aben5/buPbuuumxzL9j+3qt981tfI/WdY3uzHf0+O+FRuCT151x/D9goRHYrnluraXe4VK7UCOQKb+sAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANIzrABIz7ACID3DCoD0Np/+x/iPv/37/fHB/e/HRtm7VXTraqPrSqvrcltsfr9tn7UOk6eHY3WwztbYndi/6NvVXlqsPd2f9rGu2XbVtAO79tjLtCd4OH9b5vc3x4bgtFFY+4LHtU7PTbdtm4HRGxzXe9oLLOVpcy1Ey3DawGvbgOFT7erthnm/LlqG0Qac9/TGfYsG4D/7sQ34sbb4dsN6th/vu8d6+/nJ/kQD8O/92OT7235s8n2uPb1Nu8b6ae8w1ohtv38c1zp1/cZjfrcej+Gb9WQ/uuhLjsfyw27c9h+7ekz77ey8PNQm4MNwagPe1XO1P7YB503Az00bsB/qZzt5OK6ZuPbjs40141o/rVGv/fX8+inlaXuvvU7aTmdcaetfYZtPV/Dr5ZcVAOkZVgCkZ1gBkJ5hBUB6hhUA6RlWAKRnWAGQnmEFQHqGFQDpGVYApGdYAZDe5vF/jn20f9ydwmTdd2NvreuiY/f6zta1VlfbDpy61hGMflpXg4L9sQ92WvTQrNHuT7zHYz9/fvrebUdwaf+W2oHTNc49d86xMzhpCEYfr902Gm/DYf43SPQF77pTSzA6fV3TBtzVbfe153c8t/V197WFF/27Uk5Nvnjfn4axn/dTbfHFWrEfD7XJ9+2k6xfHFMfwYz+2Kj/UJl909eKYY41vNqc1Yp+Oa+zHNa51/b7d3k3WmO/Hx3587p+78fanZo3Hfjy2/eZ0zu/W6/lr6vFHI3Fft4n3OKzH91z1p89i6Faz4z2+9rBq7o+vX9e3PzYDJ5dAfHZLTcD2fjQBp03Ba9/fY18wSZNPI/Dr45cVAOkZVgCkZ1gBkJ5hBUB6hhUA6RlWAKRnWAGQnmEFQHqGFQDpGVYApLd598dPpZRS9r87za33D2PKZrMezm70S2gzQLe4lGxqczCHJjXTN/cj09JPHltKyVxLupzLLbXbtvtz6T02NYO1nFua3x6TTd0k2bS6vEYkgtokz11NA03TTdN1SzkliGKNuN+uEbmj6b/b949E0ud+M13imIt6v9k9WSNEoilSSY/1frzH5/Vm9l7TNeK8xBq7/nwqqe+e/r23r9mpU8Jrvk2bSoq1z11HS9drK9ZcNbfjnYub3uTa+7fX0bncUXst/Rzklb5eflkBkJ5hBUB6hhUA6RlWAKRnWAGQnmEFQHqGFQDpGVYApGdYAZCeYQVAeoYVAOlt/vDNT6WUeVPrWgfst+BZbbMr5+uWvuC195hutxsOZ9c6NefmDbpza6yjL1hbhW2jMPp2/TD/e+bTfnzddtIGXDetwn3dZlebe7FGrP3Yj6//3J16fx9rL3Bpjcf9vOu36+Zrl1LK42Z90370w/w8TbU9xVgjzkfb9Ys1H5t24XSN9nNptWtNtz3UJ4cbA3+HM++1VPhs969dYzjz2p/DrX1Mftv8sgIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANIzrABIz7ACID3DCoD0DCsA0tu82z6WUkq5W59abz/tt6WUUnb9vLX2HIsdvd+AS42zpU7btW37yePRUotP7FqD7vj4mc5hbNv22eL5tg3YN9uXUsr6MG8Dttue2oCx7frJGtG+i1Zh3I9tl5p8n8vmyRrr1TA7lqVWYjQC4zqfWlqjda7rt1uN623qGm3XL85Tv9Dkm643LHz3jud6oRk4PdZrf5He8v1e+j6/ZddPI5BL/LICID3DCoD0DCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANLbRBds2geLPttLmoDHNV6x7Wt96S7hpcZZPLZ6xflp17j1eM/14o6twgudukv7UMqk/XfjMUVP75YW3tKxXV7j/DbPa/LN24ntGtHkO5w55Fhvf+VvwYXdHNePduPFFZ72GJ8ja4vvNd8Nvl5+WQGQnmEFQHqGFQDpGVYApGdYAZCeYQVAeoYVAOkZVgCkZ1gBkJ5hBUB6hhUA6W2iKTZti0X37NfmSzcBf2m3dgYv9eOW1oj7x4bghXMbawwLz7c9vTBdc3WlhfeSNZaOabW6fY32mJ6cl/L0+1NqX3DdnT8jt5zb9py2n2Hb9WsbhofZ9/nnl7UzyNfDLysA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiA9wwqA9AwrANIzrABIz7ACIL1NtLz2w2lunesFlvK0P3aL31qvb+olvbS3aKwtrfGSz+8ttm1beGF6bVzrCy6tMfVkjYVu3qVjWVpjyaW1rl37txzTtbXe8noJb7kWvBW/rABIz7ACID3DCoD0DCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiC9zVBqWmW4Prd+y+mk1ziXoImkzVKe5jkJnPa52PY5KZ63XOPaMR0WMkgvWeMWv/R1+xbJodeu8ZrtJZPIyC8rANIzrABIz7ACID3DCoD0DCsA0jOsAEjPsAIgPcMKgPQMKwDSM6wASM+wAiC9TV+bgMOkB9bf0AnkdW7tr51r4L1m25eudYtra/3S+3PtPZ7TF3zOGtf6hres9dI14GtlKgGQnmEFQHqGFQDpGVYApGdYAZCeYQVAeoYVAOkZVgCkZ1gBkJ5hBUB6hhUA6f1/khMwNVK/D80AAAAASUVORK5CYII=" id="image3f3bd59697" transform="scale(1 -1) translate(0 -221.76)" x="58.32" y="-17.28" width="307.44" height="221.76"/>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m9b5e9430ea" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="63.871924" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.50 -->
+      <g transform="translate(52.739112 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="102.075402" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.75 -->
+      <g transform="translate(90.94259 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="140.27888" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1.00 -->
+      <g transform="translate(129.146068 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="178.482358" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 1.25 -->
+      <g transform="translate(167.349546 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="216.685837" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1.50 -->
+      <g transform="translate(205.553024 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="254.889315" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1.75 -->
+      <g transform="translate(243.756502 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="293.092793" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 2.00 -->
+      <g transform="translate(281.95998 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m9b5e9430ea" x="331.296271" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 2.25 -->
+      <g transform="translate(320.163458 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <!-- z [m] -->
+     <g transform="translate(199.116263 267.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-7a" d="M 353 3500
+L 3084 3500
+L 3084 2975
+L 922 459
+L 3084 459
+L 3084 0
+L 275 0
+L 275 525
+L 2438 3041
+L 353 3041
+L 353 3500
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863
+L 1875 4863
+L 1875 4416
+L 1125 4416
+L 1125 -397
+L 1875 -397
+L 1875 -844
+L 550 -844
+L 550 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863
+L 1947 -844
+L 622 -844
+L 622 -397
+L 1369 -397
+L 1369 4416
+L 622 4416
+L 622 4863
+L 1947 4863
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-7a"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(52.490234 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(84.277344 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(123.291016 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(220.703125 0)"/>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- 1e−5 -->
+     <g transform="translate(338.421588 266.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2212" d="M 678 2272
+L 4684 2272
+L 4684 1741
+L 678 1741
+L 678 2272
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(208.935547 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_9">
+      <defs>
+       <path id="m71e3be754b" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="235.293822" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- −1.00 -->
+      <g transform="translate(20.878125 239.093041) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="208.639976" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- −0.75 -->
+      <g transform="translate(20.878125 212.439195) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="181.98613" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- −0.50 -->
+      <g transform="translate(20.878125 185.785349) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="155.332284" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- −0.25 -->
+      <g transform="translate(20.878125 159.131502) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="128.678437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.00 -->
+      <g transform="translate(29.257813 132.477656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="102.024591" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.25 -->
+      <g transform="translate(29.257813 105.82381) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="75.370745" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0.50 -->
+      <g transform="translate(29.257813 79.169964) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="48.716899" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0.75 -->
+      <g transform="translate(29.257813 52.516118) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m71e3be754b" x="58.523438" y="22.063053" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 1.00 -->
+      <g transform="translate(29.257813 25.862272) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- y [m] -->
+     <g transform="translate(14.798438 141.99875) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-79"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(90.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(129.980469 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(227.392578 0)"/>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- 1e−5 -->
+     <g transform="translate(58.523438 14.798437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(208.935547 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 58.523438 239.558437
+L 58.523438 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 365.679401 239.558437
+L 365.679401 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 58.523438 239.558437
+L 365.679401 239.558437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 58.523438 17.798437
+L 365.679401 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 381.037199 239.558437
+L 393.323438 239.558437
+L 393.323438 17.798437
+L 381.037199 17.798437
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABEAAAE0CAYAAADKe9jLAAABzklEQVR4nO2cyw3DMAxDJcejdYTuP0rTe3vUC/BAOAMQFD+yUyDtV7/vGj67ek0xao5QVbtXz0GIcURMCmDCuFMNaNKL0IRgUhYmkDtEYtuSWMhikTuSsJlAsjabZtt7LDa5oxH2ZsYZY6jc0YAcdx4C0Qgr2myMJnMMyuKs2N8aYRGLibBRl2EAxNMdTU6opQSAMEuJuLNpxlG5kyQswiTv3AFAiAP9dOc5JgCIqTsASJawqu6EXbckIKrNdpj8PKLNptEEYjLHOO6omRx3nmJyzh0xE1HswzQ5S+kfRGNxnjvzG4rInawWezTx5ARxR1RAKCeAO57uhMVekxPKHYsmwG91onFM3SmJJruz3NGMI+oOoQnlDgLisZhwZ07E1B0IZIxRe1nGUbkDMNEIuxdwjIo2m0jYrNgjwhJh84zDuMMI6wEhLD7uPAWS5s6HAEkSFtGEcecSCWvJyaW5bok0YXIiGQfqjmWcfSE5IVpMMBF1h1gFYUziukMw0RSQuhUg4yDCWiwO647nQEfCRmgCnTuWYxQ6MiwWU92xvAMyLdYcGZo3L8riMYbKHQLkYjQBPoyCxrF8Qr4ITSBhCSbEt28L0NbkDvFvV4QmX5N0jWodFQrxAAAAAElFTkSuQmCC" id="imagea71ae1df63" transform="scale(1 -1) translate(0 -221.76)" x="380.88" y="-17.28" width="12.24" height="221.76"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_10">
+     <g id="line2d_18">
+      <defs>
+       <path id="md86f707f51" d="M 0 0
+L 3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="218.107119" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- −5 -->
+      <g transform="translate(400.323438 221.906337) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="192.569652" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- −4 -->
+      <g transform="translate(400.323438 196.368871) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="167.032185" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- −3 -->
+      <g transform="translate(400.323438 170.831404) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="141.494719" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- −2 -->
+      <g transform="translate(400.323438 145.293937) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="115.957252" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- −1 -->
+      <g transform="translate(400.323438 119.756471) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="90.419785" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 0 -->
+      <g transform="translate(400.323438 94.219004) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="64.882318" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 1 -->
+      <g transform="translate(400.323438 68.681537) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#md86f707f51" x="393.323438" y="39.344852" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 2 -->
+      <g transform="translate(400.323438 43.144071) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_30">
+     <!-- [V/m] -->
+     <g transform="translate(377.578022 142.555) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-56" d="M 1831 0
+L 50 4666
+L 709 4666
+L 2188 738
+L 3669 4666
+L 4325 4666
+L 2547 0
+L 1831 0
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666
+L 2156 4666
+L 531 -594
+L 0 -594
+L 1625 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(39.013672 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(107.421875 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(141.113281 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(238.525391 0)"/>
+     </g>
+    </g>
+    <g id="text_31">
+     <!-- 1e10 -->
+     <g transform="translate(368.082812 14.798437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(188.769531 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 381.037199 239.558437
+L 387.180318 239.558437
+L 393.323438 239.558437
+L 393.323438 17.798437
+L 387.180318 17.798437
+L 381.037199 17.798437
+L 381.037199 239.558437
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/docs/source/analysis/README_17_0.svg
+++ b/docs/source/analysis/README_17_0.svg
@@ -1,0 +1,771 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="385.78125pt" height="277.114688pt" viewBox="0 0 385.78125 277.114688" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-01-27T16:07:28.840008</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 277.114688
+L 385.78125 277.114688
+L 385.78125 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 43.78125 239.558437
+L 378.58125 239.558437
+L 378.58125 17.798437
+L 43.78125 17.798437
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mc59fff9779" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc59fff9779" x="58.999432" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- −1.00 -->
+      <g transform="translate(43.676776 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272
+L 4684 2272
+L 4684 1741
+L 678 1741
+L 678 2272
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mc59fff9779" x="97.044886" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- −0.75 -->
+      <g transform="translate(81.72223 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mc59fff9779" x="135.090341" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- −0.50 -->
+      <g transform="translate(119.767685 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mc59fff9779" x="173.135795" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- −0.25 -->
+      <g transform="translate(157.813139 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mc59fff9779" x="211.18125" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.00 -->
+      <g transform="translate(200.048438 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mc59fff9779" x="249.226705" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.25 -->
+      <g transform="translate(238.093892 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#mc59fff9779" x="287.272159" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.50 -->
+      <g transform="translate(276.139347 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mc59fff9779" x="325.317614" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.75 -->
+      <g transform="translate(314.184801 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mc59fff9779" x="363.363068" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1.00 -->
+      <g transform="translate(352.230256 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- y [m] -->
+     <g transform="translate(197.860938 267.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863
+L 1875 4863
+L 1875 4416
+L 1125 4416
+L 1125 -397
+L 1875 -397
+L 1875 -844
+L 550 -844
+L 550 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863
+L 1947 -844
+L 622 -844
+L 622 -397
+L 1369 -397
+L 1369 4416
+L 622 4416
+L 622 4863
+L 1947 4863
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-79"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(90.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(129.980469 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(227.392578 0)"/>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- 1e−5 -->
+     <g transform="translate(351.323438 266.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(208.935547 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <defs>
+       <path id="m1ba1fbe9da" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="216.414654" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.0 -->
+      <g transform="translate(20.878125 220.213873) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="191.626822" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.2 -->
+      <g transform="translate(20.878125 195.42604) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="166.838989" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.4 -->
+      <g transform="translate(20.878125 170.638208) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="142.051156" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.6 -->
+      <g transform="translate(20.878125 145.850375) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="117.263323" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.8 -->
+      <g transform="translate(20.878125 121.062542) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="92.475491" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 1.0 -->
+      <g transform="translate(20.878125 96.27471) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="67.687658" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 1.2 -->
+      <g transform="translate(20.878125 71.486877) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="42.899825" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 1.4 -->
+      <g transform="translate(20.878125 46.699044) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m1ba1fbe9da" x="43.78125" y="18.111993" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 1.6 -->
+      <g transform="translate(20.878125 21.911211) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- [V/m] -->
+     <g transform="translate(14.798438 142.555) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-56" d="M 1831 0
+L 50 4666
+L 709 4666
+L 2188 738
+L 3669 4666
+L 4325 4666
+L 2547 0
+L 1831 0
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666
+L 2156 4666
+L 531 -594
+L 0 -594
+L 1625 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(39.013672 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(107.421875 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(141.113281 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(238.525391 0)"/>
+     </g>
+    </g>
+    <g id="text_22">
+     <!-- 1e10 -->
+     <g transform="translate(43.78125 14.798437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(188.769531 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 43.78125 239.558437
+L 43.78125 17.798438
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 378.58125 239.558437
+L 378.58125 17.798438
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 43.78125 239.558437
+L 378.58125 239.558437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 43.78125 17.798437
+L 378.58125 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_19">
+    <defs>
+     <path id="m95fe1dbde9" d="M 0 3
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132
+C 2.683901 1.55874 3 0.795609 3 0
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
+C 1.55874 -2.683901 0.795609 -3 0 -3
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
+C -2.683901 -1.55874 -3 -0.795609 -3 0
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
+C -1.55874 2.683901 -0.795609 3 0 3
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p2a2393ec94)">
+     <use xlink:href="#m95fe1dbde9" x="58.999432" y="215.985739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="71.173977" y="216.779201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="83.348523" y="217.14328" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="95.523068" y="221.820145" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="107.697614" y="226.275271" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="119.872159" y="229.478437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="132.046705" y="228.967213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="144.22125" y="219.707373" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="156.395795" y="197.464574" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="168.570341" y="161.456562" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="180.744886" y="116.321261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="192.919432" y="71.757775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="205.093977" y="39.467444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="217.268523" y="27.878437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="229.443068" y="38.512628" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="241.617614" y="66.183337" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="253.792159" y="101.370034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="265.966705" y="134.922138" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="278.14125" y="162.000349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="290.315795" y="181.851006" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="302.490341" y="195.679311" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="314.664886" y="204.735917" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="326.839432" y="211.074051" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="339.013977" y="216.068544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="351.188523" y="216.304429" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m95fe1dbde9" x="363.363068" y="216.950297" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2a2393ec94">
+   <rect x="43.78125" y="17.798437" width="334.8" height="221.76"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/source/analysis/README_19_0.svg
+++ b/docs/source/analysis/README_19_0.svg
@@ -1,0 +1,786 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="385.78125pt" height="277.114688pt" viewBox="0 0 385.78125 277.114688" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-01-27T16:07:28.877880</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 277.114688
+L 385.78125 277.114688
+L 385.78125 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 43.78125 239.558437
+L 378.58125 239.558437
+L 378.58125 17.798437
+L 43.78125 17.798437
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m44c8a5e464" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m44c8a5e464" x="58.999432" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- −1.00 -->
+      <g transform="translate(43.676776 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272
+L 4684 2272
+L 4684 1741
+L 678 1741
+L 678 2272
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="97.044886" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- −0.75 -->
+      <g transform="translate(81.72223 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="135.090341" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- −0.50 -->
+      <g transform="translate(119.767685 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="173.135795" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- −0.25 -->
+      <g transform="translate(157.813139 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="211.18125" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.00 -->
+      <g transform="translate(200.048438 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="249.226705" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.25 -->
+      <g transform="translate(238.093892 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="287.272159" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.50 -->
+      <g transform="translate(276.139347 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="325.317614" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.75 -->
+      <g transform="translate(314.184801 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m44c8a5e464" x="363.363068" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1.00 -->
+      <g transform="translate(352.230256 254.156875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- y [m] -->
+     <g transform="translate(197.860938 267.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863
+L 1875 4863
+L 1875 4416
+L 1125 4416
+L 1125 -397
+L 1875 -397
+L 1875 -844
+L 550 -844
+L 550 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863
+L 1947 -844
+L 622 -844
+L 622 -397
+L 1369 -397
+L 1369 4416
+L 622 4416
+L 622 4863
+L 1947 4863
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-79"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(90.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(129.980469 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(227.392578 0)"/>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- 1e−5 -->
+     <g transform="translate(351.323438 266.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(208.935547 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <defs>
+       <path id="m5555c48706" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5555c48706" x="43.78125" y="229.478506" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.0 -->
+      <g transform="translate(20.878125 233.277725) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m5555c48706" x="43.78125" y="185.918471" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.5 -->
+      <g transform="translate(20.878125 189.71769) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m5555c48706" x="43.78125" y="142.358435" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 1.0 -->
+      <g transform="translate(20.878125 146.157654) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m5555c48706" x="43.78125" y="98.7984" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1.5 -->
+      <g transform="translate(20.878125 102.597618) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m5555c48706" x="43.78125" y="55.238364" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 2.0 -->
+      <g transform="translate(20.878125 59.037583) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- [V*kg*s^-3*A^-1] -->
+     <g transform="translate(14.798438 173.944844) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-56" d="M 1831 0
+L 50 4666
+L 709 4666
+L 2188 738
+L 3669 4666
+L 4325 4666
+L 2547 0
+L 1831 0
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2a" d="M 3009 3897
+L 1888 3291
+L 3009 2681
+L 2828 2375
+L 1778 3009
+L 1778 1831
+L 1422 1831
+L 1422 3009
+L 372 2375
+L 191 2681
+L 1313 3291
+L 191 3897
+L 372 4206
+L 1422 3572
+L 1422 4750
+L 1778 4750
+L 1778 3572
+L 2828 4206
+L 3009 3897
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863
+L 1159 4863
+L 1159 1991
+L 2875 3500
+L 3609 3500
+L 1753 1863
+L 3688 0
+L 2938 0
+L 1159 1709
+L 1159 0
+L 581 0
+L 581 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5e" d="M 2988 4666
+L 4684 2925
+L 4056 2925
+L 2681 4159
+L 1306 2925
+L 678 2925
+L 2375 4666
+L 2988 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009
+L 1997 2009
+L 1997 1497
+L 313 1497
+L 313 2009
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-41" d="M 2188 4044
+L 1331 1722
+L 3047 1722
+L 2188 4044
+z
+M 1831 4666
+L 2547 4666
+L 4325 0
+L 3669 0
+L 3244 1197
+L 1141 1197
+L 716 0
+L 50 0
+L 1831 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(39.013672 0)"/>
+      <use xlink:href="#DejaVuSans-2a" transform="translate(107.421875 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(157.421875 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(215.332031 0)"/>
+      <use xlink:href="#DejaVuSans-2a" transform="translate(278.808594 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(328.808594 0)"/>
+      <use xlink:href="#DejaVuSans-5e" transform="translate(380.908203 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(464.697266 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(500.78125 0)"/>
+      <use xlink:href="#DejaVuSans-2a" transform="translate(564.404297 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(614.404297 0)"/>
+      <use xlink:href="#DejaVuSans-5e" transform="translate(682.8125 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(766.601562 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(802.685547 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(866.308594 0)"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- 1e20 -->
+     <g transform="translate(43.78125 14.798437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(188.769531 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 43.78125 239.558437
+L 43.78125 17.798438
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 378.58125 239.558437
+L 378.58125 17.798438
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 43.78125 239.558437
+L 378.58125 239.558437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 43.78125 17.798437
+L 378.58125 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_15">
+    <defs>
+     <path id="m445b57ee06" d="M 0 3
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132
+C 2.683901 1.55874 3 0.795609 3 0
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
+C 1.55874 -2.683901 0.795609 -3 0 -3
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
+C -2.683901 -1.55874 -3 -0.795609 -3 0
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
+C -1.55874 2.683901 -0.795609 3 0 3
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#pa35865c3f6)">
+     <use xlink:href="#m445b57ee06" x="58.999432" y="229.477463" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="71.173977" y="229.477753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="83.348523" y="229.475495" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="95.523068" y="229.312788" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="107.697614" y="228.927052" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="119.872159" y="228.510587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="132.046705" y="228.58486" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="144.22125" y="229.417016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="156.395795" y="227.441825" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="168.570341" y="212.348229" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="180.744886" y="172.657107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="192.919432" y="110.79803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="205.093977" y="51.900759" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="217.268523" y="27.878437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="229.443068" y="49.979152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="241.617614" y="101.474946" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="253.792159" y="154.414156" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="265.966705" y="191.813629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="278.14125" y="212.685545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="290.315795" y="222.703024" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="302.490341" y="227.040002" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="314.664886" y="228.704948" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="326.839432" y="229.316742" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="339.013977" y="229.477827" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="351.188523" y="229.478438" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m445b57ee06" x="363.363068" y="229.476879" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa35865c3f6">
+   <rect x="43.78125" y="17.798437" width="334.8" height="221.76"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/source/analysis/README_26_0.svg
+++ b/docs/source/analysis/README_26_0.svg
@@ -1,0 +1,863 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="417.064062pt" height="277.114687pt" viewBox="0 0 417.064062 277.114687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-01-27T16:07:28.963101</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 277.114687
+L 417.064062 277.114687
+L 417.064062 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 43.78125 239.558437
+L 350.937213 239.558437
+L 350.937213 17.798437
+L 43.78125 17.798437
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAaoAAAE0CAYAAAB943fFAAAH6klEQVR4nO3XMY4kSRXH4fcia3a0Kwwk7oDFWohjjMUJ1oQjYGDMBTgLFjYSwsGbU6y0Hghpd6YzHkZ19VTvsow5f2a/T2pldURkVmSqS7+u/tWf/zjdU91TVVUzXTNdVVXdU2tNzTwfX2tXd9VM1d7rae2PXePebfx+7n7s3r4bX49r93TN3M6/v249e8/b3N5311hTq6fOfX8v86PXPtZ+2t9tL6un1trP7vH+/v/bvfzY+KfgzavXn+aNATHWx94AAPwvQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiNYz87H3EOu3f//9/PPty/rm3z+rY+2qqprpp/l99/r2GOfZWD+tu5+f6Zr7Nc/mvnedu7Hr7987r5/P3c7rnuvc3frbWK95traqal12dU/Nfv+/yzr2de3d+1Zdz79/Hrdrd08dj+vvn81t7f19dX/6f3dvXr3uD68CPsQ3KgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVAtJ6Zj70H/s/85i9/mG++/nkdnz/UF198V8exa/VU99TRU6unjrWrb6/7On/7qarr6/rh396urj19fT1dD3vVTNfDXI97uh7OVbsej3vVnq69u2a6znPVTNVMVz1eZ6ZqP6x6ert+PE5fx+ZxrOd6nHo6t7pqvTivy/fj2FSty9Q69tO+bx+jtaaOZ+PXc27P6HZfN7fndr/+/vdP0ZtXr/vDq+A936gAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoPTMfew/wyfjqH1/NX//2Ze1fvK3j5VlrTXVP9Zrqquqeuhy7uqfWmnqxzuquenGc17nedaxdq6cua9eqH34+d3VVVb09j9rTdc66Hveqh3PVOau+e3epmaqZrj1ds7se3h1Vj2M3c66qXVXTVT113WRVnV1zG19Tfcx1vvo6N1W9ptZnZ1VXze6na6/LruNyvceq69hM1VpTx/F+fO/r/8lr7TrW+/vc07Ue19zW/lS8efW6P7zqp8c3KgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIFrPzMfeA/CJ21//cr780+/qeFf1r19/W8eLs7qrek0da9daU6unXlzO6p767Div4z318nio1df5S1/HLms/v/70s59vz0ude9W7fdS5V+3pensedZ6rvnt3qdldM1WzV+2za94eNbuqHvdUq6rOrtlVvbvmmOpjqtZUTVftqjn7OnZMrcu+XvPs63xPvfj84f3+HufWZddxud5DVdVM195dvaYux/vxc3dVVXVXrZ7qu/U3t7GfAt+oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDRhAqAaEIFQDShAiCaUAEQTagAiCZUAEQTKgCiCRUA0YQKgGhCBUA0oQIgmlABEE2oAIgmVABEEyoAogkVANGECoBoQgVANKECIJpQARBNqACIJlQARBMqAKIJFQDR/gNzKsnC2e5OTwAAAABJRU5ErkJggg==" id="image612b81fd89" transform="scale(1 -1) translate(0 -221.76)" x="43.92" y="-17.28" width="306.72" height="221.76"/>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m692b400ea9" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m692b400ea9" x="70.883247" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(67.701997 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m692b400ea9" x="122.506098" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 -->
+      <g transform="translate(119.324848 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m692b400ea9" x="174.128949" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 2 -->
+      <g transform="translate(170.947699 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m692b400ea9" x="225.7518" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 3 -->
+      <g transform="translate(222.57055 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m692b400ea9" x="277.374651" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4 -->
+      <g transform="translate(274.193401 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m692b400ea9" x="328.997502" y="239.558437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 5 -->
+      <g transform="translate(325.816252 254.156875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- z [m] -->
+     <g transform="translate(184.374075 267.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-7a" d="M 353 3500
+L 3084 3500
+L 3084 2975
+L 922 459
+L 3084 459
+L 3084 0
+L 275 0
+L 275 525
+L 2438 3041
+L 353 3041
+L 353 3500
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863
+L 1875 4863
+L 1875 4416
+L 1125 4416
+L 1125 -397
+L 1875 -397
+L 1875 -844
+L 550 -844
+L 550 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863
+L 1947 -844
+L 622 -844
+L 622 -397
+L 1369 -397
+L 1369 4416
+L 622 4416
+L 622 4863
+L 1947 4863
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-7a"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(52.490234 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(84.277344 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(123.291016 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(220.703125 0)"/>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- 1e−5 -->
+     <g transform="translate(323.679401 266.835) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2212" d="M 678 2272
+L 4684 2272
+L 4684 1741
+L 678 1741
+L 678 2272
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(208.935547 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <defs>
+       <path id="m316a9bd790" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="234.729331" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.2 -->
+      <g transform="translate(20.878125 238.52855) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2e" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="207.724225" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.4 -->
+      <g transform="translate(20.878125 211.523444) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="180.719119" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.6 -->
+      <g transform="translate(20.878125 184.518338) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="153.714013" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.8 -->
+      <g transform="translate(20.878125 157.513232) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="126.708907" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1.0 -->
+      <g transform="translate(20.878125 130.508126) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="99.703801" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 1.2 -->
+      <g transform="translate(20.878125 103.50302) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="72.698695" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1.4 -->
+      <g transform="translate(20.878125 76.497914) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="45.693589" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 1.6 -->
+      <g transform="translate(20.878125 49.492807) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m316a9bd790" x="43.78125" y="18.688483" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 1.8 -->
+      <g transform="translate(20.878125 22.487701) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- t [s] -->
+     <g transform="translate(14.798438 138.733906) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(70.996094 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(110.009766 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(162.109375 0)"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- 1e−13 -->
+     <g transform="translate(43.78125 14.798437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(208.935547 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(272.558594 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 43.78125 239.558437
+L 43.78125 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 350.937213 239.558437
+L 350.937213 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 43.78125 239.558437
+L 350.937213 239.558437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 43.78125 17.798437
+L 350.937213 17.798437
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 366.295011 239.558437
+L 378.58125 239.558437
+L 378.58125 17.798437
+L 366.295011 17.798437
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABEAAAE0CAYAAADKe9jLAAABzklEQVR4nO2cyw3DMAxDJcejdYTuP0rTe3vUC/BAOAMQFD+yUyDtV7/vGj67ek0xao5QVbtXz0GIcURMCmDCuFMNaNKL0IRgUhYmkDtEYtuSWMhikTuSsJlAsjabZtt7LDa5oxH2ZsYZY6jc0YAcdx4C0Qgr2myMJnMMyuKs2N8aYRGLibBRl2EAxNMdTU6opQSAMEuJuLNpxlG5kyQswiTv3AFAiAP9dOc5JgCIqTsASJawqu6EXbckIKrNdpj8PKLNptEEYjLHOO6omRx3nmJyzh0xE1HswzQ5S+kfRGNxnjvzG4rInawWezTx5ARxR1RAKCeAO57uhMVekxPKHYsmwG91onFM3SmJJruz3NGMI+oOoQnlDgLisZhwZ07E1B0IZIxRe1nGUbkDMNEIuxdwjIo2m0jYrNgjwhJh84zDuMMI6wEhLD7uPAWS5s6HAEkSFtGEcecSCWvJyaW5bok0YXIiGQfqjmWcfSE5IVpMMBF1h1gFYUziukMw0RSQuhUg4yDCWiwO647nQEfCRmgCnTuWYxQ6MiwWU92xvAMyLdYcGZo3L8riMYbKHQLkYjQBPoyCxrF8Qr4ITSBhCSbEt28L0NbkDvFvV4QmX5N0jWodFQrxAAAAAElFTkSuQmCC" id="image8a6dc9bd9c" transform="scale(1 -1) translate(0 -221.76)" x="366.48" y="-17.28" width="12.24" height="221.76"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_10">
+     <g id="line2d_16">
+      <defs>
+       <path id="ma3eeea6ad9" d="M 0 0
+L 3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma3eeea6ad9" x="378.58125" y="218.942082" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- −1.5 -->
+      <g transform="translate(385.58125 222.741301) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(179.199219 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#ma3eeea6ad9" x="378.58125" y="178.252674" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- −1.0 -->
+      <g transform="translate(385.58125 182.051893) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#ma3eeea6ad9" x="378.58125" y="137.563267" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- −0.5 -->
+      <g transform="translate(385.58125 141.362485) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(179.199219 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#ma3eeea6ad9" x="378.58125" y="96.873859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 0.0 -->
+      <g transform="translate(385.58125 100.673078) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#ma3eeea6ad9" x="378.58125" y="56.184451" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 0.5 -->
+      <g transform="translate(385.58125 59.98367) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_25">
+     <!-- [V/m] -->
+     <g transform="translate(362.835834 142.555) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-56" d="M 1831 0
+L 50 4666
+L 709 4666
+L 2188 738
+L 3669 4666
+L 4325 4666
+L 2547 0
+L 1831 0
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666
+L 2156 4666
+L 531 -594
+L 0 -594
+L 1625 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(39.013672 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(107.421875 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(141.113281 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(238.525391 0)"/>
+     </g>
+    </g>
+    <g id="text_26">
+     <!-- 1e11 -->
+     <g transform="translate(353.340625 14.798437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.623047 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(125.146484 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(188.769531 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 366.295011 239.558437
+L 372.438131 239.558437
+L 378.58125 239.558437
+L 378.58125 17.798437
+L 372.438131 17.798437
+L 366.295011 17.798437
+L 366.295011 239.558437
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/docs/source/analysis/scipp.rst
+++ b/docs/source/analysis/scipp.rst
@@ -5,6 +5,10 @@ Scipp
 
 Load openpmd datasets to ``scipp`` ``DataArrays``.
 
+.. note::
+
+   This documentation page is also available as an interactively executable Jupyter Notebook in ``examples/15_scipp_loader.ipynb``.
+
 What is this good for?
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -63,13 +67,12 @@ Opening series
 
 .. code:: python
 
-   path = "openPMD-example-datasets/example-3d/hdf5/data%T.h5"
-   path = "./data/" + path
+   path = "../samples/git-sample/data%T.h5"
 
 .. code:: python
 
    series = pmd.Series(path, pmd.Access.read_random_access)
-   data_loader = sereies.to_scipp()
+   data_loader = series.to_scipp()
    print(data_loader.iterations)
 
 ::

--- a/docs/source/analysis/scipp.rst
+++ b/docs/source/analysis/scipp.rst
@@ -1,0 +1,370 @@
+.. _analysis-scipp:
+
+Scipp
+=====
+
+Load openpmd datasets to ``scipp`` ``DataArrays``.
+
+What is this good for?
+~~~~~~~~~~~~~~~~~~~~~~
+
+`scipp <https://github.com/scipp/scipp>`__ is an alternative to
+`xarray <https://github.com/pydata/xarray>`__ and provides basically
+numpy arrays with axes description and units.
+
+* Automatically load axes and units with openPMD data.
+* Axes information is automatically updated when slicing, indexing, or filtering your data.
+* With ``scipp``\ ’s plotting library `plopp <https://github.com/scipp/plopp>`__ it becomes an alternative to ``openpmd-viewer``.
+* Many numpy and some scipy functions including all the basic algebraic operations on arrays are supported by ``scipp``. When using these, the units and coordinates are automatically taken care of.
+
+Limitations
+~~~~~~~~~~~
+
+-  ``scipp`` currently handles units with a library, that does not
+   support non-integer exponents for units. This can become problematic
+   in some calculations.
+
+Installation
+------------
+
+It can be easily installed with pip.
+
+.. code:: bash
+
+   git clone https://github.com/pordyna/openpmd_scipp.git
+   cd openpmd-scipp
+   pip install .
+
+Getting started
+---------------
+
+Get example data sets from the ``openPMD-example-datasets`` repository.
+
+.. code:: bash
+
+   git clone https://github.com/openPMD/openPMD-example-datasets.git
+   cd openPMD-example-datasets
+   tar -zxvf example-2d.tar.gz
+   tar -zxvf example-3d.tar.gz
+
+Opening series
+~~~~~~~~~~~~~~
+
+.. code:: python
+
+   import scipp as sc
+
+   import openpmd_scipp as pmdsc
+
+.. code:: python
+
+   path = "openPMD-example-datasets/example-3d/hdf5/data%T.h5"
+
+.. code:: python
+
+   path = ".data/" + path
+
+.. code:: python
+
+   data_loader = pmdsc.DataLoader(path)
+   print(data_loader.iterations)
+
+::
+
+   <scipp.Dataset>
+   Dimensions: Sizes[t:5, ]
+   Coordinates:
+   * t                         float64              [s]  (t)  [3.28471e-14, 6.56942e-14, ..., 1.31388e-13, 1.64236e-13]
+   Data:
+     iteration_id                int64  [dimensionless]  (t)  [100, 200, ..., 400, 500]
+
+Working with meshes (fields)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Let us plot electric field’s x component at 65 fs.
+
+.. code:: python
+
+   Ex = data_loader.get_field("E", "x", time=65 * sc.Unit("fs"))
+   print(Ex)
+
+::
+
+   Series does not contain iteration at the exact time. Using closest iteration instead.
+
+
+   <scipp.DataArray>
+   Dimensions: Sizes[x:26, y:26, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  ()  6.56942e-14
+   * x                         float64              [m]  (x)  [-9.6e-06, -8.8e-06, ..., 9.6e-06, 1.04e-05]
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * z                         float64              [m]  (z)  [4.7e-06, 4.8e-06, ..., 2.46e-05, 2.47e-05]
+   Data:
+                               float64            [V/m]  (x, y, z)  [-1.08652e+08, -1.9758e+08, ..., 0, 0]
+
+You may have noticed, that the time requested does not have to match
+exactly any iteration. By default, if there is an iteration within 10 fs
+distance it will be used instead. This 10 fs tolerance can be adjusted
+by setting ``time_tolerance``. The check can be also disabled by setting
+``time_tolerance=None``, with that the method will return the closest
+iteration regardless of the difference. So that this will also work:
+
+.. code:: python
+
+   print(data_loader.get_field("E", "x", time=20 * sc.Unit("fs"), time_tolerance=20 * sc.Unit("fs")))
+
+::
+
+   Series does not contain iteration at the exact time. Using closest iteration instead.
+
+
+   <scipp.DataArray>
+   Dimensions: Sizes[x:26, y:26, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  ()  3.28471e-14
+   * x                         float64              [m]  (x)  [-9.6e-06, -8.8e-06, ..., 9.6e-06, 1.04e-05]
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * z                         float64              [m]  (z)  [-5.2e-06, -5.1e-06, ..., 1.47e-05, 1.48e-05]
+   Data:
+                               float64            [V/m]  (x, y, z)  [-1.08549e+07, -1.3967e+07, ..., 0, 0]
+
+, but ``data_loader.get_field('E', 'x', time=20 * sc.Unit('fs'))`` not.
+
+.. code:: python
+
+   # It is also possible to use iteration number instead:
+   print(data_loader.get_field("E", "x", iteration=200))
+
+::
+
+   <scipp.DataArray>
+   Dimensions: Sizes[x:26, y:26, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  ()  6.56942e-14
+   * x                         float64              [m]  (x)  [-9.6e-06, -8.8e-06, ..., 9.6e-06, 1.04e-05]
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * z                         float64              [m]  (z)  [4.7e-06, 4.8e-06, ..., 2.46e-05, 2.47e-05]
+   Data:
+                               float64            [V/m]  (x, y, z)  [-1.08652e+08, -1.9758e+08, ..., 0, 0]
+
+.. code:: python
+
+   # For scalar fields just omit the second argument:
+   print(data_loader.get_field("rho", iteration=200))
+
+::
+
+   <scipp.DataArray>
+   Dimensions: Sizes[x:26, y:26, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  ()  6.56942e-14
+   * x                         float64              [m]  (x)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * z                         float64              [m]  (z)  [4.7e-06, 4.8e-06, ..., 2.46e-05, 2.47e-05]
+   Data:
+                               float64           [mC/L]  (x, y, z)  [-7169.01, -7526.4, ..., 3.16049e-11, 1.22782e-11]
+
+Plotting
+^^^^^^^^
+
+W can’t directly plot 3D data. But we can for example select a slice.
+For that we can use a helper function ``pmdsc.closest`` to get the
+closets index, since ``scipp`` requires exact match. You can read more
+about indexing ``scipp`` arrays in ``scipp``\ ’s documentation.
+
+.. code:: python
+
+   slicing_idx = pmdsc.closest(Ex, "x", 2 * sc.Unit("um"))
+   Ex_slice = Ex["x", slicing_idx]
+   print(Ex_slice)
+
+::
+
+   <scipp.DataArray>
+   Dimensions: Sizes[y:26, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  ()  6.56942e-14
+     x                         float64              [m]  ()  2.4e-06
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * z                         float64              [m]  (z)  [4.7e-06, 4.8e-06, ..., 2.46e-05, 2.47e-05]
+   Data:
+                               float64            [V/m]  (y, z)  [4.86614e+08, 6.67018e+08, ..., 0, 0]
+
+.. code:: python
+
+   Ex_slice.plot()
+
+.. figure:: README_15_0.svg
+
+.. code:: python
+
+   # We can also plot line plots:
+   Ex_line = Ex_slice["z", pmdsc.closest(Ex_slice, "z", 1.4e-5 * sc.Unit("m"))]
+   print(Ex_line)
+
+::
+
+   <scipp.DataArray>
+   Dimensions: Sizes[y:26, ]
+   Coordinates:
+   * t                         float64              [s]  ()  6.56942e-14
+     x                         float64              [m]  ()  2.4e-06
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+     z                         float64              [m]  ()  1.4e-05
+   Data:
+                               float64            [V/m]  (y)  [3.46069e+07, -2.94134e+07, ..., 8.89353e+06, -4.32182e+07]
+
+.. code:: python
+
+   Ex_line.plot()
+
+.. figure:: README_17_0.svg
+
+Alternatively it is possible to work interactively with ``plopp``\ ’s
+tools for visualizing multidimensional data, such as ``pp.slicer``\ or
+``pp.inspector``.
+
+Doing math
+^^^^^^^^^^
+
+Just as an example we can easily plot the square of the field:
+
+.. code:: python
+
+   (Ex_line * Ex_line).plot()
+
+.. figure:: README_19_0.svg
+
+Loading chunks
+~~~~~~~~~~~~~~
+
+In the above example the whole 3D field is loaded into memory and sliced
+afterward. It is also possible to just load a sub-chunk into memory.
+When the ``relay`` option in ``get_field`` is set to ``True`` it will
+return a dummy object that only allocates memory for a single value.
+This relay object can be indexed, sliced etc. using the ``scipp``
+indexing just like before. (The only limitation given by the
+``openpmd-api`` is that the result has to a be contiguous chunk of the
+original array). The ``load_data`` method loads data and returns a
+proper ``scipp`` data array.
+
+.. code:: python
+
+   # The full 3D array is not loaded into memory at this point.
+   Ex = data_loader.get_field("E", "x", time=65 * sc.Unit("fs"), relay=True)
+   # This time we will select a range rather than a slice.
+   # For a range there is no need for an exact match.
+   # But, we could also select a slice just like in the previous example.
+   Ex = Ex["x", -2e-6 * sc.Unit("m") : 2e-6 * sc.Unit("m")]
+   # Only now the smaller subset wil be loaded into memory
+   Ex = Ex.load_data()
+   print(Ex)
+
+::
+
+   Series does not contain iteration at the exact time. Using closest iteration instead.
+
+
+   <scipp.DataArray>
+   Dimensions: Sizes[x:5, y:26, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  ()  6.56942e-14
+   * x                         float64              [m]  (x)  [-1.6e-06, -8e-07, ..., 8e-07, 1.6e-06]
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * z                         float64              [m]  (z)  [4.7e-06, 4.8e-06, ..., 2.46e-05, 2.47e-05]
+   Data:
+                               float64            [V/m]  (x, y, z)  [-3.65733e+08, -5.01237e+08, ..., 0, 0]
+
+Time axis
+~~~~~~~~~
+
+It is also possible to combine arrays from different iterations into one
+using ``scipp``\ ’s ``concat`` function. Here is an example for creating
+a 4D array from all iterations:
+
+.. code:: python
+
+   Ex = sc.concat(
+       [
+           data_loader.get_field("E", "x", iteration=iteration.value, time_tolerance=None)
+           for iteration in data_loader.iterations["iteration_id"]
+       ],
+       dim="t",
+   )
+   print(Ex)
+
+::
+
+   <scipp.DataArray>
+   Dimensions: Sizes[t:5, x:26, y:26, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  (t)  [3.28471e-14, 6.56942e-14, ..., 1.31388e-13, 1.64236e-13]
+   * x                         float64              [m]  (x)  [-9.6e-06, -8.8e-06, ..., 9.6e-06, 1.04e-05]
+   * y                         float64              [m]  (y)  [-1e-05, -9.2e-06, ..., 9.2e-06, 1e-05]
+   * z                         float64              [m]  (t, z)  [-5.2e-06, -5.1e-06, ..., 5.41e-05, 5.42e-05]
+   Data:
+                               float64            [V/m]  (t, x, y, z)  [-1.08549e+07, -1.3967e+07, ..., 0, 0]
+
+The reason for the z coordinate having two dimensions (t,z) is the fact
+that the data comes from a moving window simulation. This is clearly
+visible in the plot below.
+
+.. code:: python
+
+   # Let us just slice at some points to get a 2D dataset
+   Ex = Ex["x", 10]["y", 10]
+   print(Ex)
+
+::
+
+   <scipp.DataArray>
+   Dimensions: Sizes[t:5, z:201, ]
+   Coordinates:
+   * t                         float64              [s]  (t)  [3.28471e-14, 6.56942e-14, ..., 1.31388e-13, 1.64236e-13]
+     x                         float64              [m]  ()  -1.6e-06
+     y                         float64              [m]  ()  -2e-06
+   * z                         float64              [m]  (t, z)  [-5.2e-06, -5.1e-06, ..., 5.41e-05, 5.42e-05]
+   Data:
+                               float64            [V/m]  (t, z)  [-8.41738e+08, -7.8752e+08, ..., 0, 0]
+
+.. code:: python
+
+   Ex.plot()
+
+.. figure:: README_26_0.svg
+
+Working with particle data
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Coming soon!
+
+Developer documentation
+-----------------------
+
+Generating this README
+~~~~~~~~~~~~~~~~~~~~~~
+
+README file is generated from the README.ipynb.
+
+::
+
+   # Download and extract example datasets if not present
+   # Will download data into ``.data``
+   make data
+
+   make docs
+
+Running tests
+~~~~~~~~~~~~~
+
+At the moment we only test we have is an integration test running this
+notebook. After downloading example datasets with ``make data``, if
+needed, run:
+
+::
+
+   make test
+
+You can also run tests with different python version with tox, but you
+need to have the python version installed, for example with pyenv.

--- a/docs/source/analysis/scipp.rst
+++ b/docs/source/analysis/scipp.rst
@@ -27,13 +27,13 @@ Limitations
 Installation
 ~~~~~~~~~~~~
 
-It can be easily installed with pip.
+The adaptor from openPMD to Scipp is part of the regular openPMD-api Python distribution.
+It is loaded lazily and available as soon as ``scipp`` is also installed.
+Plotting functionality requires the additional installation of ``plopp``.
 
 .. code:: bash
 
-   git clone https://github.com/pordyna/openpmd_scipp.git
-   cd openpmd-scipp
-   pip install .
+   pip install openpmd_api scipp plopp
 
 Getting started
 ~~~~~~~~~~~~~~~
@@ -47,26 +47,29 @@ Get example data sets from the ``openPMD-example-datasets`` repository.
    tar -zxvf example-2d.tar.gz
    tar -zxvf example-3d.tar.gz
 
+.. note::
+
+   You can find scripts to download and unpack this sample data under ``share/openPMD``.
+
 Opening series
-~~~~~~~~~~~~~~
+--------------
 
 .. code:: python
 
    import scipp as sc
 
-   import openpmd_scipp as pmdsc
+   import openpmd_api as pmd
+   import openpmd_api.scipp as pmdsc
 
 .. code:: python
 
    path = "openPMD-example-datasets/example-3d/hdf5/data%T.h5"
+   path = "./data/" + path
 
 .. code:: python
 
-   path = ".data/" + path
-
-.. code:: python
-
-   data_loader = pmdsc.DataLoader(path)
+   series = pmd.Series(path, pmd.Access.read_random_access)
+   data_loader = sereies.to_scipp()
    print(data_loader.iterations)
 
 ::
@@ -338,33 +341,3 @@ Working with particle data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Coming soon!
-
-Developer documentation
------------------------
-
-Generating this README
-~~~~~~~~~~~~~~~~~~~~~~
-
-README file is generated from the README.ipynb.
-
-::
-
-   # Download and extract example datasets if not present
-   # Will download data into ``.data``
-   make data
-
-   make docs
-
-Running tests
-~~~~~~~~~~~~~
-
-At the moment we only test we have is an integration test running this
-notebook. After downloading example datasets with ``make data``, if
-needed, run:
-
-::
-
-   make test
-
-You can also run tests with different python version with tox, but you
-need to have the python version installed, for example with pyenv.

--- a/docs/source/analysis/scipp.rst
+++ b/docs/source/analysis/scipp.rst
@@ -14,18 +14,18 @@ numpy arrays with axes description and units.
 
 * Automatically load axes and units with openPMD data.
 * Axes information is automatically updated when slicing, indexing, or filtering your data.
-* With ``scipp``\ ’s plotting library `plopp <https://github.com/scipp/plopp>`__ it becomes an alternative to ``openpmd-viewer``.
+* With ``scipp``'s plotting library `plopp <https://github.com/scipp/plopp>`__ it becomes an alternative to ``openpmd-viewer``.
 * Many numpy and some scipy functions including all the basic algebraic operations on arrays are supported by ``scipp``. When using these, the units and coordinates are automatically taken care of.
 
 Limitations
-~~~~~~~~~~~
+-----------
 
 -  ``scipp`` currently handles units with a library, that does not
    support non-integer exponents for units. This can become problematic
    in some calculations.
 
 Installation
-------------
+~~~~~~~~~~~~
 
 It can be easily installed with pip.
 
@@ -36,7 +36,7 @@ It can be easily installed with pip.
    pip install .
 
 Getting started
----------------
+~~~~~~~~~~~~~~~
 
 Get example data sets from the ``openPMD-example-datasets`` repository.
 
@@ -79,9 +79,9 @@ Opening series
      iteration_id                int64  [dimensionless]  (t)  [100, 200, ..., 400, 500]
 
 Working with meshes (fields)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
-Let us plot electric field’s x component at 65 fs.
+Let us plot electric field's x component at 65 fs.
 
 .. code:: python
 
@@ -166,12 +166,12 @@ iteration regardless of the difference. So that this will also work:
                                float64           [mC/L]  (x, y, z)  [-7169.01, -7526.4, ..., 3.16049e-11, 1.22782e-11]
 
 Plotting
-^^^^^^^^
+--------
 
-W can’t directly plot 3D data. But we can for example select a slice.
+We can't directly plot 3D data. But we can for example select a slice.
 For that we can use a helper function ``pmdsc.closest`` to get the
 closets index, since ``scipp`` requires exact match. You can read more
-about indexing ``scipp`` arrays in ``scipp``\ ’s documentation.
+about indexing ``scipp`` arrays in ``scipp``'s documentation.
 
 .. code:: python
 
@@ -221,12 +221,12 @@ about indexing ``scipp`` arrays in ``scipp``\ ’s documentation.
 
 .. figure:: README_17_0.svg
 
-Alternatively it is possible to work interactively with ``plopp``\ ’s
+Alternatively it is possible to work interactively with ``plopp``'s
 tools for visualizing multidimensional data, such as ``pp.slicer``\ or
 ``pp.inspector``.
 
 Doing math
-^^^^^^^^^^
+----------
 
 Just as an example we can easily plot the square of the field:
 
@@ -237,7 +237,7 @@ Just as an example we can easily plot the square of the field:
 .. figure:: README_19_0.svg
 
 Loading chunks
-~~~~~~~~~~~~~~
+--------------
 
 In the above example the whole 3D field is loaded into memory and sliced
 afterward. It is also possible to just load a sub-chunk into memory.
@@ -277,10 +277,10 @@ proper ``scipp`` data array.
                                float64            [V/m]  (x, y, z)  [-3.65733e+08, -5.01237e+08, ..., 0, 0]
 
 Time axis
-~~~~~~~~~
+---------
 
 It is also possible to combine arrays from different iterations into one
-using ``scipp``\ ’s ``concat`` function. Here is an example for creating
+using ``scipp``'s ``concat`` function. Here is an example for creating
 a 4D array from all iterations:
 
 .. code:: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -142,6 +142,7 @@ Data Analysis
    analysis/pandas
    analysis/dask
    analysis/rapids
+   analysis/scipp
    analysis/contrib
 
 Development

--- a/examples/15_scipp_loader.ipynb
+++ b/examples/15_scipp_loader.ipynb
@@ -28,22 +28,20 @@
     "\n",
     "\n",
     "## Installation\n",
-    "It can be easily installed with pip.\n",
+    "The adaptor from openPMD to Scipp is part of the regular openPMD-api Python distribution.\n",
+    "It is loaded lazily and available as soon as `scipp` is also installed.\n",
+    "Plotting functionality requires the additional installation of `plopp`.\n",
+    "\n",
     "```bash\n",
-    "git clone https://github.com/pordyna/openpmd_scipp.git\n",
-    "cd openpmd-scipp\n",
-    "pip install .\n",
+    "pip install openpmd_api scipp plopp.\n",
     "```\n",
     "\n",
     "## Getting started\n",
     "Get example data sets from the `openPMD-example-datasets` repository.\n",
     "```bash\n",
-    "git clone https://github.com/openPMD/openPMD-example-datasets.git\n",
-    "cd openPMD-example-datasets\n",
-    "tar -zxvf example-2d.tar.gz\n",
-    "tar -zxvf example-3d.tar.gz\n",
+    "cd openPMD-api\n",
+    "./share/openPMD/download_samples.sh\n",
     "```\n",
-    " \n",
     "\n",
     "### Opening series"
    ]
@@ -57,7 +55,8 @@
    "source": [
     "import scipp as sc\n",
     "\n",
-    "import openpmd_scipp as pmdsc"
+    "import openpmd_api as pmd\n",
+    "import openpmd_api.scipp as pmdsc"
    ]
   },
   {
@@ -67,17 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = \"openPMD-example-datasets/example-3d/hdf5/data%T.h5\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cc1b21e51bd6e524",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path = \".data/\" + path"
+    "path = \"../samples/git-sample/data%T.h5\""
    ]
   },
   {
@@ -87,7 +76,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_loader = pmdsc.DataLoader(path)\n",
+    "series = pmd.Series(path, pmd.Access.read_random_access)\n",
+    "data_loader = series.to_scipp()\n",
     "print(data_loader.iterations)"
    ]
   },
@@ -165,7 +155,7 @@
    "metadata": {},
    "source": [
     "#### Plotting\n",
-    "W can't directly plot 3D data.\n",
+    "We can't directly plot 3D data.\n",
     "But we can for example select a slice. For that we can use a helper function `pmdsc.closest` to get the closets index, since `scipp` requires exact match. You can read more about indexing `scipp` arrays in `scipp`'s documentation."
    ]
   },
@@ -325,37 +315,6 @@
     "### Working with particle data\n",
     "Coming soon!"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "60ebf9bd3826ee54",
-   "metadata": {},
-   "source": [
-    "## Developer documentation\n",
-    "### Generating this README\n",
-    "README file is generated from the README.ipynb.\n",
-    "```\n",
-    "# Download and extract example datasets if not present\n",
-    "# Will download data into `.data`\n",
-    "make data\n",
-    "\n",
-    "make docs\n",
-    "```\n",
-    "### Running tests\n",
-    "At the moment we only test we have is an integration test running this notebook. After downloading example datasets with `make data`, if needed, run:\n",
-    "```\n",
-    "make test\n",
-    "```\n",
-    "You can also run tests with different python version with tox, but you need to have the python version installed, for example with pyenv.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "425c6cc9a98a5878",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/15_scipp_loader.ipynb
+++ b/examples/15_scipp_loader.ipynb
@@ -1,0 +1,381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2e89b77182b6ebd7",
+   "metadata": {},
+   "source": [
+    "# openpmd-scipp\n",
+    "Load openpmd datasets to `scipp` `DataArrays`.\n",
+    "\n",
+    "## Description\n",
+    "### What is this good for?\n",
+    "[`scipp`](https://github.com/scipp/scipp) is an alternative to [`xarray`](https://github.com/pydata/xarray) and provides basically numpy arrays with axes description and units.\n",
+    "* Automatically load axes and units with openPMD data.\n",
+    "* Axes information  is automatically updated when slicing, indexing, or filtering your data.\n",
+    "* With `scipp`'s plotting library [`plopp`](https://github.com/scipp/plopp) it becomes an alternative to `openpmd-viewer`.\n",
+    "* Many numpy and some scipy functions including all the basic algebraic operations on arrays are supported by `scipp`. When using these, the units and coordinates are automatically taken care of. \n",
+    "\n",
+    "### Limitations\n",
+    "* `scipp` currently handles units with a library, that does not support non-integer exponents for units. This can become problematic in some calculations. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc4a0023fa8afef2",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "## Installation\n",
+    "It can be easily installed with pip.\n",
+    "```bash\n",
+    "git clone https://github.com/pordyna/openpmd_scipp.git\n",
+    "cd openpmd-scipp\n",
+    "pip install .\n",
+    "```\n",
+    "\n",
+    "## Getting started\n",
+    "Get example data sets from the `openPMD-example-datasets` repository.\n",
+    "```bash\n",
+    "git clone https://github.com/openPMD/openPMD-example-datasets.git\n",
+    "cd openPMD-example-datasets\n",
+    "tar -zxvf example-2d.tar.gz\n",
+    "tar -zxvf example-3d.tar.gz\n",
+    "```\n",
+    " \n",
+    "\n",
+    "### Opening series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipp as sc\n",
+    "\n",
+    "import openpmd_scipp as pmdsc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67bba264bde780ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = \"openPMD-example-datasets/example-3d/hdf5/data%T.h5\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc1b21e51bd6e524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = \".data/\" + path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97abaf499694da8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_loader = pmdsc.DataLoader(path)\n",
+    "print(data_loader.iterations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "966866d44f32e381",
+   "metadata": {},
+   "source": [
+    "### Working with meshes (fields)\n",
+    "Let us plot electric field's x component at 65 fs. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48d147dd17b96d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ex = data_loader.get_field(\"E\", \"x\", time=65 * sc.Unit(\"fs\"))\n",
+    "print(Ex)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69d531a49c1021d4",
+   "metadata": {},
+   "source": [
+    "You may have noticed, that the time requested does not have to match exactly any iteration. By default, if there is an iteration within 10 fs distance it will be used instead. This 10 fs tolerance can be adjusted by setting `time_tolerance`. The check can be also disabled by setting `time_tolerance=None`, with that the method will return the closest iteration regardless of the difference. So that this will also work:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7811da56397eeab6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(data_loader.get_field(\"E\", \"x\", time=20 * sc.Unit(\"fs\"), time_tolerance=20 * sc.Unit(\"fs\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f05c2e19a7ea2350",
+   "metadata": {},
+   "source": [
+    ", but `data_loader.get_field('E', 'x', time=20 * sc.Unit('fs'))` not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52e59ab2524367f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# It is also possible to use iteration number instead:\n",
+    "print(data_loader.get_field(\"E\", \"x\", iteration=200))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f4b4ac390d8a45f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For scalar fields just omit the second argument:\n",
+    "print(data_loader.get_field(\"rho\", iteration=200))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "524aaf62b6967893",
+   "metadata": {},
+   "source": [
+    "#### Plotting\n",
+    "W can't directly plot 3D data.\n",
+    "But we can for example select a slice. For that we can use a helper function `pmdsc.closest` to get the closets index, since `scipp` requires exact match. You can read more about indexing `scipp` arrays in `scipp`'s documentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c35a81329a3cc83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slicing_idx = pmdsc.closest(Ex, \"x\", 2 * sc.Unit(\"um\"))\n",
+    "Ex_slice = Ex[\"x\", slicing_idx]\n",
+    "print(Ex_slice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60536b5c1b47ff20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ex_slice.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66cea62fcce29f24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can also plot line plots:\n",
+    "Ex_line = Ex_slice[\"z\", pmdsc.closest(Ex_slice, \"z\", 1.4e-5 * sc.Unit(\"m\"))]\n",
+    "print(Ex_line)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2da76154c389c9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ex_line.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0b3b040b06ab6d9",
+   "metadata": {},
+   "source": [
+    "Alternatively it is possible to work interactively with `plopp`'s tools for visualizing multidimensional data, such as `pp.slicer`or `pp.inspector`.\n",
+    "\n",
+    "#### Doing math\n",
+    "Just as an example we can easily plot the square of the field:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f8aa64caf8d2a66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(Ex_line * Ex_line).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ba6694fadbe70e5",
+   "metadata": {},
+   "source": [
+    "### Loading chunks\n",
+    "In the above example the whole 3D field is loaded into memory and sliced afterward. It is also possible to just load a sub-chunk into memory. When the `relay` option in `get_field` is set to `True` it will return a dummy object that only allocates memory for a single value. This relay object can be indexed, sliced etc. using the `scipp` indexing just like before. (The only limitation given by the `openpmd-api` is that the result has to a be contiguous chunk of the original array). The `load_data` method loads data and returns a proper `scipp` data array. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f8585597ab80058",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The full 3D array is not loaded into memory at this point.\n",
+    "Ex = data_loader.get_field(\"E\", \"x\", time=65 * sc.Unit(\"fs\"), relay=True)\n",
+    "# This time we will select a range rather than a slice.\n",
+    "# For a range there is no need for an exact match.\n",
+    "# But, we could also select a slice just like in the previous example.\n",
+    "Ex = Ex[\"x\", -2e-6 * sc.Unit(\"m\") : 2e-6 * sc.Unit(\"m\")]\n",
+    "# Only now the smaller subset wil be loaded into memory\n",
+    "Ex = Ex.load_data()\n",
+    "print(Ex)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fe77682f59178ab",
+   "metadata": {},
+   "source": [
+    "### Time axis\n",
+    "It is also possible to combine arrays from different iterations into one using `scipp`'s `concat` function. Here is an example for creating a 4D array from all iterations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74e0e0960eb431e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ex = sc.concat(\n",
+    "    [\n",
+    "        data_loader.get_field(\"E\", \"x\", iteration=iteration.value, time_tolerance=None)\n",
+    "        for iteration in data_loader.iterations[\"iteration_id\"]\n",
+    "    ],\n",
+    "    dim=\"t\",\n",
+    ")\n",
+    "print(Ex)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ea35adaeecae10d",
+   "metadata": {},
+   "source": [
+    "The reason for the z coordinate having two dimensions (t,z) is the fact that the data comes from a moving window simulation. This is clearly visible in the plot below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97c0e662a6724f16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let us just slice at some points to get a 2D dataset\n",
+    "Ex = Ex[\"x\", 10][\"y\", 10]\n",
+    "print(Ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "accb22f6ed91f90f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ex.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6118dd51b20e156e",
+   "metadata": {},
+   "source": [
+    "### Working with particle data\n",
+    "Coming soon!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60ebf9bd3826ee54",
+   "metadata": {},
+   "source": [
+    "## Developer documentation\n",
+    "### Generating this README\n",
+    "README file is generated from the README.ipynb.\n",
+    "```\n",
+    "# Download and extract example datasets if not present\n",
+    "# Will download data into `.data`\n",
+    "make data\n",
+    "\n",
+    "make docs\n",
+    "```\n",
+    "### Running tests\n",
+    "At the moment we only test we have is an integration test running this notebook. After downloading example datasets with `make data`, if needed, run:\n",
+    "```\n",
+    "make test\n",
+    "```\n",
+    "You can also run tests with different python version with tox, but you need to have the python version installed, for example with pyenv.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "425c6cc9a98a5878",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/16_scipp_loader.py
+++ b/examples/16_scipp_loader.py
@@ -1,3 +1,11 @@
+"""
+This file is part of the openPMD-api.
+
+Copyright 2025 openPMD contributors
+Authors: Franz Poeschel, Pawel Ordyna
+License: LGPLv3+
+"""
+
 import openpmd_api as pmd
 
 

--- a/examples/16_scipp_loader.py
+++ b/examples/16_scipp_loader.py
@@ -7,6 +7,7 @@ def main():
     try:
         scipp_loader = series.to_scipp()
         import plopp
+        print("Plopp version:", plopp.__version__)
     except ImportError:
         print("Need to install scipp and plopp to run this example.")
         return

--- a/examples/16_scipp_loader.py
+++ b/examples/16_scipp_loader.py
@@ -1,13 +1,19 @@
 import openpmd_api as pmd
-import openpmd_api.scipp as pmdsc
-import scipp as sc
 
 
 def main():
     series = pmd.Series("../samples/git-sample/data%T.h5", pmd.Access.read_only)
 
+    try:
+        scipp_loader = series.to_scipp()
+        import plopp
+    except ImportError:
+        print("Need to install scipp and plopp to run this example.")
+        return
+    import openpmd_api.scipp as pmdsc
+    import scipp as sc
     time = 65 * sc.Unit("fs")
-    scipp_loader = series.to_scipp()
+
     print(scipp_loader.iterations)
     Ex = scipp_loader.get_field("E", "x", time=time)
     print(Ex)

--- a/examples/16_scipp_loader.py
+++ b/examples/16_scipp_loader.py
@@ -1,0 +1,9 @@
+import openpmd_api as pmd
+
+
+def main():
+    series = pmd.Series("./out.bp5", pmd.Access.read_only)
+    scipp_loader = series.to_scipp()
+
+if __name__ == "__main__":
+    main()

--- a/examples/16_scipp_loader.py
+++ b/examples/16_scipp_loader.py
@@ -1,9 +1,48 @@
 import openpmd_api as pmd
+import openpmd_api.scipp as pmdsc
+import scipp as sc
 
 
 def main():
-    series = pmd.Series("./out.bp5", pmd.Access.read_only)
+    series = pmd.Series("../samples/git-sample/data%T.h5", pmd.Access.read_only)
+
+    time = 65 * sc.Unit("fs")
     scipp_loader = series.to_scipp()
+    print(scipp_loader.iterations)
+    Ex = scipp_loader.get_field("E", "x", time=time)
+    print(Ex)
+    slicing_idx = pmdsc.closest(Ex, "x", 2 * sc.Unit("um"))
+    Ex_slice = Ex["x", slicing_idx]
+    print(Ex_slice)
+    Ex_slice.plot().save("slice.png")
+    Ex_line = Ex_slice["z", pmdsc.closest(Ex_slice, "z", 1.4e-5 * sc.Unit("m"))]
+    print(Ex_line)
+    Ex_line.plot().save("line.png")
+    (Ex_line * Ex_line).plot().save("line_squared.png")
+
+    # The full 3D array is not loaded into memory at this point.
+    Ex = scipp_loader.get_field("E", "x", time=time, relay=True)
+    # This time we will select a range rather than a slice.
+    # For a range there is no need for an exact match.
+    # But, we could also select a slice just like in the previous example.
+    Ex = Ex["x", -2e-6 * sc.Unit("m") : 2e-6 * sc.Unit("m")]
+    # Only now the smaller subset wil be loaded into memory
+    Ex = Ex.load_data()
+    print(Ex)
+
+    Ex = sc.concat(
+        [
+            scipp_loader.get_field("E", "x", iteration=iteration.value, time_tolerance=None)
+            for iteration in scipp_loader.iterations["iteration_id"]
+        ],
+        dim="t",
+    )
+    print(Ex)
+
+    # Let us just slice at some points to get a 2D dataset
+    Ex = Ex["x", 10]["y", 10]
+    print(Ex)
+    Ex.plot().save("moving_window.png")
 
 if __name__ == "__main__":
     main()

--- a/examples/16_scipp_loader.py
+++ b/examples/16_scipp_loader.py
@@ -2,12 +2,12 @@ import openpmd_api as pmd
 
 
 def main():
-    series = pmd.Series("../samples/git-sample/data%T.h5", pmd.Access.read_only)
+    series = pmd.Series("../samples/git-sample/data%T.h5",
+                        pmd.Access.read_only)
 
     try:
         scipp_loader = series.to_scipp()
-        import plopp
-        print("Plopp version:", plopp.__version__)
+        import plopp  # noqa
     except ImportError:
         print("Need to install scipp and plopp to run this example.")
         return
@@ -22,7 +22,8 @@ def main():
     Ex_slice = Ex["x", slicing_idx]
     print(Ex_slice)
     Ex_slice.plot().save("slice.png")
-    Ex_line = Ex_slice["z", pmdsc.closest(Ex_slice, "z", 1.4e-5 * sc.Unit("m"))]
+    Ex_line = Ex_slice["z", pmdsc.closest(
+        Ex_slice, "z", 1.4e-5 * sc.Unit("m"))]
     print(Ex_line)
     Ex_line.plot().save("line.png")
     (Ex_line * Ex_line).plot().save("line_squared.png")
@@ -32,24 +33,24 @@ def main():
     # This time we will select a range rather than a slice.
     # For a range there is no need for an exact match.
     # But, we could also select a slice just like in the previous example.
-    Ex = Ex["x", -2e-6 * sc.Unit("m") : 2e-6 * sc.Unit("m")]
+    Ex = Ex["x", -2e-6 * sc.Unit("m"): 2e-6 * sc.Unit("m")]
     # Only now the smaller subset wil be loaded into memory
     Ex = Ex.load_data()
     print(Ex)
 
-    Ex = sc.concat(
-        [
-            scipp_loader.get_field("E", "x", iteration=iteration.value, time_tolerance=None)
-            for iteration in scipp_loader.iterations["iteration_id"]
-        ],
-        dim="t",
-    )
+    Ex = sc.concat([scipp_loader.get_field(
+        "E", "x", iteration=iteration.value,
+        time_tolerance=None)
+        for iteration in scipp_loader.iterations
+        ["iteration_id"]],
+        dim="t",)
     print(Ex)
 
     # Let us just slice at some points to get a 2D dataset
     Ex = Ex["x", 10]["y", 10]
     print(Ex)
     Ex.plot().save("moving_window.png")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/16_scipp_loader.py
+++ b/examples/16_scipp_loader.py
@@ -8,6 +8,7 @@ def main():
     try:
         scipp_loader = series.to_scipp()
         import plopp  # noqa
+        print("Plopp version:", plopp.__version__)
     except ImportError:
         print("Need to install scipp and plopp to run this example.")
         return

--- a/src/binding/python/openpmd_api/ScippLazyInit.py
+++ b/src/binding/python/openpmd_api/ScippLazyInit.py
@@ -1,0 +1,8 @@
+def series_to_scipp(series):
+
+    import scipp
+
+    from .scipp import DataLoader
+
+    dl = DataLoader(series)
+    return dl

--- a/src/binding/python/openpmd_api/ScippLazyInit.py
+++ b/src/binding/python/openpmd_api/ScippLazyInit.py
@@ -1,6 +1,15 @@
 def series_to_scipp(series):
 
-    import scipp
+    # lazy import
+    try:
+        import scipp
+        found_scipp = True
+    except ImportError as original_error:
+        found_scipp = False
+        original_error_string = f"{original_error}"
+
+    if not found_scipp:
+        raise ImportError(f"Scipp NOT found. Install scipp for Scipp support. Original error: {original_error_string}")
 
     from .scipp import DataLoader
 

--- a/src/binding/python/openpmd_api/ScippLazyInit.py
+++ b/src/binding/python/openpmd_api/ScippLazyInit.py
@@ -2,14 +2,16 @@ def series_to_scipp(series):
 
     # lazy import
     try:
-        import scipp
+        import scipp  # noqa
         found_scipp = True
     except ImportError as original_error:
         found_scipp = False
         original_error_string = f"{original_error}"
 
     if not found_scipp:
-        raise ImportError(f"Scipp NOT found. Install scipp for Scipp support. Original error: {original_error_string}")
+        raise ImportError(
+            f"Scipp NOT found. Install scipp for Scipp support. "
+            f"Original error: {original_error_string}")
 
     from .scipp import DataLoader
 

--- a/src/binding/python/openpmd_api/ScippLazyInit.py
+++ b/src/binding/python/openpmd_api/ScippLazyInit.py
@@ -1,7 +1,8 @@
 def series_to_scipp(series):
+
     import scipp
 
-    from . import DataLoader
+    from .scipp import DataLoader
 
     dl = DataLoader(series)
     return dl

--- a/src/binding/python/openpmd_api/ScippLazyInit.py
+++ b/src/binding/python/openpmd_api/ScippLazyInit.py
@@ -1,3 +1,12 @@
+"""
+This file is part of the openPMD-api.
+
+Copyright 2025 openPMD contributors
+Authors: Franz Poeschel
+License: LGPLv3+
+"""
+
+
 def series_to_scipp(series):
 
     # lazy import

--- a/src/binding/python/openpmd_api/__init__.py
+++ b/src/binding/python/openpmd_api/__init__.py
@@ -3,6 +3,7 @@ from .DaskArray import record_component_to_daskarray
 from .DaskDataFrame import particles_to_daskdataframe
 from .DataFrame import (iterations_to_cudf, iterations_to_dataframe,
                         particles_to_dataframe)
+from .ScippLazyInit import series_to_scipp
 from .openpmd_api_cxx import *  # noqa
 
 __version__ = cxx.__version__
@@ -16,6 +17,7 @@ ParticleSpecies.to_dask = particles_to_daskdataframe  # noqa
 Record_Component.to_dask_array = record_component_to_daskarray  # noqa
 Series.to_df = iterations_to_dataframe  # noqa
 Series.to_cudf = iterations_to_cudf  # noqa
+Series.to_scipp = series_to_scipp
 
 # TODO remove in future versions (deprecated)
 Access_Type = Access  # noqa

--- a/src/binding/python/openpmd_api/__init__.py
+++ b/src/binding/python/openpmd_api/__init__.py
@@ -3,8 +3,8 @@ from .DaskArray import record_component_to_daskarray
 from .DaskDataFrame import particles_to_daskdataframe
 from .DataFrame import (iterations_to_cudf, iterations_to_dataframe,
                         particles_to_dataframe)
-from .ScippLazyInit import series_to_scipp
 from .openpmd_api_cxx import *  # noqa
+from .scipp.lazy_init import series_to_scipp
 
 __version__ = cxx.__version__
 __doc__ = cxx.__doc__

--- a/src/binding/python/openpmd_api/__init__.py
+++ b/src/binding/python/openpmd_api/__init__.py
@@ -3,8 +3,8 @@ from .DaskArray import record_component_to_daskarray
 from .DaskDataFrame import particles_to_daskdataframe
 from .DataFrame import (iterations_to_cudf, iterations_to_dataframe,
                         particles_to_dataframe)
+from .ScippLazyInit import series_to_scipp
 from .openpmd_api_cxx import *  # noqa
-from .scipp.lazy_init import series_to_scipp
 
 __version__ = cxx.__version__
 __doc__ = cxx.__doc__

--- a/src/binding/python/openpmd_api/__init__.py
+++ b/src/binding/python/openpmd_api/__init__.py
@@ -17,7 +17,7 @@ ParticleSpecies.to_dask = particles_to_daskdataframe  # noqa
 Record_Component.to_dask_array = record_component_to_daskarray  # noqa
 Series.to_df = iterations_to_dataframe  # noqa
 Series.to_cudf = iterations_to_cudf  # noqa
-Series.to_scipp = series_to_scipp
+Series.to_scipp = series_to_scipp # noqa
 
 # TODO remove in future versions (deprecated)
 Access_Type = Access  # noqa

--- a/src/binding/python/openpmd_api/scipp/__init__.py
+++ b/src/binding/python/openpmd_api/scipp/__init__.py
@@ -1,0 +1,13 @@
+"""openpmd_scipp: A Python package for loading openPMD datasets into scipp DataArrays.
+
+See README.md for documentation
+
+Author:
+    Pawel Ordyna <p.ordyna@hzdr.de>
+
+License:
+GPL - 3.0 license. See LICENSE file for details.
+"""
+
+from .loader import DataLoader as DataLoader
+from .utils import closest as closest

--- a/src/binding/python/openpmd_api/scipp/__init__.py
+++ b/src/binding/python/openpmd_api/scipp/__init__.py
@@ -10,5 +10,5 @@ License:
 GPL - 3.0 license. See LICENSE file for details.
 """
 
-from .loader import DataLoader as DataLoader
-from .utils import closest as closest
+from .loader import DataLoader as DataLoader  # noqa
+from .utils import closest as closest  # noqa

--- a/src/binding/python/openpmd_api/scipp/__init__.py
+++ b/src/binding/python/openpmd_api/scipp/__init__.py
@@ -6,8 +6,7 @@ See README.md for documentation
 Author:
     Pawel Ordyna <p.ordyna@hzdr.de>
 
-License:
-GPL - 3.0 license. See LICENSE file for details.
+License: LGPLv3+
 """
 
 from .loader import DataLoader as DataLoader  # noqa

--- a/src/binding/python/openpmd_api/scipp/__init__.py
+++ b/src/binding/python/openpmd_api/scipp/__init__.py
@@ -1,4 +1,5 @@
-"""openpmd_scipp: A Python package for loading openPMD datasets into scipp DataArrays.
+"""openpmd_scipp: A Python package for loading openPMD datasets
+    into scipp DataArrays.
 
 See README.md for documentation
 

--- a/src/binding/python/openpmd_api/scipp/lazy_init.py
+++ b/src/binding/python/openpmd_api/scipp/lazy_init.py
@@ -1,8 +1,7 @@
 def series_to_scipp(series):
-
     import scipp
 
-    from .scipp import DataLoader
+    from . import DataLoader
 
     dl = DataLoader(series)
     return dl

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -24,8 +24,8 @@ def get_time_axis(series):
     :rtype: sc.DataArray
     """
     t = [
-        series.iterations[it].time * series.iterations[it].time_unit_SI \
-            for it in series.iterations
+        series.iterations[it].time * series.iterations[it].time_unit_SI
+        for it in series.iterations
     ]
     return sc.array(dims=["t"], values=t, unit="s", dtype="double")
 
@@ -43,8 +43,7 @@ def get_iterations(series):
     return sc.Dataset(
         data={
             "iteration_id": sc.DataArray(
-                data=sc.array(dims=["t"],
-                values=list(series.iterations)),
+                data=sc.array(dims=["t"], values=list(series.iterations)),
                 coords={"t": t}
             )
         }

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -9,7 +9,6 @@ License:
 GPL - 3.0 license. See LICENSE file for details.
 """
 
-import openpmd_api as pmd
 import scipp as sc
 
 from .mesh_loader import get_field, get_field_data_relay

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -35,7 +35,8 @@ def get_iterations(series):
 
     :param series: The openPMD series containing the data.
     :type series: openpmd_api.Series
-    :return: A Scipp dataset containing iteration IDs and their corresponding times.
+    :return: A Scipp dataset containing iteration IDs and their
+        corresponding times.
     :rtype: sc.Dataset
     """
     t = get_time_axis(series)
@@ -56,20 +57,23 @@ class DataLoader:
     The data can be retrieved as a DataRelay object or directly as a DataArray.
 
     Attributes:
-        series (openpmd_api.Series): The openPMD series initialized from the file path.
-        iterations (sc.Dataset): A dataset containing iteration IDs and their corresponding times.
+        series (openpmd_api.Series): The openPMD series initialized from
+            the file path.
+        iterations (sc.Dataset): A dataset containing iteration IDs
+            and their corresponding times.
 
     """
 
     def __init__(self, series):
-        """Initialize the DataLoader with an openPMD series from the specified file path.
+        """Initialize the DataLoader with an openPMD series from
+            the specified file path.
 
         :param path: The file path to the openPMD data file.
         :type path: str
 
-        Initializes the `series` attribute as an openPMD series in read-only mode
-        and the `iterations` attribute as a Scipp dataset containing iteration IDs
-        and their corresponding times.
+        Initializes the `series` attribute as an openPMD series in
+        read-only mode and the `iterations` attribute as a Scipp dataset
+        containing iteration IDs and their corresponding times.
         """
         self.series = series
         self.iterations = get_iterations(self.series)
@@ -122,9 +126,11 @@ class DataLoader:
             # handle integer  inputs
             time = time.astype("double")
             time_tolerance = time_tolerance.astype("double")
-            time = time.to(unit=self.iterations["iteration_id"].coords["t"].unit)
+            time = time.to(
+                unit=self.iterations["iteration_id"].coords["t"].unit)
             try:
-                iteration = int(self.iterations["iteration_id"]["t", time].value)
+                iteration = int(
+                    self.iterations["iteration_id"]["t", time].value)
             except IndexError:
                 idx = closest(self.iterations["iteration_id"], "t", time)
                 iteration = self.iterations["iteration_id"]["t", idx]

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -61,7 +61,7 @@ class DataLoader:
 
     """
 
-    def __init__(self, path):
+    def __init__(self, series):
         """Initialize the DataLoader with an openPMD series from the specified file path.
 
         :param path: The file path to the openPMD data file.
@@ -71,13 +71,13 @@ class DataLoader:
         and the `iterations` attribute as a Scipp dataset containing iteration IDs
         and their corresponding times.
         """
-        self.series = pmd.Series(str(path), pmd.Access.read_only)
+        self.series = series
         self.iterations = get_iterations(self.series)
 
     def get_field(
         self,
         field,
-        component=pmd.Mesh_Record_Component.SCALAR,
+        component=None,
         time=None,
         iteration=None,
         relay=False,

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -55,9 +55,10 @@ def get_iterations(series):
 class DataLoader:
     """DataLoader class for loading and retrieving openPMD mesh data.
 
-    This class initializes an openPMD series from a given file path and provides
-    methods to retrieve mesh data fields either by iteration index or by time.
-    The data can be retrieved as a DataRelay object or directly as a DataArray.
+    This class initializes an openPMD series from a given file path and
+    provides methods to retrieve mesh data fields either by iteration index or
+    by time. The data can be retrieved as a DataRelay object or directly as a
+    DataArray.
 
     Attributes:
         series (openpmd_api.Series): The openPMD series initialized from

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -1,0 +1,150 @@
+"""Module providing the DataLoader class.
+
+Provides the main openPMD to scpp interface class.
+
+Author:
+    Pawel Ordyna <p.ordyna@hzdr.de>
+
+License:
+GPL - 3.0 license. See LICENSE file for details.
+"""
+
+import openpmd_api as pmd
+import scipp as sc
+
+from .mesh_loader import get_field, get_field_data_relay
+from .utils import closest
+
+
+def get_time_axis(series):
+    """Get the time axis from an openPMD series.
+
+    :param series: The openPMD series containing the data.
+    :type series: openpmd_api.Series
+    :return: A Scipp array representing the time axis.
+    :rtype: sc.DataArray
+    """
+    t = [
+        series.iterations[it].time * series.iterations[it].time_unit_SI for it in series.iterations
+    ]
+    return sc.array(dims=["t"], values=t, unit="s", dtype="double")
+
+
+def get_iterations(series):
+    """Get the iterations from an openPMD series.
+
+    :param series: The openPMD series containing the data.
+    :type series: openpmd_api.Series
+    :return: A Scipp dataset containing iteration IDs and their corresponding times.
+    :rtype: sc.Dataset
+    """
+    t = get_time_axis(series)
+    return sc.Dataset(
+        data={
+            "iteration_id": sc.DataArray(
+                data=sc.array(dims=["t"], values=list(series.iterations)), coords={"t": t}
+            )
+        }
+    )
+
+
+class DataLoader:
+    """DataLoader class for loading and retrieving openPMD mesh data.
+
+    This class initializes an openPMD series from a given file path and provides
+    methods to retrieve mesh data fields either by iteration index or by time.
+    The data can be retrieved as a DataRelay object or directly as a DataArray.
+
+    Attributes:
+        series (openpmd_api.Series): The openPMD series initialized from the file path.
+        iterations (sc.Dataset): A dataset containing iteration IDs and their corresponding times.
+
+    """
+
+    def __init__(self, path):
+        """Initialize the DataLoader with an openPMD series from the specified file path.
+
+        :param path: The file path to the openPMD data file.
+        :type path: str
+
+        Initializes the `series` attribute as an openPMD series in read-only mode
+        and the `iterations` attribute as a Scipp dataset containing iteration IDs
+        and their corresponding times.
+        """
+        self.series = pmd.Series(str(path), pmd.Access.read_only)
+        self.iterations = get_iterations(self.series)
+
+    def get_field(
+        self,
+        field,
+        component=pmd.Mesh_Record_Component.SCALAR,
+        time=None,
+        iteration=None,
+        relay=False,
+        time_tolerance=10 * sc.Unit("fs"),
+    ):
+        """Retrieve a mesh data field from the openPMD series.
+
+        This method retrieves a specified field and component from the
+        openPMD series either by iteration index or by time. The data
+        can be returned as a DataRelay object or directly as a
+        DataArray.
+
+        :param field: The name of the field to retrieve.
+        :type field: str
+        :param component: The component of the field to retrieve,
+            default is SCALAR.
+        :type component: openpmd_api.Mesh_Record_Component, optional
+        :param time: The time at which to retrieve the field. Either
+            time or iteration must be provided, but not both.
+        :type time: sc.Variable, optional
+        :param iteration: The iteration index at which to retrieve the
+            field. Either time or iteration must be provided, but not
+            both.
+        :type iteration: int, optional
+        :param relay: If True, return the data as a DataRelay object;
+            otherwise, return as a DataArray.
+        :type relay: bool, optional
+        :param time_tolerance: The tolerance for matching the time when
+            retrieving by time, default is 10 femtoseconds.
+        :type time_tolerance: sc.Unit, optional
+        :return: The requested field data as a DataRelay or DataArray.
+        :rtype: DataRelay or DataArray
+        :raises AssertionError: If neither time nor iteration is
+            provided, or if both are provided.
+        :raises IndexError: If no iteration is found within the
+            specified time tolerance.
+        """
+        assert (time is None and iteration is not None) or (
+            iteration is None and time is not None
+        ), "Provide either iteration index or time"
+        if iteration is None:
+            # handle integer  inputs
+            time = time.astype("double")
+            time_tolerance = time_tolerance.astype("double")
+            time = time.to(unit=self.iterations["iteration_id"].coords["t"].unit)
+            try:
+                iteration = int(self.iterations["iteration_id"]["t", time].value)
+            except IndexError:
+                idx = closest(self.iterations["iteration_id"], "t", time)
+                iteration = self.iterations["iteration_id"]["t", idx]
+                assert time_tolerance is None or sc.abs(
+                    iteration.coords["t"] - time
+                ) <= time_tolerance.to(unit=time.unit), (
+                    f"No iteration found within time_tolerance={time_tolerance}."
+                )
+                print(
+                    "Series does not contain iteration at the exact time. "
+                    "Using closest iteration instead.",
+                    flush=True,
+                )
+                iteration = int(iteration.value)
+
+        if relay:
+            return get_field_data_relay(
+                series=self.series, field=field, component=component, iteration=iteration
+            )
+        else:
+            return get_field(
+                series=self.series, field=field, component=component, iteration=iteration
+            )

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -25,7 +25,8 @@ def get_time_axis(series):
     :rtype: sc.DataArray
     """
     t = [
-        series.iterations[it].time * series.iterations[it].time_unit_SI for it in series.iterations
+        series.iterations[it].time * series.iterations[it].time_unit_SI \
+            for it in series.iterations
     ]
     return sc.array(dims=["t"], values=t, unit="s", dtype="double")
 
@@ -43,7 +44,9 @@ def get_iterations(series):
     return sc.Dataset(
         data={
             "iteration_id": sc.DataArray(
-                data=sc.array(dims=["t"], values=list(series.iterations)), coords={"t": t}
+                data=sc.array(dims=["t"],
+                values=list(series.iterations)),
+                coords={"t": t}
             )
         }
     )
@@ -137,7 +140,8 @@ class DataLoader:
                 assert time_tolerance is None or sc.abs(
                     iteration.coords["t"] - time
                 ) <= time_tolerance.to(unit=time.unit), (
-                    f"No iteration found within time_tolerance={time_tolerance}."
+                    f"No iteration found "
+                    f"within time_tolerance={time_tolerance}."
                 )
                 print(
                     "Series does not contain iteration at the exact time. "
@@ -148,9 +152,15 @@ class DataLoader:
 
         if relay:
             return get_field_data_relay(
-                series=self.series, field=field, component=component, iteration=iteration
+                series=self.series,
+                field=field,
+                component=component,
+                iteration=iteration
             )
         else:
             return get_field(
-                series=self.series, field=field, component=component, iteration=iteration
+                series=self.series,
+                field=field,
+                component=component,
+                iteration=iteration
             )

--- a/src/binding/python/openpmd_api/scipp/loader.py
+++ b/src/binding/python/openpmd_api/scipp/loader.py
@@ -5,8 +5,7 @@ Provides the main openPMD to scpp interface class.
 Author:
     Pawel Ordyna <p.ordyna@hzdr.de>
 
-License:
-GPL - 3.0 license. See LICENSE file for details.
+License: LGPLv3+
 """
 
 import scipp as sc

--- a/src/binding/python/openpmd_api/scipp/mesh_loader.py
+++ b/src/binding/python/openpmd_api/scipp/mesh_loader.py
@@ -108,9 +108,10 @@ class DataRelay(sc.DataArray):
 
         Loads a chunk based on the current data array coordinates.
 
-        Calculates the offset and extent for each dimension using the data array
-        coordinates. Loads the data chunk from the record component, scales it
-        by the unit SI, and returns a new data array with loaded values.
+        Calculates the offset and extent for each dimension using the data
+        array coordinates. Loads the data chunk from the record component,
+        scales it by the unit SI, and returns a new data array with loaded
+        values.
 
         :return: The DataArray instance with the loaded data.
         :rtype: DataRelay
@@ -149,7 +150,8 @@ def get_field_data_relay(series, iteration, field, component=None):
     :type iteration: int
     :param field: The name of the field to retrieve.
     :type field: str
-    :param component: The component of the field to retrieve, default is SCALAR.
+    :param component: The component of the field to retrieve,
+        default is SCALAR.
     :type component: openpmd_api.Mesh_Record_Component, optional
     :return: A DataRelay instance initialized with the specified field
         and component data.
@@ -205,7 +207,8 @@ def get_field(series, iteration, field, component=None):
     :type iteration: int
     :param field: The name of the field to retrieve.
     :type field: str
-    :param component: The component of the field to retrieve, default is SCALAR.
+    :param component: The component of the field to retrieve,
+        default is SCALAR.
     :type component: openpmd_api.Mesh_Record_Component, optional
     :return: A DataArray instance with the loaded data.
     :rtype: DataRelay

--- a/src/binding/python/openpmd_api/scipp/mesh_loader.py
+++ b/src/binding/python/openpmd_api/scipp/mesh_loader.py
@@ -213,4 +213,5 @@ def get_field(series, iteration, field, component=None):
     :return: A DataArray instance with the loaded data.
     :rtype: DataRelay
     """
-    return get_field_data_relay(series, iteration, field, component).load_data()
+    return get_field_data_relay(
+        series, iteration, field, component).load_data()

--- a/src/binding/python/openpmd_api/scipp/mesh_loader.py
+++ b/src/binding/python/openpmd_api/scipp/mesh_loader.py
@@ -1,0 +1,204 @@
+"""Module providing mesh like data loading capability.
+
+Author:
+    Pawel Ordyna <p.ordyna@hzdr.de>
+
+License:
+GPL - 3.0 license. See LICENSE file for details.
+"""
+
+import numpy as np
+import openpmd_api as pmd
+import scipp as sc
+
+from .utils import _unit_dimension_to_scipp
+
+
+class DataRelay(sc.DataArray):
+    """Data relay for loading openPMD meshes into scipp.
+
+    Attributes
+    ----------
+    series : openpmd_api.Series
+        The openPMD series object
+    record : openpmd_api.Record
+        The openPMD record object associated with the mesh
+    record_component : openpmd_api.Record_Component
+        The openPMD record component associated with the mesh
+
+    Methods
+    -------
+    _verify_init():
+        Ensures that the data range to load is contiguous.
+    __getitem__(*args, **kwargs):
+        Retrieves a subset of the data, returning a new DataRelay instance.
+    load_data():
+        Loads data from the record component based on data array coordinates,
+        adjusting for offsets and extents, and updates the DataArray values.
+
+    """
+
+    def _verify_init(self):
+        """Verify that the data is contiguous.
+
+        Check if the chosen subset is contiguous in the openPMD storage by checking coordinate
+        differences against the expected grid spacing.
+
+        This is needed since openPMD does nto allow us to load strided chunks.
+        """
+        for dim in self.dims:
+            coord = self.coords[dim]
+            diffs = coord[dim, 1:] - coord[dim, :-1]
+            diffs = diffs.to(unit="m")
+            idx = list(self.record.axis_labels).index(dim)
+            step = self.record.grid_spacing[idx]
+            step *= self.record.grid_unit_SI
+            step = step * sc.Unit("m")
+            assert sc.allclose(diffs, step), (
+                f"The data has to be contiguous! diffs: {diffs}, step: {step}"
+            )
+
+    def __init__(self, series, record, record_component, dummy_array, coords):
+        """Initialize the DataRelay object.
+
+        :param series: The openPMD series object associated with the data.
+        :type series: openpmd_api.Series
+        :param record: The openPMD record object associated with the mesh.
+        :type record: openpmd_api.Record
+        :param record_component: The openPMD record component associated with the mesh.
+        :type record_component: openpmd_api.Record_Component
+        :param dummy_array: A scipp array used for the dummy interface. It should use as little
+            memory as possible. Usually achieved by setting the stride of the values array to 0. Can
+            be read- only.
+        :type dummy_array: sc.array
+        :param coords: A dictionary of coordinates for the DataArray.
+        """
+        super().__init__(data=dummy_array, coords=coords)
+        self.series = series
+        self.record = record
+        self.record_component = record_component
+        self._verify_init()
+
+    def __getitem__(self, *args, **kwargs):
+        """Retrieve a subset of the data, returning a new DataRelay instance.
+
+        Override this method from the base class to use the DataRelay initializer and ensure that
+        DataRelay is returned and the _verify_init method is used.
+
+        :param args: Forwarded to the base class.
+        :type args: tuple
+        :param kwargs: Forwarded to the base class.
+        :type kwargs: dict
+        :return: A new DataRelay instance with the sliced data.
+        :rtype: DataRelay
+        """
+        dummy_data_aray = super().__getitem__(*args, **kwargs)
+        return DataRelay(
+            series=self.series,
+            record=self.record,
+            record_component=self.record_component,
+            dummy_array=dummy_data_aray.data,
+            coords=dummy_data_aray.coords,
+        )
+
+    def load_data(self):
+        """Load data from the openPMD dataset.
+
+        Loads a chunk based on the current data array coordinates.
+
+        Calculates the offset and extent for each dimension using the data array coordinates. Loads
+        the data chunk from the record component, scales it by the unit SI, and returns a new data
+        array with loaded values.
+
+        :return: The DataArray instance with the loaded data.
+        :rtype: DataRelay
+        """
+        offset = [0] * self.record_component.ndim
+        extent = [0] * self.record_component.ndim
+        for dd, dim in enumerate(self.record.axis_labels):
+            try:
+                start = self.coords[dim].to(unit="m").value
+            except sc.DimensionError:
+                start = self.coords[dim][0].to(unit="m").value
+            start /= self.record.grid_unit_SI
+            start -= self.record.grid_global_offset[dd]
+            start /= self.record.grid_spacing[dd]
+            start -= self.record_component.position[dd]
+            offset[dd] = int(round(start))
+            extent[dd] = self.coords[dim].size
+        data = self.record_component.load_chunk(offset=offset, extent=extent)
+        self.series.flush()
+        data *= self.record_component.unit_SI
+        data = np.squeeze(data)
+        data_array = self.copy()
+        data_array.values = data
+        return data_array
+
+
+def get_field_data_relay(series, iteration, field, component=pmd.Mesh_Record_Component.SCALAR):
+    """Get openPMD mesh as a data relay.
+
+    Create a DataRelay object for a specified field and component in an openPMD series.
+
+    :param series: The openPMD series containing the data.
+    :type series: openpmd_api.Series
+    :param iteration: The iteration number to access within the series.
+    :type iteration: int
+    :param field: The name of the field to retrieve.
+    :type field: str
+    :param component: The component of the field to retrieve, default is SCALAR.
+    :type component: openpmd_api.Mesh_Record_Component, optional
+    :return: A DataRelay instance initialized with the specified field and component data.
+    :rtype: DataRelay
+    """
+    record = series.iterations[iteration].meshes[field]
+    rc = record[component]
+    dims = record.axis_labels
+    time = (series.iterations[iteration].time + record.time_offset) * series.iterations[
+        iteration
+    ].time_unit_SI
+    time = sc.scalar(time, unit="s", dtype="double")
+    coords = {"t": time}
+    for dd, dim in enumerate(dims):
+        length = rc.shape[dd]
+        start = record.grid_global_offset[dd]
+        step = record.grid_spacing[dd]
+        values = np.arange(length, dtype=np.float64)
+        values *= step
+        values += rc.position[dd] * step
+        values += start
+        values *= record.grid_unit_SI
+        coord = sc.array(dims=[dim], values=values, unit="m")
+        coords[dim] = coord
+
+    small = np.zeros(1, dtype=rc.dtype)
+    dummy_array = np.lib.stride_tricks.as_strided(
+        small, shape=rc.shape, strides=[0] * rc.ndim, writeable=False
+    )
+    dummy_array = sc.array(
+        dims=dims, values=dummy_array, unit=_unit_dimension_to_scipp(record.unit_dimension)
+    )
+
+    return DataRelay(
+        series=series, record=record, record_component=rc, dummy_array=dummy_array, coords=coords
+    )
+
+
+def get_field(series, iteration, field, component=pmd.Mesh_Record_Component.SCALAR):
+    """Retrieve and load openPMD mesh data without slicing.
+
+    This function creates a DataRelay object for a specified field and component in an openPMD
+    series, loads the whole mesh, and returns the resulting DataArray.
+
+    :param series: The openPMD series containing the data.
+    :type series: openpmd_api.Series
+    :param iteration: The iteration number to access within the series.
+    :type iteration: int
+    :param field: The name of the field to retrieve.
+    :type field: str
+    :param component: The component of the field to retrieve, default is SCALAR.
+    :type component: openpmd_api.Mesh_Record_Component, optional
+    :return: A DataArray instance with the loaded data.
+    :rtype: DataRelay
+    """
+    return get_field_data_relay(series, iteration, field, component).load_data()

--- a/src/binding/python/openpmd_api/scipp/mesh_loader.py
+++ b/src/binding/python/openpmd_api/scipp/mesh_loader.py
@@ -8,7 +8,6 @@ GPL - 3.0 license. See LICENSE file for details.
 """
 
 import numpy as np
-import openpmd_api as pmd
 import scipp as sc
 
 from .utils import _unit_dimension_to_scipp
@@ -135,7 +134,7 @@ class DataRelay(sc.DataArray):
         return data_array
 
 
-def get_field_data_relay(series, iteration, field, component=pmd.Mesh_Record_Component.SCALAR):
+def get_field_data_relay(series, iteration, field, component=None):
     """Get openPMD mesh as a data relay.
 
     Create a DataRelay object for a specified field and component in an openPMD series.
@@ -152,7 +151,7 @@ def get_field_data_relay(series, iteration, field, component=pmd.Mesh_Record_Com
     :rtype: DataRelay
     """
     record = series.iterations[iteration].meshes[field]
-    rc = record[component]
+    rc = record[component] if component else record
     dims = record.axis_labels
     time = (series.iterations[iteration].time + record.time_offset) * series.iterations[
         iteration
@@ -184,7 +183,7 @@ def get_field_data_relay(series, iteration, field, component=pmd.Mesh_Record_Com
     )
 
 
-def get_field(series, iteration, field, component=pmd.Mesh_Record_Component.SCALAR):
+def get_field(series, iteration, field, component=None):
     """Retrieve and load openPMD mesh data without slicing.
 
     This function creates a DataRelay object for a specified field and component in an openPMD

--- a/src/binding/python/openpmd_api/scipp/mesh_loader.py
+++ b/src/binding/python/openpmd_api/scipp/mesh_loader.py
@@ -3,8 +3,7 @@
 Author:
     Pawel Ordyna <p.ordyna@hzdr.de>
 
-License:
-GPL - 3.0 license. See LICENSE file for details.
+License: LGPLv3+
 """
 
 import numpy as np

--- a/src/binding/python/openpmd_api/scipp/mesh_loader.py
+++ b/src/binding/python/openpmd_api/scipp/mesh_loader.py
@@ -158,9 +158,8 @@ def get_field_data_relay(series, iteration, field, component=None):
     record = series.iterations[iteration].meshes[field]
     rc = record[component] if component else record
     dims = record.axis_labels
-    time = (series.iterations[iteration].time + record.time_offset) * series.iterations[
-        iteration
-    ].time_unit_SI
+    time = (series.iterations[iteration].time + record.time_offset) \
+        * series.iterations[iteration].time_unit_SI
     time = sc.scalar(time, unit="s", dtype="double")
     coords = {"t": time}
     for dd, dim in enumerate(dims):
@@ -185,7 +184,11 @@ def get_field_data_relay(series, iteration, field, component=None):
     )
 
     return DataRelay(
-        series=series, record=record, record_component=rc, dummy_array=dummy_array, coords=coords
+        series=series,
+        record=record,
+        record_component=rc,
+        dummy_array=dummy_array,
+        coords=coords
     )
 
 

--- a/src/binding/python/openpmd_api/scipp/mesh_loader.py
+++ b/src/binding/python/openpmd_api/scipp/mesh_loader.py
@@ -40,8 +40,8 @@ class DataRelay(sc.DataArray):
     def _verify_init(self):
         """Verify that the data is contiguous.
 
-        Check if the chosen subset is contiguous in the openPMD storage by checking coordinate
-        differences against the expected grid spacing.
+        Check if the chosen subset is contiguous in the openPMD storage
+        by checking coordinate differences against the expected grid spacing.
 
         This is needed since openPMD does nto allow us to load strided chunks.
         """
@@ -64,11 +64,13 @@ class DataRelay(sc.DataArray):
         :type series: openpmd_api.Series
         :param record: The openPMD record object associated with the mesh.
         :type record: openpmd_api.Record
-        :param record_component: The openPMD record component associated with the mesh.
+        :param record_component: The openPMD record component
+            associated with the mesh.
         :type record_component: openpmd_api.Record_Component
-        :param dummy_array: A scipp array used for the dummy interface. It should use as little
-            memory as possible. Usually achieved by setting the stride of the values array to 0. Can
-            be read- only.
+        :param dummy_array: A scipp array used for the dummy interface.
+            It should use as little memory as possible.
+            Usually achieved by setting the stride of the values array to 0.
+            Can be read- only.
         :type dummy_array: sc.array
         :param coords: A dictionary of coordinates for the DataArray.
         """
@@ -81,8 +83,9 @@ class DataRelay(sc.DataArray):
     def __getitem__(self, *args, **kwargs):
         """Retrieve a subset of the data, returning a new DataRelay instance.
 
-        Override this method from the base class to use the DataRelay initializer and ensure that
-        DataRelay is returned and the _verify_init method is used.
+        Override this method from the base class to use the DataRelay
+        initializer and ensure that DataRelay is returned and
+        the _verify_init method is used.
 
         :param args: Forwarded to the base class.
         :type args: tuple
@@ -105,9 +108,9 @@ class DataRelay(sc.DataArray):
 
         Loads a chunk based on the current data array coordinates.
 
-        Calculates the offset and extent for each dimension using the data array coordinates. Loads
-        the data chunk from the record component, scales it by the unit SI, and returns a new data
-        array with loaded values.
+        Calculates the offset and extent for each dimension using the data array
+        coordinates. Loads the data chunk from the record component, scales it
+        by the unit SI, and returns a new data array with loaded values.
 
         :return: The DataArray instance with the loaded data.
         :rtype: DataRelay
@@ -137,7 +140,8 @@ class DataRelay(sc.DataArray):
 def get_field_data_relay(series, iteration, field, component=None):
     """Get openPMD mesh as a data relay.
 
-    Create a DataRelay object for a specified field and component in an openPMD series.
+    Create a DataRelay object for a specified field and component in
+    an openPMD series.
 
     :param series: The openPMD series containing the data.
     :type series: openpmd_api.Series
@@ -147,7 +151,8 @@ def get_field_data_relay(series, iteration, field, component=None):
     :type field: str
     :param component: The component of the field to retrieve, default is SCALAR.
     :type component: openpmd_api.Mesh_Record_Component, optional
-    :return: A DataRelay instance initialized with the specified field and component data.
+    :return: A DataRelay instance initialized with the specified field
+        and component data.
     :rtype: DataRelay
     """
     record = series.iterations[iteration].meshes[field]
@@ -175,7 +180,8 @@ def get_field_data_relay(series, iteration, field, component=None):
         small, shape=rc.shape, strides=[0] * rc.ndim, writeable=False
     )
     dummy_array = sc.array(
-        dims=dims, values=dummy_array, unit=_unit_dimension_to_scipp(record.unit_dimension)
+        dims=dims, values=dummy_array, unit=_unit_dimension_to_scipp(
+            record.unit_dimension)
     )
 
     return DataRelay(
@@ -186,8 +192,9 @@ def get_field_data_relay(series, iteration, field, component=None):
 def get_field(series, iteration, field, component=None):
     """Retrieve and load openPMD mesh data without slicing.
 
-    This function creates a DataRelay object for a specified field and component in an openPMD
-    series, loads the whole mesh, and returns the resulting DataArray.
+    This function creates a DataRelay object for a specified field
+    and component in an openPMD series, loads the whole mesh, and returns
+    the resulting DataArray.
 
     :param series: The openPMD series containing the data.
     :type series: openpmd_api.Series

--- a/src/binding/python/openpmd_api/scipp/utils.py
+++ b/src/binding/python/openpmd_api/scipp/utils.py
@@ -7,6 +7,8 @@ License:
 GPL - 3.0 license. See LICENSE file for details.
 """
 
+from sys import version_info
+
 import numpy as np
 import scipp as sc
 
@@ -53,7 +55,9 @@ def _unit_dimension_to_scipp(unit_dimension):
         1.0 * sc.Unit("cd"),
     )
     unit = 1.0 * sc.Unit("1")
-    for dim, base_unit in zip(unit_dimension, base_units, strict=False):
+    zipped = zip(unit_dimension, base_units) if version_info < (
+        3, 10) else zip(unit_dimension, base_units, strict=False)
+    for dim, base_unit in zipped:
         if dim != 0:
             unit *= base_unit**dim
     return unit.unit

--- a/src/binding/python/openpmd_api/scipp/utils.py
+++ b/src/binding/python/openpmd_api/scipp/utils.py
@@ -3,8 +3,7 @@
 Author:
     Pawel Ordyna <p.ordyna@hzdr.de>
 
-License:
-GPL - 3.0 license. See LICENSE file for details.
+License: LGPLv3+
 """
 
 from sys import version_info

--- a/src/binding/python/openpmd_api/scipp/utils.py
+++ b/src/binding/python/openpmd_api/scipp/utils.py
@@ -22,7 +22,7 @@ def _unit_dimension_to_scipp(unit_dimension):
     :param tuple unit_dimension: A tuple containing seven integers, each representing
     the power of a base SI unit in the order: (length, mass, time, electric current,
     thermodynamic temperature, amount of substance, luminous intensity).
-     For example, (1, 0, -2, 0, 0, 0, 0) corresponds to meters per second squared (m/s²).
+     For example, (1, 0, -2, 0, 0, 0, 0) corresponds to meters per second squared (m/s^2).
 
     :returns: A Scipp unit object representing the combined unit as specified by the input
         unit dimensions.

--- a/src/binding/python/openpmd_api/scipp/utils.py
+++ b/src/binding/python/openpmd_api/scipp/utils.py
@@ -14,18 +14,20 @@ import scipp as sc
 def _unit_dimension_to_scipp(unit_dimension):
     """Convert a unit dimension from the openPMD standard to a Scipp unit.
 
-    This function takes a tuple representing the powers of the seven base SI units
-    (length, mass, time, electric current, thermodynamic temperature, amount of substance,
-    and luminous intensity) and converts it into a Scipp unit. The conversion is based on
-    the openPMD standard, which describes units as powers of these base measures.
+    This function takes a tuple representing the powers of the seven base SI
+    units (length, mass, time, electric current, thermodynamic temperature,
+    amount of substance, and luminous intensity) and converts it into
+    a Scipp unit. The conversion is based on the openPMD standard,
+    which describes units as powers of these base measures.
 
-    :param tuple unit_dimension: A tuple containing seven integers, each representing
-    the power of a base SI unit in the order: (length, mass, time, electric current,
-    thermodynamic temperature, amount of substance, luminous intensity).
-     For example, (1, 0, -2, 0, 0, 0, 0) corresponds to meters per second squared (m/s^2).
+    :param tuple unit_dimension: A tuple containing seven integers, each
+    representing the power of a base SI unit in the order: (length, mass, time,
+    electric current, thermodynamic temperature, amount of substance,
+    luminous intensity). For example, (1, 0, -2, 0, 0, 0, 0) corresponds
+    to meters per second squared (m/s^2).
 
-    :returns: A Scipp unit object representing the combined unit as specified by the input
-        unit dimensions.
+    :returns: A Scipp unit object representing the combined unit as specified
+        by the input unit dimensions.
     :rtype: sc.Unit
 
     :example:
@@ -34,7 +36,8 @@ def _unit_dimension_to_scipp(unit_dimension):
 
     :notes:
         - The function assumes that the input tuple has exactly seven elements.
-        - Each element in the tuple corresponds to the power of a specific base unit.
+        - Each element in the tuple corresponds to the power of
+          a specific base unit.
     """
     # unit dimension description from the openPMD standard:
     # powers of the 7 base measures characterizing the record's unit in SI
@@ -57,19 +60,20 @@ def _unit_dimension_to_scipp(unit_dimension):
 
 
 def closest(data, dim, val):
-    """Find the index of the closest value in a dataset along a specified dimension.
+    """Find the index of the closest value in a dataset
+        along a specified dimension.
 
     This function calculates the index of the element in the specified dimension
     of the dataset that is closest to the given value. It ensures that the value
-    is converted to the same unit as the dimension's coordinate before performing
-    the comparison.
+    is converted to the same unit as the dimension's coordinate before
+    performing the comparison.
 
     :param data: The data array containing the dimension to search.
     :type data: sc.DataArray
     :param dim: The name of the dimension along which to find the closest value.
     :type dim: str
-    :param val: The value to compare against, which will be converted to the unit of
-                the dimension's coordinate.
+    :param val: The value to compare against, which will be converted to the
+                unit of the dimension's coordinate.
     :type val: sc.Variable
 
     :return: The index of the closest value in the specified dimension.
@@ -78,7 +82,8 @@ def closest(data, dim, val):
     :notes:
         - The function assumes that `val` can be converted to the unit of the
           dimension's coordinate.
-        - The dataset `data` must have coordinates defined for the specified dimension.
+        - The dataset `data` must have coordinates defined
+          for the specified dimension.
     """
     val = val.astype("double")
     coord = data.coords[dim]

--- a/src/binding/python/openpmd_api/scipp/utils.py
+++ b/src/binding/python/openpmd_api/scipp/utils.py
@@ -43,8 +43,8 @@ def _unit_dimension_to_scipp(unit_dimension):
     """
     # unit dimension description from the openPMD standard:
     # powers of the 7 base measures characterizing the record's unit in SI
-    # (length L, mass M, time T, electric current I, thermodynamic temperature theta,
-    # amount of substance N, luminous intensity J)
+    # (length L, mass M, time T, electric current I, thermodynamic
+    # temperature theta, amount of substance N, luminous intensity J)
     base_units = (
         1.0 * sc.Unit("m"),
         1.0 * sc.Unit("kg"),
@@ -67,14 +67,15 @@ def closest(data, dim, val):
     """Find the index of the closest value in a dataset
         along a specified dimension.
 
-    This function calculates the index of the element in the specified dimension
-    of the dataset that is closest to the given value. It ensures that the value
-    is converted to the same unit as the dimension's coordinate before
-    performing the comparison.
+    This function calculates the index of the element in the specified
+    dimension of the dataset that is closest to the given value. It ensures
+    that the value is converted to the same unit as the dimension's coordinate
+    before performing the comparison.
 
     :param data: The data array containing the dimension to search.
     :type data: sc.DataArray
-    :param dim: The name of the dimension along which to find the closest value.
+    :param dim: The name of the dimension along which to find
+        the closest value.
     :type dim: str
     :param val: The value to compare against, which will be converted to the
                 unit of the dimension's coordinate.

--- a/src/binding/python/openpmd_api/scipp/utils.py
+++ b/src/binding/python/openpmd_api/scipp/utils.py
@@ -1,0 +1,86 @@
+"""Utility module.
+
+Author:
+    Pawel Ordyna <p.ordyna@hzdr.de>
+
+License:
+GPL - 3.0 license. See LICENSE file for details.
+"""
+
+import numpy as np
+import scipp as sc
+
+
+def _unit_dimension_to_scipp(unit_dimension):
+    """Convert a unit dimension from the openPMD standard to a Scipp unit.
+
+    This function takes a tuple representing the powers of the seven base SI units
+    (length, mass, time, electric current, thermodynamic temperature, amount of substance,
+    and luminous intensity) and converts it into a Scipp unit. The conversion is based on
+    the openPMD standard, which describes units as powers of these base measures.
+
+    :param tuple unit_dimension: A tuple containing seven integers, each representing
+    the power of a base SI unit in the order: (length, mass, time, electric current,
+    thermodynamic temperature, amount of substance, luminous intensity).
+     For example, (1, 0, -2, 0, 0, 0, 0) corresponds to meters per second squared (m/s²).
+
+    :returns: A Scipp unit object representing the combined unit as specified by the input
+        unit dimensions.
+    :rtype: sc.Unit
+
+    :example:
+        >>> _unit_dimension_to_scipp((1, 0, -2, 0, 0, 0, 0))
+        Unit('m/s^2')
+
+    :notes:
+        - The function assumes that the input tuple has exactly seven elements.
+        - Each element in the tuple corresponds to the power of a specific base unit.
+    """
+    # unit dimension description from the openPMD standard:
+    # powers of the 7 base measures characterizing the record's unit in SI
+    # (length L, mass M, time T, electric current I, thermodynamic temperature theta,
+    # amount of substance N, luminous intensity J)
+    base_units = (
+        1.0 * sc.Unit("m"),
+        1.0 * sc.Unit("kg"),
+        1.0 * sc.Unit("s"),
+        1.0 * sc.Unit("A"),
+        1.0 * sc.Unit("K"),
+        1.0 * sc.Unit("mol"),
+        1.0 * sc.Unit("cd"),
+    )
+    unit = 1.0 * sc.Unit("1")
+    for dim, base_unit in zip(unit_dimension, base_units, strict=False):
+        if dim != 0:
+            unit *= base_unit**dim
+    return unit.unit
+
+
+def closest(data, dim, val):
+    """Find the index of the closest value in a dataset along a specified dimension.
+
+    This function calculates the index of the element in the specified dimension
+    of the dataset that is closest to the given value. It ensures that the value
+    is converted to the same unit as the dimension's coordinate before performing
+    the comparison.
+
+    :param data: The data array containing the dimension to search.
+    :type data: sc.DataArray
+    :param dim: The name of the dimension along which to find the closest value.
+    :type dim: str
+    :param val: The value to compare against, which will be converted to the unit of
+                the dimension's coordinate.
+    :type val: sc.Variable
+
+    :return: The index of the closest value in the specified dimension.
+    :rtype: int
+
+    :notes:
+        - The function assumes that `val` can be converted to the unit of the
+          dimension's coordinate.
+        - The dataset `data` must have coordinates defined for the specified dimension.
+    """
+    val = val.astype("double")
+    coord = data.coords[dim]
+    val = val.to(unit=coord.unit)
+    return np.argmin(sc.abs(coord - val).values)


### PR DESCRIPTION
This merges the code from https://github.com/pordyna/openpmd_scipp into the main API such that it can be used by `series.to_scipp()`.

TODO:

- [x] Documentation (fields)
- [ ]  Documentation (particles) COMMENT: The TODO there refers to particles not being even implemented yet, I think?
- [ ] Clean up the example
- [x] Have a look at the rest of what is in the repository, see what needs to / can be transferred
- [x] CI integration
- [ ] Licensing headers
- [ ] remove Jupyter Notebook
- [ ] check image sizes