### PR TITLE
Remove venv Python workarounds in our CI workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,7 +130,7 @@ jobs:
         sudo apt update
         sudo apt install clang-14 cmake gfortran libhdf5-dev python3.11 python3.11-dev wget
         sudo .github/workflows/dependencies/install_spack
-        python -m pip install numpy pandas
+        python3.11 -m pip install numpy pandas
         git clone -b v4.0.3 https://github.com/ToruNiina/toml11
         cmake -S toml11 -B build_toml11               \
           -DCMAKE_INSTALL_PREFIX=toml11_install \
@@ -153,7 +153,7 @@ jobs:
           -DopenPMD_USE_INVASIVE_TESTS=ON   \
           -DopenPMD_USE_INTERNAL_TOML11=OFF \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
-          -DPython_EXECUTABLE="$(which python)"
+          -DPython_EXECUTABLE="$(which python3.11)"
         cmake --build build --parallel 2
         ctest --test-dir build --output-on-failure
 
@@ -277,7 +277,7 @@ jobs:
       run: |
         apk update
         apk add hdf5-dev
-        python -m pip install numpy
+        python3.10 -m pip install numpy
     - name: Build
       env: {CXXFLAGS: -Werror}
       run: |
@@ -287,7 +287,7 @@ jobs:
           -DopenPMD_USE_MPI=OFF   \
           -DopenPMD_USE_HDF5=ON   \
           -DopenPMD_USE_INVASIVE_TESTS=ON \
-          -DPython_EXECUTABLE=$(which python)
+          -DPython_EXECUTABLE=$(which python3.10)
         cmake --build build --parallel 2
         cd build
         ctest --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -128,10 +128,8 @@ jobs:
     - name: Install
       run: |
         sudo apt update
-        sudo apt install clang-14 cmake gfortran libhdf5-dev python3.11 python3.11-dev wget python3.11-venv
+        sudo apt install clang-14 cmake gfortran libhdf5-dev python3.11 python3.11-dev wget
         sudo .github/workflows/dependencies/install_spack
-        python3.11 -m venv /opt/python_venv
-        . /opt/python_venv/bin/activate
         python -m pip install numpy pandas
         git clone -b v4.0.3 https://github.com/ToruNiina/toml11
         cmake -S toml11 -B build_toml11               \
@@ -142,12 +140,8 @@ jobs:
     - name: Build
       env: {CC: clang-14, CXX: clang++-14, CXXFLAGS: -Werror}
       run: |
-        # Build Spack packages against system Python
-        # and activate the virtual environment just for the openPMD build.
-        # Spack does not play nice with venv.
         eval $(spack env activate --sh .github/ci/spack-envs/clang14_py311_nompi_h5_ad2/)
         spack install
-        . /opt/python_venv/bin/activate
 
         share/openPMD/download_samples.sh build
         export CMAKE_PREFIX_PATH="$(realpath toml11_install):$CMAKE_PREFIX_PATH"
@@ -283,15 +277,10 @@ jobs:
       run: |
         apk update
         apk add hdf5-dev
-        # Use a virtual environment in order to avoid compatibility issues
-        # between the various Python installations in this image.
-        python3.10 -m venv /opt/python_env
-        . /opt/python_env/bin/activate
         python -m pip install numpy
     - name: Build
       env: {CXXFLAGS: -Werror}
       run: |
-        . /opt/python_env/bin/activate
         share/openPMD/download_samples.sh build
         cmake -S . -B build \
           -DopenPMD_USE_PYTHON=ON \


### PR DESCRIPTION
Those workarounds were probably necessary only due to the build system issue fixed with #1684, so we should try removing them again.