### PR TITLE
Fix source/documentation CI run

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -36,14 +36,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - uses: s-weigand/setup-conda@v1.2.3
+    - uses: conda-incubator/setup-miniconda@v3
+      name: Setup conda
       with:
-        update-conda: true
-        conda-channels: conda-forge
+        auto-update-conda: true
+        channels: conda-forge,defaults
+        channel-priority: true
     - name: Install
       run: conda install -c conda-forge doxygen=1.9.6
     - name: Doxygen
-      run: .github/workflows/source/buildDoxygen
+      run: |
+        source /usr/share/miniconda/bin/activate
+        echo "Doxygen location: $(which doxygen)"
+        doxygen_path="$(dirname "$(which doxygen)")"
+        export PATH="$doxygen_path:$PATH"
+        .github/workflows/source/buildDoxygen
 
   urls:
     runs-on: ubuntu-latest

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -47,9 +47,6 @@ jobs:
     - name: Doxygen
       run: |
         source /usr/share/miniconda/bin/activate
-        echo "Doxygen location: $(which doxygen)"
-        doxygen_path="$(dirname "$(which doxygen)")"
-        export PATH="$doxygen_path:$PATH"
         .github/workflows/source/buildDoxygen
 
   urls:


### PR DESCRIPTION
Something about s-weigand/setup-conda@v1.2.3 is broken, switching to conda-incubator/setup-miniconda@v3 (used also in other CI runs) seems to fix it.

```
2025-02-12T10:32:14.7669788Z Data used for activation:
2025-02-12T10:32:14.7670287Z  {
2025-02-12T10:32:14.7670840Z   condaPaths: [
2025-02-12T10:32:14.7671270Z     '/usr/share/miniconda',
2025-02-12T10:32:14.7671695Z     '/usr/share/miniconda/condabin',
2025-02-12T10:32:14.7672169Z     '/usr/share/miniconda/bin'
2025-02-12T10:32:14.7672587Z   ],
2025-02-12T10:32:14.7672902Z   envVars: {
2025-02-12T10:32:14.7673339Z     'unset _CE_M\nunset _CE_CONDA\nPS1': '(base) ',
2025-02-12T10:32:14.7673849Z     CONDA_PREFIX: '/usr/share/miniconda',
2025-02-12T10:32:14.7674185Z     CONDA_DEFAULT_ENV: 'base',
2025-02-12T10:32:14.7674468Z     CONDA_PROMPT_MODIFIER: '(base) ',
2025-02-12T10:32:14.7674795Z     CONDA_EXE: '/usr/share/miniconda/bin/conda',
2025-02-12T10:32:14.7675176Z     CONDA_PYTHON_EXE: '/usr/share/miniconda/bin/python'
2025-02-12T10:32:14.7675497Z   }
2025-02-12T10:32:14.7675674Z }
2025-02-12T10:32:14.7679181Z ##[endgroup]
2025-02-12T10:32:14.7680297Z ##[endgroup]
2025-02-12T10:32:14.7735039Z ##[error]Unable to process file command 'env' successfully.
2025-02-12T10:32:14.7742064Z ##[error]Invalid format 'unset _CE_M'
```