### PR TITLE
Add compile-time check for issue 1720 (Cuda < 12.4.0 + C++20 + std::variant)

### DIFF
--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -25,6 +25,21 @@
 namespace openPMD
 {}
 
+#if defined(CUDA_VERSION) && !defined(OPENPMD_SKIP_CHECK_ISSUE_1720)
+static_assert(__cplusplus < 202002L || CUDA_VERSION >= 12040, R"(
+Cannot use the openPMD-api in C++20 projects under a Cuda version lower
+than 12.4.0 due to a bug in the implementation of std::variant.
+Further information at:
+https://github.com/openPMD/openPMD-api/issues/1720
+https://forums.developer.nvidia.com/t/nvcc-c-20-std-variant-complie-failed/270162/5
+This cannot be fixed on our side, please either upgrade to CUDA >= 12.4.0
+or use C++17.
+If you think that this assertion is shown wrongly, please apply
+'#define OPENPMD_SKIP_CHECK_ISSUE_1720' before including
+'<openPMD/openPMD.hpp>'.
+)");
+#endif
+
 // IWYU pragma: begin_exports
 #include "openPMD/Dataset.hpp"
 #include "openPMD/Datatype.hpp"


### PR DESCRIPTION
This tries to catch the broken combination of Cuda and C++20 and cancels compilation with a message that actually explains what is going on, so users don't wonder when running into this:

```
[2/59] Building CUDA object CMakeFiles/picongpu.dir/versionFormat.x.cpp.o
FAILED: CMakeFiles/picongpu.dir/versionFormat.x.cpp.o 
/nix/store/x76ig0ksr38mfbahrv3yjqxgssxkvrm6-cuda-merged-12.2/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/nix/store/1g6p95yz7j3kccykgwa46lv81qxlp3yb-gcc-wrapper-12.3.0/bin/g++ -DADIOS2_USE_MPI -DADIOS2_VERSION_MAJOR=2 -DADIOS2_VERSION_MINOR=10 -DADIOS2_VERSION_PATCH=2 -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY_MODE -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -DALPAKA_DEBUG=0 -DBOOST_NO_AUTO_PTR -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_ID=GNU -DCMAKE_CXX_COMPILER_VERSION=12.3.0 -DCMAKE_SYSTEM=Linux-6.8.0-52-generic -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_VERSION=3.29.2 -DENABLE_OPENPMD=1 -DH5_BUILT_AS_DYNAMIC_LIB -DJSON_USE_IMPLICIT_CONVERSIONS=0 -DPIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES=10 -DPIC_VERBOSE_LVL=33 -DPMACC_USE_ASYNC_QUEUES=1 -DPMACC_VERBOSE_LVL=0 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_POSIX_C_SOURCE=200809L -I/home/franzpoeschel/tmp/build_picongpu/include -I/home/franzpoeschel/git-repos/picongpu/include/picongpu/.. -I/home/franzpoeschel/git-repos/picongpu/include/pmacc/.. -I/home/franzpoeschel/git-repos/picongpu/thirdParty/mallocMC/src/include -isystem /home/franzpoeschel/git-repos/picongpu/thirdParty/nlohmann_json/single_include -isystem /home/franzpoeschel/tmp/env/include -isystem /home/franzpoeschel/git-repos/picongpu/thirdParty/alpaka/include -isystem /nix/store/045clr8g84ljjkhn6vlg5mlsmib6gm69-cuda_nvcc-12.2.140-dev/include -O3 -DNDEBUG -std=c++20 "--generate-code=arch=compute_52,code=[compute_52,sm_52]" --extended-lambda --expt-relaxed-constexpr --display-error-number -MD -MT CMakeFiles/picongpu.dir/versionFormat.x.cpp.o -MF CMakeFiles/picongpu.dir/versionFormat.x.cpp.o.d -x cu -c /home/franzpoeschel/git-repos/picongpu/include/picongpu/versionFormat.x.cpp -o CMakeFiles/picongpu.dir/versionFormat.x.cpp.o
/home/franzpoeschel/tmp/env/include/openPMD/openPMD.hpp(29): error: static assertion failed with "
Cannot use the openPMD-api in C++20 projects under a Cuda version lower
than 12.4.0 due to a bug in the implementation of std::variant.
Further information at:
https://github.com/openPMD/openPMD-api/issues/1720
https://forums.developer.nvidia.com/t/nvcc-c-20-std-variant-complie-failed/270162/5
This cannot be fixed on our side, please either upgrade to CUDA >= 12.4.0
or use C++17.
If you think that this assertion is shown wrongly, please apply
'#define OPENPMD_SKIP_CHECK_ISSUE_1720' before including
'<openPMD/openPMD.hpp>'.
"
  static_assert(202002L < 202002L || 12020 >= 12040, R"(
  ^

/nix/store/6vclfnmcqpm1k5bbh5syf89f21gip2v3-gcc-12.3.0/include/c++/12.3.0/variant(391): error: function "std::__detail::__variant::_Variadic_union<_First, _Rest...>::~_Variadic_union() [with _First=openPMD::UniquePtrWithLambda<void>, _Rest=<>]" (declared at line 400) cannot be referenced -- it is a deleted function
   : _M_rest(in_place_index<_Np-1>, std::forward<_Args>(__args)...)
```

Related #1720