### PR TITLE
ADIOS2: Use group tables by default in group encoding

### DIFF
--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -435,9 +435,9 @@ void ADIOS2File::configure_IO()
              * new and requires >= v2.9 features anyway.
              */
             case IterationEncoding::variableBased:
+            case IterationEncoding::groupBased:
                 m_impl->m_useGroupTable = UseGroupTable::Yes;
                 break;
-            case IterationEncoding::groupBased:
             case IterationEncoding::fileBased:
                 m_impl->m_useGroupTable = UseGroupTable::No;
                 break;


### PR DESCRIPTION
This was not done so far, since group tables have been introduced in #1310 as a replacement for another (now no longer supported) breaking ADIOS2 schema. But group tables are fully backward and forward compatible to the traditional ADIOS2 schema as they only add additional data. 
Since they in fact create files that are much easier to parse, this is a change that we should introduce by default, especially since we no longer support `Access::READ_LINEAR` for group-based ADIOS2 files if they do not contain a group table. In combination with the serialization troubles that BP5 has with group-based encoding, this might lead to situations where users will have to temporarily downgrade the openPMD-api in order to transform their data to a better encoding, as described more closely here: https://github.com/openPMD/openPMD-api/discussions/1724#discussioncomment-12377166
This sets the better-supported alternative as a default.

No need to add this to dev since the dev branch made this change by now alredy.