### PR TITLE
Followup: Bug fixes for random-access in variable encoding

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2File.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2File.hpp
@@ -67,6 +67,7 @@ struct BufferedGet : BufferedAction
 {
     std::string name;
     Parameter<Operation::READ_DATASET> param;
+    std::optional<size_t> stepSelection;
 
     void run(ADIOS2File &) override;
 };

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -146,7 +146,7 @@ void BufferedGet::run(ADIOS2File &ba)
         ba.m_IO,
         ba.getEngine(),
         ba.m_file,
-        ba.stepSelection());
+        this->stepSelection);
 }
 
 void BufferedPut::run(ADIOS2File &ba)

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1079,6 +1079,9 @@ void ADIOS2IOHandlerImpl::readDataset(
     detail::BufferedGet bg;
     bg.name = nameOfVariable(writable);
     bg.param = parameters;
+    // need to store the current step selection for deferred reads as the step
+    // selection might change again before flushing
+    bg.stepSelection = ba.stepSelection();
     ba.enqueue(std::move(bg));
     m_dirty.emplace(std::move(file));
 }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1521,7 +1521,6 @@ Random-access for variable-encoding in ADIOS2 is currently
 experimental. Support for modifiable attributes is currently not implemented
 yet, meaning that attributes such as /data/time will show useless values.
 Use Access::READ_LINEAR to retrieve those values if needed.
-The following modifiable attributes have been found:
 )";
         };
         if (!modifiable_flag)

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5901,6 +5901,30 @@ void variableBasedSeries(std::string const &file)
         REQUIRE(
             readSeries.getAttribute("some_global").get<std::string>() ==
             "attribute");
+        if (access == Access::READ_RANDOM_ACCESS)
+        {
+            std::vector<std::shared_ptr<int>> load_E_x(
+                readSeries.snapshots().size());
+            // std::vector<std::shared_ptr<int>> load_E_y(
+            //     readSeries.snapshots().size());
+
+            for (auto &[idx, iteration] : readSeries.snapshots())
+            {
+                iteration.open();
+                load_E_x[idx] = iteration.meshes["E"]["x"].loadChunk<int>();
+                // TODO: Changing dimensionality seems to not work in ADIOS2
+                // with ReadRandomAccess
+                // load_E_y[idx] = iteration.meshes["E"]["y"].loadChunk<int>();
+            }
+            readSeries.flush();
+            for (size_t i = 0; i < load_E_x.size(); ++i)
+            {
+                for (size_t j = 0; j < extent; ++j)
+                {
+                    REQUIRE(load_E_x[i].get()[j] == int(i));
+                }
+            }
+        }
         for (auto iteration : readSeries.readIterations())
         {
             if (access == Access::READ_LINEAR)
@@ -5999,6 +6023,34 @@ void variableBasedSeries(std::string const &file)
                 iteration.iterationIndex);
         }
         REQUIRE(last_iteration_index == (is_adios2 ? 9 : 0));
+        if (access == Access::READ_RANDOM_ACCESS)
+        {
+            // should be able to reopen Iterations closed previously
+            // should be able to read multiple Iterations at once
+
+            std::vector<std::shared_ptr<int>> load_E_x(
+                readSeries.snapshots().size());
+
+            // std::vector<std::shared_ptr<int>> load_E_y(
+            //     readSeries.snapshots().size());
+
+            for (auto &[idx, iteration] : readSeries.snapshots())
+            {
+                iteration.open();
+                load_E_x[idx] = iteration.meshes["E"]["x"].loadChunk<int>();
+                // Changing dimensionality seems to not work in ADIOS2
+                // with ReadRandomAccess
+                // load_E_y[idx] = iteration.meshes["E"]["y"].loadChunk<int>();
+            }
+            readSeries.flush();
+            for (size_t i = 0; i < load_E_x.size(); ++i)
+            {
+                for (size_t j = 0; j < extent; ++j)
+                {
+                    REQUIRE(load_E_x[i].get()[j] == int(i));
+                }
+            }
+        }
     };
 
     std::string jsonConfig = R"(

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5914,6 +5914,7 @@ void variableBasedSeries(std::string const &file)
                 load_E_x[idx] = iteration.meshes["E"]["x"].loadChunk<int>();
                 // TODO: Changing dimensionality seems to not work in ADIOS2
                 // with ReadRandomAccess
+                // https://github.com/ornladios/ADIOS2/issues/4474
                 // load_E_y[idx] = iteration.meshes["E"]["y"].loadChunk<int>();
             }
             readSeries.flush();
@@ -6040,6 +6041,7 @@ void variableBasedSeries(std::string const &file)
                 load_E_x[idx] = iteration.meshes["E"]["x"].loadChunk<int>();
                 // Changing dimensionality seems to not work in ADIOS2
                 // with ReadRandomAccess
+                // https://github.com/ornladios/ADIOS2/issues/4474
                 // load_E_y[idx] = iteration.meshes["E"]["y"].loadChunk<int>();
             }
             readSeries.flush();


### PR DESCRIPTION
- For deferred read operations, the step selection from the time of enqueuing must be used rather than the step selection from the time of running
- Fix warning message

- [x] Test for this

@ax3l With this fix, the openPMD-viewer is able to read from variable-encoded datasets