### PR TITLE
Wheels: More on GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,28 +10,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: "x86_64"
+            env:
+              CMAKE_BUILD_PARALLEL_LEVEL: 4
 
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: "i686"
+            env:
+              CMAKE_BUILD_PARALLEL_LEVEL: 4
+
+          - os: ubuntu-24.04-arm
+            arch: "aarch64"
+            env:
+              CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           # builds faster on Travis-CI:
-          #- os: ubuntu-20.04
-          #  arch: "aarch64"
-
-          # builds faster on Travis-CI:
-          #- os: ubuntu-20.04
-          #  arch: "ppc64le"
+          # - os: ubuntu-24.04
+          #   arch: "ppc64le"
+          #   env:
+          #     CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           # builds faster on Travis-CI:
           # blocked by https://github.com/GTkorvo/dill/issues/15
-          #- os: ubuntu-20.04
+          #- os: ubuntu-24.04
           #  arch: "s390x"
+          #  env:
+          #    CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           # x86-64 (64bit)
           - os: windows-2019
             arch: "AMD64"
+            env:
+              CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           # x86 (32bit)
           - os: windows-2019
@@ -39,11 +50,13 @@ jobs:
             env:
               CMAKE_GENERATOR: "Visual Studio 16 2019"
               CMAKE_GENERATOR_PLATFORM: "Win32"
+              CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           - os: macos-13
             arch: "x86_64"
             env:
               MACOSX_DEPLOYMENT_TARGET: 11.0
+              CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           # Apple Silicon M1/arm64/aarch64 builds:
           #   https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
@@ -53,6 +66,7 @@ jobs:
             env:
               CMAKE_OSX_ARCHITECTURES: "arm64"
               MACOSX_DEPLOYMENT_TARGET: 11.0
+              CMAKE_BUILD_PARALLEL_LEVEL: 3
 
           # Apple universal builds that contain x86-64 and arm64 binary code
           #   Needs extra treatment of all librarys that are not CMake
@@ -65,6 +79,7 @@ jobs:
           #  env:
           #    CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
           #    MACOSX_DEPLOYMENT_TARGET: 11.0
+          #    CMAKE_BUILD_PARALLEL_LEVEL: 3
 
     steps:
     - uses: actions/checkout@v4
@@ -125,6 +140,7 @@ jobs:
         # static dependencies of HDF5 and ADIOS1 (see setup.py)
         CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' ZLIB_USE_STATIC_LIBS='ON' ADIOS_USE_STATIC_LIBS='ON' openPMD_CMAKE_openPMD_USE_HDF5='ON' openPMD_CMAKE_openPMD_USE_ADIOS2='ON'
         CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' ZLIB_USE_STATIC_LIBS='ON' openPMD_CMAKE_openPMD_USE_HDF5='ON' openPMD_CMAKE_openPMD_USE_ADIOS2='ON' CMAKE_PREFIX_PATH='C:/Program Files (x86)/ADIOS2;C:/Program Files (x86)/blosc2;C:/Program Files (x86)/HDF5;C:/Program Files (x86)/ZFP;C:/Program Files (x86)/zlib'
+        CMAKE_BUILD_PARALLEL_LEVEL: "${{ matrix.env.CMAKE_BUILD_PARALLEL_LEVEL }}"
         # C++17 support in macOS 10.13+ (partial) and 10.14+ (std::visit) and 10.15+ (std::filesystem::path)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
         # arm64/aarch64 (M1/M2) requires 11.0+

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -1,7 +1,7 @@
 set CURRENTDIR="%cd%"
 
 set BUILD_PREFIX="C:/Program Files (x86)"
-set CPU_COUNT="2"
+set CPU_COUNT="4"
 
 echo "CFLAGS: %CFLAGS%"
 echo "CXXFLAGS: %CXXFLAGS%"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -72,34 +72,6 @@ function install_buildessentials {
     touch buildessentials-stamp
 }
 
-function build_adios1 {
-    if [ -e adios1-stamp ]; then return; fi
-
-    curl -k -sLo adios-1.13.1.tar.gz \
-        https://users.nccs.gov/~pnorbert/adios-1.13.1.tar.gz
-    file adios*.tar.gz
-    tar -xzf adios*.tar.gz
-    rm adios*.tar.gz
-    cd adios-*
-
-    # Cross-Compile hints for autotools based builds
-    HOST_ARG=""
-    if [[ "${CMAKE_OSX_ARCHITECTURES-}" == "arm64" ]]; then
-        HOST_ARG="--host=aarch64-apple-darwin"
-    fi
-
-    ./configure --enable-static --disable-shared --disable-fortran --without-mpi ${HOST_ARG} --prefix=${BUILD_PREFIX} --with-blosc=/usr
-    make -j${CPU_COUNT}
-    make install
-    cd -
-
-    # note: for universal binaries on macOS
-    #   https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
-    #lipo -create -output universal_app x86_app arm_app
-
-    touch adios1-stamp
-}
-
 function build_adios2 {
     if [ -e adios2-stamp ]; then return; fi
 
@@ -151,51 +123,6 @@ function build_adios2 {
     rm -rf build-adios2
 
     touch adios2-stamp
-}
-
-function build_blosc {
-    if [ -e blosc-stamp ]; then return; fi
-
-    curl -sLo c-blosc-1.21.0.tar.gz \
-        https://github.com/Blosc/c-blosc/archive/v1.21.0.tar.gz
-    file c-blosc*.tar.gz
-    tar -xzf c-blosc*.tar.gz
-    rm c-blosc*.tar.gz
-
-    # Patch PThread Propagation
-    curl -sLo blosc-pthread.patch \
-        https://patch-diff.githubusercontent.com/raw/Blosc/c-blosc/pull/318.patch
-    python3 -m patch -p 1 -d c-blosc-1.21.0 blosc-pthread.patch
-
-    # SSE2 support
-    #   https://github.com/Blosc/c-blosc/issues/334
-    DEACTIVATE_SSE2=OFF
-    if [[ "${CMAKE_OSX_ARCHITECTURES-}" == *"arm64"* ]]; then
-      # error: SSE2 is not supported by the target architecture/platform and/or this compiler.
-      DEACTIVATE_SSE2=ON
-    fi
-
-    mkdir build-blosc
-    cd build-blosc
-    PY_BIN=$(which python3)
-    CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/"
-    PATH=${CMAKE_BIN}:${PATH} cmake          \
-      -DDEACTIVATE_SNAPPY=ON                 \
-      -DDEACTIVATE_SSE2=${DEACTIVATE_SSE2}   \
-      -DBUILD_SHARED=OFF                     \
-      -DBUILD_TESTS=OFF                      \
-      -DBUILD_BENCHMARKS=OFF                 \
-      -DCMAKE_VERBOSE_MAKEFILE=ON            \
-      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX} \
-      -DZLIB_USE_STATIC_LIBS=ON              \
-      ../c-blosc-*
-    make -j${CPU_COUNT}
-    make install
-    cd -
-
-    rm -rf build-blosc
-
-    touch blosc-stamp
 }
 
 function build_blosc2 {
@@ -377,15 +304,6 @@ fi
 install_buildessentials
 build_zlib
 build_zfp
-if [[ "$(uname -m)" != "ppc64le" ]]; then
-    # builds too long for Travis-CI
-    build_blosc
-fi
 build_blosc2
 build_hdf5
-if [[ "${CMAKE_OSX_ARCHITECTURES-}" != "arm64" && "$(uname -m)" != "ppc64le" ]]; then
-    # macOS: skip ADIOS1 build for M1
-    # Linux: with ADIOS2 also enabled, this builds too long for Travis-CI
-    build_adios1
-fi
 build_adios2

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -10,7 +10,7 @@ if [ "$(uname -s)" = "Darwin" ]
 then
     CPU_COUNT="${CPU_COUNT:-3}"
 else
-    CPU_COUNT="${CPU_COUNT:-2}"
+    CPU_COUNT="${CPU_COUNT:-4}"
 fi
 
 function install_buildessentials {


### PR DESCRIPTION
Build aarch64/arm64 on native arm runners ([GH action feature preview](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)).

Build ppc64le on emulated x64 runners on GH action (Travis keeps cancelling our runners even though they need 0 credits; support always needs to unblock us). Related to https://github.com/BLAST-WarpX/warpx/pull/5759

Update Ubuntu host systems to 24.04: we anyway run in docker containers and the 20.04 host is about to be removed from GH actions.