### PR TITLE
Attribute preparsing for variable-encoded files in ReadRandomAccess mode: Support modifiable attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,7 @@ set(IO_SOURCE
         src/IO/JSON/JSONIOHandlerImpl.cpp
         src/IO/JSON/JSONFilePosition.cpp
         src/IO/ADIOS/ADIOS2IOHandler.cpp
+        src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
         src/IO/ADIOS/ADIOS2File.cpp
         src/IO/ADIOS/ADIOS2Auxiliary.cpp
         src/IO/InvalidatableFile.cpp)

--- a/docs/source/usage/workflow.rst
+++ b/docs/source/usage/workflow.rst
@@ -77,13 +77,15 @@ The openPMD-api distinguishes between a number of different access modes:
      When using such a backend, the access mode will be coerced automatically to *linear read mode*.
      Use of Series::readIterations() is mandatory for access.
   4. *Random-access read mode* for a variable-based Series is currently experimental.
-     There is currently only very restricted support for metadata definitions that change across steps:
+     Support for metadata definitions that change across steps is (currently) restricted:
 
-     1. Modifiable attributes (except ``/data/snapshot``) can currently not be read. Attributes such as ``/data/time`` that naturally change their value across Iterations will hence not be really well-usable; the last Iteration's value will currently leak into all other Iterations.
-     2. There is no support for datasets that do not exist in all Iterations. The internal Iteration layouts should be homogeneous.
+     1. There is no support for datasets that do not exist in all Iterations. The internal Iteration layouts should be homogeneous.
         If you need this feature, please contact the openPMD-api developers; implementing this is currently not a priority.
         Datasets that do not exist in all steps will be skipped at read time (with an error).
-     3. Datasets with changing extents are supported.
+
+        This restriction affects only datasets that contain array data.
+        Datasets defined exlusively in terms of attributes (especially: constant components) may be defined and read in a subselection of Iterations.
+     2. Datasets with changing extents are supported under the condition that they do not change their dimensionality.
 
 * **Read/Write mode**: Creates a new Series if not existing, otherwise opens an existing Series for reading and writing.
   New datasets and iterations will be inserted as needed.

--- a/include/openPMD/IO/ADIOS/ADIOS2File.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2File.hpp
@@ -411,6 +411,11 @@ public:
     void setStepSelection(std::optional<size_t>);
     [[nodiscard]] std::optional<size_t> stepSelection() const;
 
+    [[nodiscard]] detail::AdiosAttributes const &attributes() const
+    {
+        return m_attributes;
+    }
+
 private:
     ADIOS2IOHandlerImpl *m_impl;
     std::optional<adios2::Engine> m_engine; //! ADIOS engine

--- a/include/openPMD/IO/ADIOS/ADIOS2File.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2File.hpp
@@ -415,6 +415,10 @@ public:
     {
         return m_attributes;
     }
+    [[nodiscard]] detail::AdiosAttributes &attributes()
+    {
+        return m_attributes;
+    }
 
 private:
     ADIOS2IOHandlerImpl *m_impl;

--- a/include/openPMD/IO/ADIOS/ADIOS2File.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2File.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/IOTask.hpp"
 #include "openPMD/IO/InvalidatableFile.hpp"
@@ -325,15 +326,8 @@ public:
      */
     void drop();
 
-    AttributeMap_t const &availableAttributes();
-
     std::vector<std::string>
     availableAttributesPrefixed(std::string const &prefix);
-
-    /*
-     * See description below.
-     */
-    void invalidateAttributesMap();
 
     AttributeMap_t const &availableVariables();
 
@@ -442,7 +436,7 @@ private:
      * the map that would be returned by a call to
      * IO::Available(Attributes|Variables).
      */
-    std::optional<AttributeMap_t> m_availableAttributes;
+    AdiosAttributes m_attributes;
     std::optional<AttributeMap_t> m_availableVariables;
 
     std::set<Writable *> m_pathsMarkedAsActive;

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -23,6 +23,7 @@
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2FilePosition.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
 #include "openPMD/IO/ADIOS/macros.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
@@ -541,9 +542,26 @@ namespace detail
 
     struct AttributeReader
     {
+        struct GetAttribute
+        {
+            size_t step;
+            adios2::IO &IO;
+            detail::AdiosAttributes const &attributes;
+            template <typename AdiosType>
+            auto call(std::string const &name) const
+                -> detail::AttributeWithShapeAndResource<AdiosType>
+            {
+                return attributes.getAttribute<AdiosType>(step, IO, name);
+            }
+        };
+
         template <typename T>
-        static Datatype
-        call(adios2::IO &IO, std::string name, Attribute::resource &resource);
+        static Datatype call(
+            size_t step,
+            adios2::IO &IO,
+            std::string name,
+            Attribute::resource &resource,
+            detail::AdiosAttributes const &);
 
         template <int n, typename... Params>
         static Datatype call(Params &&...);

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -113,7 +113,6 @@ public:
      * be loaded along with the next adios2::Engine flush.
      *
      * @param IO
-     * @param engine
      */
     void preloadAttributes(adios2::IO &IO);
 

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -20,7 +20,9 @@
  */
 #pragma once
 
+#include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/config.hpp"
+#include <variant>
 #if openPMD_HAVE_ADIOS2
 
 #include <adios2.h>
@@ -133,6 +135,12 @@ public:
     AttributeWithShape<T> getAttribute(std::string const &name) const;
 
     Datatype attributeType(std::string const &name) const;
+
+    std::map<std::string, AttributeLocation> const &
+    availableAttributes() const &
+    {
+        return m_offsets;
+    }
 };
 
 struct AdiosAttributes
@@ -144,7 +152,32 @@ struct AdiosAttributes
         std::optional<std::map<std::string, adios2::Params>> m_attributes;
     };
 
-    std::variant<RandomAccess_t, StreamAccess_t> m_data;
+    std::variant<RandomAccess_t, StreamAccess_t> m_data = StreamAccess_t{};
+
+    template <typename Functor>
+    auto withAvailableAttributes(size_t step, adios2::IO &IO, Functor &&f)
+        -> decltype(std::forward<Functor>(f)(
+            std::declval<std::map<std::string, adios2::Params> &>()))
+    {
+        using ret_t = decltype(std::forward<Functor>(f)(
+            std::declval<std::map<std::string, adios2::Params> &>()));
+        return std::visit(
+            auxiliary::overloaded{
+                [step, &f](RandomAccess_t &ra) -> ret_t {
+                    auto &attribute_data = ra.at(step);
+                    return std::forward<Functor>(f)(
+                        attribute_data.availableAttributes());
+                },
+                [step, &f, &IO](StreamAccess_t &sa) -> ret_t {
+                    if (!sa.m_attributes.has_value() ||
+                        sa.m_currentStep != step)
+                    {
+                        sa = StreamAccess_t{step, IO.AvailableAttributes()};
+                    }
+                    return std::forward<Functor>(f)(*sa.m_attributes);
+                }},
+            m_data);
+    }
 };
 } // namespace openPMD::detail
 

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -143,6 +143,41 @@ public:
     }
 };
 
+template <typename T>
+struct AttributeWithShapeAndResource : AttributeWithShape<T>
+{
+    AttributeWithShapeAndResource(AttributeWithShape<T> parent)
+        : AttributeWithShape<T>(std::move(parent))
+    {}
+    AttributeWithShapeAndResource(
+        size_t len_in,
+        T const *data_in,
+        std::optional<std::vector<T>> resource_in)
+        : AttributeWithShape<T>{len_in, data_in}
+        , resource{std::move(resource_in)}
+    {}
+    explicit AttributeWithShapeAndResource() : AttributeWithShape<T>(0, nullptr)
+    {}
+    AttributeWithShapeAndResource(adios2::Attribute<T> attr)
+    {
+        if (!attr)
+        {
+            this->data = nullptr;
+            this->len = 0;
+            return;
+        }
+        auto vec = attr.Data();
+        this->len = vec.size();
+        this->data = vec.data();
+        this->resource = std::move(vec);
+    }
+    operator bool() const
+    {
+        return this->data;
+    }
+    std::optional<std::vector<T>> resource;
+};
+
 struct AdiosAttributes
 {
     using RandomAccess_t = std::vector<PreloadAdiosAttributes>;
@@ -178,6 +213,10 @@ struct AdiosAttributes
                 }},
             m_data);
     }
+
+    template <typename T>
+    AttributeWithShapeAndResource<T>
+    getAttribute(size_t step, adios2::IO &IO, std::string const &name) const;
 };
 } // namespace openPMD::detail
 

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -1,0 +1,139 @@
+/* Copyright 2020-2021 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "openPMD/config.hpp"
+#if openPMD_HAVE_ADIOS2
+
+#include <adios2.h>
+#include <functional>
+#include <map>
+#include <sstream>
+#include <stddef.h>
+#include <type_traits>
+
+#include "openPMD/Datatype.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
+
+namespace openPMD::detail
+{
+/**
+ * @brief Pointer to an attribute's data along with its shape.
+ *
+ * @tparam T Underlying attribute data type.
+ */
+template <typename T>
+struct AttributeWithShape
+{
+    adios2::Dims shape;
+    T const *data;
+};
+
+/**
+ * Class that is responsible for scheduling and buffering openPMD attribute
+ * loads from ADIOS2, if using ADIOS variables to store openPMD attributes.
+ *
+ * Reasoning: ADIOS variables can be of any shape and size, and ADIOS cannot
+ * know which variables to buffer. While it will preload and buffer scalar
+ * variables, openPMD also stores vector-type attributes which are not
+ * preloaded. Since in Streaming setups, every variable load requires full
+ * communication back to the writer, this can quickly become very expensive.
+ * Hence, do this manually.
+ *
+ */
+class PreloadAdiosAttributes
+{
+public:
+    /**
+     * Internally used struct to store meta information on a buffered
+     * attribute. Public for simplicity (helper struct in the
+     * implementation uses it).
+     */
+    struct AttributeLocation
+    {
+        adios2::Dims shape;
+        size_t offset;
+        Datatype dt;
+        char *destroy = nullptr;
+
+        AttributeLocation() = delete;
+        AttributeLocation(adios2::Dims shape, size_t offset, Datatype dt);
+
+        AttributeLocation(AttributeLocation const &other) = delete;
+        AttributeLocation &operator=(AttributeLocation const &other) = delete;
+
+        AttributeLocation(AttributeLocation &&other);
+        AttributeLocation &operator=(AttributeLocation &&other);
+
+        ~AttributeLocation();
+    };
+
+private:
+    /*
+     * Allocate one large buffer instead of hundreds of single heap
+     * allocations.
+     * This will comply with alignment requirements, since
+     * std::allocator<char>::allocate() will call the untyped new operator
+     * ::operator new(std::size_t)
+     * https://en.cppreference.com/w/cpp/memory/allocator/allocate
+     */
+    std::vector<char> m_rawBuffer;
+    std::map<std::string, AttributeLocation> m_offsets;
+
+public:
+    explicit PreloadAdiosAttributes() = default;
+    PreloadAdiosAttributes(PreloadAdiosAttributes const &other) = delete;
+    PreloadAdiosAttributes &
+    operator=(PreloadAdiosAttributes const &other) = delete;
+
+    PreloadAdiosAttributes(PreloadAdiosAttributes &&other) = default;
+    PreloadAdiosAttributes &operator=(PreloadAdiosAttributes &&other) = default;
+
+    /**
+     * @brief Schedule attributes for preloading.
+     *
+     * This will invalidate all previously buffered attributes.
+     * This will *not* flush the scheduled loads. This way, attributes can
+     * be loaded along with the next adios2::Engine flush.
+     *
+     * @param IO
+     * @param engine
+     */
+    void preloadAttributes(adios2::IO &IO, adios2::Engine &engine);
+
+    /**
+     * @brief Get an attribute that has been buffered previously.
+     *
+     * @tparam T The underlying primitive datatype of the attribute.
+     *      Will fail if the type found in ADIOS does not match.
+     * @param name The full name of the attribute.
+     * @return Pointer to the buffered attribute along with information on
+     *      the attribute's shape. Valid only until any non-const member
+     *      of PreloadAdiosAttributes is called.
+     */
+    template <typename T>
+    AttributeWithShape<T> getAttribute(std::string const &name) const;
+
+    Datatype attributeType(std::string const &name) const;
+};
+} // namespace openPMD::detail
+
+#endif // openPMD_HAVE_ADIOS2

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -22,18 +22,14 @@
 
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/config.hpp"
+#include <optional>
 #include <variant>
 #if openPMD_HAVE_ADIOS2
 
 #include <adios2.h>
-#include <functional>
 #include <map>
-#include <sstream>
-#include <stddef.h>
-#include <type_traits>
 
 #include "openPMD/Datatype.hpp"
-#include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
 
 namespace openPMD::detail
 {

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -43,7 +43,7 @@ namespace openPMD::detail
 template <typename T>
 struct AttributeWithShape
 {
-    adios2::Dims shape;
+    size_t len;
     T const *data;
 };
 
@@ -69,13 +69,13 @@ public:
      */
     struct AttributeLocation
     {
-        adios2::Dims shape;
+        size_t len;
         size_t offset;
         Datatype dt;
         char *destroy = nullptr;
 
         AttributeLocation() = delete;
-        AttributeLocation(adios2::Dims shape, size_t offset, Datatype dt);
+        AttributeLocation(size_t len, size_t offset, Datatype dt);
 
         AttributeLocation(AttributeLocation const &other) = delete;
         AttributeLocation &operator=(AttributeLocation const &other) = delete;
@@ -117,7 +117,7 @@ public:
      * @param IO
      * @param engine
      */
-    void preloadAttributes(adios2::IO &IO, adios2::Engine &engine);
+    void preloadAttributes(adios2::IO &IO);
 
     /**
      * @brief Get an attribute that has been buffered previously.
@@ -133,6 +133,18 @@ public:
     AttributeWithShape<T> getAttribute(std::string const &name) const;
 
     Datatype attributeType(std::string const &name) const;
+};
+
+struct AdiosAttributes
+{
+    using RandomAccess_t = std::vector<PreloadAdiosAttributes>;
+    struct StreamAccess_t
+    {
+        size_t m_currentStep = 0;
+        std::optional<std::map<std::string, adios2::Params>> m_attributes;
+    };
+
+    std::variant<RandomAccess_t, StreamAccess_t> m_data;
 };
 } // namespace openPMD::detail
 

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Franz Poeschel
+/* Copyright 2020-2025 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *
@@ -20,16 +20,16 @@
  */
 #pragma once
 
-#include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/config.hpp"
-#include <optional>
-#include <variant>
 #if openPMD_HAVE_ADIOS2
 
 #include <adios2.h>
 #include <map>
+#include <optional>
+#include <variant>
 
 #include "openPMD/Datatype.hpp"
+#include "openPMD/auxiliary/Variant.hpp"
 
 namespace openPMD::detail
 {
@@ -46,24 +46,21 @@ struct AttributeWithShape
 };
 
 /**
- * Class that is responsible for scheduling and buffering openPMD attribute
- * loads from ADIOS2, if using ADIOS variables to store openPMD attributes.
+ * Class that is responsible for buffering loaded openPMD attributes from
+ * ADIOS2.
  *
- * Reasoning: ADIOS variables can be of any shape and size, and ADIOS cannot
- * know which variables to buffer. While it will preload and buffer scalar
- * variables, openPMD also stores vector-type attributes which are not
- * preloaded. Since in Streaming setups, every variable load requires full
- * communication back to the writer, this can quickly become very expensive.
- * Hence, do this manually.
+ * This is used for reading variable-encoded files in random-access mode.
+ * Random-access mode in ADIOS2 has the restriction that modifiable attributes
+ * can only be recovered in normal non-random-access read mode, so we open the
+ * file first in that mode, store all attribute metadata in this class and only
+ * then continue in random-access mode.
  *
  */
 class PreloadAdiosAttributes
 {
 public:
     /**
-     * Internally used struct to store meta information on a buffered
-     * attribute. Public for simplicity (helper struct in the
-     * implementation uses it).
+     * Meta information on a buffered attribute.
      */
     struct AttributeLocation
     {
@@ -106,11 +103,7 @@ public:
     PreloadAdiosAttributes &operator=(PreloadAdiosAttributes &&other) = default;
 
     /**
-     * @brief Schedule attributes for preloading.
-     *
-     * This will invalidate all previously buffered attributes.
-     * This will *not* flush the scheduled loads. This way, attributes can
-     * be loaded along with the next adios2::Engine flush.
+     * @brief Load attributes from the current step into the buffer.
      *
      * @param IO
      */
@@ -131,45 +124,27 @@ public:
 
     Datatype attributeType(std::string const &name) const;
 
-    std::map<std::string, AttributeLocation> const &
-    availableAttributes() const &
-    {
-        return m_offsets;
-    }
+    std::map<std::string, AttributeLocation> const &availableAttributes() const;
 };
 
 template <typename T>
 struct AttributeWithShapeAndResource : AttributeWithShape<T>
 {
-    AttributeWithShapeAndResource(AttributeWithShape<T> parent)
-        : AttributeWithShape<T>(std::move(parent))
-    {}
+    AttributeWithShapeAndResource(AttributeWithShape<T> parent);
     AttributeWithShapeAndResource(
         size_t len_in,
         T const *data_in,
-        std::optional<std::vector<T>> resource_in)
-        : AttributeWithShape<T>{len_in, data_in}
-        , resource{std::move(resource_in)}
-    {}
-    explicit AttributeWithShapeAndResource() : AttributeWithShape<T>(0, nullptr)
-    {}
-    AttributeWithShapeAndResource(adios2::Attribute<T> attr)
-    {
-        if (!attr)
-        {
-            this->data = nullptr;
-            this->len = 0;
-            return;
-        }
-        auto vec = attr.Data();
-        this->len = vec.size();
-        this->data = vec.data();
-        this->resource = std::move(vec);
-    }
-    operator bool() const
-    {
-        return this->data;
-    }
+        std::optional<std::vector<T>> resource_in);
+    AttributeWithShapeAndResource(adios2::Attribute<T> attr);
+    operator bool() const;
+
+private:
+    /*
+     * Users should still use the API of AttributeWithShape (parent type), we
+     * just need somewhere to store the std::vector<T> returned by
+     * Attribute<T>::Data(). This field will not be used when using preparsing,
+     * because the data pointer will go right into the preparse buffer.
+     */
     std::optional<std::vector<T>> resource;
 };
 
@@ -178,12 +153,34 @@ struct AdiosAttributes
     using RandomAccess_t = std::vector<PreloadAdiosAttributes>;
     struct StreamAccess_t
     {
+        /*
+         * These are only buffered for performance reasons.
+         * IO::AvailableAttributes() returns by value, so we should avoid
+         * calling it too often. Instead, store the returned value along with
+         * the step, so we know when we need to update again (i.e. when the
+         * current step changes).
+         */
         size_t m_currentStep = 0;
         std::optional<std::map<std::string, adios2::Params>> m_attributes;
     };
 
+    /*
+     * Variant RandomAcces_t has to be initialized explicitly by
+     * ADIOS2IOHandlerImpl::readAttributeAllsteps(), so we use StreamAccess_t by
+     * default.
+     */
     std::variant<RandomAccess_t, StreamAccess_t> m_data = StreamAccess_t{};
 
+    /*
+     * Needs to be this somewhat ugly API since the AvailableAttributes map has
+     * a different type depending if we use preparsing or not. If we don't use
+     * preparsing, we just use the returned std::map<std::string,
+     * adios2::Params> from IO::AvailableAttributes(). Otherwise, we use the
+     * std::map<std::string, AttributeLocation> map from the
+     * PreloadAdiosAttributes class. The functor f will be called either with
+     * the one or the other, so needs to be written such that the mapped-to type
+     * does not matter.
+     */
     template <typename Functor>
     auto withAvailableAttributes(size_t step, adios2::IO &IO, Functor &&f)
         -> decltype(std::forward<Functor>(f)(

--- a/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp
@@ -78,8 +78,8 @@ public:
         AttributeLocation(AttributeLocation const &other) = delete;
         AttributeLocation &operator=(AttributeLocation const &other) = delete;
 
-        AttributeLocation(AttributeLocation &&other);
-        AttributeLocation &operator=(AttributeLocation &&other);
+        AttributeLocation(AttributeLocation &&other) noexcept;
+        AttributeLocation &operator=(AttributeLocation &&other) noexcept;
 
         ~AttributeLocation();
     };

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -759,19 +759,21 @@ void ADIOS2File::configure_IO()
 
 auto ADIOS2File::detectGroupTable() -> UseGroupTable
 {
-    auto const &attributes = availableAttributes();
-    auto lower_bound =
-        attributes.lower_bound(adios_defaults::str_activeTablePrefix);
-    if (lower_bound != attributes.end() &&
-        auxiliary::starts_with(
-            lower_bound->first, adios_defaults::str_activeTablePrefix))
-    {
-        return UseGroupTable::Yes;
-    }
-    else
-    {
-        return UseGroupTable::No;
-    }
+    return m_attributes.withAvailableAttributes(
+        currentStep(), m_IO, [&](auto const &attributes) {
+            auto lower_bound =
+                attributes.lower_bound(adios_defaults::str_activeTablePrefix);
+            if (lower_bound != attributes.end() &&
+                auxiliary::starts_with(
+                    lower_bound->first, adios_defaults::str_activeTablePrefix))
+            {
+                return UseGroupTable::Yes;
+            }
+            else
+            {
+                return UseGroupTable::No;
+            }
+        });
 }
 
 adios2::Engine &ADIOS2File::getEngine()
@@ -1264,7 +1266,6 @@ AdvanceStatus ADIOS2File::advance(AdvanceMode mode)
         case adios2::StepStatus::OtherError:
             throw std::runtime_error("[ADIOS2] Unexpected step status.");
         }
-        invalidateAttributesMap();
         invalidateVariablesMap();
         m_pathsMarkedAsActive.clear();
         return res;
@@ -1280,13 +1281,11 @@ void ADIOS2File::drop()
     assert(m_buffer.empty());
 }
 
+template <typename AttributesMap>
 static std::vector<std::string> availableAttributesOrVariablesPrefixed(
-    std::string const &prefix,
-    ADIOS2File::AttributeMap_t const &(ADIOS2File::*getBasicMap)(),
-    ADIOS2File &ba)
+    std::string const &prefix, AttributesMap const &attributes)
 {
     std::string var = auxiliary::ends_with(prefix, '/') ? prefix : prefix + '/';
-    ADIOS2File::AttributeMap_t const &attributes = (ba.*getBasicMap)();
     std::vector<std::string> ret;
     for (auto it = attributes.lower_bound(prefix); it != attributes.end(); ++it)
     {
@@ -1305,33 +1304,17 @@ static std::vector<std::string> availableAttributesOrVariablesPrefixed(
 std::vector<std::string>
 ADIOS2File::availableAttributesPrefixed(std::string const &prefix)
 {
-    return availableAttributesOrVariablesPrefixed(
-        prefix, &ADIOS2File::availableAttributes, *this);
+    return m_attributes.withAvailableAttributes(
+        currentStep(), m_IO, [&](auto const &attributes) {
+            return availableAttributesOrVariablesPrefixed(prefix, attributes);
+        });
 }
 
 std::vector<std::string>
 ADIOS2File::availableVariablesPrefixed(std::string const &prefix)
 {
     return availableAttributesOrVariablesPrefixed(
-        prefix, &ADIOS2File::availableVariables, *this);
-}
-
-void ADIOS2File::invalidateAttributesMap()
-{
-    m_availableAttributes = std::optional<AttributeMap_t>();
-}
-
-ADIOS2File::AttributeMap_t const &ADIOS2File::availableAttributes()
-{
-    if (m_availableAttributes)
-    {
-        return m_availableAttributes.value();
-    }
-    else
-    {
-        m_availableAttributes = std::make_optional(m_IO.AvailableAttributes());
-        return m_availableAttributes.value();
-    }
+        prefix, ADIOS2File::availableVariables());
 }
 
 void ADIOS2File::invalidateVariablesMap()

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -344,7 +344,11 @@ namespace
 
 size_t ADIOS2File::currentStep()
 {
-    if (nonpersistentEngine(m_impl->m_engineType))
+    if (auto step_selection = stepSelection(); step_selection.has_value())
+    {
+        return *step_selection;
+    }
+    else if (nonpersistentEngine(m_impl->m_engineType))
     {
         return m_currentStep;
     }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -52,6 +52,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <variant>
 
 namespace openPMD
 {
@@ -1782,7 +1783,10 @@ void ADIOS2IOHandlerImpl::listPaths(
                 fileData.availableAttributesPrefixed(tablePrefix);
             if (fileData.streamStatus ==
                     detail::ADIOS2File::StreamStatus::DuringStep ||
-                fileData.stepSelection().has_value())
+                (fileData.stepSelection().has_value() &&
+                 std::holds_alternative<
+                     detail::AdiosAttributes::RandomAccess_t>(
+                     fileData.attributes().m_data)))
             {
                 auto currentStep = fileData.currentStep();
                 auto &IO = fileData.m_IO;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1291,7 +1291,7 @@ namespace
 
             if (type == determineDatatype<rep>())
             {
-                auto meta = IO.InquireAttribute<rep>(metaAttr);
+                auto meta = IO.template InquireAttribute<rep>(metaAttr);
                 if (meta.Data().size() == 1 && meta.Data()[0] == 1)
                 {
                     std::forward<Functor>(fun)(
@@ -1425,6 +1425,59 @@ namespace
         }
 
         static constexpr char const *errorMsg = "ReadAttributeAllsteps";
+    };
+
+    struct ReadAttributeAllstepsFullPreparsing
+    {
+        struct GetAttribute
+        {
+            detail::PreloadAdiosAttributes const &p;
+            template <typename AdiosType>
+            [[nodiscard]] auto call(std::string const &name) const
+                -> detail::AttributeWithShapeAndResource<AdiosType>
+            {
+                return p.getAttribute<AdiosType>(name);
+            }
+        };
+
+        template <typename T>
+        static void call(
+            std::vector<detail::PreloadAdiosAttributes> const &preload,
+            adios2::IO &IO,
+            std::string const &name,
+            Parameter<Operation::READ_ATT_ALLSTEPS>::result_type
+                &put_result_here)
+        {
+            std::vector<T> res;
+            res.reserve(preload.size());
+            for (auto const &p : preload)
+            {
+                genericReadAttribute<T>(
+                    [&res](auto &&val) {
+                        using type = std::remove_reference_t<decltype(val)>;
+                        if constexpr (std::is_same_v<type, bool>)
+                        {
+                            throw error::ReadError(
+                                error::AffectedObject::Attribute,
+                                error::Reason::UnexpectedContent,
+                                "ADIOS2",
+                                "[ReadAttributeAllsteps] No support for "
+                                "Boolean attributes.");
+                        }
+                        else
+                        {
+                            res.emplace_back(static_cast<decltype(val)>(val));
+                        }
+                    },
+                    IO,
+                    name,
+                    GetAttribute{p});
+            }
+            put_result_here = std::move(res);
+        }
+
+        static constexpr char const *errorMsg =
+            "ReadAttributeAllstepsFullPreparsing";
     };
 
 #if openPMD_HAVE_MPI
@@ -1561,6 +1614,8 @@ Use Access::READ_LINEAR to retrieve those values if needed.
     }
 } // namespace
 
+#define OPENPMD_PREPARSE_EVERYTHING 1
+
 void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     Writable *writable, Parameter<Operation::READ_ATT_ALLSTEPS> &param)
 {
@@ -1568,6 +1623,52 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     auto pos = setAndGetFilePosition(writable);
     auto name = nameOfAttribute(writable, param.name);
 
+#if OPENPMD_PREPARSE_EVERYTHING
+    detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
+#if openPMD_HAVE_MPI
+    auto adios = [&]() {
+        if (m_communicator.has_value())
+        {
+            return adios2::ADIOS(*m_communicator);
+        }
+        else
+        {
+            return adios2::ADIOS{};
+        }
+    }();
+#else
+    adios2::ADIOS adios;
+#endif
+    auto IO = adios.DeclareIO("PreparseSnapshots");
+    // @todo check engine type
+    IO.SetEngine(realEngineType());
+    IO.SetParameter("StreamReader", "ON"); // this be for BP4
+    auto engine = IO.Open(fullPath(*file), adios2::Mode::Read);
+    std::vector<detail::PreloadAdiosAttributes> preload;
+    preload.reserve(engine.Steps());
+    adios2::StepStatus status;
+    while ((status = engine.BeginStep()) == adios2::StepStatus::OK)
+    {
+        auto &new_entry = preload.emplace_back();
+        new_entry.preloadAttributes(IO);
+        engine.EndStep();
+    }
+    if (status != adios2::StepStatus::EndOfStream)
+    {
+        throw std::runtime_error(
+            "[ADIOS2IOHandlerImpl::readAttributeAllsteps] Unexpected step "
+            "status while beginning a step.");
+    }
+    engine.Close();
+    auto &attributes = ba.attributes();
+    switchType<ReadAttributeAllstepsFullPreparsing>(
+        preload.at(0).attributeType(param.name),
+        preload,
+        IO,
+        param.name,
+        *param.resource);
+    attributes.m_data = std::move(preload);
+#else
     auto read_from_file_in_serial = [&]() {
         adios2::ADIOS adios;
         auto IO = adios.DeclareIO("PreparseSnapshots");
@@ -1602,6 +1703,7 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
         type, *param.resource, *m_communicator, rank);
 #else
     read_from_file_in_serial();
+#endif
 #endif
 }
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1591,6 +1591,9 @@ namespace
     };
 #endif
 
+#define OPENPMD_PREPARSE_EVERYTHING 1
+
+#if !OPENPMD_PREPARSE_EVERYTHING
     void warn_ignored_modifiable_attributes(adios2::IO &IO)
     {
         auto modifiable_flag = IO.InquireAttribute<detail::bool_representation>(
@@ -1612,9 +1615,8 @@ Use Access::READ_LINEAR to retrieve those values if needed.
             print_warning("File uses modifiable attributes.");
         }
     }
+#endif
 } // namespace
-
-#define OPENPMD_PREPARSE_EVERYTHING 1
 
 void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     Writable *writable, Parameter<Operation::READ_ATT_ALLSTEPS> &param)
@@ -1777,7 +1779,8 @@ void ADIOS2IOHandlerImpl::listPaths(
             std::vector attrs =
                 fileData.availableAttributesPrefixed(tablePrefix);
             if (fileData.streamStatus ==
-                detail::ADIOS2File::StreamStatus::DuringStep)
+                    detail::ADIOS2File::StreamStatus::DuringStep ||
+                fileData.stepSelection().has_value())
             {
                 auto currentStep = fileData.currentStep();
                 auto &IO = fileData.m_IO;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -27,6 +27,7 @@
 #include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2FilePosition.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
 #include "openPMD/IO/IOTask.hpp"
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/Streaming.hpp"
@@ -1236,7 +1237,12 @@ void ADIOS2IOHandlerImpl::readAttribute(
     }
 
     Datatype ret = switchType<detail::AttributeReader>(
-        type, ba.m_IO, name, *parameters.resource);
+        type,
+        ba.currentStep(),
+        ba.m_IO,
+        name,
+        *parameters.resource,
+        ba.attributes());
     *parameters.dtype = ret;
 }
 
@@ -1246,9 +1252,12 @@ namespace
        Functor fun will be called with the value of the retrieved attribute;
        both functions use different logic for processing the retrieved values.
      */
-    template <typename T, typename Functor>
-    Datatype
-    genericReadAttribute(Functor &&fun, adios2::IO &IO, std::string const &name)
+    template <typename T, typename Functor, typename GetAttribute>
+    Datatype genericReadAttribute(
+        Functor &&fun,
+        adios2::IO &IO,
+        std::string const &name,
+        GetAttribute const &getAttribute)
     {
         /*
          * If we store an attribute of boolean type, we store an additional
@@ -1259,7 +1268,7 @@ namespace
 
         if constexpr (std::is_same<T, rep>::value)
         {
-            auto attr = IO.InquireAttribute<rep>(name);
+            auto attr = getAttribute.template call<rep>(name);
             if (!attr)
             {
                 throw std::runtime_error(
@@ -1286,11 +1295,11 @@ namespace
                 if (meta.Data().size() == 1 && meta.Data()[0] == 1)
                 {
                     std::forward<Functor>(fun)(
-                        detail::bool_repr::fromRep(attr.Data()[0]));
+                        detail::bool_repr::fromRep(attr.data[0]));
                     return determineDatatype<bool>();
                 }
             }
-            std::forward<Functor>(fun)(attr.Data()[0]);
+            std::forward<Functor>(fun)(attr.data[0]);
         }
         else if constexpr (detail::IsUnsupportedComplex_v<T>)
         {
@@ -1300,27 +1309,30 @@ namespace
         }
         else if constexpr (auxiliary::IsVector_v<T>)
         {
-            auto attr = IO.InquireAttribute<typename T::value_type>(name);
+            auto attr =
+                getAttribute.template call<typename T::value_type>(name);
             if (!attr)
             {
                 throw std::runtime_error(
                     "[ADIOS2] Internal error: Failed reading attribute '" +
                     name + "'.");
             }
-            std::forward<Functor>(fun)(attr.Data());
+            std::forward<Functor>(fun)(std::vector<typename T::value_type>(
+                attr.data, attr.data + attr.len));
         }
         else if constexpr (auxiliary::IsArray_v<T>)
         {
-            auto attr = IO.InquireAttribute<typename T::value_type>(name);
+            auto attr =
+                getAttribute.template call<typename T::value_type>(name);
             if (!attr)
             {
                 throw std::runtime_error(
                     "[ADIOS2] Internal error: Failed reading attribute '" +
                     name + "'.");
             }
-            auto data = attr.Data();
+            auto data = attr.data;
             T res;
-            for (size_t i = 0; i < data.size(); i++)
+            for (size_t i = 0; i < attr.len; i++)
             {
                 res[i] = data[i];
             }
@@ -1333,14 +1345,14 @@ namespace
         }
         else
         {
-            auto attr = IO.InquireAttribute<T>(name);
+            auto attr = getAttribute.template call<T>(name);
             if (!attr)
             {
                 throw std::runtime_error(
                     "[ADIOS2] Internal error: Failed reading attribute '" +
                     name + "'.");
             }
-            std::forward<Functor>(fun)(attr.Data()[0]);
+            std::forward<Functor>(fun)(attr.data[0]);
         }
 
         return determineDatatype<T>();
@@ -1348,6 +1360,17 @@ namespace
 
     struct ReadAttributeAllsteps
     {
+        struct GetAttribute
+        {
+            adios2::IO &IO;
+            template <typename AdiosType>
+            [[nodiscard]] auto call(std::string const &name) const
+                -> detail::AttributeWithShapeAndResource<AdiosType>
+            {
+                return {IO.InquireAttribute<AdiosType>(name)};
+            }
+        };
+
         template <typename T>
         static void call(
             adios2::IO &IO,
@@ -1379,7 +1402,8 @@ namespace
                         }
                     },
                     IO,
-                    name);
+                    name,
+                    GetAttribute{IO});
                 engine.EndStep();
                 status = engine.BeginStep();
             }
@@ -1657,11 +1681,12 @@ void ADIOS2IOHandlerImpl::listPaths(
                 detail::ADIOS2File::StreamStatus::DuringStep)
             {
                 auto currentStep = fileData.currentStep();
+                auto &IO = fileData.m_IO;
                 for (auto const &attrName : attrs)
                 {
                     using table_t = unsigned long long;
-                    auto attr = fileData.m_IO.InquireAttribute<table_t>(
-                        tablePrefix + attrName);
+                    auto attr = fileData.attributes().getAttribute<table_t>(
+                        currentStep, IO, tablePrefix + attrName);
                     if (!attr)
                     {
                         std::cerr << "[ADIOS2 backend] Unable to inquire group "
@@ -1671,7 +1696,7 @@ void ADIOS2IOHandlerImpl::listPaths(
                                   << std::endl;
                         continue;
                     }
-                    if (attr.Data()[0] != currentStep)
+                    if (attr.data[0] != currentStep)
                     {
                         // group wasn't defined in current step
                         continue;
@@ -2113,14 +2138,19 @@ namespace detail
 {
     template <typename T>
     Datatype AttributeReader::call(
-        adios2::IO &IO, std::string name, Attribute::resource &resource)
+        size_t step,
+        adios2::IO &IO,
+        std::string name,
+        Attribute::resource &resource,
+        detail::AdiosAttributes const &attributes)
     {
         return genericReadAttribute<T>(
             [&resource](auto &&value) {
                 resource = static_cast<decltype(value)>(value);
             },
             IO,
-            name);
+            name,
+            GetAttribute{step, IO, attributes});
     }
 
     template <int n, typename... Params>

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1246,6 +1246,7 @@ void ADIOS2IOHandlerImpl::readAttribute(
     *parameters.dtype = ret;
 }
 
+#define openPMD_PREPARSE_EVERYTHING 1
 namespace
 {
     /* Used by both readAttribute() and readAttributeAllsteps() tasks.
@@ -1358,6 +1359,62 @@ namespace
         return determineDatatype<T>();
     }
 
+#if openPMD_PREPARSE_EVERYTHING
+
+    struct ReadAttributeAllstepsFullPreparsing
+    {
+        struct GetAttribute
+        {
+            detail::PreloadAdiosAttributes const &p;
+            template <typename AdiosType>
+            [[nodiscard]] auto call(std::string const &name) const
+                -> detail::AttributeWithShapeAndResource<AdiosType>
+            {
+                return p.getAttribute<AdiosType>(name);
+            }
+        };
+
+        template <typename T>
+        static void call(
+            std::vector<detail::PreloadAdiosAttributes> const &preload,
+            adios2::IO &IO,
+            std::string const &name,
+            Parameter<Operation::READ_ATT_ALLSTEPS>::result_type
+                &put_result_here)
+        {
+            std::vector<T> res;
+            res.reserve(preload.size());
+            for (auto const &p : preload)
+            {
+                genericReadAttribute<T>(
+                    [&res](auto &&val) {
+                        using type = std::remove_reference_t<decltype(val)>;
+                        if constexpr (std::is_same_v<type, bool>)
+                        {
+                            throw error::ReadError(
+                                error::AffectedObject::Attribute,
+                                error::Reason::UnexpectedContent,
+                                "ADIOS2",
+                                "[ReadAttributeAllsteps] No support for "
+                                "Boolean attributes.");
+                        }
+                        else
+                        {
+                            res.emplace_back(static_cast<decltype(val)>(val));
+                        }
+                    },
+                    IO,
+                    name,
+                    GetAttribute{p});
+            }
+            put_result_here = std::move(res);
+        }
+
+        static constexpr char const *errorMsg =
+            "ReadAttributeAllstepsFullPreparsing";
+    };
+
+#else
     struct ReadAttributeAllsteps
     {
         struct GetAttribute
@@ -1425,59 +1482,6 @@ namespace
         }
 
         static constexpr char const *errorMsg = "ReadAttributeAllsteps";
-    };
-
-    struct ReadAttributeAllstepsFullPreparsing
-    {
-        struct GetAttribute
-        {
-            detail::PreloadAdiosAttributes const &p;
-            template <typename AdiosType>
-            [[nodiscard]] auto call(std::string const &name) const
-                -> detail::AttributeWithShapeAndResource<AdiosType>
-            {
-                return p.getAttribute<AdiosType>(name);
-            }
-        };
-
-        template <typename T>
-        static void call(
-            std::vector<detail::PreloadAdiosAttributes> const &preload,
-            adios2::IO &IO,
-            std::string const &name,
-            Parameter<Operation::READ_ATT_ALLSTEPS>::result_type
-                &put_result_here)
-        {
-            std::vector<T> res;
-            res.reserve(preload.size());
-            for (auto const &p : preload)
-            {
-                genericReadAttribute<T>(
-                    [&res](auto &&val) {
-                        using type = std::remove_reference_t<decltype(val)>;
-                        if constexpr (std::is_same_v<type, bool>)
-                        {
-                            throw error::ReadError(
-                                error::AffectedObject::Attribute,
-                                error::Reason::UnexpectedContent,
-                                "ADIOS2",
-                                "[ReadAttributeAllsteps] No support for "
-                                "Boolean attributes.");
-                        }
-                        else
-                        {
-                            res.emplace_back(static_cast<decltype(val)>(val));
-                        }
-                    },
-                    IO,
-                    name,
-                    GetAttribute{p});
-            }
-            put_result_here = std::move(res);
-        }
-
-        static constexpr char const *errorMsg =
-            "ReadAttributeAllstepsFullPreparsing";
     };
 
 #if openPMD_HAVE_MPI
@@ -1589,11 +1593,7 @@ namespace
         }
         static constexpr char const *errorMsg = "DistributeToAllRanks";
     };
-#endif
 
-#define OPENPMD_PREPARSE_EVERYTHING 1
-
-#if !OPENPMD_PREPARSE_EVERYTHING
     void warn_ignored_modifiable_attributes(adios2::IO &IO)
     {
         auto modifiable_flag = IO.InquireAttribute<detail::bool_representation>(
@@ -1615,7 +1615,8 @@ Use Access::READ_LINEAR to retrieve those values if needed.
             print_warning("File uses modifiable attributes.");
         }
     }
-#endif
+#endif // openPMD_HAVE_MPI
+#endif // openPMD_PREPARSE_EVERYTHING
 } // namespace
 
 void ADIOS2IOHandlerImpl::readAttributeAllsteps(
@@ -1626,7 +1627,7 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     auto name = nameOfAttribute(writable, param.name);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
 
-#if OPENPMD_PREPARSE_EVERYTHING
+#if openPMD_PREPARSE_EVERYTHING
     auto type = detail::attributeInfo(ba.m_IO, name, /* verbose = */ true);
 #if openPMD_HAVE_MPI
     auto adios = [&]() {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1247,7 +1247,6 @@ void ADIOS2IOHandlerImpl::readAttribute(
     *parameters.dtype = ret;
 }
 
-#define openPMD_PREPARSE_EVERYTHING 1
 namespace
 {
     /* Used by both readAttribute() and readAttributeAllsteps() tasks.
@@ -1360,9 +1359,7 @@ namespace
         return determineDatatype<T>();
     }
 
-#if openPMD_PREPARSE_EVERYTHING
-
-    struct ReadAttributeAllstepsFullPreparsing
+    struct ReadAttributeAllsteps
     {
         struct GetAttribute
         {
@@ -1383,7 +1380,7 @@ namespace
             Parameter<Operation::READ_ATT_ALLSTEPS>::result_type
                 &put_result_here)
         {
-            std::vector<T> res;
+            auto &res = put_result_here.emplace<std::vector<T>>();
             res.reserve(preload.size());
             for (auto const &p : preload)
             {
@@ -1408,216 +1405,10 @@ namespace
                     name,
                     GetAttribute{p});
             }
-            put_result_here = std::move(res);
-        }
-
-        static constexpr char const *errorMsg =
-            "ReadAttributeAllstepsFullPreparsing";
-    };
-
-#else
-    struct ReadAttributeAllsteps
-    {
-        struct GetAttribute
-        {
-            adios2::IO &IO;
-            template <typename AdiosType>
-            [[nodiscard]] auto call(std::string const &name) const
-                -> detail::AttributeWithShapeAndResource<AdiosType>
-            {
-                return {IO.InquireAttribute<AdiosType>(name)};
-            }
-        };
-
-        template <typename T>
-        static void call(
-            adios2::IO &IO,
-            adios2::Engine &engine,
-            std::string const &name,
-            adios2::StepStatus status,
-            Parameter<Operation::READ_ATT_ALLSTEPS>::result_type
-                &put_result_here)
-        {
-            std::vector<T> res;
-            res.reserve(engine.Steps());
-            while (status == adios2::StepStatus::OK)
-            {
-                genericReadAttribute<T>(
-                    [&res](auto &&val) {
-                        using type = std::remove_reference_t<decltype(val)>;
-                        if constexpr (std::is_same_v<type, bool>)
-                        {
-                            throw error::ReadError(
-                                error::AffectedObject::Attribute,
-                                error::Reason::UnexpectedContent,
-                                "ADIOS2",
-                                "[ReadAttributeAllsteps] No support for "
-                                "Boolean attributes.");
-                        }
-                        else
-                        {
-                            res.emplace_back(static_cast<decltype(val)>(val));
-                        }
-                    },
-                    IO,
-                    name,
-                    GetAttribute{IO});
-                engine.EndStep();
-                status = engine.BeginStep();
-            }
-            switch (status)
-            {
-            case adios2::StepStatus::OK:
-                throw error::Internal("Control flow error.");
-            case adios2::StepStatus::NotReady:
-            case adios2::StepStatus::OtherError:
-                throw error::ReadError(
-                    error::AffectedObject::File,
-                    error::Reason::CannotRead,
-                    "ADIOS2",
-                    "Unexpected step status while preparsing snapshots.");
-            case adios2::StepStatus::EndOfStream:
-                break;
-            }
-            put_result_here = std::move(res);
         }
 
         static constexpr char const *errorMsg = "ReadAttributeAllsteps";
     };
-
-#if openPMD_HAVE_MPI
-    struct DistributeToAllRanks
-    {
-        template <typename T>
-        static void call(
-            Parameter<Operation::READ_ATT_ALLSTEPS>::result_type
-                &put_result_here_in,
-            MPI_Comm comm,
-            int rank)
-        {
-            if (rank != 0)
-            {
-                put_result_here_in = std::vector<T>{};
-            }
-            std::vector<T> &put_result_here =
-                std::get<std::vector<T>>(put_result_here_in);
-            size_t num_items = put_result_here.size();
-            MPI_CHECK(MPI_Bcast(
-                &num_items, 1, auxiliary::openPMD_MPI_type<size_t>(), 0, comm));
-            if constexpr (
-                std::is_same_v<T, std::string> ||
-                std::is_same_v<T, std::vector<std::string>> ||
-                std::is_same_v<T, bool> ||
-                std::is_same_v<T, std::vector<bool>> ||
-                auxiliary::IsArray_v<T> || isComplexFloatingPoint<T>())
-            {
-                throw error::OperationUnsupportedInBackend(
-                    "ADIOS2",
-                    "[readAttributeAllsteps] No support for attributes of type "
-                    "std::string, bool, std::complex or std::array in "
-                    "parallel.");
-            }
-            else if constexpr (
-                // auxiliary::IsArray_v<T> ||
-                auxiliary::IsVector_v<T>)
-            {
-                std::vector<size_t> sizes;
-                sizes.reserve(num_items);
-                if (rank == 0)
-                {
-                    std::transform(
-                        put_result_here.begin(),
-                        put_result_here.end(),
-                        std::back_inserter(sizes),
-                        [](T const &arr) { return arr.size(); });
-                }
-                sizes.resize(num_items);
-                MPI_CHECK(MPI_Bcast(
-                    sizes.data(),
-                    num_items,
-                    auxiliary::openPMD_MPI_type<size_t>(),
-                    0,
-                    comm));
-                size_t total_flat_size =
-                    std::accumulate(sizes.begin(), sizes.end(), size_t(0));
-                using flat_type = typename T::value_type;
-                std::vector<flat_type> flat_vector;
-                flat_vector.reserve(total_flat_size);
-                if (rank == 0)
-                {
-                    for (auto const &arr : put_result_here)
-                    {
-                        for (auto val : arr)
-                        {
-                            flat_vector.push_back(val);
-                        }
-                    }
-                }
-                flat_vector.resize(total_flat_size);
-                MPI_CHECK(MPI_Bcast(
-                    flat_vector.data(),
-                    total_flat_size,
-                    auxiliary::openPMD_MPI_type<flat_type>(),
-                    0,
-                    comm));
-                if (rank != 0)
-                {
-                    size_t offset = 0;
-                    put_result_here.reserve(num_items);
-                    for (size_t current_extent : sizes)
-                    {
-                        put_result_here.emplace_back(
-                            flat_vector.begin() + offset,
-                            flat_vector.begin() + offset + current_extent);
-                        offset += current_extent;
-                    }
-                }
-            }
-            else
-            {
-                std::vector<T> receive;
-                if (rank != 0)
-                {
-                    receive.resize(num_items);
-                }
-                MPI_CHECK(MPI_Bcast(
-                    rank == 0 ? put_result_here.data() : receive.data(),
-                    num_items,
-                    auxiliary::openPMD_MPI_type<T>(),
-                    0,
-                    comm));
-                if (rank != 0)
-                {
-                    put_result_here = std::move(receive);
-                }
-            }
-        }
-        static constexpr char const *errorMsg = "DistributeToAllRanks";
-    };
-
-    void warn_ignored_modifiable_attributes(adios2::IO &IO)
-    {
-        auto modifiable_flag = IO.InquireAttribute<detail::bool_representation>(
-            adios_defaults::str_useModifiableAttributes);
-        auto print_warning = [](std::string const &note) {
-            std::cerr << "Warning: " << note << R"(
-Random-access for variable-encoding in ADIOS2 is currently
-experimental. Support for modifiable attributes is currently not implemented
-yet, meaning that attributes such as /data/time will show useless values.
-Use Access::READ_LINEAR to retrieve those values if needed.
-)";
-        };
-        if (!modifiable_flag)
-        {
-            print_warning("File might be using modifiable attributes.");
-        }
-        else if (modifiable_flag.Data().at(0) != 0)
-        {
-            print_warning("File uses modifiable attributes.");
-        }
-    }
-#endif // openPMD_HAVE_MPI
-#endif // openPMD_PREPARSE_EVERYTHING
 } // namespace
 
 void ADIOS2IOHandlerImpl::readAttributeAllsteps(
@@ -1628,7 +1419,6 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     auto name = nameOfAttribute(writable, param.name);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
 
-#if openPMD_PREPARSE_EVERYTHING
     auto type = detail::attributeInfo(ba.m_IO, name, /* verbose = */ true);
 #if openPMD_HAVE_MPI
     auto adios = [&]() {
@@ -1667,46 +1457,8 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     }
     engine.Close();
     auto &attributes = ba.attributes();
-    switchType<ReadAttributeAllstepsFullPreparsing>(
-        type, preload, IO, name, *param.resource);
+    switchType<ReadAttributeAllsteps>(type, preload, IO, name, *param.resource);
     attributes.m_data = std::move(preload);
-#else
-    auto read_from_file_in_serial = [&]() {
-        adios2::ADIOS adios;
-        auto IO = adios.DeclareIO("PreparseSnapshots");
-        IO.SetEngine(ba.m_IO.EngineType());
-        IO.SetParameters(ba.m_IO.Parameters());
-        IO.SetParameter("StreamReader", "ON"); // this be for BP4
-        auto engine = IO.Open(fullPath(*file), adios2::Mode::Read);
-        auto status = engine.BeginStep();
-        warn_ignored_modifiable_attributes(IO);
-        auto type = detail::attributeInfo(IO, name, /* verbose = */ true);
-        switchType<ReadAttributeAllsteps>(
-            type, IO, engine, name, status, *param.resource);
-        engine.Close();
-        return type;
-    };
-#if openPMD_HAVE_MPI
-    if (!m_communicator.has_value())
-    {
-        read_from_file_in_serial();
-        return;
-    }
-    int rank, size;
-    MPI_Comm_rank(*m_communicator, &rank);
-    MPI_Comm_size(*m_communicator, &size);
-    Datatype type;
-    if (rank == 0)
-    {
-        type = read_from_file_in_serial();
-    }
-    MPI_CHECK(MPI_Bcast(&type, 1, MPI_INT, 0, *m_communicator));
-    switchType<DistributeToAllRanks>(
-        type, *param.resource, *m_communicator, rank);
-#else
-    read_from_file_in_serial();
-#endif
-#endif
 }
 
 void ADIOS2IOHandlerImpl::listPaths(

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -2148,7 +2148,6 @@ namespace detail
 
         auto &filedata = impl->getFileData(
             file, ADIOS2IOHandlerImpl::IfFileNotOpen::ThrowError);
-        filedata.invalidateAttributesMap();
         adios2::IO IO = filedata.m_IO;
         impl->m_dirty.emplace(std::move(file));
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1625,6 +1625,7 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
 
 #if OPENPMD_PREPARSE_EVERYTHING
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
+    auto type = detail::attributeInfo(ba.m_IO, name, /* verbose = */ true);
 #if openPMD_HAVE_MPI
     auto adios = [&]() {
         if (m_communicator.has_value())
@@ -1662,11 +1663,7 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     engine.Close();
     auto &attributes = ba.attributes();
     switchType<ReadAttributeAllstepsFullPreparsing>(
-        preload.at(0).attributeType(param.name),
-        preload,
-        IO,
-        param.name,
-        *param.resource);
+        type, preload, IO, name, *param.resource);
     attributes.m_data = std::move(preload);
 #else
     auto read_from_file_in_serial = [&]() {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1624,9 +1624,9 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto pos = setAndGetFilePosition(writable);
     auto name = nameOfAttribute(writable, param.name);
+    detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
 
 #if OPENPMD_PREPARSE_EVERYTHING
-    detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
     auto type = detail::attributeInfo(ba.m_IO, name, /* verbose = */ true);
 #if openPMD_HAVE_MPI
     auto adios = [&]() {
@@ -1643,10 +1643,11 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     adios2::ADIOS adios;
 #endif
     auto IO = adios.DeclareIO("PreparseSnapshots");
-    // @todo check engine type
-    IO.SetEngine(realEngineType());
+    IO.SetEngine(ba.m_IO.EngineType());
+    IO.SetParameters(ba.m_IO.Parameters());
     IO.SetParameter("StreamReader", "ON"); // this be for BP4
     auto engine = IO.Open(fullPath(*file), adios2::Mode::Read);
+
     std::vector<detail::PreloadAdiosAttributes> preload;
     preload.reserve(engine.Steps());
     adios2::StepStatus status;
@@ -1671,8 +1672,8 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     auto read_from_file_in_serial = [&]() {
         adios2::ADIOS adios;
         auto IO = adios.DeclareIO("PreparseSnapshots");
-        // @todo check engine type
-        IO.SetEngine(realEngineType());
+        IO.SetEngine(ba.m_IO.EngineType());
+        IO.SetParameters(ba.m_IO.Parameters());
         IO.SetParameter("StreamReader", "ON"); // this be for BP4
         auto engine = IO.Open(fullPath(*file), adios2::Mode::Read);
         auto status = engine.BeginStep();

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1252,6 +1252,9 @@ namespace
     /* Used by both readAttribute() and readAttributeAllsteps() tasks.
        Functor fun will be called with the value of the retrieved attribute;
        both functions use different logic for processing the retrieved values.
+       Functor getAttribute is called for retrieving an attribute (Different
+       wrappers around IO::InquireAttribute<>()::Data(), together with
+       buffering).
      */
     template <typename T, typename Functor, typename GetAttribute>
     Datatype genericReadAttribute(
@@ -1364,6 +1367,7 @@ namespace
         struct GetAttribute
         {
             detail::PreloadAdiosAttributes const &p;
+
             template <typename AdiosType>
             [[nodiscard]] auto call(std::string const &name) const
                 -> detail::AttributeWithShapeAndResource<AdiosType>
@@ -1533,9 +1537,15 @@ void ADIOS2IOHandlerImpl::listPaths(
             auto tablePrefix = adios_defaults::str_activeTablePrefix + myName;
             std::vector attrs =
                 fileData.availableAttributesPrefixed(tablePrefix);
-            if (fileData.streamStatus ==
+            if (
+                // either a step is currently active...
+                fileData.streamStatus ==
                     detail::ADIOS2File::StreamStatus::DuringStep ||
+                // ...or a step selection is currently active
                 (fileData.stepSelection().has_value() &&
+                 // This check is currently redundant, but may be relevant if we
+                 // (re-)introduce a RandomAccessMode lite that does no
+                 // preparsing of attributes.
                  std::holds_alternative<
                      detail::AdiosAttributes::RandomAccess_t>(
                      fileData.attributes().m_data)))

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Franz Poeschel
+/* Copyright 2020-2025 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *
@@ -20,7 +20,6 @@
  */
 
 #include "openPMD/config.hpp"
-#include <algorithm>
 #if openPMD_HAVE_ADIOS2
 
 #include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
@@ -28,8 +27,10 @@
 #include "openPMD/Datatype.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
+#include <optional>
 
 namespace openPMD::detail
 {
@@ -176,7 +177,7 @@ PreloadAdiosAttributes::AttributeLocation::~AttributeLocation()
 void PreloadAdiosAttributes::preloadAttributes(adios2::IO &IO)
 {
     m_offsets.clear();
-    std::map<Datatype, std::vector<std::string> > attributesByType;
+    std::map<Datatype, std::vector<std::string>> attributesByType;
     auto addAttribute = [&attributesByType](Datatype dt, std::string name) {
         constexpr size_t reserve = 10;
         auto it = attributesByType.find(dt);
@@ -271,6 +272,12 @@ Datatype PreloadAdiosAttributes::attributeType(std::string const &name) const
     return it->second.dt;
 }
 
+std::map<std::string, AttributeLocation> const &
+PreloadAdiosAttributes::availableAttributes() const
+{
+    return m_offsets;
+}
+
 template <typename T>
 auto AdiosAttributes::getAttribute(
     size_t step, adios2::IO &IO, std::string const &name) const
@@ -291,12 +298,54 @@ auto AdiosAttributes::getAttribute(
         m_data);
 }
 
+template <typename T>
+AttributeWithShapeAndResource<T>::AttributeWithShapeAndResource(
+    AttributeWithShape<T> parent)
+    : AttributeWithShape<T>(std::move(parent))
+{}
+template <typename T>
+AttributeWithShapeAndResource<T>::AttributeWithShapeAndResource(
+    size_t len_in, T const *data_in, std::optional<std::vector<T>> resource_in)
+    : AttributeWithShape<T>{len_in, data_in}, resource{std::move(resource_in)}
+{}
+template <typename T>
+AttributeWithShapeAndResource<T>::AttributeWithShapeAndResource(
+    adios2::Attribute<T> attr)
+{
+    if (!attr)
+    {
+        this->data = nullptr;
+        this->len = 0;
+        return;
+    }
+    auto vec = attr.Data();
+    this->len = vec.size();
+    this->data = vec.data();
+    this->resource = std::move(vec);
+}
+template <typename T>
+AttributeWithShapeAndResource<T>::operator bool() const
+{
+    return this->data;
+}
+
 #define OPENPMD_INSTANTIATE_GETATTRIBUTE(type)                                 \
     template AttributeWithShape<type> PreloadAdiosAttributes::getAttribute(    \
         std::string const &name) const;                                        \
     template auto AdiosAttributes::getAttribute(                               \
         size_t step, adios2::IO &IO, std::string const &name) const            \
-        -> AttributeWithShapeAndResource<type>;
+        -> AttributeWithShapeAndResource<type>;                                \
+    template AttributeWithShapeAndResource<                                    \
+        type>::AttributeWithShapeAndResource(AttributeWithShape<type> parent); \
+    template AttributeWithShapeAndResource<type>::                             \
+        AttributeWithShapeAndResource(                                         \
+            size_t len_in,                                                     \
+            type const                                                         \
+                *data_in, /* NOLINTNEXTLINE(bugprone-macro-parentheses)  */    \
+            std::optional<std::vector<type>> resource_in);                     \
+    template AttributeWithShapeAndResource<                                    \
+        type>::AttributeWithShapeAndResource(adios2::Attribute<type> attr);    \
+    template AttributeWithShapeAndResource<type>::operator bool() const;
 ADIOS2_FOREACH_TYPE_1ARG(OPENPMD_INSTANTIATE_GETATTRIBUTE)
 #undef OPENPMD_INSTANTIATE_GETATTRIBUTE
 } // namespace openPMD::detail

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -144,13 +144,14 @@ AttributeLocation::AttributeLocation(
     : len(len_in), offset(offset_in), dt(dt_in)
 {}
 
-AttributeLocation::AttributeLocation(AttributeLocation &&other)
+AttributeLocation::AttributeLocation(AttributeLocation &&other) noexcept
     : len{other.len}, offset{other.offset}, dt{other.dt}, destroy{other.destroy}
 {
     other.destroy = nullptr;
 }
 
-AttributeLocation &AttributeLocation::operator=(AttributeLocation &&other)
+AttributeLocation &
+AttributeLocation::operator=(AttributeLocation &&other) noexcept
 {
     this->len = other.len;
     this->offset = other.offset;

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -260,12 +260,6 @@ PreloadAdiosAttributes::getAttribute(std::string const &name) const
     return res;
 }
 
-#define OPENPMD_INSTANTIATE_GETATTRIBUTE(type)                                 \
-    template AttributeWithShape<type> PreloadAdiosAttributes::getAttribute(    \
-        std::string const &name) const;
-ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(OPENPMD_INSTANTIATE_GETATTRIBUTE)
-#undef OPENPMD_INSTANTIATE_GETATTRIBUTE
-
 Datatype PreloadAdiosAttributes::attributeType(std::string const &name) const
 {
     auto it = m_offsets.find(name);
@@ -275,6 +269,35 @@ Datatype PreloadAdiosAttributes::attributeType(std::string const &name) const
     }
     return it->second.dt;
 }
+
+template <typename T>
+auto AdiosAttributes::getAttribute(
+    size_t step, adios2::IO &IO, std::string const &name) const
+    -> AttributeWithShapeAndResource<T>
+{
+    return std::visit(
+        auxiliary::overloaded{
+            [step, &name](
+                RandomAccess_t const &ra) -> AttributeWithShapeAndResource<T> {
+                auto &attribute_data = ra.at(step);
+                return attribute_data.getAttribute<T>(name);
+            },
+            [&name,
+             &IO](StreamAccess_t const &) -> AttributeWithShapeAndResource<T> {
+                auto attr = IO.InquireAttribute<T>(name);
+                return {std::move(attr)};
+            }},
+        m_data);
+}
+
+#define OPENPMD_INSTANTIATE_GETATTRIBUTE(type)                                 \
+    template AttributeWithShape<type> PreloadAdiosAttributes::getAttribute(    \
+        std::string const &name) const;                                        \
+    template auto AdiosAttributes::getAttribute(                               \
+        size_t step, adios2::IO &IO, std::string const &name) const            \
+        -> AttributeWithShapeAndResource<type>;
+ADIOS2_FOREACH_TYPE_1ARG(OPENPMD_INSTANTIATE_GETATTRIBUTE)
+#undef OPENPMD_INSTANTIATE_GETATTRIBUTE
 } // namespace openPMD::detail
 
 #endif // openPMD_HAVE_ADIOS2

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -1,0 +1,314 @@
+/* Copyright 2020-2021 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openPMD/config.hpp"
+#if openPMD_HAVE_ADIOS2
+
+#include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
+
+#include "openPMD/Datatype.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
+#include "openPMD/auxiliary/StringManip.hpp"
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <numeric>
+#include <type_traits>
+
+namespace openPMD::detail
+{
+namespace
+{
+    struct GetAlignment
+    {
+        template <typename T>
+        static constexpr size_t call()
+        {
+            return alignof(T);
+        }
+
+        template <unsigned long, typename... Args>
+        static constexpr size_t call(Args &&...)
+        {
+            return alignof(std::max_align_t);
+        }
+    };
+
+    struct GetSize
+    {
+        template <typename T>
+        static constexpr size_t call()
+        {
+            return sizeof(T);
+        }
+
+        template <unsigned long, typename... Args>
+        static constexpr size_t call(Args &&...)
+        {
+            return 0;
+        }
+    };
+
+    struct ScheduleLoad
+    {
+        template <typename T>
+        static void call(
+            adios2::IO &IO,
+            adios2::Engine &engine,
+            std::string const &name,
+            char *buffer,
+            PreloadAdiosAttributes::AttributeLocation &location)
+        {
+            adios2::Variable<T> var = IO.InquireVariable<T>(name);
+            if (!var)
+            {
+                throw std::runtime_error(
+                    "[ADIOS2] Variable not found: " + name);
+            }
+            adios2::Dims const &shape = location.shape;
+            adios2::Dims offset(shape.size(), 0);
+            if (shape.size() > 0)
+            {
+                var.SetSelection({offset, shape});
+            }
+            T *dest = reinterpret_cast<T *>(buffer);
+            size_t numItems = 1;
+            for (auto extent : shape)
+            {
+                numItems *= extent;
+            }
+            /*
+             * MSVC does not like placement new of arrays, so we do it
+             * in a loop instead.
+             * https://developercommunity.visualstudio.com/t/c-placement-new-is-incorrectly-compiled/206439
+             */
+            for (size_t i = 0; i < numItems; ++i)
+            {
+                new (dest + i) T();
+            }
+            location.destroy = buffer;
+            engine.Get(var, dest, adios2::Mode::Deferred);
+        }
+
+        static constexpr char const *errorMsg = "ADIOS2";
+    };
+
+    struct VariableShape
+    {
+        template <typename T>
+        static adios2::Dims call(adios2::IO &IO, std::string const &name)
+        {
+            auto var = IO.InquireVariable<T>(name);
+            if (!var)
+            {
+                throw std::runtime_error(
+                    "[ADIOS2] Variable not found: " + name);
+            }
+            return var.Shape();
+        }
+
+        template <unsigned long n, typename... Args>
+        static adios2::Dims call(Args &&...)
+        {
+            return {};
+        }
+    };
+
+    struct AttributeLocationDestroy
+    {
+        template <typename T>
+        static void call(char *ptr, size_t numItems)
+        {
+            T *destroy = reinterpret_cast<T *>(ptr);
+            for (size_t i = 0; i < numItems; ++i)
+            {
+                destroy[i].~T();
+            }
+        }
+
+        template <unsigned long n, typename... Args>
+        static void call(Args &&...)
+        {}
+    };
+} // namespace
+
+using AttributeLocation = PreloadAdiosAttributes::AttributeLocation;
+
+AttributeLocation::AttributeLocation(
+    adios2::Dims shape_in, size_t offset_in, Datatype dt_in)
+    : shape(std::move(shape_in)), offset(offset_in), dt(dt_in)
+{}
+
+AttributeLocation::AttributeLocation(AttributeLocation &&other)
+    : shape{std::move(other.shape)}
+    , offset{std::move(other.offset)}
+    , dt{std::move(other.dt)}
+    , destroy{std::move(other.destroy)}
+{
+    other.destroy = nullptr;
+}
+
+AttributeLocation &AttributeLocation::operator=(AttributeLocation &&other)
+{
+    this->shape = std::move(other.shape);
+    this->offset = std::move(other.offset);
+    this->dt = std::move(other.dt);
+    this->destroy = std::move(other.destroy);
+    other.destroy = nullptr;
+    return *this;
+}
+
+PreloadAdiosAttributes::AttributeLocation::~AttributeLocation()
+{
+    /*
+     * If the object has been moved from, this may be empty.
+     * Or else, if no custom destructor has been emplaced.
+     */
+    if (destroy)
+    {
+        size_t length = 1;
+        for (auto ext : shape)
+        {
+            length *= ext;
+        }
+        switchAdios2AttributeType<AttributeLocationDestroy>(
+            dt, destroy, length);
+    }
+}
+
+void PreloadAdiosAttributes::preloadAttributes(
+    adios2::IO &IO, adios2::Engine &engine)
+{
+    m_offsets.clear();
+    std::map<Datatype, std::vector<std::string> > attributesByType;
+    auto addAttribute = [&attributesByType](Datatype dt, std::string name) {
+        constexpr size_t reserve = 10;
+        auto it = attributesByType.find(dt);
+        if (it == attributesByType.end())
+        {
+            it = attributesByType.emplace_hint(
+                it, dt, std::vector<std::string>());
+            it->second.reserve(reserve);
+        }
+        it->second.push_back(std::move(name));
+    };
+    // PHASE 1: collect names of available attributes by ADIOS datatype
+    for (auto &variable : IO.AvailableVariables())
+    {
+        if (auxiliary::ends_with(variable.first, "/__data__"))
+        {
+            continue;
+        }
+        // this will give us basic types only, no fancy vectors or similar
+        Datatype dt = fromADIOS2Type(IO.VariableType(variable.first));
+        addAttribute(dt, std::move(variable.first));
+    }
+
+    // PHASE 2: get offsets for attributes in buffer
+    std::map<Datatype, size_t> offsets;
+    size_t currentOffset = 0;
+    for (auto &pair : attributesByType)
+    {
+        size_t alignment = switchAdios2AttributeType<GetAlignment>(pair.first);
+        size_t size = switchAdios2AttributeType<GetSize>(pair.first);
+        // go to next offset with valid alignment
+        size_t modulus = currentOffset % alignment;
+        if (modulus > 0)
+        {
+            currentOffset += alignment - modulus;
+        }
+        for (std::string &name : pair.second)
+        {
+            adios2::Dims shape =
+                switchAdios2AttributeType<VariableShape>(pair.first, IO, name);
+            size_t elements = 1;
+            for (auto extent : shape)
+            {
+                elements *= extent;
+            }
+            m_offsets.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(std::move(name)),
+                std::forward_as_tuple(
+                    std::move(shape), currentOffset, pair.first));
+            currentOffset += elements * size;
+        }
+    }
+    // now, currentOffset is the number of bytes that we need to allocate
+    // PHASE 3: allocate new buffer and schedule loads
+    m_rawBuffer.resize(currentOffset);
+    for (auto &pair : m_offsets)
+    {
+        switchAdios2AttributeType<ScheduleLoad>(
+            pair.second.dt,
+            IO,
+            engine,
+            pair.first,
+            &m_rawBuffer[pair.second.offset],
+            pair.second);
+    }
+}
+
+template <typename T>
+AttributeWithShape<T>
+PreloadAdiosAttributes::getAttribute(std::string const &name) const
+{
+    auto it = m_offsets.find(name);
+    if (it == m_offsets.end())
+    {
+        throw std::runtime_error(
+            "[ADIOS2] Requested attribute not found: " + name);
+    }
+    AttributeLocation const &location = it->second;
+    Datatype determinedDatatype = determineDatatype<T>();
+    if (location.dt != determinedDatatype)
+    {
+        std::stringstream errorMsg;
+        errorMsg << "[ADIOS2] Wrong datatype for attribute: " << name
+                 << "(location.dt=" << location.dt
+                 << ", T=" << determineDatatype<T>() << ")";
+        throw std::runtime_error(errorMsg.str());
+    }
+    AttributeWithShape<T> res;
+    res.shape = location.shape;
+    res.data = reinterpret_cast<T const *>(&m_rawBuffer[location.offset]);
+    return res;
+}
+
+#define OPENPMD_INSTANTIATE_GETATTRIBUTE(type)                                 \
+    template AttributeWithShape<type> PreloadAdiosAttributes::getAttribute(    \
+        std::string const &name) const;
+ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(OPENPMD_INSTANTIATE_GETATTRIBUTE)
+#undef OPENPMD_INSTANTIATE_GETATTRIBUTE
+
+Datatype PreloadAdiosAttributes::attributeType(std::string const &name) const
+{
+    auto it = m_offsets.find(name);
+    if (it == m_offsets.end())
+    {
+        return Datatype::UNDEFINED;
+    }
+    return it->second.dt;
+}
+} // namespace openPMD::detail
+
+#endif // openPMD_HAVE_ADIOS2

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "openPMD/config.hpp"
+#include <algorithm>
 #if openPMD_HAVE_ADIOS2
 
 #include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
@@ -73,61 +74,50 @@ namespace
         template <typename T>
         static void call(
             adios2::IO &IO,
-            adios2::Engine &engine,
             std::string const &name,
             char *buffer,
             PreloadAdiosAttributes::AttributeLocation &location)
         {
-            adios2::Variable<T> var = IO.InquireVariable<T>(name);
-            if (!var)
+            adios2::Attribute<T> attr = IO.InquireAttribute<T>(name);
+            if (!attr)
             {
                 throw std::runtime_error(
                     "[ADIOS2] Variable not found: " + name);
-            }
-            adios2::Dims const &shape = location.shape;
-            adios2::Dims offset(shape.size(), 0);
-            if (shape.size() > 0)
-            {
-                var.SetSelection({offset, shape});
-            }
-            T *dest = reinterpret_cast<T *>(buffer);
-            size_t numItems = 1;
-            for (auto extent : shape)
-            {
-                numItems *= extent;
             }
             /*
              * MSVC does not like placement new of arrays, so we do it
              * in a loop instead.
              * https://developercommunity.visualstudio.com/t/c-placement-new-is-incorrectly-compiled/206439
              */
-            for (size_t i = 0; i < numItems; ++i)
+            T *dest = reinterpret_cast<T *>(buffer);
+            for (size_t i = 0; i < location.len; ++i)
             {
                 new (dest + i) T();
             }
             location.destroy = buffer;
-            engine.Get(var, dest, adios2::Mode::Deferred);
+            auto data = attr.Data();
+            std::copy_n(data.begin(), data.size(), dest);
         }
 
         static constexpr char const *errorMsg = "ADIOS2";
     };
 
-    struct VariableShape
+    struct AttributeLen
     {
         template <typename T>
-        static adios2::Dims call(adios2::IO &IO, std::string const &name)
+        static size_t call(adios2::IO &IO, std::string const &name)
         {
-            auto var = IO.InquireVariable<T>(name);
-            if (!var)
+            auto attr = IO.InquireAttribute<T>(name);
+            if (!attr)
             {
                 throw std::runtime_error(
                     "[ADIOS2] Variable not found: " + name);
             }
-            return var.Shape();
+            return attr.Data().size();
         }
 
         template <unsigned long n, typename... Args>
-        static adios2::Dims call(Args &&...)
+        static size_t call(Args &&...)
         {
             return {};
         }
@@ -154,25 +144,22 @@ namespace
 using AttributeLocation = PreloadAdiosAttributes::AttributeLocation;
 
 AttributeLocation::AttributeLocation(
-    adios2::Dims shape_in, size_t offset_in, Datatype dt_in)
-    : shape(std::move(shape_in)), offset(offset_in), dt(dt_in)
+    size_t len_in, size_t offset_in, Datatype dt_in)
+    : len(len_in), offset(offset_in), dt(dt_in)
 {}
 
 AttributeLocation::AttributeLocation(AttributeLocation &&other)
-    : shape{std::move(other.shape)}
-    , offset{std::move(other.offset)}
-    , dt{std::move(other.dt)}
-    , destroy{std::move(other.destroy)}
+    : len{other.len}, offset{other.offset}, dt{other.dt}, destroy{other.destroy}
 {
     other.destroy = nullptr;
 }
 
 AttributeLocation &AttributeLocation::operator=(AttributeLocation &&other)
 {
-    this->shape = std::move(other.shape);
-    this->offset = std::move(other.offset);
-    this->dt = std::move(other.dt);
-    this->destroy = std::move(other.destroy);
+    this->len = other.len;
+    this->offset = other.offset;
+    this->dt = other.dt;
+    this->destroy = other.destroy;
     other.destroy = nullptr;
     return *this;
 }
@@ -185,18 +172,11 @@ PreloadAdiosAttributes::AttributeLocation::~AttributeLocation()
      */
     if (destroy)
     {
-        size_t length = 1;
-        for (auto ext : shape)
-        {
-            length *= ext;
-        }
-        switchAdios2AttributeType<AttributeLocationDestroy>(
-            dt, destroy, length);
+        switchAdios2AttributeType<AttributeLocationDestroy>(dt, destroy, len);
     }
 }
 
-void PreloadAdiosAttributes::preloadAttributes(
-    adios2::IO &IO, adios2::Engine &engine)
+void PreloadAdiosAttributes::preloadAttributes(adios2::IO &IO)
 {
     m_offsets.clear();
     std::map<Datatype, std::vector<std::string> > attributesByType;
@@ -212,15 +192,11 @@ void PreloadAdiosAttributes::preloadAttributes(
         it->second.push_back(std::move(name));
     };
     // PHASE 1: collect names of available attributes by ADIOS datatype
-    for (auto &variable : IO.AvailableVariables())
+    for (auto &attribute : IO.AvailableAttributes())
     {
-        if (auxiliary::ends_with(variable.first, "/__data__"))
-        {
-            continue;
-        }
         // this will give us basic types only, no fancy vectors or similar
-        Datatype dt = fromADIOS2Type(IO.VariableType(variable.first));
-        addAttribute(dt, std::move(variable.first));
+        Datatype dt = fromADIOS2Type(IO.AttributeType(attribute.first));
+        addAttribute(dt, attribute.first);
     }
 
     // PHASE 2: get offsets for attributes in buffer
@@ -238,18 +214,13 @@ void PreloadAdiosAttributes::preloadAttributes(
         }
         for (std::string &name : pair.second)
         {
-            adios2::Dims shape =
-                switchAdios2AttributeType<VariableShape>(pair.first, IO, name);
-            size_t elements = 1;
-            for (auto extent : shape)
-            {
-                elements *= extent;
-            }
+            size_t elements =
+                switchAdios2AttributeType<AttributeLen>(pair.first, IO, name);
+
             m_offsets.emplace(
                 std::piecewise_construct,
                 std::forward_as_tuple(std::move(name)),
-                std::forward_as_tuple(
-                    std::move(shape), currentOffset, pair.first));
+                std::forward_as_tuple(elements, currentOffset, pair.first));
             currentOffset += elements * size;
         }
     }
@@ -261,7 +232,6 @@ void PreloadAdiosAttributes::preloadAttributes(
         switchAdios2AttributeType<ScheduleLoad>(
             pair.second.dt,
             IO,
-            engine,
             pair.first,
             &m_rawBuffer[pair.second.offset],
             pair.second);
@@ -289,7 +259,7 @@ PreloadAdiosAttributes::getAttribute(std::string const &name) const
         throw std::runtime_error(errorMsg.str());
     }
     AttributeWithShape<T> res;
-    res.shape = location.shape;
+    res.len = location.len;
     res.data = reinterpret_cast<T const *>(&m_rawBuffer[location.offset]);
     return res;
 }

--- a/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadAttributes.cpp
@@ -27,13 +27,9 @@
 
 #include "openPMD/Datatype.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
-#include "openPMD/auxiliary/StringManip.hpp"
 
 #include <cstddef>
 #include <cstdlib>
-#include <iostream>
-#include <numeric>
-#include <type_traits>
 
 namespace openPMD::detail
 {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5971,13 +5971,12 @@ void variableBasedSeries(std::string const &file)
 
             last_iteration_index = iteration.iterationIndex;
 
-            if (access == Access::READ_RANDOM_ACCESS)
-            {
-                continue;
-            }
-
             // this loop ensures that only the recordcomponent ["E"]["i"] is
             // present where i == iteration.iterationIndex
+            // Note that this works for ReadRandomAccess as well since constant
+            // components contain no datasets. The ADIOS2 backend is however not
+            // (yet) able to deal with array datasets that are present only in a
+            // subselection of steps.
             for (uint64_t otherIteration = 0; otherIteration < 10;
                  ++otherIteration)
             {

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -5950,11 +5950,8 @@ void variableBasedSeries(std::string const &file)
             {
                 REQUIRE(
                     iteration.getAttribute("changing_value").get<unsigned>() ==
-                    (supportsModifiableAttributes
-                         ? (access == Access::READ_LINEAR
-                                ? iteration.iterationIndex
-                                : 9)
-                         : 0));
+                    (supportsModifiableAttributes ? iteration.iterationIndex
+                                                  : 0));
             }
             auto E_x = iteration.meshes["E"]["x"];
             REQUIRE(E_x.getDimensionality() == 1);


### PR DESCRIPTION
This tries removing the major of two WIP restrictions for random-access reading of variable-encoded Series by preparsing.

TODO

- [x] Docs
- [x] Testing
- [x] Forward engine parameters to the preparsing engine as well

Discussion: The ADIOS2 backend now contains two implementations for preparsing:

* *The old implementation:* Only `/data/snapshot` is preparsed, metadata is otherwise considered to be fully static. Advantage: The file needs to be opened in `adios2::Mode::Read` for preparsing only on a single rank, only the collected values for `/data/snapshot` are distributed in a single MPI operation at the end.
* *The new implementation:* Full support for reading modifiable attributes. Shows the correct values for attributes such as `/data/time` and has (restricted) support for groups that are present only in some steps (as long as they only consist of attributes and not arrays, i.e. as long as they are constant components). Disadvantage: Requires collectively reading the entire dataset and keeping the preparsed attributes for all steps in memory.

Hence:

- [x] Should we keep the old implementation around for its performance benefits when the capabilities of the new implementation are not needed? – No, the old implementation is removed.