### PR TITLE
working around an unusual encounter when the joined_dim has actual value "max::size_t - 1"

### DIFF
--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -86,5 +86,6 @@ public:
     bool empty() const;
 
     std::optional<size_t> joinedDimension() const;
+    static std::optional<size_t> joinedDimension(Extent const &);
 };
 } // namespace openPMD

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -509,32 +509,34 @@ private:
         }
         else
         {
-           if (var.ShapeID() ==  adios2::ShapeID::JoinedArray)
-           {
-               // When you reach here due to a mysterious inconsistency observed from time to time
-               // e.g. adios2::JoinedDim=(~(size_t)0) which for 64 bits = 18446744073709551615
-               // but the particle shape,  when printed out,  turns out to be
-               // [18446744073709551614]
-               //
-               if (!offset.empty())
-               {
-                 throw std::runtime_error(
-                     "[ADIOS2] Offset must be an empty vector in case of joined "
-                     "array.");
-               }
-           }
-           else
-           {
-            for (unsigned int i = 0; i < actualDim; i++)
+            if (var.ShapeID() == adios2::ShapeID::JoinedArray)
             {
-                if (!(joinedDim.has_value() && *joinedDim == i) &&
-                    offset[i] + extent[i] > shape[i])
+                // When you reach here due to a mysterious inconsistency
+                // observed from time to time e.g.
+                // adios2::JoinedDim=(~(size_t)0) which for 64 bits =
+                // 18446744073709551615 but the particle shape,  when printed
+                // out,  turns out to be [18446744073709551614]
+                //
+                if (!offset.empty())
                 {
                     throw std::runtime_error(
-                        "[ADIOS2] Dataset access out of bounds.");
+                        "[ADIOS2] Offset must be an empty vector in case of "
+                        "joined "
+                        "array.");
                 }
             }
-	   }// else
+            else
+            {
+                for (unsigned int i = 0; i < actualDim; i++)
+                {
+                    if (!(joinedDim.has_value() && *joinedDim == i) &&
+                        offset[i] + extent[i] > shape[i])
+                    {
+                        throw std::runtime_error(
+                            "[ADIOS2] Dataset access out of bounds.");
+                    }
+                }
+            } // else
         }
 
         var.SetSelection(

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -542,7 +542,7 @@ private:
                     throw make_runtime_error("Dataset access out of bounds.");
                 }
             }
-        } // else
+        }
 
         var.SetSelection(
             {adios2::Dims(offset.begin(), offset.end()),

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -489,12 +489,20 @@ private:
             }
         }
         auto joinedDim = joinedDimension(shape);
-        if (joinedDim.has_value())
+        if (joinedDim.has_value() ||
+            var.ShapeID() == adios2::ShapeID::JoinedArray)
         {
             if (!offset.empty())
             {
                 throw std::runtime_error(
                     "[ADIOS2] Offset must be an empty vector in case of joined "
+                    "array.");
+            }
+            if (!joinedDim.has_value())
+            {
+                throw std::runtime_error(
+                    "[ADIOS2] Trying to access a dataset as a non-joined "
+                    "array, but it has previously been configured as a joined "
                     "array.");
             }
             for (unsigned int i = 0; i < actualDim; i++)
@@ -509,35 +517,16 @@ private:
         }
         else
         {
-            if (var.ShapeID() == adios2::ShapeID::JoinedArray)
+            for (unsigned int i = 0; i < actualDim; i++)
             {
-                // When you reach here due to a mysterious inconsistency
-                // observed from time to time e.g.
-                // adios2::JoinedDim=(~(size_t)0) which for 64 bits =
-                // 18446744073709551615 but the particle shape,  when printed
-                // out,  turns out to be [18446744073709551614]
-                //
-                if (!offset.empty())
+                if (!(joinedDim.has_value() && *joinedDim == i) &&
+                    offset[i] + extent[i] > shape[i])
                 {
                     throw std::runtime_error(
-                        "[ADIOS2] Offset must be an empty vector in case of "
-                        "joined "
-                        "array.");
+                        "[ADIOS2] Dataset access out of bounds.");
                 }
             }
-            else
-            {
-                for (unsigned int i = 0; i < actualDim; i++)
-                {
-                    if (!(joinedDim.has_value() && *joinedDim == i) &&
-                        offset[i] + extent[i] > shape[i])
-                    {
-                        throw std::runtime_error(
-                            "[ADIOS2] Dataset access out of bounds.");
-                    }
-                }
-            } // else
-        }
+        } // else
 
         var.SetSelection(
             {adios2::Dims(offset.begin(), offset.end()),

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -34,6 +34,7 @@
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/ThrowError.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
+#include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/config.hpp"
 #include <stdexcept>
@@ -489,28 +490,44 @@ private:
             }
         }
         auto joinedDim = joinedDimension(shape);
+        auto make_runtime_error = [&](char const *message) {
+            std::stringstream s;
+            s << "[ADIOS2IOHandlerImpl::verifyDataset()] " << message;
+            s << "\nNote: Variable '" << varName << "' has shape ";
+            auxiliary::write_vec_to_stream(s, shape)
+                << ", is accessed from offset ";
+            auxiliary::write_vec_to_stream(s, offset) << " with extent ";
+            auxiliary::write_vec_to_stream(s, extent);
+            if (joinedDim.has_value())
+            {
+                s << " (joined dimension on index " << *joinedDim << ").";
+            }
+            else
+            {
+                s << " (no joined dimension).";
+            }
+            return std::runtime_error(s.str());
+        };
         if (joinedDim.has_value() ||
             var.ShapeID() == adios2::ShapeID::JoinedArray)
         {
             if (!offset.empty())
             {
-                throw std::runtime_error(
-                    "[ADIOS2] Offset must be an empty vector in case of joined "
-                    "array.");
+                throw make_runtime_error(
+                    "Offset must be an empty vector in case of joined array.");
             }
             if (!joinedDim.has_value())
             {
-                throw std::runtime_error(
-                    "[ADIOS2] Trying to access a dataset as a non-joined "
-                    "array, but it has previously been configured as a joined "
-                    "array.");
+                throw make_runtime_error(
+                    "Trying to access a dataset as a non-joined array, but it "
+                    "has previously been array.");
             }
             for (unsigned int i = 0; i < actualDim; i++)
             {
                 if (*joinedDim != i && extent[i] != shape[i])
                 {
-                    throw std::runtime_error(
-                        "[ADIOS2] store_chunk extent of non-joined dimensions "
+                    throw make_runtime_error(
+                        "store_chunk extent of non-joined dimensions "
                         "must be equivalent to the total extent.");
                 }
             }
@@ -522,8 +539,7 @@ private:
                 if (!(joinedDim.has_value() && *joinedDim == i) &&
                     offset[i] + extent[i] > shape[i])
                 {
-                    throw std::runtime_error(
-                        "[ADIOS2] Dataset access out of bounds.");
+                    throw make_runtime_error("Dataset access out of bounds.");
                 }
             }
         } // else

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -509,6 +509,22 @@ private:
         }
         else
         {
+           if (var.ShapeID() ==  adios2::ShapeID::JoinedArray)
+           {
+               // When you reach here due to a mysterious inconsistency observed from time to time
+               // e.g. adios2::JoinedDim=(~(size_t)0) which for 64 bits = 18446744073709551615
+               // but the particle shape,  when printed out,  turns out to be
+               // [18446744073709551614]
+               //
+               if (!offset.empty())
+               {
+                 throw std::runtime_error(
+                     "[ADIOS2] Offset must be an empty vector in case of joined "
+                     "array.");
+               }
+           }
+           else
+           {
             for (unsigned int i = 0; i < actualDim; i++)
             {
                 if (!(joinedDim.has_value() && *joinedDim == i) &&
@@ -518,6 +534,7 @@ private:
                         "[ADIOS2] Dataset access out of bounds.");
                 }
             }
+	   }// else
         }
 
         var.SetSelection(

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -116,6 +116,13 @@ struct OPENPMDAPI_EXPORT AbstractParameter
         std::string const &currentBackendName,
         std::string const &warningMessage);
 
+    // Used as a tag in some constructors to make callsites explicitly
+    // acknowledge that joined dimensions will not be automatically resolved
+    struct I_dont_want_to_use_joined_dimensions_t
+    {};
+    constexpr static I_dont_want_to_use_joined_dimensions_t
+        I_dont_want_to_use_joined_dimensions{};
+
 protected:
     // avoid object slicing
     // by allow only child classes to use these things for defining their own
@@ -359,7 +366,17 @@ template <>
 struct OPENPMDAPI_EXPORT Parameter<Operation::CREATE_DATASET>
     : public AbstractParameter
 {
-    Parameter() = default;
+    Parameter(Dataset const &ds)
+        : extent(ds.extent)
+        , dtype(ds.dtype)
+        , options(ds.options)
+        , joinedDimension(ds.joinedDimension())
+    {}
+
+    // default constructor, but callsites need to explicitly acknowledge that
+    // joined dimensions will not be automatically configured when using it
+    Parameter(I_dont_want_to_use_joined_dimensions_t)
+    {}
     Parameter(Parameter &&) = default;
     Parameter(Parameter const &) = default;
     Parameter &operator=(Parameter &&) = default;

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -405,7 +405,15 @@ template <>
 struct OPENPMDAPI_EXPORT Parameter<Operation::EXTEND_DATASET>
     : public AbstractParameter
 {
-    Parameter() = default;
+    Parameter(Extent e) : joinedDimension(Dataset::joinedDimension(e))
+    {
+        this->extent = std::move(e);
+    }
+
+    // default constructor, but callsites need to explicitly acknowledge that
+    // joined dimensions will not be automatically configured when using it
+    Parameter(I_dont_want_to_use_joined_dimensions_t)
+    {}
     Parameter(Parameter &&) = default;
     Parameter(Parameter const &) = default;
     Parameter &operator=(Parameter &&) = default;
@@ -418,6 +426,7 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::EXTEND_DATASET>
     }
 
     Extent extent = {};
+    std::optional<size_t> joinedDimension;
 };
 
 template <>

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -356,18 +356,14 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
     if (!written())
     {
         auto &rc = get();
-        Parameter<Operation::CREATE_DATASET> dCreate;
-        dCreate.name = rc.m_name;
-        dCreate.extent = getExtent();
-        dCreate.dtype = getDatatype();
-        dCreate.joinedDimension = joinedDimension();
         if (!rc.m_dataset.has_value())
         {
             throw error::WrongAPIUsage(
                 "[RecordComponent] Must specify dataset type and extent before "
                 "using storeChunk() (see RecordComponent::resetDataset()).");
         }
-        dCreate.options = rc.m_dataset.value().options;
+        Parameter<Operation::CREATE_DATASET> dCreate(rc.m_dataset.value());
+        dCreate.name = rc.m_name;
         IOHandler()->enqueue(IOTask(this, dCreate));
     }
     Parameter<Operation::GET_BUFFER_VIEW> getBufferView;

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -242,5 +242,40 @@ namespace auxiliary
         });
         return std::forward<S>(s);
     }
+
+    template <typename Stream, typename Vec>
+    auto write_vec_to_stream(Stream &&s, Vec const &vec) -> Stream &&
+    {
+        if (vec.empty())
+        {
+            s << "[]";
+        }
+        else
+        {
+            s << '[';
+            auto it = vec.begin();
+            s << *it++;
+            auto end = vec.end();
+            for (; it != end; ++it)
+            {
+                s << ", " << *it;
+            }
+            s << ']';
+        }
+        return std::forward<Stream>(s);
+    }
+
+    template <typename Vec>
+    auto vec_as_string(Vec const &vec) -> std::string
+    {
+        if (vec.empty())
+        {
+            return "[]";
+        }
+        else
+        {
+            return write_vec_to_stream(std::stringstream(), vec).str();
+        }
+    }
 } // namespace auxiliary
 } // namespace openPMD

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -69,6 +69,11 @@ bool Dataset::empty() const
 
 std::optional<size_t> Dataset::joinedDimension() const
 {
+    return joinedDimension(extent);
+}
+
+std::optional<size_t> Dataset::joinedDimension(Extent const &extent)
+{
     std::optional<size_t> res;
     for (size_t i = 0; i < extent.size(); ++i)
     {

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -888,6 +888,57 @@ namespace detail
             {
                 dims.push_back(ext);
             }
+            auto joinedDim = joinedDimension(var.Shape());
+            auto make_runtime_error = [&](char const *message) {
+                std::stringstream s;
+                s << "[ADIOS2IOHandlerImpl::extendDataset()] " << message
+                  << "\nNote: Variable '" << variable << "' has old shape ";
+                auxiliary::write_vec_to_stream(s, var.Shape());
+                if (joinedDim.has_value())
+                {
+                    s << " (joined dimension on index " << *joinedDim << ").";
+                }
+                else
+                {
+                    s << " (no joined dimension)";
+                }
+                s << " and is extended to new shape ";
+                auxiliary::write_vec_to_stream(s, newShape) << ".";
+                return std::runtime_error(s.str());
+            };
+            if (joinedDim.has_value() ||
+                var.ShapeID() == adios2::ShapeID::JoinedArray)
+            {
+                if (!joinedDim.has_value())
+                {
+                    throw make_runtime_error(
+                        "Inconsistent state of variable: Has shape ID "
+                        "JoinedArray, but its shape contains no value "
+                        "adios2::JoinedDim.");
+                }
+                if (newShape.at(*joinedDim) != Dataset::JOINED_DIMENSION)
+                {
+                    throw make_runtime_error(
+                        "Variable was previously configured with a joined "
+                        "dimension, so the new dataset extent must keep the "
+                        "joined dimension on that index.");
+                }
+                dims[*joinedDim] = adios2::JoinedDim;
+            }
+            else
+            {
+                for (auto s : newShape)
+                {
+                    if (s == Dataset::JOINED_DIMENSION)
+                    {
+                        throw make_runtime_error(
+                            "Variable was not previously configured with a "
+                            "joined dimension, but is now requested to change "
+                            "extent to a joined array.");
+                    }
+                }
+            }
+
             var.SetShape(dims);
         }
 

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -873,7 +873,10 @@ namespace detail
     {
         template <typename T, typename... Args>
         static void call(
-            adios2::IO &IO, std::string const &variable, Extent const &newShape)
+            adios2::IO &IO,
+            std::string const &variable,
+            Extent const &newShape,
+            std::optional<size_t> const &newJoinedDim)
         {
             auto var = IO.InquireVariable<T>(variable);
             if (!var)
@@ -888,54 +891,60 @@ namespace detail
             {
                 dims.push_back(ext);
             }
-            auto joinedDim = joinedDimension(var.Shape());
+            auto oldJoinedDim = joinedDimension(var.Shape());
             auto make_runtime_error = [&](char const *message) {
                 std::stringstream s;
                 s << "[ADIOS2IOHandlerImpl::extendDataset()] " << message
                   << "\nNote: Variable '" << variable << "' has old shape ";
                 auxiliary::write_vec_to_stream(s, var.Shape());
-                if (joinedDim.has_value())
+                if (oldJoinedDim.has_value())
                 {
-                    s << " (joined dimension on index " << *joinedDim << ").";
+                    s << " (joined dimension on index " << *oldJoinedDim << ")";
                 }
                 else
                 {
                     s << " (no joined dimension)";
                 }
                 s << " and is extended to new shape ";
-                auxiliary::write_vec_to_stream(s, newShape) << ".";
+                auxiliary::write_vec_to_stream(s, newShape);
+                if (newJoinedDim.has_value())
+                {
+                    s << " (joined dimension on index " << *newJoinedDim
+                      << ").";
+                }
+                else
+                {
+                    s << " (no joined dimension).";
+                }
                 return std::runtime_error(s.str());
             };
-            if (joinedDim.has_value() ||
+            if (oldJoinedDim.has_value() ||
                 var.ShapeID() == adios2::ShapeID::JoinedArray)
             {
-                if (!joinedDim.has_value())
+                if (!oldJoinedDim.has_value())
                 {
                     throw make_runtime_error(
                         "Inconsistent state of variable: Has shape ID "
                         "JoinedArray, but its shape contains no value "
                         "adios2::JoinedDim.");
                 }
-                if (newShape.at(*joinedDim) != Dataset::JOINED_DIMENSION)
+                if (newJoinedDim != oldJoinedDim)
                 {
                     throw make_runtime_error(
                         "Variable was previously configured with a joined "
                         "dimension, so the new dataset extent must keep the "
                         "joined dimension on that index.");
                 }
-                dims[*joinedDim] = adios2::JoinedDim;
+                dims[*newJoinedDim] = adios2::JoinedDim;
             }
             else
             {
-                for (auto s : newShape)
+                if (newJoinedDim.has_value())
                 {
-                    if (s == Dataset::JOINED_DIMENSION)
-                    {
-                        throw make_runtime_error(
-                            "Variable was not previously configured with a "
-                            "joined dimension, but is now requested to change "
-                            "extent to a joined array.");
-                    }
+                    throw make_runtime_error(
+                        "Variable was not previously configured with a "
+                        "joined dimension, but is now requested to change "
+                        "extent to a joined array.");
                 }
             }
 
@@ -958,7 +967,7 @@ void ADIOS2IOHandlerImpl::extendDataset(
     auto &filedata = getFileData(file, IfFileNotOpen::ThrowError);
     Datatype dt = detail::fromADIOS2Type(filedata.m_IO.VariableType(name));
     switchAdios2VariableType<detail::DatasetExtender>(
-        dt, filedata.m_IO, name, parameters.extent);
+        dt, filedata.m_IO, name, parameters.extent, parameters.joinedDimension);
 }
 
 void ADIOS2IOHandlerImpl::openFile(

--- a/src/IO/AbstractIOHandlerImpl.cpp
+++ b/src/IO/AbstractIOHandlerImpl.cpp
@@ -24,8 +24,8 @@
 #include "openPMD/IO/IOTask.hpp"
 #include "openPMD/Streaming.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
+#include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
-#include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/Writable.hpp"
 
 #include <iostream>
@@ -47,29 +47,6 @@ AbstractIOHandlerImpl::AbstractIOHandlerImpl(AbstractIOHandler *handler)
 
 namespace
 {
-    template <typename Vec>
-    auto vec_as_string(Vec const &vec) -> std::string
-    {
-        if (vec.empty())
-        {
-            return "[]";
-        }
-        else
-        {
-            std::stringstream res;
-            res << '[';
-            auto it = vec.begin();
-            res << *it++;
-            auto end = vec.end();
-            for (; it != end; ++it)
-            {
-                res << ", " << *it;
-            }
-            res << ']';
-            return res.str();
-        }
-    }
-
     template <typename T, typename SFINAE = void>
     struct self_or_invoked
     {

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -840,6 +840,12 @@ void HDF5IOHandlerImpl::extendDataset(
         throw std::runtime_error(
             "[HDF5] Extending an unwritten Dataset is not possible.");
 
+    if (parameters.joinedDimension.has_value())
+    {
+        error::throwOperationUnsupportedInBackend(
+            "HDF5", "Joined Arrays currently only supported in ADIOS2");
+    }
+
     auto res = getFile(writable);
     if (!res)
         res = getFile(writable->parent);

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -711,6 +711,13 @@ void JSONIOHandlerImpl::extendDataset(
     VERIFY_ALWAYS(
         access::write(m_handler->m_backendAccess),
         "[JSON] Cannot extend a dataset in read-only mode.")
+
+    if (parameters.joinedDimension.has_value())
+    {
+        error::throwOperationUnsupportedInBackend(
+            "JSON", "Joined Arrays currently only supported in ADIOS2");
+    }
+
     setAndGetFilePosition(writable);
     refreshFileFromParent(writable);
     auto &j = obtainJsonContents(writable);

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -312,12 +312,9 @@ void RecordComponent::flush(
             }
             else
             {
-                Parameter<Operation::CREATE_DATASET> dCreate;
+                Parameter<Operation::CREATE_DATASET> dCreate(
+                    rc.m_dataset.value());
                 dCreate.name = name;
-                dCreate.extent = getExtent();
-                dCreate.dtype = getDatatype();
-                dCreate.options = rc.m_dataset.value().options;
-                dCreate.joinedDimension = joinedDimension();
                 IOHandler()->enqueue(IOTask(this, dCreate));
             }
         }

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -339,8 +339,8 @@ void RecordComponent::flush(
             }
             else
             {
-                Parameter<Operation::EXTEND_DATASET> pExtend;
-                pExtend.extent = rc.m_dataset.value().extent;
+                Parameter<Operation::EXTEND_DATASET> pExtend(
+                    rc.m_dataset.value().extent);
                 IOHandler()->enqueue(IOTask(this, std::move(pExtend)));
                 rc.m_hasBeenExtended = false;
             }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -415,7 +415,8 @@ void Series::flushRankTable()
         {
             return;
         }
-        Parameter<Operation::CREATE_DATASET> param;
+        Parameter<Operation::CREATE_DATASET> param(
+            AbstractParameter::I_dont_want_to_use_joined_dimensions);
         param.name = "rankTable";
         param.dtype = Datatype::CHAR;
         param.extent = {uint64_t(size), uint64_t(maxSize)};

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -21,6 +21,7 @@
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/Error.hpp"
 #include "openPMD/Iteration.hpp"
+#include <optional>
 
 namespace openPMD
 {
@@ -75,7 +76,7 @@ std::optional<size_t> BaseRecordComponent::joinedDimension() const
     }
     else
     {
-        return false;
+        return std::nullopt;
     }
 }
 

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -79,7 +79,8 @@ void init_Dataset(py::module &m)
                 })
 
             .def_property_readonly(
-                "joined_dimension", &Dataset::joinedDimension)
+                "joined_dimension",
+                py::overload_cast<>(&Dataset::joinedDimension, py::const_))
             .def_readonly("extent", &Dataset::extent)
             .def("extend", &Dataset::extend)
             .def_readonly("rank", &Dataset::rank)

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1995,7 +1995,29 @@ void joined_dim(std::string const &ext)
             patchExtent.store<type>(10);
         }
         writeFrom.clear();
+        // There seems to be a bug making this flush call necessary, need to fix
+        it.seriesFlush();
         it.close();
+
+        it = s.writeIterations()[200];
+
+        // Test issue fixed with
+        // https://github.com/openPMD/openPMD-api/pull/1740
+
+        auto bug_dataset = it.particles["flush_multiple_times"]["position"];
+
+        std::vector<int> buffer(length_of_patch * 2);
+        std::iota(buffer.begin(), buffer.end(), length_of_patch * 2 * rank);
+
+        bug_dataset.resetDataset({Datatype::INT, {Dataset::JOINED_DIMENSION}});
+        bug_dataset.storeChunkRaw(buffer.data(), {}, {length_of_patch});
+        it.seriesFlush();
+
+        bug_dataset.resetDataset({Datatype::INT, {Dataset::JOINED_DIMENSION}});
+        bug_dataset.storeChunkRaw(
+            buffer.data() + length_of_patch, {}, {length_of_patch});
+        it.seriesFlush();
+
         s.close();
     }
 


### PR DESCRIPTION
from time to time, I see exception was caught for joined array cases here:

 for (unsigned int i = 0; i < actualDim; i++)
   {
                if (!(joinedDim.has_value() && *joinedDim == i) &&
                    offset[i] + extent[i] > shape[I])
    }
because offset is given as {} for joined array variable.

the shape of the joined var is 18446744073709551615

 joined array: 
- from application:  
      - particle variable is initialized to  openPMD::Dataset::JOINED_DIMENSION
- definition in openPMD: 
      - Dataset.hpp:        JOINED_DIMENSION = std::numeric_limits<std::uint64_t>::max() 
      - ADIOS2IOHandler.cpp: finding  if (dims[i] == adios2::JoinedDim) 
- from ADIOS:
      -  ADIOSTypes.h:              constexpr uint64_t JoinedDim = MaxU64 - 1;
   
The reason it reached here is because the joined dimension from ADIOS is 18446744073709551614,  one less than the supposed max of size_t,  18446744073709551615 , which is the shape of the variable.

This pull request checked the variable shape ID and acknowledge as joined array if adios2::ShapeID::JoinedArary is returned. 

