### PR TITLE
Performance optimizations for interacting with many meshes / species types

### DIFF
--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -114,6 +114,15 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
         dCreate.name = rc.m_name;
         IOHandler()->enqueue(IOTask(this, dCreate));
     }
+
+    if (size == 0)
+    {
+        // Don't forward this operation to the backend as it might create ugly
+        // zero-blocks in ADIOS2
+        setDirtyRecursive(true);
+        return DynamicMemoryView<T>();
+    }
+
     Parameter<Operation::GET_BUFFER_VIEW> getBufferView;
     getBufferView.offset = o;
     getBufferView.extent = e;

--- a/include/openPMD/Span.hpp
+++ b/include/openPMD/Span.hpp
@@ -113,7 +113,10 @@ private:
     }
 
 public:
-    explicit DynamicMemoryView() = default;
+    explicit DynamicMemoryView()
+    {
+        m_param.out->backendManagedBuffer = false;
+    }
 
     /**
      * @brief Acquire the underlying buffer at its current position in memory.

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -28,7 +28,6 @@
 #include "openPMD/backend/Container.hpp"
 
 #include <array>
-#include <optional>
 #include <stdexcept>
 #include <string>
 #include <type_traits> // std::remove_reference_t

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -28,6 +28,7 @@
 #include "openPMD/backend/Container.hpp"
 
 #include <array>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <type_traits> // std::remove_reference_t

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -362,10 +362,10 @@ void Iteration::flush(internal::FlushParams const &flushParams)
                 s.setMeshesPath("meshes/");
                 s.flushMeshesPath();
             }
-            meshes.flush(s.meshesPath(), flushParams);
-            for (auto &m : meshes)
+            if (meshes.dirtyRecursive())
             {
-                if (m.second.dirtyRecursive())
+                meshes.flush(s.meshesPath(), flushParams);
+                for (auto &m : meshes)
                 {
                     m.second.flush(m.first, flushParams);
                 }
@@ -383,10 +383,10 @@ void Iteration::flush(internal::FlushParams const &flushParams)
                 s.setParticlesPath("particles/");
                 s.flushParticlesPath();
             }
-            particles.flush(s.particlesPath(), flushParams);
-            for (auto &species : particles)
+            if (particles.dirtyRecursive())
             {
-                if (species.second.dirtyRecursive())
+                particles.flush(s.particlesPath(), flushParams);
+                for (auto &species : particles)
                 {
                     species.second.flush(species.first, flushParams);
                 }

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -480,6 +480,11 @@ void Iteration::readGorVBased(
 
 void Iteration::read_impl(std::string const &groupPath)
 {
+    if (!get().m_deferredParseAccess.has_value())
+    {
+        throw error::Internal(
+            "Attempted reparsing an Iteration that is already parsed.");
+    }
     Parameter<Operation::OPEN_PATH> pOpen;
     pOpen.path = groupPath;
     IOHandler()->enqueue(IOTask(this, pOpen));

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -364,7 +364,12 @@ void Iteration::flush(internal::FlushParams const &flushParams)
             }
             meshes.flush(s.meshesPath(), flushParams);
             for (auto &m : meshes)
-                m.second.flush(m.first, flushParams);
+            {
+                if (m.second.dirtyRecursive())
+                {
+                    m.second.flush(m.first, flushParams);
+                }
+            }
         }
         else
         {
@@ -380,7 +385,12 @@ void Iteration::flush(internal::FlushParams const &flushParams)
             }
             particles.flush(s.particlesPath(), flushParams);
             for (auto &species : particles)
-                species.second.flush(species.first, flushParams);
+            {
+                if (species.second.dirtyRecursive())
+                {
+                    species.second.flush(species.first, flushParams);
+                }
+            }
         }
         else
         {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -366,6 +366,10 @@ template Mesh &Mesh::setTimeOffset(float);
 void Mesh::flush_impl(
     std::string const &name, internal::FlushParams const &flushParams)
 {
+    if (!dirtyRecursive())
+    {
+        return;
+    }
     if (access::readOnly(IOHandler()->m_frontendAccess))
     {
         auto &m = get();

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -155,6 +155,10 @@ namespace
 void ParticleSpecies::flush(
     std::string const &path, internal::FlushParams const &flushParams)
 {
+    if (!dirtyRecursive())
+    {
+        return;
+    }
     if (access::readOnly(IOHandler()->m_frontendAccess))
     {
         for (auto &record : *this)

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -168,12 +168,15 @@ void ParticleSpecies::flush(
     }
     else
     {
-        auto it = find("position");
-        if (it != end())
-            it->second.setUnitDimension({{UnitDimension::L, 1}});
-        it = find("positionOffset");
-        if (it != end())
-            it->second.setUnitDimension({{UnitDimension::L, 1}});
+        if (flushParams.flushLevel != FlushLevel::SkeletonOnly)
+        {
+            auto it = find("position");
+            if (it != end())
+                it->second.setUnitDimension({{UnitDimension::L, 1}});
+            it = find("positionOffset");
+            if (it != end())
+                it->second.setUnitDimension({{UnitDimension::L, 1}});
+        }
 
         Container<Record>::flush(path, flushParams);
 

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -52,6 +52,10 @@ Record &Record::setUnitDimension(unit_representations::AsArray const &udim)
 void Record::flush_impl(
     std::string const &name, internal::FlushParams const &flushParams)
 {
+    if (!dirtyRecursive())
+    {
+        return;
+    }
     if (access::readOnly(IOHandler()->m_frontendAccess))
     {
         if (scalar())

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -45,8 +45,8 @@ Record &Record::setUnitDimension(unit_representations::AsMap const &udim)
 }
 Record &Record::setUnitDimension(unit_representations::AsArray const &udim)
 {
-    return setUnitDimension(
-        unit_representations::asMap(udim, /* skip_zeros = */ false));
+    setAttribute("unitDimension", udim);
+    return *this;
 }
 
 void Record::flush_impl(

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -255,6 +255,10 @@ bool RecordComponent::empty() const
 void RecordComponent::flush(
     std::string const &name, internal::FlushParams const &flushParams)
 {
+    if (!dirtyRecursive())
+    {
+        return;
+    }
     auto &rc = get();
     if (flushParams.flushLevel == FlushLevel::SkeletonOnly)
     {

--- a/src/backend/BaseRecord.cpp
+++ b/src/backend/BaseRecord.cpp
@@ -819,6 +819,11 @@ template <typename T_elem>
 inline void BaseRecord<T_elem>::flush(
     std::string const &name, internal::FlushParams const &flushParams)
 {
+    if (!this->dirtyRecursive())
+    {
+        return;
+    }
+
     if (!this->written() && this->empty() && !this->datasetDefined())
         throw std::runtime_error(
             "A Record can not be written without any contained "

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -72,6 +72,10 @@ void MeshRecordComponent::read()
 void MeshRecordComponent::flush(
     std::string const &name, internal::FlushParams const &params)
 {
+    if (!dirtyRecursive())
+    {
+        return;
+    }
     if (access::write(IOHandler()->m_frontendAccess) &&
         !containsAttribute("position"))
     {

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -41,6 +41,10 @@ PatchRecord::setUnitDimension(std::map<UnitDimension, double> const &udim)
 void PatchRecord::flush_impl(
     std::string const &path, internal::FlushParams const &flushParams)
 {
+    if (!dirtyRecursive())
+    {
+        return;
+    }
     if (!this->datasetDefined())
     {
         if (IOHandler()->m_frontendAccess != Access::READ_ONLY)


### PR DESCRIPTION
Some assorted performance optimizations notices when developing the openPMD plugin for CP2K. These mostly affect the performance of flushing Iterations.

TODO:

- [x] Check if we should check for `dirtyRecursive()` in other places, too, or when reading. Update: No need in reading, Iterations are not reparsed.
- [x] Merge #1644 first