### PR TITLE
Fix broken CI: Deactivate build dependencies that fail to configure with CMake 4.0

### DIFF
--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -13,6 +13,10 @@ spack:
   packages:
     adios2:
       variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2 ~mgard
+    c-blosc2:
+      # snappy broken on CMake 4.0
+      # fixed snappy not yet deployed to a Spack release
+      variants: ~snappy
     cmake:
       externals:
       - spec: cmake@3.31.5

--- a/.github/ci/spack-envs/gcc12_py36_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/gcc12_py36_ompi_h5_ad2/spack.yaml
@@ -12,7 +12,14 @@ spack:
 
   packages:
     adios2:
-      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2
+      # mgard not supported on CMake 4.0 due to unresolved compatibility
+      # issue in dependency yaml-cpp
+      # https://github.com/jbeder/yaml-cpp/issues/1352
+      variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2 ~mgard
+    c-blosc2:
+      # snappy broken on CMake 4.0
+      # fixed snappy not yet deployed to a Spack release
+      variants: ~snappy
     cmake:
       externals:
       - spec: cmake@3.31.5


### PR DESCRIPTION
Seems we're running into the issue mentioned in the release notes for https://github.com/google/snappy/releases/tag/1.2.2:

> Started to use minimum CMake 3.10 because older ones are not planned to be supported.

Same for https://github.com/jbeder/yaml-cpp/issues/1352