### PR TITLE
JSON backend: Fix uninitialized values

### DIFF
--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -307,8 +307,8 @@ private:
     {
         // Initialized in init()
         DatasetMode m_mode{};
-        SpecificationVia m_specificationVia;
-        bool m_skipWarnings;
+        SpecificationVia m_specificationVia = SpecificationVia::DefaultValue;
+        bool m_skipWarnings = false;
 
         template <typename A, typename B, typename C>
         operator std::tuple<A, B, C>()

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -603,7 +603,6 @@ void JSONIOHandlerImpl::createDataset(
         parameter.options, /* considerFiles = */ false);
     // Retrieves mode from dataset-specific configuration, falls back to global
     // value if not defined
-    DatasetMode_s dm;
     auto [localMode, _, skipWarnings] = retrieveDatasetMode(config);
     (void)_;
     // No use in introducing logic to skip warnings only for one particular


### PR DESCRIPTION
`JSONIOHandlerImpl::init()` only initializes these values if it sees a reason to specify them explicitly from configuration, otherwise the default-constructed values persist. So, give them a default value.