### PR TITLE
Fix error when reading in linear mode from file-based Series

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1288,9 +1288,16 @@ void Series::flushFileBased(
     bool flushIOHandler)
 {
     auto &series = get();
-    if (end == begin)
+    /*
+     * Iterations might have been present, but have been closed and deleted from
+     * internal structures. In this case, previous flushes were successful and
+     * the Series is now in written() state.
+     */
+    if (end == begin && !written())
+    {
         throw std::runtime_error(
             "fileBased output can not be written with no iterations.");
+    }
 
     switch (IOHandler()->m_frontendAccess)
     {

--- a/src/snapshots/StatefulIterator.cpp
+++ b/src/snapshots/StatefulIterator.cpp
@@ -648,8 +648,6 @@ std::optional<StatefulIterator *> StatefulIterator::loopBody(Seek const &seek)
             else if (
                 series.IOHandler()->m_frontendAccess == Access::READ_LINEAR)
             {
-                std::cout << "Closing Iteration " << *maybe_current_iteration
-                          << std::endl;
                 data.series.iterations.container().erase(
                     *maybe_current_iteration);
             }

--- a/src/snapshots/StatefulIterator.cpp
+++ b/src/snapshots/StatefulIterator.cpp
@@ -648,6 +648,8 @@ std::optional<StatefulIterator *> StatefulIterator::loopBody(Seek const &seek)
             else if (
                 series.IOHandler()->m_frontendAccess == Access::READ_LINEAR)
             {
+                std::cout << "Closing Iteration " << *maybe_current_iteration
+                          << std::endl;
                 data.series.iterations.container().erase(
                     *maybe_current_iteration);
             }


### PR DESCRIPTION
```
[~Series] An error occurred: fileBased output can not be written with no iterations.
```

This happens, since the new `series.snapshots()` logic will remove Iterations from the object model once they are closed by the user, leading to a situation where at the end of the Series the Iterations container might be empty.