### PR TITLE
Update error message for group encoding in BP5

### DIFF
--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -1319,8 +1319,6 @@ Please consider using either of the following instead:
 * another openPMD backend (e.g. by selecting file extension .h5)
 * (experimental) variable encoding (e.g. by `Series::setIterationEncoding()`
   or by the JSON config {"iteration_encoding": "variable_based"}).
-  Note that there is at this point no complete read support for variable-encoded
-  outputs.
 
 Use the environment variable OPENPMD_BP5_GROUPENCODING_MAX_STEPS to adjust the
 number of allowed steps. Set the value as 0 to disable this check.


### PR DESCRIPTION
There is now full support for reading variable-based data, so we can recommend that a bit more liberally.
Follow-up to #1732 and #1746.