### PR TITLE
Workaround for Hipcc error (reference to host function in host device function)

### DIFF
--- a/include/openPMD/snapshots/RandomAccessIterator.hpp
+++ b/include/openPMD/snapshots/RandomAccessIterator.hpp
@@ -66,10 +66,11 @@ public:
     RandomAccessIterator(RandomAccessIterator &&other) noexcept(
         noexcept(iterator_t(std::declval<iterator_t &&>())));
 
-    RandomAccessIterator &operator=(RandomAccessIterator const &other);
     RandomAccessIterator &
-    operator=(RandomAccessIterator &&other) noexcept(noexcept(
-        std::declval<iterator_t>().operator=(std::declval<iterator_t &&>())));
+    operator=(RandomAccessIterator const &other) = default;
+    RandomAccessIterator &operator=(RandomAccessIterator &&other) noexcept(
+        noexcept(std::declval<iterator_t>().operator=(
+            std::declval<iterator_t &&>()))) = default;
 
     auto operator*() -> value_type &;
     auto operator*() const -> value_type const &;

--- a/include/openPMD/snapshots/RandomAccessIterator.hpp
+++ b/include/openPMD/snapshots/RandomAccessIterator.hpp
@@ -62,9 +62,9 @@ public:
 
     ~RandomAccessIterator() override;
 
-    RandomAccessIterator(RandomAccessIterator const &other);
+    RandomAccessIterator(RandomAccessIterator const &other) = default;
     RandomAccessIterator(RandomAccessIterator &&other) noexcept(
-        noexcept(iterator_t(std::declval<iterator_t &&>())));
+        noexcept(iterator_t(std::declval<iterator_t &&>()))) = default;
 
     RandomAccessIterator &
     operator=(RandomAccessIterator const &other) = default;

--- a/src/snapshots/RandomAccessIterator.cpp
+++ b/src/snapshots/RandomAccessIterator.cpp
@@ -10,24 +10,6 @@ template <typename iterator_t>
 RandomAccessIterator<iterator_t>::~RandomAccessIterator() = default;
 
 template <typename iterator_t>
-RandomAccessIterator<iterator_t>::RandomAccessIterator(
-    RandomAccessIterator const &other) = default;
-template <typename iterator_t>
-RandomAccessIterator<iterator_t>::RandomAccessIterator(
-    RandomAccessIterator
-        &&other) noexcept(noexcept(iterator_t(std::declval<iterator_t &&>()))) =
-    default;
-template <typename iterator_t>
-RandomAccessIterator<iterator_t> &RandomAccessIterator<iterator_t>::operator=(
-    RandomAccessIterator const &other) = default;
-template <typename iterator_t>
-RandomAccessIterator<iterator_t> &RandomAccessIterator<iterator_t>::operator=(
-    RandomAccessIterator
-        &&other) noexcept(noexcept(std::declval<iterator_t>().
-                                   operator=(std::declval<iterator_t &&>()))) =
-    default;
-
-template <typename iterator_t>
 auto RandomAccessIterator<iterator_t>::operator*() -> value_type &
 {
     return *m_it;


### PR DESCRIPTION
Observed on Frontier:

```
/ccs/home/fpoeschel/git-repos/openPMD-api/src/snapshots/RandomAccessIterator.cpp:13:35: error: reference to __host__ function '~AbstractSeriesIterator' in _
_host__ __device__ function                                                                                                                                 
   13 | RandomAccessIterator<iterator_t>::RandomAccessIterator(

/ccs/home/fpoeschel/git-repos/openPMD-api/src/snapshots/RandomAccessIterator.cpp:16:35: error: reference to __host__ function '~AbstractSeriesIterator' in _
_host__ __device__ function                                                                                                                                 
   16 | RandomAccessIterator<iterator_t>::RandomAccessIterator(
```

These look like compiler bugs to me. Since this is an internal header, we can move the defaulted implementation to the header file without trouble. This fixes the observed error.