### PR TITLE
CMake: Install toml11 and nlohmann_json for inclusion in downstream code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1076,14 +1076,24 @@ if(openPMD_INSTALL)
         RUNTIME DESTINATION ${openPMD_INSTALL_BINDIR}
         INCLUDES DESTINATION ${openPMD_INSTALL_INCLUDEDIR}
     )
-    install(CODE "
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} \
-                --build \"${CMAKE_BINARY_DIR}\" \
-                --target fetchedtoml11-install \
-                --target fetchednlohmann_json-install
-        )
-    ")
+    if(TARGET fetchednlohmann_json-install)
+        install(CODE "
+            execute_process(
+                COMMAND ${CMAKE_COMMAND} \
+                    --build \"${CMAKE_BINARY_DIR}\" \
+                    --target fetchednlohmann_json-install
+            )
+        ")
+    endif()
+    if(TARGET fetchedtoml11-install)
+        install(CODE "
+            execute_process(
+                COMMAND ${CMAKE_COMMAND} \
+                    --build \"${CMAKE_BINARY_DIR}\" \
+                    --target fetchedtoml11-install
+            )
+        ")
+    endif()
     # install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build \"${CMAKE_BINARY_DIR}\" --target toml11_install)")
     # install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build \"${CMAKE_BINARY_DIR}\" --target json_install)")
     if(openPMD_HAVE_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1076,6 +1076,16 @@ if(openPMD_INSTALL)
         RUNTIME DESTINATION ${openPMD_INSTALL_BINDIR}
         INCLUDES DESTINATION ${openPMD_INSTALL_INCLUDEDIR}
     )
+    install(CODE "
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} \
+                --build \"${CMAKE_BINARY_DIR}\" \
+                --target fetchedtoml11-install \
+                --target fetchednlohmann_json-install
+        )
+    ")
+    # install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build \"${CMAKE_BINARY_DIR}\" --target toml11_install)")
+    # install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build \"${CMAKE_BINARY_DIR}\" --target json_install)")
     if(openPMD_HAVE_PYTHON)
         install(
             DIRECTORY   ${openPMD_SOURCE_DIR}/src/binding/python/openpmd_api

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,9 +524,8 @@ endif()
 # JSON Backend and User-Facing Runtime Options
 #target_link_libraries(openPMD PRIVATE openPMD::thirdparty::nlohmann_json)
 target_include_directories(openPMD SYSTEM PRIVATE
-    $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
-    #$<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
-target_link_libraries(openPMD PRIVATE openPMD::thirdparty::toml11)
+    $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # HDF5 Backend
 #   TODO: Once we require CMake 3.20+, simply link hdf5::hdf5 C lib target
@@ -1070,30 +1069,12 @@ if(openPMD_INSTALL)
         endif()
     endif()
 
-    # if(openPMD_USE_INTERNAL_TOML11)
-    #     install(EXPORT toml11Targets
-    #         NAMESPACE toml11::
-    #         DESTINATION ${openPMD_INSTALL_CMAKEDIR}
-    #     )
-    # endif()
     install(TARGETS ${openPMD_INSTALL_TARGET_NAMES}
         EXPORT openPMDTargets
         LIBRARY DESTINATION ${openPMD_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${openPMD_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${openPMD_INSTALL_BINDIR}
         INCLUDES DESTINATION ${openPMD_INSTALL_INCLUDEDIR}
-    )
-    install(TARGETS toml11 EXPORT toml11Targets)
-
-    install(EXPORT toml11Targets
-            FILE toml11Targets.cmake
-            NAMESPACE toml11::
-            DESTINATION lib/cmake/toml11)
-    # add_dependencies(openPMD toml11)
-    message(STATUS "INSTALLING TOML FROM ${toml11_SOURCE_DIR}/toml11")
-    install(DIRECTORY ${toml11_SOURCE_DIR}
-        DESTINATION ${openPMD_INSTALL_INCLUDEDIR}
-        FILES_MATCHING PATTERN "*.hpp"
     )
     if(openPMD_HAVE_PYTHON)
         install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1094,8 +1094,6 @@ if(openPMD_INSTALL)
             )
         ")
     endif()
-    # install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build \"${CMAKE_BINARY_DIR}\" --target toml11_install)")
-    # install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build \"${CMAKE_BINARY_DIR}\" --target json_install)")
     if(openPMD_HAVE_PYTHON)
         install(
             DIRECTORY   ${openPMD_SOURCE_DIR}/src/binding/python/openpmd_api

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,8 +524,9 @@ endif()
 # JSON Backend and User-Facing Runtime Options
 #target_link_libraries(openPMD PRIVATE openPMD::thirdparty::nlohmann_json)
 target_include_directories(openPMD SYSTEM PRIVATE
-    $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
+    $<TARGET_PROPERTY:openPMD::thirdparty::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+    #$<TARGET_PROPERTY:openPMD::thirdparty::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(openPMD PRIVATE openPMD::thirdparty::toml11)
 
 # HDF5 Backend
 #   TODO: Once we require CMake 3.20+, simply link hdf5::hdf5 C lib target
@@ -1069,12 +1070,30 @@ if(openPMD_INSTALL)
         endif()
     endif()
 
+    # if(openPMD_USE_INTERNAL_TOML11)
+    #     install(EXPORT toml11Targets
+    #         NAMESPACE toml11::
+    #         DESTINATION ${openPMD_INSTALL_CMAKEDIR}
+    #     )
+    # endif()
     install(TARGETS ${openPMD_INSTALL_TARGET_NAMES}
         EXPORT openPMDTargets
         LIBRARY DESTINATION ${openPMD_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${openPMD_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${openPMD_INSTALL_BINDIR}
         INCLUDES DESTINATION ${openPMD_INSTALL_INCLUDEDIR}
+    )
+    install(TARGETS toml11 EXPORT toml11Targets)
+
+    install(EXPORT toml11Targets
+            FILE toml11Targets.cmake
+            NAMESPACE toml11::
+            DESTINATION lib/cmake/toml11)
+    # add_dependencies(openPMD toml11)
+    message(STATUS "INSTALLING TOML FROM ${toml11_SOURCE_DIR}/toml11")
+    install(DIRECTORY ${toml11_SOURCE_DIR}
+        DESTINATION ${openPMD_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.hpp"
     )
     if(openPMD_HAVE_PYTHON)
         install(

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -50,7 +50,11 @@
         set(cmake_args -DJSON_BuildTests=OFF)
         if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
             OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
-            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
+            cmake_path(
+                ABSOLUTE_PATH openPMD_INSTALL_PREFIX
+                BASE_DIRECTORY "${openPMD_BINARY_DIR}"
+                OUTPUT_VARIABLE openPMD_resolved_install_prefix)
+            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_resolved_install_prefix})
         endif()
         ExternalProject_Add(fetchednlohmann_json
             SOURCE_DIR ${openPMD_used_json_src}

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -1,4 +1,4 @@
-    function(find_json)
+function(find_json)
     if(TARGET nlohmann_json::nlohmann_json)
         message(STATUS "nlohmann_json::nlohmann_json target already imported")
     elseif(openPMD_USE_INTERNAL_JSON)
@@ -40,6 +40,13 @@
         endif()
         FetchContent_MakeAvailable(fetchednlohmann_json)
 
+        # advanced fetch options
+        mark_as_advanced(FETCHCONTENT_BASE_DIR)
+        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+        mark_as_advanced(FETCHCONTENT_QUIET)
+        #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDnlohmann_json)
+        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+        #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDnlohmann_json)
     elseif(NOT openPMD_USE_INTERNAL_JSON)
         find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)
         message(STATUS "nlohmann_json: Found version '${nlohmann_json_VERSION}'")

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -21,29 +21,24 @@ function(find_json)
     elseif(openPMD_USE_INTERNAL_JSON AND openPMD_json_src)
         add_subdirectory(${openPMD_json_src} _deps/localnlohmann_json-build/)
     elseif(openPMD_USE_INTERNAL_JSON AND (openPMD_json_tar OR openPMD_json_branch))
-        include(FetchContent)
+        include(ExternalProject)
         if(openPMD_json_tar)
-            FetchContent_Declare(fetchednlohmann_json
+            ExternalProject_Add(fetchednlohmann_json
                 URL             ${openPMD_json_tar}
                 URL_HASH        ${openPMD_json_tar_hash}
                 BUILD_IN_SOURCE OFF
+                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         else()
-            FetchContent_Declare(fetchednlohmann_json
+            ExternalProject_Add(fetchednlohmann_json
                 GIT_REPOSITORY ${openPMD_json_repo}
                 GIT_TAG        ${openPMD_json_branch}
                 BUILD_IN_SOURCE OFF
+                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DJSON_BuildTests=OFF
+                INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         endif()
-        FetchContent_MakeAvailable(fetchednlohmann_json)
-
-        # advanced fetch options
-        mark_as_advanced(FETCHCONTENT_BASE_DIR)
-        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-        mark_as_advanced(FETCHCONTENT_QUIET)
-        #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDnlohmann_json)
-        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-        #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDnlohmann_json)
     elseif(NOT openPMD_USE_INTERNAL_JSON)
         find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)
         message(STATUS "nlohmann_json: Found version '${nlohmann_json_VERSION}'")

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -27,7 +27,7 @@ function(find_json)
                 URL             ${openPMD_json_tar}
                 URL_HASH        ${openPMD_json_tar_hash}
                 BUILD_IN_SOURCE OFF
-                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DJSON_BuildTests=OFF
                 INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         else()
@@ -39,6 +39,9 @@ function(find_json)
                 INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         endif()
+        # Need this call to have nlohmann_json available at build time
+        # ExternalProject_Add will later separately install it at install time
+        add_subdirectory("${openPMD_BINARY_DIR}/fetchednlohmann_json-prefix/src/fetchednlohmann_json" _deps/localfetchednlohmann_json-build/)
     elseif(NOT openPMD_USE_INTERNAL_JSON)
         find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)
         message(STATUS "nlohmann_json: Found version '${nlohmann_json_VERSION}'")

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -22,26 +22,30 @@ function(find_json)
         add_subdirectory(${openPMD_json_src} _deps/localnlohmann_json-build/)
     elseif(openPMD_USE_INTERNAL_JSON AND (openPMD_json_tar OR openPMD_json_branch))
         include(ExternalProject)
+        include(FetchContent)
         if(openPMD_json_tar)
-            ExternalProject_Add(fetchednlohmann_json
+            FetchContent_Declare(fetchednlohmann_json
                 URL             ${openPMD_json_tar}
                 URL_HASH        ${openPMD_json_tar_hash}
                 BUILD_IN_SOURCE OFF
-                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DJSON_BuildTests=OFF
-                INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         else()
-            ExternalProject_Add(fetchednlohmann_json
+            FetchContent_Declare(fetchednlohmann_json
                 GIT_REPOSITORY ${openPMD_json_repo}
                 GIT_TAG        ${openPMD_json_branch}
                 BUILD_IN_SOURCE OFF
-                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DJSON_BuildTests=OFF
-                INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         endif()
-        # Need this call to have nlohmann_json available at build time
-        # ExternalProject_Add will later separately install it at install time
-        add_subdirectory("${openPMD_BINARY_DIR}/fetchednlohmann_json-prefix/src/fetchednlohmann_json" _deps/localfetchednlohmann_json-build/)
+        FetchContent_MakeAvailable(fetchednlohmann_json)
+        set(cmake_args -DJSON_BuildTests=OFF)
+        if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
+            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
+        endif()
+        ExternalProject_Add(fetchednlohmann_json
+            SOURCE_DIR _deps/fetchednlohmann_json-src/
+            BUILD_IN_SOURCE OFF
+            CMAKE_ARGS ${cmake_args}
+        )
     elseif(NOT openPMD_USE_INTERNAL_JSON)
         find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)
         message(STATUS "nlohmann_json: Found version '${nlohmann_json_VERSION}'")

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -44,7 +44,9 @@ function(find_json)
         ExternalProject_Add(fetchednlohmann_json
             SOURCE_DIR _deps/fetchednlohmann_json-src/
             BUILD_IN_SOURCE OFF
+            EXCLUDE_FROM_ALL TRUE
             CMAKE_ARGS ${cmake_args}
+            STEP_TARGETS install
         )
     elseif(NOT openPMD_USE_INTERNAL_JSON)
         find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)

--- a/cmake/dependencies/json.cmake
+++ b/cmake/dependencies/json.cmake
@@ -1,4 +1,4 @@
-function(find_json)
+    function(find_json)
     if(TARGET nlohmann_json::nlohmann_json)
         message(STATUS "nlohmann_json::nlohmann_json target already imported")
     elseif(openPMD_USE_INTERNAL_JSON)
@@ -8,12 +8,15 @@ function(find_json)
             if(NOT IS_DIRECTORY ${openPMD_json_src})
                 message(FATAL_ERROR "Specified directory openPMD_json_src='${openPMD_json_src}' does not exist!")
             endif()
+            set(openPMD_used_json_src "${openPMD_json_src}")
         elseif(openPMD_json_tar)
             message(STATUS "Downloading nlohmann_json ...")
             message(STATUS "nlohmann_json source: ${openPMD_json_tar}")
+            set(openPMD_used_json_src "_deps/fetchednlohmann_json-src/")
         elseif(openPMD_json_branch)
             message(STATUS "Downloading nlohmann_json ...")
             message(STATUS "nlohmann_json repository: ${openPMD_json_repo} (${openPMD_json_branch})")
+            set(openPMD_used_json_src "_deps/fetchednlohmann_json-src/")
         endif()
     endif()
     if(TARGET nlohmann_json::nlohmann_json)
@@ -21,7 +24,6 @@ function(find_json)
     elseif(openPMD_USE_INTERNAL_JSON AND openPMD_json_src)
         add_subdirectory(${openPMD_json_src} _deps/localnlohmann_json-build/)
     elseif(openPMD_USE_INTERNAL_JSON AND (openPMD_json_tar OR openPMD_json_branch))
-        include(ExternalProject)
         include(FetchContent)
         if(openPMD_json_tar)
             FetchContent_Declare(fetchednlohmann_json
@@ -37,20 +39,26 @@ function(find_json)
             )
         endif()
         FetchContent_MakeAvailable(fetchednlohmann_json)
+
+    elseif(NOT openPMD_USE_INTERNAL_JSON)
+        find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)
+        message(STATUS "nlohmann_json: Found version '${nlohmann_json_VERSION}'")
+    endif()
+
+    if(DEFINED openPMD_used_json_src)
+        include(ExternalProject)
         set(cmake_args -DJSON_BuildTests=OFF)
-        if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
+        if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
+            OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
             list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
         endif()
         ExternalProject_Add(fetchednlohmann_json
-            SOURCE_DIR _deps/fetchednlohmann_json-src/
+            SOURCE_DIR ${openPMD_used_json_src}
             BUILD_IN_SOURCE OFF
             EXCLUDE_FROM_ALL TRUE
             CMAKE_ARGS ${cmake_args}
             STEP_TARGETS install
         )
-    elseif(NOT openPMD_USE_INTERNAL_JSON)
-        find_package(nlohmann_json 3.9.1 CONFIG REQUIRED)
-        message(STATUS "nlohmann_json: Found version '${nlohmann_json_VERSION}'")
     endif()
 endfunction()
 

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -47,7 +47,6 @@ function(find_toml11)
         #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDtoml11)
         mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
         #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDtoml11)
-
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake
         # logic: version 4.0 is not accepted by a call to find_package(toml11 3.7).

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -39,6 +39,10 @@ function(find_toml11)
                 INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         endif()
+        # Need this call to have toml11 available at build time
+        # ExternalProject_Add will later separately install it at install time
+        add_subdirectory("${openPMD_BINARY_DIR}/fetchedtoml11-prefix/src/fetchedtoml11" _deps/localtoml11-build/)
+        # message(STATUS "toml11: Found version '${toml11_VERSION}'")
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake
         # logic: version 4.0 is not accepted by a call to find_package(toml11 3.7).

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -8,12 +8,15 @@ function(find_toml11)
             if(NOT IS_DIRECTORY ${openPMD_toml11_src})
                 message(FATAL_ERROR "Specified directory openPMD_toml11_src='${openPMD_toml11_src}' does not exist!")
             endif()
+            set(openPMD_used_toml11_src "${openPMD_toml11_src}")
         elseif(openPMD_toml11_tar)
             message(STATUS "Downloading toml11 ...")
             message(STATUS "toml11 source: ${openPMD_toml11_tar}")
+            set(openPMD_used_toml11_src "_deps/fetchedtoml11-src/")
         elseif(openPMD_toml11_branch)
             message(STATUS "Downloading toml11 ...")
             message(STATUS "toml11 repository: ${openPMD_toml11_repo} (${openPMD_toml11_branch})")
+            set(openPMD_used_toml11_src "_deps/fetchedtoml11-src/")
         endif()
     endif()
     if(TARGET toml11::toml11)
@@ -21,7 +24,6 @@ function(find_toml11)
     elseif(openPMD_USE_INTERNAL_TOML11 AND openPMD_toml11_src)
         add_subdirectory(${openPMD_toml11_src} _deps/localtoml11-build/)
     elseif(openPMD_USE_INTERNAL_TOML11 AND (openPMD_toml11_tar OR openPMD_toml11_branch))
-        include(ExternalProject)
         include(FetchContent)
         if(openPMD_toml11_tar)
             FetchContent_Declare(fetchedtoml11
@@ -37,17 +39,6 @@ function(find_toml11)
             )
         endif()
         FetchContent_MakeAvailable(fetchedtoml11)
-        set(cmake_args "")
-        if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
-            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
-        endif()
-        ExternalProject_Add(fetchedtoml11
-            SOURCE_DIR _deps/fetchedtoml11-src
-            BUILD_IN_SOURCE OFF
-            EXCLUDE_FROM_ALL TRUE
-            CMAKE_ARGS ${cmake_args}
-            STEP_TARGETS install
-        )
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake
         # logic: version 4.0 is not accepted by a call to find_package(toml11 3.7).
@@ -59,6 +50,21 @@ function(find_toml11)
             find_package(toml11 3.7.1 CONFIG REQUIRED)
         endif()
         message(STATUS "toml11: Found version '${toml11_VERSION}'")
+    endif()
+
+    if(DEFINED openPMD_used_toml11_src)
+        include(ExternalProject)
+        set(cmake_args "")
+        if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
+            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
+        endif()
+        ExternalProject_Add(fetchedtoml11
+            SOURCE_DIR _deps/fetchedtoml11-src
+            BUILD_IN_SOURCE OFF
+            EXCLUDE_FROM_ALL TRUE
+            CMAKE_ARGS ${cmake_args}
+            STEP_TARGETS install
+        )
     endif()
 endfunction()
 

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -1,5 +1,4 @@
 function(find_toml11)
-    variable_watch(fetchedtoml11)
     if(TARGET toml11::toml11)
         message(STATUS "toml11::toml11 target already imported")
     elseif(openPMD_USE_INTERNAL_TOML11)
@@ -37,17 +36,6 @@ function(find_toml11)
             )
         endif()
         FetchContent_MakeAvailable(fetchedtoml11)
-        # install(TARGETS toml11 EXPORT toml11Targets)
-        # add_subdirectory(
-        #     "${openPMD_toml11_src}"
-        #     _deps/localtoml11-build/
-        #     # EXCLUDE_FROM_ALL ensures that toml11 is not part of
-        #     # make install.
-        #     # The library is header-only and linking it against
-        #     # PIConGPU targets is sufficient.
-        #     # It needs not be part of any build or install targets
-        #     # explicitly.
-        #     )
 
         # advanced fetch options
         mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -21,29 +21,24 @@ function(find_toml11)
     elseif(openPMD_USE_INTERNAL_TOML11 AND openPMD_toml11_src)
         add_subdirectory(${openPMD_toml11_src} _deps/localtoml11-build/)
     elseif(openPMD_USE_INTERNAL_TOML11 AND (openPMD_toml11_tar OR openPMD_toml11_branch))
-        include(FetchContent)
+        include(ExternalProject)
         if(openPMD_toml11_tar)
-            FetchContent_Declare(fetchedtoml11
+            ExternalProject_Add(fetchedtoml11
                     URL             ${openPMD_toml11_tar}
                     URL_HASH        ${openPMD_toml11_tar_hash}
                     BUILD_IN_SOURCE OFF
+                    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                    INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         else()
-            FetchContent_Declare(fetchedtoml11
+        ExternalProject_Add(fetchedtoml11
                 GIT_REPOSITORY ${openPMD_toml11_repo}
                 GIT_TAG        ${openPMD_toml11_branch}
                 BUILD_IN_SOURCE OFF
+                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         endif()
-        FetchContent_MakeAvailable(fetchedtoml11)
-
-        # advanced fetch options
-        mark_as_advanced(FETCHCONTENT_BASE_DIR)
-        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
-        mark_as_advanced(FETCHCONTENT_QUIET)
-        #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDtoml11)
-        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
-        #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDtoml11)
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake
         # logic: version 4.0 is not accepted by a call to find_package(toml11 3.7).

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -42,9 +42,11 @@ function(find_toml11)
             list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
         endif()
         ExternalProject_Add(fetchedtoml11
-                SOURCE_DIR _deps/fetchedtoml11-src
-                BUILD_IN_SOURCE OFF
-                CMAKE_ARGS ${cmake_args}
+            SOURCE_DIR _deps/fetchedtoml11-src
+            BUILD_IN_SOURCE OFF
+            EXCLUDE_FROM_ALL TRUE
+            CMAKE_ARGS ${cmake_args}
+            STEP_TARGETS install
         )
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -1,4 +1,5 @@
 function(find_toml11)
+    variable_watch(fetchedtoml11)
     if(TARGET toml11::toml11)
         message(STATUS "toml11::toml11 target already imported")
     elseif(openPMD_USE_INTERNAL_TOML11)
@@ -36,6 +37,17 @@ function(find_toml11)
             )
         endif()
         FetchContent_MakeAvailable(fetchedtoml11)
+        # install(TARGETS toml11 EXPORT toml11Targets)
+        # add_subdirectory(
+        #     "${openPMD_toml11_src}"
+        #     _deps/localtoml11-build/
+        #     # EXCLUDE_FROM_ALL ensures that toml11 is not part of
+        #     # make install.
+        #     # The library is header-only and linking it against
+        #     # PIConGPU targets is sufficient.
+        #     # It needs not be part of any build or install targets
+        #     # explicitly.
+        #     )
 
         # advanced fetch options
         mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -22,27 +22,30 @@ function(find_toml11)
         add_subdirectory(${openPMD_toml11_src} _deps/localtoml11-build/)
     elseif(openPMD_USE_INTERNAL_TOML11 AND (openPMD_toml11_tar OR openPMD_toml11_branch))
         include(ExternalProject)
+        include(FetchContent)
         if(openPMD_toml11_tar)
-            ExternalProject_Add(fetchedtoml11
+            FetchContent_Declare(fetchedtoml11
                     URL             ${openPMD_toml11_tar}
                     URL_HASH        ${openPMD_toml11_tar_hash}
                     BUILD_IN_SOURCE OFF
-                    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                    INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         else()
-        ExternalProject_Add(fetchedtoml11
+            FetchContent_Declare(fetchedtoml11
                 GIT_REPOSITORY ${openPMD_toml11_repo}
                 GIT_TAG        ${openPMD_toml11_branch}
                 BUILD_IN_SOURCE OFF
-                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                INSTALL_DIR ${openPMD_INSTALL_PREFIX}
             )
         endif()
-        # Need this call to have toml11 available at build time
-        # ExternalProject_Add will later separately install it at install time
-        add_subdirectory("${openPMD_BINARY_DIR}/fetchedtoml11-prefix/src/fetchedtoml11" _deps/localtoml11-build/)
-        # message(STATUS "toml11: Found version '${toml11_VERSION}'")
+        FetchContent_MakeAvailable(fetchedtoml11)
+        set(cmake_args "")
+        if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
+            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
+        endif()
+        ExternalProject_Add(fetchedtoml11
+                SOURCE_DIR _deps/fetchedtoml11-src
+                BUILD_IN_SOURCE OFF
+                CMAKE_ARGS ${cmake_args}
+        )
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake
         # logic: version 4.0 is not accepted by a call to find_package(toml11 3.7).

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -56,10 +56,14 @@ function(find_toml11)
         include(ExternalProject)
         set(cmake_args "")
         if(NOT DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
-            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_INSTALL_PREFIX})
+            cmake_path(
+                ABSOLUTE_PATH openPMD_INSTALL_PREFIX
+                BASE_DIRECTORY "${openPMD_BINARY_DIR}"
+                OUTPUT_VARIABLE openPMD_resolved_install_prefix)
+            list(APPEND cmake_args -DCMAKE_INSTALL_PREFIX=${openPMD_resolved_install_prefix})
         endif()
         ExternalProject_Add(fetchedtoml11
-            SOURCE_DIR _deps/fetchedtoml11-src
+            SOURCE_DIR ${openPMD_used_toml11_src}
             BUILD_IN_SOURCE OFF
             EXCLUDE_FROM_ALL TRUE
             CMAKE_ARGS ${cmake_args}

--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -39,6 +39,15 @@ function(find_toml11)
             )
         endif()
         FetchContent_MakeAvailable(fetchedtoml11)
+
+        # advanced fetch options
+        mark_as_advanced(FETCHCONTENT_BASE_DIR)
+        mark_as_advanced(FETCHCONTENT_FULLY_DISCONNECTED)
+        mark_as_advanced(FETCHCONTENT_QUIET)
+        #mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FETCHEDtoml11)
+        mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED)
+        #mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDtoml11)
+
     elseif(NOT openPMD_USE_INTERNAL_TOML11)
         # toml11 4.0 was a breaking change. This is reflected in the library's CMake
         # logic: version 4.0 is not accepted by a call to find_package(toml11 3.7).


### PR DESCRIPTION
This is an attempt at finding a solution for this issue https://github.com/ComputationalRadiationPhysics/picongpu/issues/5355

**Problem:** If a downstream code wants to use nlohmann_json / toml11 as well, then it must use the same version used also in openPMD, otherwise it might happen that the same symbol defined by toml11/nlohmann_json might exist in different implementations (different versions) in libopenPMD.so and the compiled binary of the downstream. The linker might then jump between implementations, causing undefined behavior.

**Attempted solution in this PR:**

1. By default, do not use internally shipped dependencies, but look for an installation of toml11/nlohmann_json in the system. (not yet implemented)
2. If using an internally shipped dependency, then install it along with openPMD such that these versions become available in the software environment.
3. Downstream codes can then use the same logic to agree on common versions of toml11/nlohmann_json.

**Alternatives:**

* Maybe include toml11 / nlohmann_json into their own namespaces in openPMD instead?

TODO:

- [ ] Look for nlohmann_json/toml11 in the system software environment by default
- [ ] Implement this logic also for workflows using openPMD_toml11_src / openPMD_json_src
- [ ] Add a flag to opt-out from this. (Yes, opt-**out**, this can only be a viable solution for the described issue if we can assume that an openPMD installation will share its versions of toml11 / nlohmann_json by default)
- [ ] Open PRs at toml11/nlohmann_json for binary symbol versioning with `inline namespace`