### PR TITLE
Upgrade Windows-2019 runner to Windows-2022

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,7 @@ jobs:
 
   build_win_clang:
     name: Clang w/o MPI
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
         python3.exe -m pip install --upgrade pip
         python3.exe -m pip install --upgrade numpy
 
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         pwsh "share\openPMD\download_samples.ps1" build
         cmake -S . -B build   ^
               -G "Ninja"      ^


### PR DESCRIPTION
Brownout of Windows-2019 runner until end of June