### PR TITLE
Fix typo in MPI benchmark example: m_configurations instead of m_compressions

### DIFF
--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -300,7 +300,7 @@ void MPIBenchmark<DatasetFillerProvider>::addConfiguration(
 template <typename DatasetFillerProvider>
 void MPIBenchmark<DatasetFillerProvider>::resetConfigurations()
 {
-    this->m_compressions.clear();
+    this->m_configurations.clear();
 }
 
 template <typename DatasetFillerProvider>


### PR DESCRIPTION
Close #1761