### PR TITLE
Snapshots API: Inherit from Attributable

### DIFF
--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -117,6 +117,10 @@ namespace internal
         AttributableData &operator=(AttributableData const &) = delete;
         AttributableData &operator=(AttributableData &&) = delete;
 
+        // Make copies explicit, only to be used under the conditions described
+        // above
+        void cloneFrom(AttributableData const &other);
+
         template <typename T>
         T asInternalCopyOf()
         {
@@ -209,6 +213,7 @@ class Attributable
     friend T &internal::makeOwning(T &self, Series);
     friend class StatefulSnapshotsContainer;
     friend class internal::AttributableData;
+    friend class Snapshots;
 
 protected:
     // tag for internal constructor

--- a/include/openPMD/snapshots/Snapshots.hpp
+++ b/include/openPMD/snapshots/Snapshots.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/Iteration.hpp"
+#include "openPMD/backend/Attributable.hpp"
 #include "openPMD/snapshots/ContainerTraits.hpp"
 #include <functional>
 #include <memory>
@@ -46,14 +47,16 @@ namespace openPMD
  * an Iteration handle goes invalid after closing it, a new Iteration handle is
  * acquired by Snapshots::operator[]().
  */
-class Snapshots
+class Snapshots : public Attributable
 {
 private:
     friend class Series;
 
     std::shared_ptr<AbstractSnapshotsContainer> m_snapshots;
 
-    Snapshots(std::shared_ptr<AbstractSnapshotsContainer> snapshots);
+    Snapshots(
+        std::shared_ptr<AbstractSnapshotsContainer> snapshots,
+        Attributable &iterations);
 
     inline auto get() const -> AbstractSnapshotsContainer const &;
     inline auto get() -> AbstractSnapshotsContainer &;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3314,7 +3314,8 @@ Series::snapshots(std::optional<SnapshotWorkflow> const snapshot_workflow)
     case SnapshotWorkflow::RandomAccess: {
         return Snapshots(
             std::shared_ptr<RandomAccessIteratorContainer>{
-                new RandomAccessIteratorContainer(series.iterations)});
+                new RandomAccessIteratorContainer(series.iterations)},
+            series.iterations);
     }
     case SnapshotWorkflow::Synchronous: {
         std::function<StatefulIterator *()> begin;
@@ -3329,7 +3330,8 @@ Series::snapshots(std::optional<SnapshotWorkflow> const snapshot_workflow)
         }
         return Snapshots(
             std::shared_ptr<StatefulSnapshotsContainer>(
-                new StatefulSnapshotsContainer(std::move(begin))));
+                new StatefulSnapshotsContainer(std::move(begin))),
+            series.iterations);
     }
     }
     throw std::runtime_error("unreachable!");

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -50,6 +50,13 @@ namespace internal
     AttributableData::AttributableData(SharedAttributableData *raw_ptr)
         : SharedData_t({raw_ptr, [](auto const *) {}})
     {}
+
+    void AttributableData::cloneFrom(AttributableData const &other)
+    {
+        using parent_t = std::shared_ptr<SharedAttributableData>;
+        static_cast<parent_t &>(*this) = static_cast<parent_t const &>(other);
+    }
+
 } // namespace internal
 
 Attributable::Attributable()

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -24,6 +24,7 @@
 #include "openPMD/Iteration.hpp"
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/backend/Attributable.hpp"
 #include "openPMD/binding/python/Common.hpp"
 #include "openPMD/binding/python/Pickle.hpp"
 #include "openPMD/binding/python/auxiliary.hpp"
@@ -261,7 +262,7 @@ void init_Series(py::module &m)
     py::class_<IndexedIteration, Iteration>(m, "IndexedIteration")
         .def_readonly("iteration_index", &IndexedIteration::iterationIndex);
 
-    py::class_<WriteIterations>(m, "WriteIterations", R"END(
+    py::class_<WriteIterations, Attributable>(m, "WriteIterations", R"END(
 Writing side of the streaming API.
 
 Create instance via Series.writeIterations().

--- a/src/snapshots/Snapshots.cpp
+++ b/src/snapshots/Snapshots.cpp
@@ -1,9 +1,20 @@
 #include "openPMD/snapshots/Snapshots.hpp"
+#include "openPMD/backend/Attributable.hpp"
 namespace openPMD
 {
-Snapshots::Snapshots(std::shared_ptr<AbstractSnapshotsContainer> snapshots)
-    : m_snapshots(std::move(snapshots))
-{}
+Snapshots::Snapshots(
+    std::shared_ptr<AbstractSnapshotsContainer> snapshots,
+    Attributable &iterations)
+    : Attributable(Attributable::NoInit()), m_snapshots(std::move(snapshots))
+{
+    // Check the documentation of internal::AttributableData, we don't copy
+    // the first-level pointer, only the second level
+    // This avoids introducing depencencies between series.iterations and
+    // series.snapshots()
+    auto attributable_data = std::make_shared<internal::AttributableData>();
+    attributable_data->cloneFrom(*iterations.m_attri);
+    Attributable::setData(std::move(attributable_data));
+}
 inline auto Snapshots::get() const -> AbstractSnapshotsContainer const &
 {
     return *m_snapshots;

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -190,7 +190,7 @@ TEST_CASE("myPath", "[core]")
 {
 #if openPMD_USE_INVASIVE_TESTS
     using vec_t = std::vector<std::string>;
-    auto pathOf = [](Attributable &attr) {
+    auto pathOf = [](Attributable const &attr) {
         auto res = attr.myPath();
 #if false
         std::cout << "Directory:\t" << res.directory << "\nSeries name:\t"
@@ -206,6 +206,8 @@ TEST_CASE("myPath", "[core]")
 
     Series series("../samples/myPath.json", Access::CREATE);
     REQUIRE(pathOf(series) == vec_t{});
+    REQUIRE(pathOf(series.iterations) == vec_t{"data"});
+    REQUIRE(pathOf(series.snapshots()) == vec_t{"data"});
     auto iteration = series.iterations[1234];
     REQUIRE(pathOf(iteration) == vec_t{"data", "1234"});
 
@@ -377,6 +379,12 @@ TEST_CASE("output_modification_test", "[core]")
 
     o.setName("MyOutput");
     REQUIRE(o.name() == "MyOutput");
+
+    o.snapshots().setAttribute("test", "value");
+    REQUIRE(o.iterations.getAttribute("test").get<std::string>() == "value");
+
+    o.iterations.setAttribute<int>("test2", 2);
+    REQUIRE(o.snapshots().getAttribute("test2").get<int>() == 2);
 
     o.iterations[0];
 }


### PR DESCRIPTION
This allows reading and writing attributes from `series.snapshots()` just as it is possible with `series.iterations`. Necessary since this API is aiming for a feature-complete replacement of `series.iterations`.

TODO:

- [x] Testing