### PR TITLE
Windows Clang w/o MPI: Fix recent error

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,8 @@ jobs:
               -DCMAKE_C_COMPILER=clang-cl   ^
               -DCMAKE_CXX_COMPILER=clang-cl ^
               -DCMAKE_BUILD_TYPE=Release    ^
-              -DopenPMD_USE_MPI=OFF
+              -DopenPMD_USE_MPI=OFF ^
+              -DCMAKE_CXX_FLAGS="-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
         cmake --build build --config Release --parallel 2
         cmake --build build --config Debug --target install
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,8 +78,8 @@ jobs:
         pwsh "share\openPMD\download_samples.ps1" build
         cmake -S . -B build   ^
               -G "Ninja"      ^
-              -DCMAKE_C_COMPILER=clang-cl-19   ^
-              -DCMAKE_CXX_COMPILER=clang-cl-19 ^
+              -DCMAKE_C_COMPILER=clang-cl   ^
+              -DCMAKE_CXX_COMPILER=clang-cl ^
               -DCMAKE_BUILD_TYPE=Release    ^
               -DopenPMD_USE_MPI=OFF ^
               -DCMAKE_CXX_FLAGS="/DWIN32 /D_WINDOWS /EHsc -fexceptions -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,6 +60,16 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build & Install
       shell: cmd
+      # In the below script, the -DCMAKE_CXX_FLAGS are a workaround, since the
+      # windows-2022 runner currently ships with Clang-18, but the STL
+      # implementation wants to have Clang-19.
+      # We define -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH, this way telling
+      # the STL not to be picky.
+      # The other flags just bring back the default options since there is no
+      # simple way to append to the compiler flags instead of overriding them.
+      #
+      # This workaround should hopefully be temporary until the Runner upgrades
+      # to Clang-19.
       run: |
         python3.exe -m pip install --upgrade pip
         python3.exe -m pip install --upgrade numpy

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang-cl ^
               -DCMAKE_BUILD_TYPE=Release    ^
               -DopenPMD_USE_MPI=OFF ^
-              -DCMAKE_CXX_FLAGS="-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+              -DCMAKE_CXX_FLAGS="/DWIN32 /D_WINDOWS /EHsc -fexceptions -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
         cmake --build build --config Release --parallel 2
         cmake --build build --config Debug --target install
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,8 +78,8 @@ jobs:
         pwsh "share\openPMD\download_samples.ps1" build
         cmake -S . -B build   ^
               -G "Ninja"      ^
-              -DCMAKE_C_COMPILER=clang-cl   ^
-              -DCMAKE_CXX_COMPILER=clang-cl ^
+              -DCMAKE_C_COMPILER=clang-cl-19   ^
+              -DCMAKE_CXX_COMPILER=clang-cl-19 ^
               -DCMAKE_BUILD_TYPE=Release    ^
               -DopenPMD_USE_MPI=OFF ^
               -DCMAKE_CXX_FLAGS="/DWIN32 /D_WINDOWS /EHsc -fexceptions -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"


### PR DESCRIPTION
It seems like the STL installed on windows-2022 runners now starts requiring Clang-19, but the installed Clang version is still 18. Until this is fixed upstream, this PR implements a workaround telling the STL not to be so picky.