### PR TITLE
Clang on Windows: Fix build errors

### DIFF
--- a/include/openPMD/binding/python/Mpi.hpp
+++ b/include/openPMD/binding/python/Mpi.hpp
@@ -94,7 +94,7 @@ pythonObjectAsMpiComm(pybind11::object &comm)
             e_t::is_not_an_mpi_communicator};
     // only checks same layout, e.g. an `int` in `PyObject` could pass this
     if (!py::isinstance<py::class_<openPMD_PyMPIIntracommObject> >(
-            comm.get_type()))
+            py::type::of(comm)))
         // TODO add mpi4py version from above import check to error message
         return e{
             "comm has unexpected type layout in " + comm_str +

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -275,7 +275,7 @@ template <typename RequestedType>
 bool setAttributeFromObject_default(
     Attributable &attr, std::string const &key, py::object &obj)
 {
-    if (std::string(py::str(obj.get_type())) == "<class 'list'>")
+    if (std::string(py::str(py::type::of(obj))) == "<class 'list'>")
     {
         using ListType = std::vector<RequestedType>;
         return attr.setAttribute<ListType>(key, obj.cast<ListType>());
@@ -289,7 +289,7 @@ bool setAttributeFromObject_default(
 bool setAttributeFromObject_double(
     Attributable &attr, std::string const &key, py::object &obj)
 {
-    if (std::string(py::str(obj.get_type())) == "<class 'list'>")
+    if (std::string(py::str(py::type::of(obj))) == "<class 'list'>")
     {
         using ListType = std::vector<double>;
         using ArrayType = std::array<double, 7>;
@@ -342,7 +342,7 @@ std::optional<TargetType> tryCast(py::object const &obj)
     {
         TargetType val{};
         auto python_val = py::cast(std::move(val));
-        if (!py::isinstance(obj, python_val.get_type()))
+        if (!py::isinstance(obj, py::type::of(python_val)))
         {
             return std::nullopt;
         }

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -387,7 +387,10 @@ not possible once it has been closed.
         std::tuple<py::object, std::string>,
         std::tuple<py::object, py::object>
 #endif
-        >::template call(cl);
+        >::template call<py::class_<Series, Attributable> &>(cl);
+    //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    // need to explicitly state template parameters, otherwise Clang on
+    // Windows does not understand that it really is a template
 
     cl.def("__bool__", &Series::operator bool)
         .def("__len__", [](Series const &s) { return s.iterations.size(); })


### PR DESCRIPTION
Seen this error in multiple PRs:

```
2025-07-11T14:01:54.3705882Z D:\a\openPMD-api\openPMD-api\src\binding\python\Series.cpp(390,21): error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
2025-07-11T14:01:54.8783327Z   390 |         >::template call(cl);
```

```cpp
    ::auxiliary::ForEachType<
        ::internal::DefineSeriesConstructorPerPathType,
    // First tuple components are eligible types for the path argument
    // second component for the config argument
    // py::object needs to always come last, as a catch-all pattern
#if openPMD_USE_FILESYSTEM_HEADER
        std::tuple<std::string, std::string>,
        std::tuple<std::string, std::filesystem::path>,
        std::tuple<std::string, py::object>,
        std::tuple<std::filesystem::path, std::string>,
        std::tuple<std::filesystem::path, std::filesystem::path>,
        std::tuple<std::filesystem::path, py::object>
#else
        std::tuple<std::string, std::string>,
        std::tuple<std::string, py::object>,
        std::tuple<py::object, std::string>,
        std::tuple<py::object, py::object>
#endif
        >::template call(cl); // line 390, this is a template, but Clang on Windows no longer believes so
```

First commit is empty to verify that this affects dev already. Second will push a workaround.

This also uncovered a deprecated API call in Pybind.