### PR TITLE
Deactivate Span API by default in BP5

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1247,6 +1247,11 @@ void ADIOS2IOHandlerImpl::getBufferView(
     Writable *writable, Parameter<Operation::GET_BUFFER_VIEW> &parameters)
 {
     // @todo check access mode
+    /*
+     * We will check BP5 again below. BP5 fundamentally supports the Span API,
+     * but runs into this bug https://github.com/ornladios/ADIOS2/issues/4586,
+     * so we treat the Span API as opt-in there.
+     */
     std::string optInEngines[] = {"bp4", "bp5", "file", "filestream"};
     if (std::none_of(
             begin(optInEngines),
@@ -1270,7 +1275,16 @@ void ADIOS2IOHandlerImpl::getBufferView(
         return;
     case UseSpan::Auto:
         if (switchAdios2VariableType<detail::HasOperators>(
-                parameters.dtype, name, ba.m_IO))
+                parameters.dtype, name, ba.m_IO)
+#if (                                                                          \
+    ADIOS2_VERSION_MAJOR * 1000 + ADIOS2_VERSION_MINOR * 10 +                  \
+    ADIOS2_VERSION_PATCH) <= 2102
+            ||
+            // Deactivate the Span API in BP5 by default due to this bug
+            // https://github.com/ornladios/ADIOS2/issues/4586,
+            this->realEngineType() == "bp5"
+#endif
+        )
         {
             parameters.out->backendManagedBuffer = false;
             return;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1250,6 +1250,7 @@ void ADIOS2IOHandlerImpl::getBufferView(
     /*
      * We will check BP5 again below. BP5 fundamentally supports the Span API,
      * but runs into this bug https://github.com/ornladios/ADIOS2/issues/4586,
+     * fixed by https://github.com/ornladios/ADIOS2/pull/4587,
      * so we treat the Span API as opt-in there.
      */
     std::string optInEngines[] = {"bp4", "bp5", "file", "filestream"};
@@ -1282,6 +1283,7 @@ void ADIOS2IOHandlerImpl::getBufferView(
             ||
             // Deactivate the Span API in BP5 by default due to this bug
             // https://github.com/ornladios/ADIOS2/issues/4586,
+            // fixed by https://github.com/ornladios/ADIOS2/pull/4587
             this->realEngineType() == "bp5"
 #endif
         )

--- a/test/Files_ParallelIO/iterate_nonstreaming_series.cpp
+++ b/test/Files_ParallelIO/iterate_nonstreaming_series.cpp
@@ -21,7 +21,17 @@ static auto run_test(
     size_t const extent = base_extent * size_t(mpi_size);
 
     {
-        Series writeSeries(file, Access::CREATE, MPI_COMM_WORLD, jsonConfig);
+        Series writeSeries(
+            file,
+            Access::CREATE,
+            MPI_COMM_WORLD,
+            /*
+             * The ADIOS2 backend deactivates the Span API by default due to
+             * this bug: https://github.com/ornladios/ADIOS2/issues/4586.
+             * For this test, we enable it.
+             */
+            json::merge(
+                jsonConfig, R"({"adios2":{"use_span_based_put": true}})"));
         if (variableBasedLayout)
         {
             writeSeries.setIterationEncoding(IterationEncoding::variableBased);

--- a/test/Files_ParallelIO/iterate_nonstreaming_series.cpp
+++ b/test/Files_ParallelIO/iterate_nonstreaming_series.cpp
@@ -27,7 +27,8 @@ static auto run_test(
             MPI_COMM_WORLD,
             /*
              * The ADIOS2 backend deactivates the Span API by default due to
-             * this bug: https://github.com/ornladios/ADIOS2/issues/4586.
+             * this bug: https://github.com/ornladios/ADIOS2/issues/4586,
+             * fixed by https://github.com/ornladios/ADIOS2/pull/4587.
              * For this test, we enable it.
              */
             json::merge(

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6394,7 +6394,16 @@ void iterate_nonstreaming_series(
 {
     constexpr size_t extent = 100;
     {
-        Series writeSeries(file, Access::CREATE, jsonConfig);
+        Series writeSeries(
+            file,
+            Access::CREATE,
+            /*
+             * The ADIOS2 backend deactivates the Span API by default due to
+             * this bug: https://github.com/ornladios/ADIOS2/issues/4586.
+             * For this test, we enable it.
+             */
+            json::merge(
+                jsonConfig, R"({"adios2":{"use_span_based_put": true}})"));
         if (variableBasedLayout)
         {
             writeSeries.setIterationEncoding(IterationEncoding::variableBased);

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6399,7 +6399,8 @@ void iterate_nonstreaming_series(
             Access::CREATE,
             /*
              * The ADIOS2 backend deactivates the Span API by default due to
-             * this bug: https://github.com/ornladios/ADIOS2/issues/4586.
+             * this bug: https://github.com/ornladios/ADIOS2/issues/4586,
+             * fixed by https://github.com/ornladios/ADIOS2/pull/4587.
              * For this test, we enable it.
              */
             json::merge(


### PR DESCRIPTION
Workaround for this bug https://github.com/ornladios/ADIOS2/issues/4586.
Since BP5 can write directly from user buffers, this change (essentially activating our fallback implementation) is not too costly.

TODO:

- [x]  Wait for an answer in the issue linked above. The current draft assumes that this will be fixed in upcoming versions, but let's be sure of that.