### PR TITLE
Fix Appveyor CI: Add Cython to Conda install

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -86,7 +86,7 @@ install:
   - cmd: conda config --append channels conda-forge
 
   # Configure the VM.
-  - cmd: conda install -n root --quiet --yes numpy cmake hdf5 python=%CONDA_PY%
+  - cmd: conda install -n root --quiet --yes cython numpy cmake hdf5 python=%CONDA_PY%
   # ADIOS2 build only for 64bit Windows
   - cmd: if "%TARGET_ARCH%"=="x64" conda install -n root --quiet --yes adios2 python=%CONDA_PY%
 


### PR DESCRIPTION
Appveyor Python runs started giving me this error:

```
19: INTEL oneMKL ERROR: The specified module could not be found. mkl_intel_thread.2.dll.
19: Intel oneMKL FATAL ERROR: Cannot load mkl_intel_thread.2.dll.
```

[This](https://stackoverflow.com/questions/57567892/intel-mkl-fatal-error-cannot-load-mkl-intel-thread-dll) suggests that installing cython could fix the issue, so let's try.