### PR TITLE
Fix missing check for constant components

### DIFF
--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -272,7 +272,7 @@ void RecordComponent::flush(
         {
             // The check for !written() is technically not needed, just
             // defensive programming against internal bugs that go on us.
-            if (!written() && rc.m_chunks.empty())
+            if (!written() && rc.m_chunks.empty() && !rc.m_isConstant)
             {
                 // No data written yet, just accessed the object so far without
                 // doing anything
@@ -283,7 +283,8 @@ void RecordComponent::flush(
             {
                 throw error::WrongAPIUsage(
                     "[RecordComponent] Must specify dataset type and extent "
-                    "before flushing (see RecordComponent::resetDataset()).");
+                    "before flushing or setting a constant value (see "
+                    "RecordComponent::resetDataset()).");
             }
         }
         if (!containsAttribute("unitSI"))

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -109,6 +109,8 @@ class APITest(unittest.TestCase):
             for dim in ["x", "y"]:
                 # Do not bother with a positionOffset
                 position_offset = e["positionOffset"][dim]
+                position_offset.reset_dataset(
+                    io.Dataset(np.dtype("int"), [100]))
                 position_offset.make_constant(0)
 
                 position = e["position"][dim]


### PR DESCRIPTION
Found by the JSON Schema verification added to our CI by #1426. The positionOffset in this test was silently ignored since I forgot specifying the dataset. Adds a check to our flushing logic so this won't happen again in future and fixes the test.