### PR TITLE
Fixes for deferred initialization

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -266,12 +266,15 @@ jobs:
       env: {CXXFLAGS: -Werror, PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig}
       run: |
         share/openPMD/download_samples.sh build
+        # Run a debug build,
+        # Pybind has some builtin checks only activated in debug mode.
         cmake -S . -B build                  \
           -DopenPMD_USE_PYTHON=ON            \
           -DopenPMD_USE_MPI=ON               \
           -DopenPMD_USE_HDF5=ON              \
           -DopenPMD_USE_FILESYSTEM_HEADER=ON \
-          -DopenPMD_USE_INVASIVE_TESTS=ON
+          -DopenPMD_USE_INVASIVE_TESTS=ON \
+          -DCMAKE_BUILD_TYPE=Debug
         cmake --build build --parallel 4
         ctest --test-dir build --output-on-failure
 

--- a/include/openPMD/snapshots/ContainerImpls.hpp
+++ b/include/openPMD/snapshots/ContainerImpls.hpp
@@ -34,12 +34,14 @@ private:
          * make_reading_stateful_iterator.
          * The iterator is resolved upon calling get() below.
          */
-        std::function<StatefulIterator *()> m_begin;
-        std::optional<StatefulIterator *> m_bufferedIterator = std::nullopt;
+        std::variant<std::function<StatefulIterator *()>, StatefulIterator *>
+            m_bufferedIterator;
     };
     Members members;
 
-    StatefulSnapshotsContainer(std::function<StatefulIterator *()> begin);
+    StatefulSnapshotsContainer(
+        std::variant<std::function<StatefulIterator *()>, StatefulIterator *>
+            begin);
 
     auto get() -> StatefulIterator *;
     auto get() const -> StatefulIterator const *;
@@ -64,6 +66,7 @@ public:
 
     using AbstractSnapshotsContainer::currentIteration;
     auto currentIteration() const -> std::optional<value_type const *> override;
+    auto currentIteration() -> std::optional<value_type *> override;
 
     auto begin() -> iterator override;
     auto end() -> iterator override;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3194,7 +3194,7 @@ namespace
 {
     auto make_writing_stateful_iterator(
         Series const &copied_series, internal::SeriesData &series)
-        -> std::function<StatefulIterator *()>
+        -> StatefulIterator *
     {
         if (!series.m_sharedStatefulIterator)
         {
@@ -3202,12 +3202,16 @@ namespace
                 std::make_unique<StatefulIterator>(
                     StatefulIterator::tag_write, copied_series);
         }
-        return [ptr = series.m_sharedStatefulIterator.get()]() { return ptr; };
+        return series.m_sharedStatefulIterator.get();
     }
     auto make_reading_stateful_iterator(
         Series copied_series, internal::SeriesData &series)
-        -> std::function<StatefulIterator *()>
+        -> std::variant<std::function<StatefulIterator *()>, StatefulIterator *>
     {
+        if (series.m_sharedStatefulIterator)
+        {
+            return series.m_sharedStatefulIterator.get();
+        }
         return [s = std::move(copied_series), &series]() mutable {
             if (!series.m_sharedStatefulIterator)
             {
@@ -3317,7 +3321,7 @@ Snapshots Series::makeSynchronousSnapshots()
             internal::default_or_explicit::default_);
     }
 
-    std::function<StatefulIterator *()> begin;
+    std::variant<std::function<StatefulIterator *()>, StatefulIterator *> begin;
 
     if (access::write(IOHandler()->m_frontendAccess))
     {

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -1,6 +1,7 @@
 #include "openPMD/snapshots/ContainerImpls.hpp"
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/Access.hpp"
+#include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/snapshots/ContainerTraits.hpp"
 #include "openPMD/snapshots/IteratorHelpers.hpp"
 #include "openPMD/snapshots/RandomAccessIterator.hpp"
@@ -12,7 +13,7 @@
 namespace openPMD
 {
 StatefulSnapshotsContainer::StatefulSnapshotsContainer(
-    std::function<StatefulIterator *()> begin)
+    std::variant<std::function<StatefulIterator *()>, StatefulIterator *> begin)
     : members{std::move(begin)}
 {}
 
@@ -30,15 +31,34 @@ operator=(StatefulSnapshotsContainer &&other) noexcept(noexcept(
 
 auto StatefulSnapshotsContainer::get() -> StatefulIterator *
 {
-    if (!members.m_bufferedIterator.has_value())
-    {
-        members.m_bufferedIterator = members.m_begin();
-    }
-    return *members.m_bufferedIterator;
+    return std::visit(
+        auxiliary::overloaded{
+            [this](
+                std::function<StatefulIterator *()> &deferred_initialization) {
+                auto it = deferred_initialization();
+                this->members.m_bufferedIterator = it;
+                return it;
+            },
+            [](StatefulIterator *it) { return it; }},
+        members.m_bufferedIterator);
 }
+
+void breakpoint()
+{}
 auto StatefulSnapshotsContainer::get() const -> StatefulIterator const *
 {
-    return members.m_bufferedIterator.value_or(nullptr);
+    return std::visit(
+        auxiliary::overloaded{
+            [](std::function<StatefulIterator *()> const &)
+                -> StatefulIterator const * {
+                breakpoint();
+                throw std::runtime_error(
+                    "[StatefulSnapshotscontainer] Initialization has been "
+                    "deferred, but container is accessed as const, so cannot "
+                    "initialize.");
+            },
+            [](StatefulIterator const *it) { return it; }},
+        members.m_bufferedIterator);
 }
 
 auto StatefulSnapshotsContainer::stateful_to_opaque(StatefulIterator const &it)
@@ -49,6 +69,19 @@ auto StatefulSnapshotsContainer::stateful_to_opaque(StatefulIterator const &it)
 
 auto StatefulSnapshotsContainer::currentIteration() const
     -> std::optional<value_type const *>
+{
+    if (auto it = get(); it)
+    {
+        return it->peekCurrentlyOpenIteration();
+    }
+    else
+    {
+        return std::nullopt;
+    }
+}
+
+auto StatefulSnapshotsContainer::currentIteration()
+    -> std::optional<value_type *>
 {
     if (auto it = get(); it)
     {


### PR DESCRIPTION
In `Series::snapshots()`, the stateful container initialization is deferred, since IO accesses should occur only upon user request and not earlier. However, it currently had no constructor without deferring, leading to troubles when accessing the container as const, because initialization can only done as non-const.
This adds a non-deferred constructor, using deferred initialization only in such cases where IO accesses are actual deferred.

TODO:

- [x] Change some CI run to create a Debug build, this bug was uncovered by Pybind11 GIL checks activated in Debug builds