### PR TITLE
storeChunk: use const-type pointers

### DIFF
--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -388,7 +388,7 @@ public:
      * @param extent Extent within the dataset, counted from the offset.
      */
     template <typename T>
-    void storeChunkRaw(T *data, Offset offset, Extent extent);
+    void storeChunkRaw(T const *data, Offset offset, Extent extent);
 
     /** Store a chunk of data from a contiguous container.
      *

--- a/include/openPMD/auxiliary/ShareRawInternal.hpp
+++ b/include/openPMD/auxiliary/ShareRawInternal.hpp
@@ -61,16 +61,14 @@ std::shared_ptr<T const> shareRaw(T const *x)
 }
 
 template <typename T>
-auto shareRaw(T &c)
-    -> std::shared_ptr<typename std::remove_pointer<decltype(c.data())>::type>
+auto shareRaw(T &c) -> std::shared_ptr<typename T::value_type>
 {
     using value_type = typename std::remove_pointer<decltype(c.data())>::type;
     return std::shared_ptr<value_type>(c.data(), [](value_type *) {});
 }
 
 template <typename T>
-auto shareRaw(T const &c)
-    -> std::shared_ptr<typename std::remove_pointer<decltype(c.data())>::type>
+auto shareRaw(T const &c) -> std::shared_ptr<typename T::value_type>
 {
     using value_type = typename std::remove_pointer<decltype(c.data())>::type;
     return std::shared_ptr<value_type>(c.data(), [](value_type *) {});

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -826,7 +826,7 @@ void RecordComponent::storeChunk(std::shared_ptr<T[]> data, Offset o, Extent e)
 }
 
 template <typename T>
-void RecordComponent::storeChunkRaw(T *ptr, Offset offset, Extent extent)
+void RecordComponent::storeChunkRaw(T const *ptr, Offset offset, Extent extent)
 {
     storeChunk(auxiliary::shareRaw(ptr), std::move(offset), std::move(extent));
 }
@@ -864,15 +864,15 @@ void RecordComponent::verifyChunk(Offset const &o, Extent const &e) const
     template void RecordComponent::verifyChunk<type>(                          \
         Offset const &o, Extent const &e) const;                               \
     template DynamicMemoryView<type> RecordComponent::storeChunk<type>(        \
-        Offset offset, Extent extent);
+        Offset offset, Extent extent);                                         \
+    template void RecordComponent::storeChunkRaw<type>(                        \
+        OPENPMD_PTR(type const) ptr, Offset offset, Extent extent);
 
 #define OPENPMD_INSTANTIATE_CONST_AND_NONCONST(type)                           \
     template void RecordComponent::storeChunk<type>(                           \
         std::shared_ptr<type> data, Offset o, Extent e);                       \
     template void RecordComponent::storeChunk<type>(                           \
-        std::shared_ptr<OPENPMD_ARRAY(type)> data, Offset o, Extent e);        \
-    template void RecordComponent::storeChunkRaw<type>(                        \
-        OPENPMD_PTR(type) ptr, Offset offset, Extent extent);
+        std::shared_ptr<OPENPMD_ARRAY(type)> data, Offset o, Extent e);
 
 #define OPENPMD_INSTANTIATE_WITH_AND_WITHOUT_EXTENT(type)                      \
     template std::shared_ptr<type> RecordComponent::loadChunk<type>(           \

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -820,7 +820,7 @@ template <typename T>
 void RecordComponent::storeChunk(std::shared_ptr<T[]> data, Offset o, Extent e)
 {
     storeChunk(
-        std::static_pointer_cast<T>(std::move(data)),
+        std::static_pointer_cast<T const>(std::move(data)),
         std::move(o),
         std::move(e));
 }


### PR DESCRIPTION
We do not modify buffers in storeChunk(), and I think by our API contract we would/should not be allowed to anyway?

TODO: 

- [x] ~~Do the same for `shared_ptr` overloads, too.~~ Nah, don't. The type system does not deduce `shared_ptr<T>` to `shared_ptr<T const>`, so we need the overload.
- Do NOT do this for `unique_ptr` overloads, we are allowed to modify these as unique owners.