### PR TITLE
Doc: First Write `np.float64`

### DIFF
--- a/docs/source/usage/firstwrite.rst
+++ b/docs/source/usage/firstwrite.rst
@@ -180,7 +180,7 @@ Python
 
    x_data = np.arange(
        150 * 300,
-       dtype=np.float
+       dtype=np.float64
    ).reshape(150, 300)
 
 


### PR DESCRIPTION
Newer numpy removed the alias for `np.float`, so use an explicit type now.