### PR TITLE
JSON Backend: Fix repeated flush to disk

### DIFF
--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1078,7 +1078,6 @@ void JSONIOHandlerImpl::deletePath(
         lastPointer->erase(splitPath[splitPath.size() - 1]);
     }
 
-    putJsonContents(file);
     writable->abstractFilePosition.reset();
     writable->written = false;
 }
@@ -1120,7 +1119,6 @@ void JSONIOHandlerImpl::deleteDataset(
         parent = &obtainJsonContents(writable);
     }
     parent->erase(dataset);
-    putJsonContents(file);
     writable->written = false;
     writable->abstractFilePosition.reset();
 }
@@ -1139,7 +1137,6 @@ void JSONIOHandlerImpl::deleteAttribute(
     auto file = refreshFileFromParent(writable);
     auto &j = obtainJsonContents(writable);
     j.erase(parameters.name);
-    putJsonContents(file);
 }
 
 void JSONIOHandlerImpl::writeDataset(
@@ -1172,7 +1169,6 @@ void JSONIOHandlerImpl::writeDataset(
     switchType<DatasetWriter>(parameters.dtype, j, parameters);
 
     writable->written = true;
-    putJsonContents(file);
 }
 
 void JSONIOHandlerImpl::writeAttribute(


### PR DESCRIPTION
Fix #1781

These calls should never have been in those functions, writing to disk once per file and flush operation is enough.