### PR TITLE
Clang Tidy and Sanitizer: Use clang-19 on Ubuntu 24.04

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,5 +2,5 @@
 # FIXME: all performance-* reports
 # FIXME: all cert-* reports
 # FIXME: all bugprone-* reports
-Checks: -*,bugprone-*,-bugprone-unhandled-self-assignment,-bugprone-parent-virtual-call,-bugprone-narrowing-conversions,-bugprone-exception-escape,-bugprone-string-literal-with-embedded-nul,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,performance-*,modernize-*,-modernize-use-trailing-return-type,-modernize-use-bool-literals,-modernize-avoid-c-arrays,-modernize-use-auto,-modernize-return-braced-init-list,-bugprone-easily-swappable-parameters
+Checks: -*,bugprone-*,-bugprone-unhandled-self-assignment,-bugprone-parent-virtual-call,-bugprone-narrowing-conversions,-bugprone-exception-escape,-bugprone-string-literal-with-embedded-nul,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,performance-*,-performance-avoid-endl,modernize-*,-modernize-use-trailing-return-type,-modernize-use-bool-literals,-modernize-avoid-c-arrays,-modernize-use-auto,-modernize-return-braced-init-list,-bugprone-easily-swappable-parameters
 HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,5 +2,5 @@
 # FIXME: all performance-* reports
 # FIXME: all cert-* reports
 # FIXME: all bugprone-* reports
-Checks: -*,bugprone-*,-bugprone-unhandled-self-assignment,-bugprone-parent-virtual-call,-bugprone-narrowing-conversions,-bugprone-exception-escape,-bugprone-string-literal-with-embedded-nul,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,performance-*,-performance-avoid-endl,modernize-*,-modernize-use-trailing-return-type,-modernize-use-bool-literals,-modernize-avoid-c-arrays,-modernize-use-auto,-modernize-return-braced-init-list,-bugprone-easily-swappable-parameters
+Checks: -*,bugprone-*,-bugprone-unhandled-self-assignment,-bugprone-parent-virtual-call,-bugprone-narrowing-conversions,-bugprone-exception-escape,-bugprone-string-literal-with-embedded-nul,cppcoreguidelines-slicing,mpi-*,readability-non-const-parameter,performance-*,-performance-avoid-endl,modernize-*,-modernize-use-trailing-return-type,-modernize-use-bool-literals,-modernize-avoid-c-arrays,-modernize-use-auto,-modernize-return-braced-init-list,-bugprone-easily-swappable-parameters,-bugprone-chained-comparison
 HeaderFilterRegex: '((^(?!\/share\/openPMD\/).*)*include\/openPMD\/.+\.hpp|src\/^(?!binding).+\.cpp$)'

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -49,14 +49,16 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
-        c: [clang]
-        cxx: [clang]
+        c: [llvm]
+        cxx: [llvm]
         fortran: [gcc]
         gcc-runtime: [gcc-runtime@13.3.0]
+      prefer:
+      - "%llvm"
 
-    clang:
+    llvm:
       externals:
-      - spec: clang@19.1.1 target=x86_64
+      - spec: llvm@19.1.1 target=x86_64
         prefix: /
         paths:
           cc: /usr/bin/clang-19

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -43,6 +43,8 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
+        c: [clang@19.1.1]
+        cxx: [clang@19.1.1]
       compiler: [clang@19.1.1]
 
   compilers:

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -43,7 +43,7 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
-      compiler: [clang@19.0.0]
+      compiler: [clang@14.0.6]
 
   compilers:
   - compiler:
@@ -53,11 +53,11 @@ spack:
       modules: []
       operating_system: ubuntu22.04
       paths:
-        cc: /usr/bin/clang-19
-        cxx: /usr/bin/clang++-19
+        cc: /usr/bin/clang-14
+        cxx: /usr/bin/clang++-14
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
-      spec: clang@19.0.0
+      spec: clang@14.0.6
       target: x86_64
 
   config:

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -14,30 +14,36 @@ spack:
   packages:
     adios2:
       variants: ~zfp ~sz ~png ~dataman ~python ~fortran ~ssc ~shared ~bzip2 ~mgard
+
     c-blosc2:
       # snappy broken on CMake 4.0
       # fixed snappy not yet deployed to a Spack release
       variants: ~snappy
+
     cmake:
       externals:
       - spec: cmake@3.31.8
         prefix: /usr/local
       buildable: False
+
     openmpi:
       externals:
-      - spec: openmpi@4.1.2
+      - spec: openmpi@4.1.6
         prefix: /usr
       buildable: False
+
     perl:
       externals:
-      - spec: perl@5.34.0
+      - spec: perl@5.38.2
         prefix: /usr
       buildable: False
+
     python:
       externals:
-      - spec: python@3.10.12
+      - spec: python@3.12.3
         prefix: /usr
       buildable: False
+
     all:
       target: [x86_64]
       variants: ~fortran
@@ -45,6 +51,9 @@ spack:
         mpi: [openmpi]
         c: [clang]
         cxx: [clang]
+        fortran: [gcc]
+        gcc-runtime: [gcc-runtime@13.3.0]
+
     clang:
       externals:
       - spec: clang@19.1.1 target=x86_64
@@ -52,12 +61,11 @@ spack:
         paths:
           cc: /usr/bin/clang-19
           cxx: /usr/bin/clang++-19
-        extra_rpaths: []
         modules: []
         environment: {}
-        dependencies:
-          gcc-runtime: gcc-runtime@13.3.0
+        extra_rpaths: []
       buildable: False
+
     gcc:
       externals:
       - spec: gcc@13.3.0
@@ -65,17 +73,44 @@ spack:
         paths:
           f77: /usr/bin/gfortran
           fc: /usr/bin/gfortran
-        extra_rpaths: []
         modules: []
         environment: {}
-        dependencies:
-          gcc-runtime: gcc-runtime@13.3.0
+        extra_rpaths: []
       buildable: False
+
     gcc-runtime:
       externals:
-        - spec: gcc-runtime@13.3.0
-          prefix: /usr
+      - spec: gcc-runtime@13.3.0
+        prefix: /usr
       buildable: False
+
+  compilers:
+  - compiler:
+      spec: gcc@13.3.0
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      modules: []
+      paths:
+        cc: /usr/bin/gcc-13
+        cxx: /usr/bin/g++-13
+        f77: /usr/bin/gfortran-13
+        fc: /usr/bin/gfortran-13
+      operating_system: ubuntu24.04
+      target: x86_64
+  - compiler:
+      spec: clang@19.1.1
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      modules: []
+      paths:
+        cc: /usr/bin/clang-19
+        cxx: /usr/bin/clang++-19
+        f77: /usr/bin/gfortran-13
+        fc: /usr/bin/gfortran-13
+      operating_system: ubuntu24.04
+      target: x86_64
 
   config:
     build_jobs: 2

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -43,7 +43,7 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
-      compiler: [clang@14.0.0]
+      compiler: [clang@19.0.0]
 
   compilers:
   - compiler:
@@ -53,11 +53,11 @@ spack:
       modules: []
       operating_system: ubuntu22.04
       paths:
-        cc: /usr/bin/clang-14
-        cxx: /usr/bin/clang++-14
+        cc: /usr/bin/clang-19
+        cxx: /usr/bin/clang++-19
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
-      spec: clang@14.0.0
+      spec: clang@19.0.0
       target: x86_64
 
   config:

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -43,7 +43,7 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
-      compiler: [clang@14.0.6]
+      compiler: [clang@14.0.0]
 
   compilers:
   - compiler:
@@ -57,7 +57,7 @@ spack:
         cxx: /usr/bin/clang++-14
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
-      spec: clang@14.0.6
+      spec: clang@14.0.0
       target: x86_64
 
   config:

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -49,10 +49,9 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
-        c: [llvm]
+        cc: [llvm]
         cxx: [llvm]
         fortran: [gcc]
-        gcc-runtime: [gcc-runtime@13.3.0]
       prefer:
       - "%llvm"
 
@@ -79,40 +78,6 @@ spack:
         environment: {}
         extra_rpaths: []
       buildable: False
-
-    gcc-runtime:
-      externals:
-      - spec: gcc-runtime@13.3.0
-        prefix: /usr
-      buildable: False
-
-  compilers:
-  - compiler:
-      spec: gcc@13.3.0
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules: []
-      paths:
-        cc: /usr/bin/gcc-13
-        cxx: /usr/bin/g++-13
-        f77: /usr/bin/gfortran-13
-        fc: /usr/bin/gfortran-13
-      operating_system: ubuntu24.04
-      target: x86_64
-  - compiler:
-      spec: clang@19.1.1
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules: []
-      paths:
-        cc: /usr/bin/clang-19
-        cxx: /usr/bin/clang++-19
-        f77: /usr/bin/gfortran-13
-        fc: /usr/bin/gfortran-13
-      operating_system: ubuntu24.04
-      target: x86_64
 
   config:
     build_jobs: 2

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -43,7 +43,7 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
-      compiler: [clang@14.0.0]
+      compiler: [clang@19.1.1]
 
   compilers:
   - compiler:
@@ -53,11 +53,11 @@ spack:
       modules: []
       operating_system: ubuntu22.04
       paths:
-        cc: /usr/bin/clang-14
-        cxx: /usr/bin/clang++-14
+        cc: /usr/bin/clang-19
+        cxx: /usr/bin/clang++-19
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
-      spec: clang@14.0.0
+      spec: clang@19.1.1
       target: x86_64
 
   config:

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -20,8 +20,8 @@ spack:
       variants: ~snappy
     cmake:
       externals:
-      - spec: cmake@3.31.5
-        prefix: /usr
+      - spec: cmake@3.31.8
+        prefix: /usr/local
       buildable: False
     openmpi:
       externals:
@@ -43,24 +43,39 @@ spack:
       variants: ~fortran
       providers:
         mpi: [openmpi]
-        c: [clang@19.1.1]
-        cxx: [clang@19.1.1]
-      compiler: [clang@19.1.1]
-
-  compilers:
-  - compiler:
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules: []
-      operating_system: ubuntu22.04
-      paths:
-        cc: /usr/bin/clang-19
-        cxx: /usr/bin/clang++-19
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      spec: clang@19.1.1
-      target: x86_64
+        c: [clang]
+        cxx: [clang]
+    clang:
+      externals:
+      - spec: clang@19.1.1 target=x86_64
+        prefix: /
+        paths:
+          cc: /usr/bin/clang-19
+          cxx: /usr/bin/clang++-19
+        extra_rpaths: []
+        modules: []
+        environment: {}
+        dependencies:
+          gcc-runtime: gcc-runtime@13.3.0
+      buildable: False
+    gcc:
+      externals:
+      - spec: gcc@13.3.0
+        prefix: /
+        paths:
+          f77: /usr/bin/gfortran
+          fc: /usr/bin/gfortran
+        extra_rpaths: []
+        modules: []
+        environment: {}
+        dependencies:
+          gcc-runtime: gcc-runtime@13.3.0
+      buildable: False
+    gcc-runtime:
+      externals:
+        - spec: gcc-runtime@13.3.0
+          prefix: /usr
+      buildable: False
 
   config:
     build_jobs: 2

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -56,7 +56,7 @@ spack:
     llvm:
       externals:
       - spec: llvm@19.1.1
-        prefix: /
+        prefix: /usr
         paths:
           cc: /usr/bin/clang-19
           cxx: /usr/bin/clang++-19
@@ -64,6 +64,25 @@ spack:
         environment: {}
         extra_rpaths: []
       buildable: False
+
+    gcc:
+      externals:
+      - spec: gcc@13.3.0
+        prefix: /usr
+        paths:
+          cc: /usr/bin/gcc
+          cxx: /usr/bin/g++
+          fortran: /usr/bin/gfortran
+        modules: []
+        environment: {}
+        extra_rpaths: []
+      buildable: False
+
+    gcc-runtime:
+      buildable: false
+      externals:
+        - spec: gcc-runtime@13.3.0
+          prefix: /usr
 
   config:
     build_jobs: 2

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -65,18 +65,6 @@ spack:
         extra_rpaths: []
       buildable: False
 
-    gcc:
-      externals:
-      - spec: gcc@13.3.0
-        prefix: /
-        paths:
-          f77: /usr/bin/gfortran
-          fc: /usr/bin/gfortran
-        modules: []
-        environment: {}
-        extra_rpaths: []
-      buildable: False
-
   config:
     build_jobs: 2
 

--- a/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
+++ b/.github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/spack.yaml
@@ -52,12 +52,10 @@ spack:
         cc: [llvm]
         cxx: [llvm]
         fortran: [gcc]
-      prefer:
-      - "%llvm"
 
     llvm:
       externals:
-      - spec: llvm@19.1.1 target=x86_64
+      - spec: llvm@19.1.1
         prefix: /
         paths:
           cc: /usr/bin/clang-19
@@ -83,4 +81,4 @@ spack:
     build_jobs: 2
 
   mirrors:
-    E4S: https://cache.e4s.io
+    spack-public: https://mirror.spack.io

--- a/.github/workflows/dependencies/install_spack
+++ b/.github/workflows/dependencies/install_spack
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-spack_ver="0.22.3"
+spack_ver="${SPACK_VER:-0.22.3}"
 
 cd /opt
 if [[ -d spack && ! -f spack_${spack_ver} ]]

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clangtidy14_nopy_ompi_h5_ad2:
+  clangtidy19_nopy_ompi_h5_ad2:
     name: clang-tidy w/o py
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Spack Cache
       uses: actions/cache@v3
-      with: {path: /opt/spack, key: clangtidy14_nopy_ompi_h5_ad2 }
+      with: {path: /opt/spack, key: clangtidy19_nopy_ompi_h5_ad2 }
     - name: Install
       run: |
         sudo apt-get update
@@ -37,7 +37,7 @@ jobs:
         cat build/clang-tidy.log
         if [[ $(wc -m <build/clang-tidy.log) -gt 1 ]]; then exit 1; fi
 
-  clangsanitizer14_py38_ompi_h5_ad2:
+  clangsanitizer19_py38_ompi_h5_ad2:
     name: Clang ASAN UBSAN
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
@@ -45,15 +45,15 @@ jobs:
     - uses: actions/checkout@v4
     - name: Spack Cache
       uses: actions/cache@v3
-      with: {path: /opt/spack, key: clang14_nopy_ompi_h5_ad2 }
+      with: {path: /opt/spack, key: clang19_nopy_ompi_h5_ad2 }
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install clang-14 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev python3-numpy
+        sudo apt-get install clang-19 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev python3-numpy
         SPACK_VER=1.0.1 sudo -E .github/workflows/dependencies/install_spack
         echo "SPACK VERSION: $(spack --version)"
     - name: Build
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-14, OMPI_CXX: clang++-14, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
+      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-19, OMPI_CXX: clang++-19, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
       run: |
         sudo ln -s "$(which cmake)" /usr/bin/cmake
         eval $(spack env activate --sh .github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/)
@@ -72,7 +72,7 @@ jobs:
         cmake --build build --parallel 2
         export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         export LSAN_OPTIONS=suppressions="$SOURCEPATH/.github/ci/sanitizer/clang/Leak.supp"
-        export LD_PRELOAD=/usr/lib/clang/14/lib/linux/libclang_rt.asan-x86_64.so
+        export LD_PRELOAD=/usr/lib/clang/19/lib/linux/libclang_rt.asan-x86_64.so
         ctest --test-dir build -E 3b --output-on-failure
         export OPENPMD_HDF5_CHUNKS="auto"
         ctest --test-dir build -R 3b --output-on-failure

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clangtidy14_nopy_ompi_h5_ad2:
+  clangtidy19_nopy_ompi_h5_ad2:
     name: clang-tidy w/o py
     runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Spack Cache
       uses: actions/cache@v3
-      with: {path: /opt/spack, key: clangtidy14_nopy_ompi_h5_ad2 }
+      with: {path: /opt/spack, key: clangtidy19_nopy_ompi_h5_ad2 }
     - name: Install
       run: |
         sudo apt-get update
@@ -36,24 +36,24 @@ jobs:
         cat build/clang-tidy.log
         if [[ $(wc -m <build/clang-tidy.log) -gt 1 ]]; then exit 1; fi
 
-  clangsanitizer14_py38_ompi_h5_ad2:
+  clangsanitizer19_py38_ompi_h5_ad2:
     name: Clang ASAN UBSAN
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4
     - name: Spack Cache
       uses: actions/cache@v3
-      with: {path: /opt/spack, key: clang14_nopy_ompi_h5_ad2 }
+      with: {path: /opt/spack, key: clang19_nopy_ompi_h5_ad2 }
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install clang-14 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev
+        sudo apt-get install clang-19 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev
         python3 -m pip install -U pip
         python3 -m pip install -U numpy
         sudo .github/workflows/dependencies/install_spack
     - name: Build
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-14, OMPI_CXX: clang++-14, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
+      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-19, OMPI_CXX: clang++-19, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
       run: |
         sudo ln -s "$(which cmake)" /usr/bin/cmake
         eval $(spack env activate --sh .github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/)
@@ -72,7 +72,7 @@ jobs:
         cmake --build build --parallel 2
         export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         export LSAN_OPTIONS=suppressions="$SOURCEPATH/.github/ci/sanitizer/clang/Leak.supp"
-        export LD_PRELOAD=/usr/lib/clang/14/lib/linux/libclang_rt.asan-x86_64.so
+        export LD_PRELOAD=/usr/lib/clang/19/lib/linux/libclang_rt.asan-x86_64.so
         ctest --test-dir build -E 3b --output-on-failure
         export OPENPMD_HDF5_CHUNKS="auto"
         ctest --test-dir build -R 3b --output-on-failure

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   clangtidy14_nopy_ompi_h5_ad2:
     name: clang-tidy w/o py
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4
@@ -21,6 +21,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install clang clang-tidy gfortran libopenmpi-dev python-is-python3
         SPACK_VER=1.0.1 sudo .github/workflows/dependencies/install_spack
+        echo "SPACK VERSION: $(spack --version)"
     - name: Build
       env: {CC: clang, CXX: clang++}
       run: |
@@ -48,10 +49,9 @@ jobs:
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install clang-14 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev
-        python3 -m pip install -U pip
-        python3 -m pip install -U numpy
+        sudo apt-get install clang-14 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev python3-numpy
         SPACK_VER=1.0.1 sudo .github/workflows/dependencies/install_spack
+        echo "SPACK VERSION: $(spack --version)"
     - name: Build
       env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-14, OMPI_CXX: clang++-14, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
       run: |

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install clang clang-tidy gfortran libopenmpi-dev python-is-python3
-        SPACK_VER=1.0.1 sudo .github/workflows/dependencies/install_spack
+        SPACK_VER=1.0.1 sudo -E .github/workflows/dependencies/install_spack
         echo "SPACK VERSION: $(spack --version)"
     - name: Build
       env: {CC: clang, CXX: clang++}
@@ -50,7 +50,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install clang-14 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev python3-numpy
-        SPACK_VER=1.0.1 sudo .github/workflows/dependencies/install_spack
+        SPACK_VER=1.0.1 sudo -E .github/workflows/dependencies/install_spack
         echo "SPACK VERSION: $(spack --version)"
     - name: Build
       env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-14, OMPI_CXX: clang++-14, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -61,7 +61,7 @@ jobs:
         SOURCEPATH="$(pwd)"
         share/openPMD/download_samples.sh build
         export LDFLAGS="${LDFLAGS} -fsanitize=address,undefined -shared-libsan"
-        export CXXFLAGS="${CXXFLAGS} -fsanitize=address,undefined -shared-libsan"
+        export CXXFLAGS="${CXXFLAGS} -fsanitize=address,undefined -shared-libsan -DOMPI_SKIP_MPICXX"
         cmake -S . -B build               \
           -DopenPMD_USE_MPI=ON            \
           -DopenPMD_USE_PYTHON=ON         \

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install clang clang-tidy gfortran libopenmpi-dev python-is-python3
-        sudo .github/workflows/dependencies/install_spack
+        SPACK_VER=1.0.1 sudo .github/workflows/dependencies/install_spack
     - name: Build
       env: {CC: clang, CXX: clang++}
       run: |
@@ -51,7 +51,7 @@ jobs:
         sudo apt-get install clang-14 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev
         python3 -m pip install -U pip
         python3 -m pip install -U numpy
-        sudo .github/workflows/dependencies/install_spack
+        SPACK_VER=1.0.1 sudo .github/workflows/dependencies/install_spack
     - name: Build
       env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-14, OMPI_CXX: clang++-14, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
       run: |

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clangtidy19_nopy_ompi_h5_ad2:
+  clangtidy14_nopy_ompi_h5_ad2:
     name: clang-tidy w/o py
     runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Spack Cache
       uses: actions/cache@v3
-      with: {path: /opt/spack, key: clangtidy19_nopy_ompi_h5_ad2 }
+      with: {path: /opt/spack, key: clangtidy14_nopy_ompi_h5_ad2 }
     - name: Install
       run: |
         sudo apt-get update
@@ -36,7 +36,7 @@ jobs:
         cat build/clang-tidy.log
         if [[ $(wc -m <build/clang-tidy.log) -gt 1 ]]; then exit 1; fi
 
-  clangsanitizer19_py38_ompi_h5_ad2:
+  clangsanitizer14_py38_ompi_h5_ad2:
     name: Clang ASAN UBSAN
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
@@ -44,16 +44,16 @@ jobs:
     - uses: actions/checkout@v4
     - name: Spack Cache
       uses: actions/cache@v3
-      with: {path: /opt/spack, key: clang19_nopy_ompi_h5_ad2 }
+      with: {path: /opt/spack, key: clang14_nopy_ompi_h5_ad2 }
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install clang-19 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev
+        sudo apt-get install clang-14 libc++-dev libc++abi-dev python3 gfortran libopenmpi-dev
         python3 -m pip install -U pip
         python3 -m pip install -U numpy
         sudo .github/workflows/dependencies/install_spack
     - name: Build
-      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-19, OMPI_CXX: clang++-19, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
+      env: {CC: mpicc, CXX: mpic++, OMPI_CC: clang-14, OMPI_CXX: clang++-14, CXXFLAGS: -Werror, OPENPMD_HDF5_CHUNKS: none, OPENPMD_TEST_NFILES_MAX: 100}
       run: |
         sudo ln -s "$(which cmake)" /usr/bin/cmake
         eval $(spack env activate --sh .github/ci/spack-envs/clangtidy_nopy_ompi_h5_ad2/)
@@ -72,7 +72,7 @@ jobs:
         cmake --build build --parallel 2
         export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
         export LSAN_OPTIONS=suppressions="$SOURCEPATH/.github/ci/sanitizer/clang/Leak.supp"
-        export LD_PRELOAD=/usr/lib/clang/19/lib/linux/libclang_rt.asan-x86_64.so
+        export LD_PRELOAD=/usr/lib/clang/14/lib/linux/libclang_rt.asan-x86_64.so
         ctest --test-dir build -E 3b --output-on-failure
         export OPENPMD_HDF5_CHUNKS="auto"
         ctest --test-dir build -R 3b --output-on-failure

--- a/examples/8b_benchmark_read_parallel.cpp
+++ b/examples/8b_benchmark_read_parallel.cpp
@@ -135,7 +135,6 @@ public:
     ~Timer()
     {
         MPI_Barrier(MPI_COMM_WORLD);
-        std::string tt = "~" + m_Tag;
         // MemoryProfiler (m_Rank, tt.c_str());
         m_End = std::chrono::system_clock::now();
 

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -132,6 +132,8 @@ private:
         hid_t id;
     };
     std::optional<File> getFile(Writable *);
+    File
+    requireFile(std::string const &functionName, Writable *, bool checkParent);
 }; // HDF5IOHandlerImpl
 #else
 class HDF5IOHandlerImpl

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -525,9 +525,7 @@ private:
     };
 
     template <typename T>
-    struct JsonToCpp<
-        T,
-        typename std::enable_if<std::is_floating_point<T>::value>::type>
+    struct JsonToCpp<T, typename std::enable_if_t<std::is_floating_point_v<T>>>
     {
         T operator()(nlohmann::json const &);
     };

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -317,7 +317,7 @@ public:
     template <class InputIt>
     void insert(InputIt first, InputIt last);
     void insert(std::initializer_list<value_type> ilist);
-    void swap(BaseRecord &other);
+    void swap(BaseRecord &other) noexcept;
     bool contains(key_type const &key) const;
     template <class... Args>
     auto emplace(Args &&...args) -> std::pair<iterator, bool>;

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -28,6 +28,7 @@
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 
+#include <cstdint>
 #include <optional>
 #include <stdexcept>
 
@@ -317,7 +318,7 @@ namespace
         return false;
     }
 
-    enum class PerstepParsing
+    enum class PerstepParsing : std::uint8_t
     {
         Supported,
         Unsupported,
@@ -1086,7 +1087,7 @@ void ADIOS2File::flush_impl(ADIOS2FlushParams flushParams, bool writeLatePuts)
 #if ADIOS2_VERSION_MAJOR * 1000000000 + ADIOS2_VERSION_MINOR * 100000000 +     \
         ADIOS2_VERSION_PATCH * 1000000 + ADIOS2_VERSION_TWEAK >=               \
     2701001223
-        enum class CleanedFlushTarget
+        enum class CleanedFlushTarget : std::uint8_t
         {
             Buffer,
             Disk,

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1371,7 +1371,7 @@ namespace
          */
         using rep = detail::AttributeTypes<bool>::rep;
 
-        if constexpr (std::is_same<T, rep>::value)
+        if constexpr (std::is_same_v<T, rep>)
         {
             auto attr = getAttribute.template call<rep>(name);
             if (!attr)
@@ -2239,7 +2239,6 @@ namespace detail
         auto file = impl->refreshFileFromParent(
             writable, /* preferParentFile = */ false);
         auto fullName = impl->nameOfAttribute(writable, parameters.name);
-        auto prefix = impl->filePositionToString(pos);
 
         auto &filedata = impl->getFileData(
             file, ADIOS2IOHandlerImpl::IfFileNotOpen::ThrowError);

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<ParallelHDF5IOHandler, openPMD_HAVE_HDF5>(
             "HDF5",
             std::move(initialize_from),
-            path,
+            std::move(path),
             access,
             comm,
             std::move(options));
@@ -139,7 +139,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<JSONIOHandler, openPMD_HAVE_JSON>(
             "JSON",
             std::move(initialize_from),
-            path,
+            std::move(path),
             access,
             comm,
             std::move(options),
@@ -149,7 +149,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<JSONIOHandler, openPMD_HAVE_JSON>(
             "JSON",
             std::move(initialize_from),
-            path,
+            std::move(path),
             access,
             comm,
             std::move(options),
@@ -181,7 +181,7 @@ std::unique_ptr<AbstractIOHandler> createIOHandler<json::TracingJSON>(
         return constructIOHandler<HDF5IOHandler, openPMD_HAVE_HDF5>(
             "HDF5",
             std::move(initialize_from),
-            path,
+            std::move(path),
             access,
             std::move(options));
     case Format::ADIOS2_BP:

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -408,7 +408,8 @@ void HDF5IOHandlerImpl::createPath(
         else
             position = writable; /* root does not have a parent but might still
                                     have to be written */
-        File file = getFile(position).value();
+        File file =
+            requireFile("createPath", position, /* checkParent = */ false);
         hid_t node_id =
             H5Gopen(file.id, concrete_h5_file_position(position).c_str(), gapl);
         VERIFY(
@@ -569,9 +570,8 @@ void HDF5IOHandlerImpl::createDataset(
                 if (chunks_json.json().is_string())
                 {
 
-                    compute_chunking =
-                        json::asLowerCaseStringDynamic(chunks_json.json())
-                            .value();
+                    compute_chunking = auxiliary::lowerCase(
+                        chunks_json.json().get<std::string>());
                 }
                 else if (chunks_json.json().is_array())
                 {
@@ -849,13 +849,10 @@ void HDF5IOHandlerImpl::extendDataset(
             "HDF5", "Joined Arrays currently only supported in ADIOS2");
     }
 
-    auto res = getFile(writable);
-    if (!res)
-        res = getFile(writable->parent);
+    File file =
+        requireFile("extendDataset", writable, /* checkParent = */ true);
     hid_t dataset_id = H5Dopen(
-        res.value().id,
-        concrete_h5_file_position(writable).c_str(),
-        H5P_DEFAULT);
+        file.id, concrete_h5_file_position(writable).c_str(), H5P_DEFAULT);
     VERIFY(
         dataset_id >= 0,
         "[HDF5] Internal error: Failed to open HDF5 dataset during dataset "
@@ -954,8 +951,7 @@ void HDF5IOHandlerImpl::availableChunks(
     {
         extent.push_back(e);
     }
-    parameters.chunks->push_back(
-        WrittenChunkInfo(std::move(offset), std::move(extent)));
+    parameters.chunks->emplace_back(std::move(offset), std::move(extent));
 
     herr_t status;
     status = H5Sclose(dataset_space);
@@ -1028,13 +1024,13 @@ void HDF5IOHandlerImpl::closeFile(
     Writable *writable, Parameter<Operation::CLOSE_FILE> const &)
 {
     auto optionalFile = getFile(writable);
-    if (!optionalFile)
+    if (!optionalFile.has_value())
     {
         throw std::runtime_error(
             "[HDF5] Trying to close a file that is not "
             "present in the backend");
     }
-    File file = optionalFile.value();
+    File file = *optionalFile;
     H5Fclose(file.id);
     m_openFileIDs.erase(file.id);
     m_fileNames.erase(writable);
@@ -1045,7 +1041,8 @@ void HDF5IOHandlerImpl::closeFile(
 void HDF5IOHandlerImpl::openPath(
     Writable *writable, Parameter<Operation::OPEN_PATH> const &parameters)
 {
-    File file = getFile(writable->parent).value();
+    File file =
+        requireFile("openPath", writable->parent, /* checkParent = */ false);
     hid_t node_id, path_id;
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
@@ -1132,7 +1129,14 @@ void HDF5IOHandlerImpl::openPath(
 void HDF5IOHandlerImpl::openDataset(
     Writable *writable, Parameter<Operation::OPEN_DATASET> &parameters)
 {
-    File file = getFile(writable->parent).value();
+    std::optional<File> fileOpt = getFile(writable->parent);
+    if (!fileOpt.has_value())
+    {
+        throw error::Internal(
+            "[HDF5] Failed to retrieve file for dataset opening. No file "
+            "associated with the writable's parent.");
+    }
+    File file = *fileOpt;
     hid_t node_id, dataset_id;
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
@@ -1383,7 +1387,8 @@ void HDF5IOHandlerImpl::deleteFile(
 
     if (writable->written)
     {
-        hid_t file_id = getFile(writable).value().id;
+        hid_t file_id =
+            requireFile("deleteFile", writable, /* checkParent = */ false).id;
         herr_t status = H5Fclose(file_id);
         VERIFY(
             status == 0,
@@ -1429,8 +1434,8 @@ void HDF5IOHandlerImpl::deletePath(
          * Ugly hack: H5Ldelete can't delete "."
          *            Work around this by deleting from the parent
          */
-        auto res = getFile(writable);
-        File file = res ? res.value() : getFile(writable->parent).value();
+        File file =
+            requireFile("deletePath", writable, /* checkParent = */ true);
         hid_t node_id = H5Gopen(
             file.id,
             concrete_h5_file_position(writable->parent).c_str(),
@@ -1481,8 +1486,8 @@ void HDF5IOHandlerImpl::deleteDataset(
          * Ugly hack: H5Ldelete can't delete "."
          *            Work around this by deleting from the parent
          */
-        auto res = getFile(writable);
-        File file = res ? res.value() : getFile(writable->parent).value();
+        File file =
+            requireFile("deleteDataset", writable, /* checkParent = */ true);
         hid_t node_id = H5Gopen(
             file.id,
             concrete_h5_file_position(writable->parent).c_str(),
@@ -1525,8 +1530,8 @@ void HDF5IOHandlerImpl::deleteAttribute(
         std::string name = parameters.name;
 
         /* Open H5Object to delete in */
-        auto res = getFile(writable);
-        File file = res ? res.value() : getFile(writable->parent).value();
+        File file =
+            requireFile("deleteAttribute", writable, /* checkParent = */ true);
         hid_t node_id = H5Oopen(
             file.id, concrete_h5_file_position(writable).c_str(), H5P_DEFAULT);
         VERIFY(
@@ -1555,8 +1560,7 @@ void HDF5IOHandlerImpl::writeDataset(
             "[HDF5] Writing into a dataset in a file opened as read only is "
             "not possible.");
 
-    auto res = getFile(writable);
-    File file = res ? res.value() : getFile(writable->parent).value();
+    File file = requireFile("writeDataset", writable, /* checkParent = */ true);
 
     hid_t dataset_id, filespace, memspace;
     herr_t status;
@@ -2040,8 +2044,7 @@ void HDF5IOHandlerImpl::writeAttribute(
 void HDF5IOHandlerImpl::readDataset(
     Writable *writable, Parameter<Operation::READ_DATASET> &parameters)
 {
-    auto res = getFile(writable);
-    File file = res ? res.value() : getFile(writable->parent).value();
+    File file = requireFile("readDataset", writable, /* checkParent = */ true);
     hid_t dataset_id, memspace, filespace;
     herr_t status;
     dataset_id = H5Dopen(
@@ -2213,8 +2216,8 @@ void HDF5IOHandlerImpl::readAttribute(
             "[HDF5] Internal error: Writable not marked written during "
             "attribute read");
 
-    auto res = getFile(writable);
-    File file = res ? res.value() : getFile(writable->parent).value();
+    File file =
+        requireFile("readAttribute", writable, /* checkParent = */ true);
 
     hid_t obj_id, attr_id;
     herr_t status;
@@ -2693,7 +2696,14 @@ void HDF5IOHandlerImpl::readAttribute(
             if (H5Tis_variable_str(attr_type))
             {
                 std::vector<char *> vc(dims[0]);
-                status = H5Aread(attr_id, attr_type, vc.data());
+                // clang-format off
+                // NOLINTBEGIN(bugprone-multi-level-implicit-pointer-conversion)
+                // clang-format on
+                status =
+                    H5Aread(attr_id, attr_type, static_cast<void *>(vc.data()));
+                // clang-format off
+                // NOLINTEND(bugprone-multi-level-implicit-pointer-conversion)
+                // clang-format on
                 if (status != 0)
                 {
                     throw error::ReadError(
@@ -2706,8 +2716,17 @@ void HDF5IOHandlerImpl::readAttribute(
                 }
                 for (auto const &val : vc)
                     vs.push_back(auxiliary::strip(std::string(val), {'\0'}));
+                // clang-format off
+                // NOLINTBEGIN(bugprone-multi-level-implicit-pointer-conversion)
+                // clang-format on
                 status = H5Dvlen_reclaim(
-                    attr_type, attr_space, H5P_DEFAULT, vc.data());
+                    attr_type,
+                    attr_space,
+                    H5P_DEFAULT,
+                    static_cast<void *>(vc.data()));
+                // clang-format off
+                // NOLINTEND(bugprone-multi-level-implicit-pointer-conversion)
+                // clang-format on
             }
             else
             {
@@ -2836,8 +2855,7 @@ void HDF5IOHandlerImpl::listPaths(
             "[HDF5] Internal error: Writable not marked written during path "
             "listing");
 
-    auto res = getFile(writable);
-    File file = res ? res.value() : getFile(writable->parent).value();
+    File file = requireFile("listPaths", writable, /* checkParent = */ true);
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
 #if H5_VERSION_GE(1, 10, 0) && openPMD_HAVE_MPI
@@ -2868,7 +2886,7 @@ void HDF5IOHandlerImpl::listPaths(
             ssize_t name_length = H5Gget_objname_by_idx(node_id, i, nullptr, 0);
             std::vector<char> name(name_length + 1);
             H5Gget_objname_by_idx(node_id, i, name.data(), name_length + 1);
-            paths->push_back(std::string(name.data(), name_length));
+            paths->emplace_back(name.data(), name_length);
         }
     }
 
@@ -2892,8 +2910,7 @@ void HDF5IOHandlerImpl::listDatasets(
             "[HDF5] Internal error: Writable not marked written during dataset "
             "listing");
 
-    auto res = getFile(writable);
-    File file = res ? res.value() : getFile(writable->parent).value();
+    File file = requireFile("listDatasets", writable, /* checkParent = */ true);
 
     hid_t gapl = H5Pcreate(H5P_GROUP_ACCESS);
 #if H5_VERSION_GE(1, 10, 0) && openPMD_HAVE_MPI
@@ -2925,7 +2942,7 @@ void HDF5IOHandlerImpl::listDatasets(
             ssize_t name_length = H5Gget_objname_by_idx(node_id, i, nullptr, 0);
             std::vector<char> name(name_length + 1);
             H5Gget_objname_by_idx(node_id, i, name.data(), name_length + 1);
-            datasets->push_back(std::string(name.data(), name_length));
+            datasets->emplace_back(name.data(), name_length);
         }
     }
 
@@ -2949,8 +2966,8 @@ void HDF5IOHandlerImpl::listAttributes(
             "[HDF5] Internal error: Writable not marked written during "
             "attribute listing");
 
-    auto res = getFile(writable);
-    File file = res ? res.value() : getFile(writable->parent).value();
+    File file =
+        requireFile("listAttributes", writable, /* checkParent = */ true);
     hid_t node_id;
 
     hid_t fapl = H5Pcreate(H5P_LINK_ACCESS);
@@ -3003,7 +3020,7 @@ void HDF5IOHandlerImpl::listAttributes(
             name.data(),
             name_length + 1,
             H5P_DEFAULT);
-        attributes->push_back(std::string(name.data(), name_length));
+        attributes->emplace_back(name.data(), name_length);
     }
 
     status = H5Oclose(node_id);
@@ -3046,6 +3063,41 @@ HDF5IOHandlerImpl::getFile(Writable *writable)
     res.name = it->second;
     res.id = it2->second;
     return std::make_optional(std::move(res));
+}
+auto HDF5IOHandlerImpl::requireFile(
+    std::string const &functionName, Writable *w, bool checkParent) -> File
+{
+    std::optional<File> fileOpt = getFile(w);
+    if (!fileOpt.has_value())
+    {
+        if (checkParent)
+        {
+            fileOpt = getFile(w->parent);
+            if (!fileOpt.has_value())
+            {
+
+                throw error::Internal(
+                    "[HDF5IOHandlerImpl::" + functionName +
+                    "] Control flow error: getFile returned no file for the "
+                    "current Writable or its parent.");
+            }
+            else
+            {
+                return *fileOpt;
+            }
+        }
+        else
+        {
+
+            throw error::Internal(
+                "[HDF5IOHandlerImpl::" + functionName +
+                "] Control flow error: getFile returned no file.");
+        }
+    }
+    else
+    {
+        return *fileOpt;
+    }
 }
 
 std::future<void> HDF5IOHandlerImpl::flush(internal::ParsedFlushParams &params)

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1203,13 +1203,13 @@ void JSONIOHandlerImpl::writeAttribute(
     switch (m_attributeMode.m_mode)
     {
     case AttributeMode::Long:
-        (*jsonVal)[filePosition->id]["attributes"][parameter.name] = {
+        (*jsonVal)[filePosition->id]["attributes"][name] = {
             {"datatype", jsonDatatypeToString(parameter.dtype)},
             {"value", value}};
         break;
     case AttributeMode::Short:
         // short form
-        (*jsonVal)[filePosition->id]["attributes"][parameter.name] = value;
+        (*jsonVal)[filePosition->id]["attributes"][name] = value;
         break;
     }
     writable->written = true;
@@ -1540,7 +1540,6 @@ void JSONIOHandlerImpl::readAttribute(
     auto const &jsonContents = obtainJsonContents(writable);
     auto const &jsonLoc = jsonContents["attributes"];
     setAndGetFilePosition(writable);
-    std::string error_msg("[JSON] No such attribute '");
     if (!hasKey(jsonLoc, name))
     {
         throw error::ReadError(
@@ -2365,9 +2364,9 @@ nlohmann::json JSONIOHandlerImpl::platformSpecifics()
         Datatype::CDOUBLE,
         Datatype::CLONG_DOUBLE,
         Datatype::BOOL};
-    for (auto it = std::begin(datatypes); it != std::end(datatypes); it++)
+    for (auto &datatype : datatypes)
     {
-        res[jsonDatatypeToString(*it)] = toBytes(*it);
+        res[jsonDatatypeToString(datatype)] = toBytes(datatype);
     }
     return res;
 }
@@ -2483,10 +2482,9 @@ std::array<T, n> JSONIOHandlerImpl::JsonToCpp<std::array<T, n>>::operator()(
 }
 
 template <typename T>
-T JSONIOHandlerImpl::JsonToCpp<
-    T,
-    typename std::enable_if<std::is_floating_point<T>::value>::type>::
-operator()(nlohmann::json const &j)
+T JSONIOHandlerImpl::
+    JsonToCpp<T, std::enable_if_t<std::is_floating_point_v<T>>>::operator()(
+        nlohmann::json const &j)
 {
     try
     {

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -132,6 +132,12 @@ RecordComponent &RecordComponent::resetDataset(Dataset d)
     rc.m_isEmpty = false;
     if (written())
     {
+        if (!rc.m_dataset.has_value())
+        {
+            throw error::Internal(
+                "Internal control flow error: Written record component must "
+                "have defined datatype and extent.");
+        }
         rc.m_dataset.value().extend(std::move(d.extent));
     }
     else

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1092,6 +1092,12 @@ void Series::initSeries(
     series.m_filenamePrefix = input->filenamePrefix;
     series.m_filenamePostfix = input->filenamePostfix;
     series.m_filenamePadding = input->filenamePadding;
+    if (!input->filenameExtension)
+    {
+        throw error::Internal(
+            "Control flow error: filename extension has not been resolved.");
+    }
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     series.m_filenameExtension = input->filenameExtension.value();
 
     if (series.m_iterationEncoding == IterationEncoding::fileBased &&
@@ -1704,7 +1710,8 @@ void Series::readFileBased(
         {
             if (forwardFirstError.has_value())
             {
-                auto &firstError = forwardFirstError.value();
+                // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+                auto &firstError = *forwardFirstError;
                 firstError.description.append(
                     "\n[Note] Not a single iteration can be successfully "
                     "parsed (see above errors). Returning the first observed "
@@ -3406,7 +3413,7 @@ auto Series::currentSnapshot() -> std::optional<std::vector<IterationIndex_t>>
         auto res = attribute.getOptional<vec_t>();
         if (res.has_value())
         {
-            return res.value();
+            return res;
         }
         else
         {
@@ -3429,6 +3436,7 @@ AbstractIOHandler *Series::runDeferredInitialization()
     auto &series = get();
     if (series.m_deferred_initialization.has_value())
     {
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         auto functor = std::move(*m_series->m_deferred_initialization);
         m_series->m_deferred_initialization = std::nullopt;
         return functor(*this);

--- a/src/auxiliary/Memory.cpp
+++ b/src/auxiliary/Memory.cpp
@@ -40,7 +40,8 @@ allocatePtr(Datatype dtype, uint64_t numPoints)
     {
         using DT = Datatype;
     case DT::VEC_STRING:
-        data = new char *[numPoints];
+        // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
+        data = static_cast<void *>(new char *[numPoints]);
         del = [](void *p) { delete[] static_cast<char **>(p); };
         break;
     case DT::VEC_LONG_DOUBLE:

--- a/src/backend/Attribute.cpp
+++ b/src/backend/Attribute.cpp
@@ -73,6 +73,8 @@ auto Attribute::get_impl() const -> std::variant<U, std::runtime_error>
     switch (index)
     {
         OPENPMD_FOREACH_DATATYPE(OPENPMD_ENUMERATE_TYPES)
+    default:
+        return {std::runtime_error("Unreachable!")};
     }
 #undef OPENPMD_ENUMERATE_TYPES
 

--- a/src/backend/BaseRecord.cpp
+++ b/src/backend/BaseRecord.cpp
@@ -744,7 +744,7 @@ auto BaseRecord<T_elem>::insert(std::initializer_list<value_type> ilist) -> void
 }
 
 template <typename T_elem>
-auto BaseRecord<T_elem>::swap(BaseRecord &other) -> void
+auto BaseRecord<T_elem>::swap(BaseRecord &other) noexcept -> void
 {
     detail::verifyNonscalar(this);
     detail::verifyNonscalar(&other);

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -33,7 +33,12 @@ Writable::Writable(internal::AttributableData *a) : attributable{a}
 
 Writable::~Writable()
 {
-    if (!IOHandler || !IOHandler->has_value())
+    if (!IOHandler)
+    {
+        return;
+    }
+    auto &optional = *IOHandler;
+    if (!optional.has_value())
     {
         return;
     }
@@ -42,7 +47,7 @@ Writable::~Writable()
      * The DEREGISTER task must not dereference the pointer, but only use it to
      * remove references to this object from internal data structures.
      */
-    IOHandler->value()->enqueue(
+    (*optional)->enqueue(
         IOTask(this, Parameter<Operation::DEREGISTER>(parent)));
 }
 

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -202,6 +202,7 @@ inline std::tuple<Offset, Extent, std::vector<bool>> parseTupleSlices(
 
             continue;
         }
+        // NOLINTNEXTLINE(bugprone-empty-catch)
         catch (const py::cast_error &e)
         {
             // not an index

--- a/src/cli/convert-toml-json.cpp
+++ b/src/cli/convert-toml-json.cpp
@@ -13,6 +13,7 @@ void parsed_main(std::string jsonOrToml)
     auto [config, originallySpecifiedAs] = json::parseOptions(
         jsonOrToml, /* considerFiles = */ true, /* convertLowercase = */ false);
     {
+        // NOLINTNEXTLINE(bugprone-unused-local-non-trivial-variable)
         [[maybe_unused]] auto _ = std::move(jsonOrToml);
     }
     switch (originallySpecifiedAs)

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -195,12 +195,18 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
 {
     auto base_iterator = get();
     auto &shared = base_iterator->m_data;
-    if (!shared || !shared->has_value())
+    if (!shared)
     {
         throw error::WrongAPIUsage(
             "[WriteIterations] Trying to access after closing Series.");
     }
-    auto &s = shared->value();
+    auto &optional = *shared;
+    if (!optional.has_value())
+    {
+        throw error::WrongAPIUsage(
+            "[WriteIterations] Trying to access after closing Series.");
+    }
+    auto &s = optional.value();
     auto access = s.series.IOHandler()->m_frontendAccess;
 
     if (access == Access::READ_WRITE)

--- a/src/snapshots/StatefulIterator.cpp
+++ b/src/snapshots/StatefulIterator.cpp
@@ -172,10 +172,14 @@ StatefulIterator::operator=(StatefulIterator &&other) noexcept = default;
 
 auto StatefulIterator::get() -> SharedData &
 {
+    // forward the std::optional exception in doubt
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     return m_data->value();
 }
 auto StatefulIterator::get() const -> SharedData const &
 {
+    // forward the std::optional exception in doubt
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     return m_data->value();
 }
 
@@ -346,11 +350,16 @@ auto StatefulIterator::resetCurrentIterationToBegin(
 auto StatefulIterator::peekCurrentlyOpenIteration() const
     -> std::optional<value_type const *>
 {
-    if (!m_data || !m_data->has_value())
+    if (!m_data)
     {
         return std::nullopt;
     }
-    auto &s = m_data->value();
+    auto &optional = *m_data;
+    if (!optional.has_value())
+    {
+        return std::nullopt;
+    }
+    auto &s = optional.value();
     auto const &maybeCurrentIteration = s.currentIteration();
     if (!maybeCurrentIteration.has_value())
     {
@@ -938,7 +947,12 @@ StatefulIterator StatefulIterator::end()
 
 auto StatefulIterator::is_end() const -> bool
 {
-    return !m_data || !m_data->has_value() ||
+    if (!m_data)
+    {
+        return true;
+    }
+    auto &optional = *m_data;
+    return !optional.has_value() ||
         std::visit(
             auxiliary::overloaded{
                 [](CurrentStep::Before_t const &) { return false; },
@@ -946,7 +960,7 @@ auto StatefulIterator::is_end() const -> bool
                     return !during.iteration_idx.has_value();
                 },
                 [](CurrentStep::After_t const &) { return true; }},
-            (**m_data).currentStep.as_base());
+            optional->currentStep.as_base());
 }
 
 auto StatefulIterator::assert_end_iterator() const -> void

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1575,7 +1575,7 @@ TEST_CASE("adios2_ssc", "[parallel][adios2]")
     adios2_ssc();
 }
 
-enum class ParseMode
+enum class ParseMode : std::uint8_t
 {
     /*
      * Conventional workflow. Just parse the whole thing and yield iterations

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -4246,7 +4246,7 @@ TEST_CASE("git_adios2_early_chunk_query", "[serial][adios2]")
  */
 #if defined(__unix__) && openPMD_HAVE_ADIOS2_BP5
 
-enum class FlushDuringStep
+enum class FlushDuringStep : std::uint8_t
 {
     Never,
     Default_No,
@@ -5799,6 +5799,8 @@ void adios2_group_table(
                 REQUIRE(iteration.meshes["E"].size() == 2);
             }
             break;
+        default:
+            break;
         }
     }
     REQUIRE(counter == 2);
@@ -6557,13 +6559,6 @@ TEST_CASE("iterate_nonstreaming_series", "[serial][adios2]")
 #if openPMD_HAVE_ADIOS2 && openPMD_HAVE_ADIOS2_BP5
 void adios2_bp5_no_steps(bool usesteps)
 {
-    std::string const config = R"END(
-{
-    "adios2":
-    {
-        "use_group_table": true
-    }
-})END";
     {
         adios2::ADIOS adios;
         auto IO = adios.DeclareIO("IO");
@@ -7282,7 +7277,7 @@ TEST_CASE("varying_zero_pattern", "[serial]")
     }
 }
 
-enum class ParseMode
+enum class ParseMode : std::uint8_t
 {
     /*
      * Conventional workflow. Just parse the whole thing and yield iterations


### PR DESCRIPTION
* Updates Spack to version 1.0.1 for the tooling runs
* Updates the tooling runs to Ubuntu 24.04 with clang-19
* Updates the Spack config files to >= v.1.0.0 format
* Applies some of the new hints found by clang-tidy