### PR TITLE
CMake: Skip MPICXX

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -61,7 +61,7 @@ jobs:
         SOURCEPATH="$(pwd)"
         share/openPMD/download_samples.sh build
         export LDFLAGS="${LDFLAGS} -fsanitize=address,undefined -shared-libsan"
-        export CXXFLAGS="${CXXFLAGS} -fsanitize=address,undefined -shared-libsan -DOMPI_SKIP_MPICXX"
+        export CXXFLAGS="${CXXFLAGS} -fsanitize=address,undefined -shared-libsan"
         cmake -S . -B build               \
           -DopenPMD_USE_MPI=ON            \
           -DopenPMD_USE_PYTHON=ON         \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ message(STATUS "openPMD-api superbuild: ${openPMD_SUPERBUILD}")
 #     Clang+MPI: Potentially needed MPI::MPI_C targets in the past
 #                (exact MPI flavor & Clang version lost)
 #     BullMPI: PUBLIC dependency to MPI::MPI_CXX is missing in MPI::MPI_C target
+set(MPI_CXX_SKIP_MPICXX ON)  # We do not use MPI-2 only MPI C++ bindings
 set(openPMD_MPI_LINK_C_DEFAULT OFF)
 option(openPMD_MPI_LINK_C  "Also link the MPI C targets" ${openPMD_MPI_LINK_C_DEFAULT})
 mark_as_advanced(openPMD_MPI_LINK_C)


### PR DESCRIPTION
We do not use the MPI-2 only MPI C++ bindings, but some implemenations (esp. OpenMPI) still create an internal dependency on it, which is unnecessary and complicates tooling and deployments.

Follow-up to #1783