### PR TITLE
Fix Iteration::open(), needed for correct use of Span API

### DIFF
--- a/docs/source/details/mpi.rst
+++ b/docs/source/details/mpi.rst
@@ -30,7 +30,6 @@ Functionality                Behavior           Description
 ``::resetDataset`` [1]_ [2]_ *backend-specific* declare, write
 ``::makeConstant`` [3]_      *backend-specific* declare, write
 ``::storeChunk`` [1]_        independent        write
-``::storeChunk`` [5]_        collective         Span-based overloads
 ``::loadChunk``              independent        read
 ``::availableChunks`` [4]_   collective         read, immediate result
 ============================ ================== ================================
@@ -49,8 +48,6 @@ Functionality                Behavior           Description
 
 .. [4] We usually open iterations delayed on first access. This first access is usually the ``flush()`` call after a ``storeChunk``/``loadChunk`` operation. If the first access is non-collective, an explicit, collective ``Iteration::open()`` can be used to have the files already open.
        Alternatively, iterations might be accessed for the first time by immediate operations such as ``::availableChunks()``.
-
-.. [5] The Span-based ``storeChunk`` API calls return a backend-allocated pointer, requiring flush operations. These API calls hence inherit the collective properties of flushing. Use store calls with zero-size extent if a rank does not contribute anything.
 
 .. warning::
 

--- a/docs/source/details/mpi.rst
+++ b/docs/source/details/mpi.rst
@@ -30,6 +30,7 @@ Functionality                Behavior           Description
 ``::resetDataset`` [1]_ [2]_ *backend-specific* declare, write
 ``::makeConstant`` [3]_      *backend-specific* declare, write
 ``::storeChunk`` [1]_        independent        write
+``::storeChunk`` [5]_        collective         Span-based overloads
 ``::loadChunk``              independent        read
 ``::availableChunks`` [4]_   collective         read, immediate result
 ============================ ================== ================================
@@ -48,6 +49,8 @@ Functionality                Behavior           Description
 
 .. [4] We usually open iterations delayed on first access. This first access is usually the ``flush()`` call after a ``storeChunk``/``loadChunk`` operation. If the first access is non-collective, an explicit, collective ``Iteration::open()`` can be used to have the files already open.
        Alternatively, iterations might be accessed for the first time by immediate operations such as ``::availableChunks()``.
+
+.. [5] The Span-based ``storeChunk`` API calls return a backend-allocated pointer, requiring flush operations. These API calls hence inherit the collective properties of flushing. Use store calls with zero-size extent if a rank does not contribute anything.
 
 .. warning::
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -82,16 +82,6 @@ namespace internal
          */
         Attribute m_constantValue{-1};
         /**
-         * The same std::string that the parent class would pass as parameter to
-         * RecordComponent::flush().
-         * This is stored only upon RecordComponent::flush() if
-         * AbstractIOHandler::flushLevel is set to FlushLevel::SkeletonOnly
-         * (for use by the Span<T>-based overload of
-         * RecordComponent::storeChunk()).
-         * @todo Merge functionality with ownKeyInParent?
-         */
-        std::string m_name;
-        /**
          * True if this component is an empty dataset, i.e. its extent is zero
          * in at least one dimension.
          * Treated by the openPMD-api as a special case of constant record
@@ -109,7 +99,6 @@ namespace internal
             BaseRecordComponentData::reset();
             m_chunks = std::queue<IOTask>();
             m_constantValue = -1;
-            m_name = std::string();
             m_isEmpty = false;
             m_hasBeenExtended = false;
         }

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -406,11 +406,6 @@ public:
      * @brief Overload of storeChunk() that lets the openPMD API allocate
      *        a buffer.
      *
-     * Collective call: Unlike most other storeChunk() calls, this call returns
-     * pointers allocated by the IO backends and hence inherits the collective
-     * properties of flushing. Apply zero-extent storeChunk() calls from ranks
-     * that do not contribute anything.
-     *
      * This may save memory if the openPMD backend in use is able to provide
      * users a view into its own buffers, avoiding the need to allocate
      * a new buffer.
@@ -447,11 +442,6 @@ public:
     /**
      * Overload of span-based storeChunk() that uses operator new() to create
      * a buffer.
-     *
-     * Collective call: Unlike most other storeChunk() calls, this call returns
-     * pointers allocated by the IO backends and hence inherits the collective
-     * properties of flushing. Apply zero-extent storeChunk() calls from ranks
-     * that do not contribute anything.
      */
     template <typename T>
     DynamicMemoryView<T> storeChunk(Offset, Extent);

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -417,6 +417,11 @@ public:
      * @brief Overload of storeChunk() that lets the openPMD API allocate
      *        a buffer.
      *
+     * Collective call: Unlike most other storeChunk() calls, this call returns
+     * pointers allocated by the IO backends and hence inherits the collective
+     * properties of flushing. Apply zero-extent storeChunk() calls from ranks
+     * that do not contribute anything.
+     *
      * This may save memory if the openPMD backend in use is able to provide
      * users a view into its own buffers, avoiding the need to allocate
      * a new buffer.
@@ -453,6 +458,11 @@ public:
     /**
      * Overload of span-based storeChunk() that uses operator new() to create
      * a buffer.
+     *
+     * Collective call: Unlike most other storeChunk() calls, this call returns
+     * pointers allocated by the IO backends and hence inherits the collective
+     * properties of flushing. Apply zero-extent storeChunk() calls from ranks
+     * that do not contribute anything.
      */
     template <typename T>
     DynamicMemoryView<T> storeChunk(Offset, Extent);

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -29,6 +29,7 @@
 #include "openPMD/auxiliary/ShareRawInternal.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/auxiliary/UniquePtr.hpp"
+#include "openPMD/backend/Attributable.hpp"
 
 #include <memory>
 #include <type_traits>
@@ -111,7 +112,7 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
                 "using storeChunk() (see RecordComponent::resetDataset()).");
         }
         Parameter<Operation::CREATE_DATASET> dCreate(rc.m_dataset.value());
-        dCreate.name = rc.m_name;
+        dCreate.name = Attributable::get().m_writable.ownKeyWithinParent;
         IOHandler()->enqueue(IOTask(this, dCreate));
     }
 

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -115,14 +115,6 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
         IOHandler()->enqueue(IOTask(this, dCreate));
     }
 
-    if (size == 0)
-    {
-        // Don't forward this operation to the backend as it might create ugly
-        // zero-blocks in ADIOS2
-        setDirtyRecursive(true);
-        return DynamicMemoryView<T>();
-    }
-
     Parameter<Operation::GET_BUFFER_VIEW> getBufferView;
     getBufferView.offset = o;
     getBufferView.extent = e;
@@ -136,7 +128,10 @@ RecordComponent::storeChunk(Offset o, Extent e, F &&createBuffer)
         // type shared_ptr<T> or shared_ptr<T[]>
         auto data = std::forward<F>(createBuffer)(size);
         out.ptr = static_cast<void *>(data.get());
-        storeChunk(std::move(data), std::move(o), std::move(e));
+        if (size > 0)
+        {
+            storeChunk(std::move(data), std::move(o), std::move(e));
+        }
     }
     setDirtyRecursive(true);
     return DynamicMemoryView<T>{std::move(getBufferView), size, *this};

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -89,6 +89,7 @@ class Writable final
     friend class ParticleSpecies;
     friend class Series;
     friend class Record;
+    friend class RecordComponent;
     friend class AbstractIOHandlerImpl;
     friend class ADIOS2IOHandlerImpl;
     friend class detail::ADIOS2File;

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1299,6 +1299,17 @@ void ADIOS2IOHandlerImpl::getBufferView(
     auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
 
+    if (std::any_of(
+            parameters.extent.begin(), parameters.extent.end(), [](auto val) {
+                return val == 0;
+            }))
+    {
+        // Refuse empty operations, ADIOS2 creates ugly zero blocks for them,
+        // tell the frontend to do sth about it instead
+        parameters.out->backendManagedBuffer = false;
+        return;
+    }
+
     std::string name = nameOfVariable(writable);
     switch (m_useSpanBasedPutByDefault)
     {

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -161,12 +161,21 @@ Iteration &Iteration::open()
         it.m_closed = CloseStatus::Open;
         runDeferredParseAccess();
     }
-    if (getStepStatus() == StepStatus::OutOfStep)
+    switch (getStepStatus())
     {
+    case StepStatus::OutOfStep:
         beginStep(/* reread = */ false);
         setStepStatus(StepStatus::DuringStep);
+        break;
+    case StepStatus::DuringStep:
+    case StepStatus::NoStep: {
+        auto end = begin;
+        ++end;
+        s.flush_impl(begin, end, {FlushLevel::CreateOrOpenFiles});
     }
-    IOHandler()->flush(internal::defaultFlushParams);
+    break;
+    }
+    // IOHandler()->flush(internal::defaultFlushParams);
     return *this;
 }
 

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -262,7 +262,6 @@ void RecordComponent::flush(
     auto &rc = get();
     if (flushParams.flushLevel == FlushLevel::SkeletonOnly)
     {
-        rc.m_name = name;
         return;
     }
     if (access::readOnly(IOHandler()->m_frontendAccess))


### PR DESCRIPTION
Seen on #1791, fixes:

* an optimization introduced by #1741 
* `Iteration::open()` in random-access mode (did not open files, leading to later hangups due to non-collective file opening)