### PR TITLE
iterator::operator== fix for C++20

### DIFF
--- a/src/IO/ADIOS/ADIOS2PreloadVariables.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadVariables.cpp
@@ -56,7 +56,8 @@ namespace
         }
         auto operator==(FilteredInputIterator const &other) const -> bool
         {
-            return static_cast<Iterator const *>(this)->operator==(other);
+	    return static_cast<Iterator const &>(*this)
+	      == static_cast<Iterator const &>(other);
         }
         using Iterator::operator*;
         using Iterator::operator->;

--- a/src/IO/ADIOS/ADIOS2PreloadVariables.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadVariables.cpp
@@ -56,8 +56,8 @@ namespace
         }
         auto operator==(FilteredInputIterator const &other) const -> bool
         {
-	    return static_cast<Iterator const &>(*this)
-	      == static_cast<Iterator const &>(other);
+            return static_cast<Iterator const &>(*this) ==
+                static_cast<Iterator const &>(other);
         }
         using Iterator::operator*;
         using Iterator::operator->;


### PR DESCRIPTION
When compiling in C++20 mode, this PR avoids an error seen with GCC 13:
```
  [ 66%] Building CXX object openPMD-api/CMakeFiles/openPMD.dir/src/IO/ADIOS/ADIOS2PreloadVariables.cpp.o
  /home/runner/work/quokka/quokka/extern/openPMD-api/src/IO/ADIOS/ADIOS2PreloadVariables.cpp: In instantiation of ‘bool
  openPMD::detail::{anonymous}::FilteredInputIterator<Iterator, Filter>::operator==(const openPMD::detail::
  {anonymous}::FilteredInputIterator<Iterator, Filter>&) const [with Iterator = std::_Rb_tree_iterator<std::pair<const
  std::__cxx11::basic_string<char>, std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >; Filter =
  openPMD::detail::AdiosVariables::availableVariables(size_t, bool, adios2::IO&)::<lambda(const auto:47&)>]’:
  /usr/include/c++/13/bits/stl_tree.h:1103:19:   required from ‘std::__enable_if_t<std::is_same<_Val, typename
  std::iterator_traits<_InputIterator>::value_type>::value> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare,
  _Alloc>::_M_insert_range_unique(_InputIterator, _InputIterator) [with _InputIterator = openPMD::detail::
  {anonymous}::FilteredInputIterator<std::_Rb_tree_iterator<std::pair<const std::__cxx11::basic_string<char>,
  std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >,
  openPMD::detail::AdiosVariables::availableVariables(size_t, bool, adios2::IO&)::<lambda(const auto:47&)> >; _Key =
  std::__cxx11::basic_string<char>; _Val = std::pair<const std::__cxx11::basic_string<char>,
  std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >; _KeyOfValue = std::_Select1st<std::pair<const
  std::__cxx11::basic_string<char>, std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >; _Compare =
  std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>,
  std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >; std::__enable_if_t<std::is_same<_Val, typename
  std::iterator_traits<_InputIterator>::value_type>::value> = void; typename std::iterator_traits<_InputIterator>::value_type =
  std::pair<const std::__cxx11::basic_string<char>, std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >]’
  /usr/include/c++/13/bits/stl_map.h:287:31:   required from ‘std::map<_Key, _Tp, _Compare, _Alloc>::map(_InputIterator,
  _InputIterator) [with _InputIterator = openPMD::detail::{anonymous}::FilteredInputIterator<std::_Rb_tree_iterator<std::pair<const
  std::__cxx11::basic_string<char>, std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >,
  openPMD::detail::AdiosVariables::availableVariables(size_t, bool, adios2::IO&)::<lambda(const auto:47&)> >; _Key =
  std::__cxx11::basic_string<char>; _Tp = std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >; _Compare =
  std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>,
  std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >]’
  /home/runner/work/quokka/quokka/extern/openPMD-api/src/IO/ADIOS/ADIOS2PreloadVariables.cpp:108:55:   required from here
  /home/runner/work/quokka/quokka/extern/openPMD-api/src/IO/ADIOS/ADIOS2PreloadVariables.cpp:59:65: error: ‘const struct
  std::_Rb_tree_iterator<std::pair<const std::__cxx11::basic_string<char>, std::map<std::__cxx11::basic_string<char>,
  std::__cxx11::basic_string<char> > > >’ has no member named ‘operator==’; did you mean ‘operator*’?
     59 |             return static_cast<Iterator const *>(this)->operator==(other);
        |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
        |                    operator*

```

Required for https://github.com/quokka-astro/quokka/pull/1408.