### PR TITLE
Wheels: Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Install cibuildwheel
       run: |
@@ -121,7 +121,7 @@ jobs:
         #     https://github.com/pypa/manylinux/issues/899
         CIBW_SKIP: "pp*-manylinux*"
         CIBW_ARCHS: "${{ matrix.arch }}"
-        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
+        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
         # Install dependencies
         CIBW_BEFORE_BUILD_LINUX: bash -x .github/library_builders.sh
         CIBW_BEFORE_BUILD_MACOS: bash -x .github/library_builders.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install cibuildwheel
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install cibuildwheel==2.21.2
+        python -m pip install cibuildwheel==3.2.1
 
     # 0.16.1.post1 bump
     - name: Download Patch 1/1

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,11 @@ jobs:
       arch: arm64
       dist: focal
       env:
+        - CIBW_BUILD="cp314-manylinux_aarch64"
+    - services: docker
+      arch: arm64
+      dist: focal
+      env:
         - CIBW_BUILD="pp310-manylinux_aarch64"
     - services: docker
       arch: arm64
@@ -65,6 +70,11 @@ jobs:
       dist: focal
       env:
         - CIBW_BUILD="cp312-musllinux_aarch64 cp313-musllinux_aarch64"
+    - services: docker
+      arch: arm64
+      dist: focal
+      env:
+        - CIBW_BUILD="cp314-musllinux_aarch64"
 
     # perform a linux PPC64LE build
     - services: docker
@@ -96,6 +106,11 @@ jobs:
       arch: ppc64le
       dist: focal
       env:
+        - CIBW_BUILD="cp314-manylinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
         - CIBW_BUILD="cp39-musllinux_ppc64le"
     - services: docker
       arch: ppc64le
@@ -117,6 +132,11 @@ jobs:
       dist: focal
       env:
         - CIBW_BUILD="cp313-musllinux_ppc64le"
+    - services: docker
+      arch: ppc64le
+      dist: focal
+      env:
+        - CIBW_BUILD="cp314-musllinux_ppc64le"
 
     # perform a linux S390X build
     # blocked by https://github.com/GTkorvo/dill/issues/15
@@ -136,7 +156,7 @@ install:
   - git clone --branch ${OPENPMD_GIT_REF} --depth 1 https://github.com/openPMD/openPMD-api.git src
   - cp library_builders.sh src/.github/
   - python -m pip install --upgrade pip setuptools wheel
-  - python -m pip install cibuildwheel==2.21.2
+  - python -m pip install cibuildwheel==3.2.1
   # twine & cryptography: see
   #   https://github.com/scikit-build/cmake-python-distributions/blob/4730aeee240917303f293dffc89a8d8d5a4787c4/requirements-deploy.txt
   #   https://github.com/pyca/cryptography/issues/6086

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.9"
+  - "3.11"
 
 branches:
   only:
@@ -10,7 +10,7 @@ env:
   global:
     - OPENPMD_GIT_REF="0.16.1"
 
-    - CIBW_PROJECT_REQUIRES_PYTHON=">=3.9"
+    - CIBW_PROJECT_REQUIRES_PYTHON=">=3.10"
     # Install dependencies on Linux and OSX
     - CIBW_BEFORE_BUILD="bash -x .github/library_builders.sh"
     # for the openPMD-api build, CMake shall search for
@@ -24,11 +24,6 @@ jobs:
     # perform a linux ARMv8 build
     # note: takes >50min, so we need to split
     # +manylinux
-    - services: docker
-      arch: arm64
-      dist: focal
-      env:
-        - CIBW_BUILD="cp39-manylinux_aarch64"
     - services: docker
       arch: arm64
       dist: focal
@@ -49,17 +44,7 @@ jobs:
       dist: focal
       env:
         - CIBW_BUILD="pp310-manylinux_aarch64"
-    - services: docker
-      arch: arm64
-      dist: focal
-      env:
-        - CIBW_BUILD="pp39-manylinux_aarch64"
     # +musllinux
-    - services: docker
-      arch: arm64
-      dist: focal
-      env:
-        - CIBW_BUILD="cp38-musllinux_aarch64 cp39-musllinux_aarch64"
     - services: docker
       arch: arm64
       dist: focal
@@ -77,11 +62,6 @@ jobs:
         - CIBW_BUILD="cp314-musllinux_aarch64"
 
     # perform a linux PPC64LE build
-    - services: docker
-      arch: ppc64le
-      dist: focal
-      env:
-        - CIBW_BUILD="cp39-manylinux_ppc64le"
     - services: docker
       arch: ppc64le
       dist: focal
@@ -107,11 +87,6 @@ jobs:
       dist: focal
       env:
         - CIBW_BUILD="cp314-manylinux_ppc64le"
-    - services: docker
-      arch: ppc64le
-      dist: focal
-      env:
-        - CIBW_BUILD="cp39-musllinux_ppc64le"
     - services: docker
       arch: ppc64le
       dist: focal


### PR DESCRIPTION
Build wheels for Python 3.14 for the latest stable release.