### PR TITLE
HIP: Fix host-only constructors

### DIFF
--- a/include/openPMD/snapshots/RandomAccessIterator.hpp
+++ b/include/openPMD/snapshots/RandomAccessIterator.hpp
@@ -72,15 +72,14 @@ public:
 
     ~RandomAccessIterator() override;
 
-    RandomAccessIterator(RandomAccessIterator const &other) = default;
+    RandomAccessIterator(RandomAccessIterator const &other);
     RandomAccessIterator(RandomAccessIterator &&other) noexcept(
-        noexcept(iterator_t(std::declval<iterator_t &&>()))) = default;
+        noexcept(iterator_t(std::declval<iterator_t &&>())));
 
+    RandomAccessIterator &operator=(RandomAccessIterator const &other);
     RandomAccessIterator &
-    operator=(RandomAccessIterator const &other) = default;
-    RandomAccessIterator &operator=(RandomAccessIterator &&other) noexcept(
-        noexcept(std::declval<iterator_t>().operator=(
-            std::declval<iterator_t &&>()))) = default;
+    operator=(RandomAccessIterator &&other) noexcept(noexcept(
+        std::declval<iterator_t>().operator=(std::declval<iterator_t &&>())));
 
     auto operator*() -> value_type &;
     auto operator*() const -> value_type const &;

--- a/src/auxiliary/UniquePtr.cpp
+++ b/src/auxiliary/UniquePtr.cpp
@@ -65,7 +65,7 @@ namespace auxiliary
 } // namespace auxiliary
 
 template <typename T>
-#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
+#ifdef __HIPCC__ // ROCm 6.2.4 issue, see #1797
 __host__
 #endif
 UniquePtrWithLambda<T>::UniquePtrWithLambda() = default;

--- a/src/auxiliary/UniquePtr.cpp
+++ b/src/auxiliary/UniquePtr.cpp
@@ -65,7 +65,7 @@ namespace auxiliary
 } // namespace auxiliary
 
 template <typename T>
-#ifdef __HIPCC__
+#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
 __host__
 #endif
 UniquePtrWithLambda<T>::UniquePtrWithLambda() = default;

--- a/src/auxiliary/UniquePtr.cpp
+++ b/src/auxiliary/UniquePtr.cpp
@@ -65,6 +65,9 @@ namespace auxiliary
 } // namespace auxiliary
 
 template <typename T>
+#ifdef __HIPCC__
+__host__
+#endif
 UniquePtrWithLambda<T>::UniquePtrWithLambda() = default;
 
 template <typename T>

--- a/src/backend/BaseRecord.cpp
+++ b/src/backend/BaseRecord.cpp
@@ -56,7 +56,7 @@ namespace internal
         typename T_BaseRecord_,
         typename T_BaseRecordData_,
         typename T_BaseIterator>
-#ifdef __HIPCC__
+#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
     __host__
 #endif
     ScalarIterator<T_BaseRecord_, T_BaseRecordData_, T_BaseIterator>::

--- a/src/backend/BaseRecord.cpp
+++ b/src/backend/BaseRecord.cpp
@@ -56,7 +56,7 @@ namespace internal
         typename T_BaseRecord_,
         typename T_BaseRecordData_,
         typename T_BaseIterator>
-#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
+#ifdef __HIPCC__ // ROCm 6.2.4 issue, see #1797
     __host__
 #endif
     ScalarIterator<T_BaseRecord_, T_BaseRecordData_, T_BaseIterator>::

--- a/src/backend/BaseRecord.cpp
+++ b/src/backend/BaseRecord.cpp
@@ -56,6 +56,9 @@ namespace internal
         typename T_BaseRecord_,
         typename T_BaseRecordData_,
         typename T_BaseIterator>
+#ifdef __HIPCC__
+    __host__
+#endif
     ScalarIterator<T_BaseRecord_, T_BaseRecordData_, T_BaseIterator>::
         ScalarIterator() = default;
 

--- a/src/snapshots/RandomAccessIterator.cpp
+++ b/src/snapshots/RandomAccessIterator.cpp
@@ -15,6 +15,7 @@ __host__
 #endif
 RandomAccessIterator<iterator_t>::RandomAccessIterator(
     RandomAccessIterator const &other) = default;
+
 template <typename iterator_t>
 #ifdef __HIPCC__ // ROCm 6.2.4 issue, see #1797
 __host__
@@ -23,9 +24,11 @@ RandomAccessIterator<iterator_t>::RandomAccessIterator(
     RandomAccessIterator
         &&other) noexcept(noexcept(iterator_t(std::declval<iterator_t &&>()))) =
     default;
+
 template <typename iterator_t>
 RandomAccessIterator<iterator_t> &RandomAccessIterator<iterator_t>::operator=(
     RandomAccessIterator const &other) = default;
+
 template <typename iterator_t>
 RandomAccessIterator<iterator_t> &RandomAccessIterator<iterator_t>::operator=(
     RandomAccessIterator

--- a/src/snapshots/RandomAccessIterator.cpp
+++ b/src/snapshots/RandomAccessIterator.cpp
@@ -10,6 +10,24 @@ template <typename iterator_t>
 RandomAccessIterator<iterator_t>::~RandomAccessIterator() = default;
 
 template <typename iterator_t>
+RandomAccessIterator<iterator_t>::RandomAccessIterator(
+    RandomAccessIterator const &other) = default;
+template <typename iterator_t>
+RandomAccessIterator<iterator_t>::RandomAccessIterator(
+    RandomAccessIterator
+        &&other) noexcept(noexcept(iterator_t(std::declval<iterator_t &&>()))) =
+    default;
+template <typename iterator_t>
+RandomAccessIterator<iterator_t> &RandomAccessIterator<iterator_t>::operator=(
+    RandomAccessIterator const &other) = default;
+template <typename iterator_t>
+RandomAccessIterator<iterator_t> &RandomAccessIterator<iterator_t>::operator=(
+    RandomAccessIterator
+        &&other) noexcept(noexcept(std::declval<iterator_t>().
+                                   operator=(std::declval<iterator_t &&>()))) =
+    default;
+
+template <typename iterator_t>
 auto RandomAccessIterator<iterator_t>::operator*() -> value_type &
 {
     return *m_it;

--- a/src/snapshots/RandomAccessIterator.cpp
+++ b/src/snapshots/RandomAccessIterator.cpp
@@ -10,13 +10,13 @@ template <typename iterator_t>
 RandomAccessIterator<iterator_t>::~RandomAccessIterator() = default;
 
 template <typename iterator_t>
-#ifdef __HIPCC__
+#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
 __host__
 #endif
 RandomAccessIterator<iterator_t>::RandomAccessIterator(
     RandomAccessIterator const &other) = default;
 template <typename iterator_t>
-#ifdef __HIPCC__
+#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
 __host__
 #endif
 RandomAccessIterator<iterator_t>::RandomAccessIterator(

--- a/src/snapshots/RandomAccessIterator.cpp
+++ b/src/snapshots/RandomAccessIterator.cpp
@@ -10,13 +10,13 @@ template <typename iterator_t>
 RandomAccessIterator<iterator_t>::~RandomAccessIterator() = default;
 
 template <typename iterator_t>
-#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
+#ifdef __HIPCC__ // ROCm 6.2.4 issue, see #1797
 __host__
 #endif
 RandomAccessIterator<iterator_t>::RandomAccessIterator(
     RandomAccessIterator const &other) = default;
 template <typename iterator_t>
-#ifdef __HIPCC__  // ROCm 6.2.4 issue, see #1797
+#ifdef __HIPCC__ // ROCm 6.2.4 issue, see #1797
 __host__
 #endif
 RandomAccessIterator<iterator_t>::RandomAccessIterator(

--- a/src/snapshots/RandomAccessIterator.cpp
+++ b/src/snapshots/RandomAccessIterator.cpp
@@ -10,9 +10,15 @@ template <typename iterator_t>
 RandomAccessIterator<iterator_t>::~RandomAccessIterator() = default;
 
 template <typename iterator_t>
+#ifdef __HIPCC__
+__host__
+#endif
 RandomAccessIterator<iterator_t>::RandomAccessIterator(
     RandomAccessIterator const &other) = default;
 template <typename iterator_t>
+#ifdef __HIPCC__
+__host__
+#endif
 RandomAccessIterator<iterator_t>::RandomAccessIterator(
     RandomAccessIterator
         &&other) noexcept(noexcept(iterator_t(std::declval<iterator_t &&>()))) =


### PR DESCRIPTION
Declaring default constructors seems to make HIP compilers treat them as `__host__ __device__` by default. This explicitly annotates the offending constructors as `__host__`.

Reverts #1754 which worked around the same problem by pulling the constructors into headers.
Fixes #1797.

TODO: 

- [ ] Comment: Rocm versions