### PR TITLE
Fix Variant issue with certain Cuda versions

### DIFF
--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -58,31 +58,11 @@ namespace auxiliary
             using parent_t = std::shared_ptr<UniquePtrWithLambda<void>>;
 
         public:
-            MovableUniquePtr() = default;
-            MovableUniquePtr(UniquePtrWithLambda<void> ptr_in)
-                : parent_t{std::make_shared<UniquePtrWithLambda<void>>(
-                      std::move(ptr_in))}
-            {}
-            auto get() -> void *
-            {
-                return (**this).get();
-            }
-            [[nodiscard]] auto get() const -> void const *
-            {
-                return (**this).get();
-            }
-            [[nodiscard]] auto release() -> UniquePtrWithLambda<void>
-            {
-                if (parent_t::use_count() > 1)
-                {
-                    throw error::Internal(
-                        "Control flow error: UniquePtr variant of WriteBuffer "
-                        "has been copied.");
-                }
-                UniquePtrWithLambda<void> res = std::move(**this);
-                this->reset();
-                return res;
-            }
+            MovableUniquePtr();
+            MovableUniquePtr(UniquePtrWithLambda<void> ptr_in);
+            auto get() -> void *;
+            [[nodiscard]] auto get() const -> void const *;
+            [[nodiscard]] auto release() -> UniquePtrWithLambda<void>;
         };
         using SharedPtr = std::shared_ptr<void const>;
         /*

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -22,16 +22,13 @@
 
 #include "openPMD/Dataset.hpp"
 #include "openPMD/Datatype.hpp"
+#include "openPMD/Error.hpp"
 #include "openPMD/auxiliary/UniquePtr.hpp"
 
 #include <any>
-#include <complex>
 #include <functional>
-#include <iostream>
 #include <memory>
-#include <type_traits>
 #include <utility>
-#include <variant>
 
 namespace openPMD
 {
@@ -52,8 +49,41 @@ namespace auxiliary
         /*
          * Sic. Have to put the unique_ptr behind a shared_ptr because
          * std::variant does not want immovable types.
+         * Use a separate class to avoid mistakes in double dereference.
          */
-        using UniquePtr = std::shared_ptr<UniquePtrWithLambda<void>>;
+        struct MovableUniquePtr
+            : private std::shared_ptr<UniquePtrWithLambda<void>>
+        {
+        private:
+            using parent_t = std::shared_ptr<UniquePtrWithLambda<void>>;
+
+        public:
+            MovableUniquePtr() = default;
+            MovableUniquePtr(UniquePtrWithLambda<void> ptr_in)
+                : parent_t{std::make_shared<UniquePtrWithLambda<void>>(
+                      std::move(ptr_in))}
+            {}
+            auto get() -> void *
+            {
+                return (**this).get();
+            }
+            [[nodiscard]] auto get() const -> void const *
+            {
+                return (**this).get();
+            }
+            [[nodiscard]] auto release() -> UniquePtrWithLambda<void>
+            {
+                if (parent_t::use_count() > 1)
+                {
+                    throw error::Internal(
+                        "Control flow error: UniquePtr variant of WriteBuffer "
+                        "has been copied.");
+                }
+                UniquePtrWithLambda<void> res = std::move(**this);
+                this->reset();
+                return res;
+            }
+        };
         using SharedPtr = std::shared_ptr<void const>;
         /*
          * Use std::any publically since some compilers have trouble with

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -49,8 +49,18 @@ namespace auxiliary
      */
     struct WriteBuffer
     {
+        /*
+         * Sic. Have to put the unique_ptr behind a shared_ptr because
+         * std::variant does not want immovable types.
+         */
         using UniquePtr = std::shared_ptr<UniquePtrWithLambda<void>>;
         using SharedPtr = std::shared_ptr<void const>;
+        /*
+         * Use std::any publically since some compilers have trouble with
+         * certain uses of std::variant, so hide it from them.
+         * Look into Memory_internal.hpp for the variant type.
+         * https://github.com/openPMD/openPMD-api/issues/1720
+         */
         std::any m_buffer;
 
         WriteBuffer();

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -74,10 +74,7 @@ namespace auxiliary
         std::any m_buffer;
 
         WriteBuffer();
-
         WriteBuffer(std::shared_ptr<void const> ptr);
-        // WriteBuffer(std::shared_ptr<void> const &ptr);
-
         WriteBuffer(UniquePtrWithLambda<void> ptr);
 
         WriteBuffer(WriteBuffer &&) noexcept;
@@ -86,8 +83,6 @@ namespace auxiliary
         WriteBuffer &operator=(WriteBuffer const &) = delete;
 
         WriteBuffer const &operator=(std::shared_ptr<void const> ptr);
-        // WriteBuffer const &operator=(std::shared_ptr<void> const &ptr);
-
         WriteBuffer const &operator=(UniquePtrWithLambda<void> ptr);
 
         void const *get() const;

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -24,6 +24,7 @@
 #include "openPMD/Datatype.hpp"
 #include "openPMD/auxiliary/UniquePtr.hpp"
 
+#include <any>
 #include <complex>
 #include <functional>
 #include <iostream>
@@ -48,30 +49,40 @@ namespace auxiliary
      */
     struct WriteBuffer
     {
-        using EligibleTypes = std::
-            variant<std::shared_ptr<void const>, UniquePtrWithLambda<void>>;
-        EligibleTypes m_buffer;
+        using UniquePtr = std::shared_ptr<UniquePtrWithLambda<void>>;
+        using SharedPtr = std::shared_ptr<void const>;
+        std::any m_buffer;
 
         WriteBuffer();
 
-        template <typename... Args>
-        explicit WriteBuffer(Args &&...args)
-            : m_buffer(std::forward<Args>(args)...)
-        {}
+        WriteBuffer(std::shared_ptr<void const> ptr);
+        // WriteBuffer(std::shared_ptr<void> const &ptr);
 
-        WriteBuffer(WriteBuffer &&) noexcept(
-            noexcept(EligibleTypes(std::declval<EligibleTypes &&>())));
+        WriteBuffer(UniquePtrWithLambda<void> ptr);
+
+        WriteBuffer(WriteBuffer &&) noexcept;
         WriteBuffer(WriteBuffer const &) = delete;
-        WriteBuffer &operator=(WriteBuffer &&) noexcept(noexcept(
-            std::declval<EligibleTypes &>() =
-                std::declval<EligibleTypes &&>()));
+        WriteBuffer &operator=(WriteBuffer &&) noexcept;
         WriteBuffer &operator=(WriteBuffer const &) = delete;
 
         WriteBuffer const &operator=(std::shared_ptr<void const> ptr);
+        // WriteBuffer const &operator=(std::shared_ptr<void> const &ptr);
 
-        WriteBuffer const &operator=(UniquePtrWithLambda<void const> ptr);
+        WriteBuffer const &operator=(UniquePtrWithLambda<void> ptr);
 
         void const *get() const;
+
+        template <typename variant_t>
+        auto as_variant() -> variant_t &
+        {
+            return *std::any_cast<variant_t>(&m_buffer);
+        }
+
+        template <typename variant_t>
+        auto as_variant() const -> variant_t const &
+        {
+            return *std::any_cast<variant_t>(&m_buffer);
+        }
     };
 } // namespace auxiliary
 } // namespace openPMD

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -48,18 +48,18 @@ namespace auxiliary
     {
         /*
          * Sic. Have to put the unique_ptr behind a shared_ptr because
-         * std::variant does not want immovable types.
+         * std::variant does not want non-copyable types.
          * Use a separate class to avoid mistakes in double dereference.
          */
-        struct MovableUniquePtr
+        struct CopyableUniquePtr
             : private std::shared_ptr<UniquePtrWithLambda<void>>
         {
         private:
             using parent_t = std::shared_ptr<UniquePtrWithLambda<void>>;
 
         public:
-            MovableUniquePtr();
-            MovableUniquePtr(UniquePtrWithLambda<void> ptr_in);
+            CopyableUniquePtr();
+            CopyableUniquePtr(UniquePtrWithLambda<void> ptr_in);
             auto get() -> void *;
             [[nodiscard]] auto get() const -> void const *;
             [[nodiscard]] auto release() -> UniquePtrWithLambda<void>;

--- a/include/openPMD/auxiliary/Memory_internal.hpp
+++ b/include/openPMD/auxiliary/Memory_internal.hpp
@@ -21,12 +21,10 @@
 #pragma once
 
 #include "openPMD/auxiliary/Memory.hpp"
-#include "openPMD/auxiliary/UniquePtr.hpp"
-#include <memory>
 
 namespace openPMD::auxiliary
 {
 // cannot use a unique_ptr inside a std::variant, so we represent it with this
 using WriteBufferTypes =
-    std::variant<WriteBuffer::UniquePtr, WriteBuffer::SharedPtr>;
+    std::variant<WriteBuffer::MovableUniquePtr, WriteBuffer::SharedPtr>;
 } // namespace openPMD::auxiliary

--- a/include/openPMD/auxiliary/Memory_internal.hpp
+++ b/include/openPMD/auxiliary/Memory_internal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2025 Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Memory_internal.hpp
+++ b/include/openPMD/auxiliary/Memory_internal.hpp
@@ -1,0 +1,32 @@
+/* Copyright 2017-2021 Fabian Koller
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "openPMD/auxiliary/Memory.hpp"
+#include "openPMD/auxiliary/UniquePtr.hpp"
+#include <memory>
+
+namespace openPMD::auxiliary
+{
+// cannot use a unique_ptr inside a std::variant, so we represent it with this
+using WriteBufferTypes =
+    std::variant<WriteBuffer::UniquePtr, WriteBuffer::SharedPtr>;
+} // namespace openPMD::auxiliary

--- a/include/openPMD/auxiliary/Memory_internal.hpp
+++ b/include/openPMD/auxiliary/Memory_internal.hpp
@@ -26,5 +26,5 @@ namespace openPMD::auxiliary
 {
 // cannot use a unique_ptr inside a std::variant, so we represent it with this
 using WriteBufferTypes =
-    std::variant<WriteBuffer::MovableUniquePtr, WriteBuffer::SharedPtr>;
+    std::variant<WriteBuffer::CopyableUniquePtr, WriteBuffer::SharedPtr>;
 } // namespace openPMD::auxiliary

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -25,21 +25,6 @@
 namespace openPMD
 {}
 
-#if defined(CUDA_VERSION) && !defined(OPENPMD_SKIP_CHECK_ISSUE_1720)
-static_assert(__cplusplus < 202002L || CUDA_VERSION >= 12040, R"(
-Cannot use the openPMD-api in C++20 projects under a Cuda version lower
-than 12.4.0 due to a bug in the implementation of std::variant.
-Further information at:
-https://github.com/openPMD/openPMD-api/issues/1720
-https://forums.developer.nvidia.com/t/nvcc-c-20-std-variant-complie-failed/270162/5
-This cannot be fixed on our side, please either upgrade to CUDA >= 12.4.0
-or use C++17.
-If you think that this assertion is shown wrongly, please apply
-'#define OPENPMD_SKIP_CHECK_ISSUE_1720' before including
-'<openPMD/openPMD.hpp>'.
-)");
-#endif
-
 // IWYU pragma: begin_exports
 #include "openPMD/Dataset.hpp"
 #include "openPMD/Datatype.hpp"

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -116,7 +116,7 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
             }
             else if constexpr (std::is_same_v<
                                    ptr_type,
-                                   auxiliary::WriteBuffer::MovableUniquePtr>)
+                                   auxiliary::WriteBuffer::CopyableUniquePtr>)
             {
                 BufferedUniquePtrPut bput;
                 bput.name = std::move(bp.name);

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -26,6 +26,7 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
+#include "openPMD/auxiliary/Memory_internal.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 
 #include <cstdint>
@@ -114,7 +115,7 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
             }
             else if constexpr (std::is_same_v<
                                    ptr_type,
-                                   UniquePtrWithLambda<void>>)
+                                   std::shared_ptr<UniquePtrWithLambda<void>>>)
             {
                 BufferedUniquePtrPut bput;
                 bput.name = std::move(bp.name);
@@ -128,7 +129,7 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
                  * (ptr_type does not work for this case).
                  */
                 // clang-format off
-                    bput.data = std::move(arg); // NOLINT(bugprone-move-forwarding-reference)
+                bput.data = std::move(*arg); // NOLINT(bugprone-move-forwarding-reference)
                 // clang-format on
                 bput.dtype = bp.param.dtype;
                 ba.m_uniquePtrPuts.push_back(std::move(bput));
@@ -139,7 +140,7 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
                     always_false_v<ptr_type>, "Unhandled std::variant branch");
             }
         },
-        bp.param.data.m_buffer);
+        bp.param.data.as_variant<auxiliary::WriteBufferTypes>());
 }
 
 template <int n, typename... Params>

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -26,6 +26,7 @@
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
+#include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/auxiliary/Memory_internal.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 
@@ -115,22 +116,13 @@ void WriteDataset::call(ADIOS2File &ba, detail::BufferedPut &bp)
             }
             else if constexpr (std::is_same_v<
                                    ptr_type,
-                                   std::shared_ptr<UniquePtrWithLambda<void>>>)
+                                   auxiliary::WriteBuffer::MovableUniquePtr>)
             {
                 BufferedUniquePtrPut bput;
                 bput.name = std::move(bp.name);
                 bput.offset = std::move(bp.param.offset);
                 bput.extent = std::move(bp.param.extent);
-                /*
-                 * Note: Moving is required here since it's a unique_ptr.
-                 * std::forward<>() would theoretically work, but it
-                 * requires the type parameter and we don't have that
-                 * inside the lambda.
-                 * (ptr_type does not work for this case).
-                 */
-                // clang-format off
-                bput.data = std::move(*arg); // NOLINT(bugprone-move-forwarding-reference)
-                // clang-format on
+                bput.data = arg.release();
                 bput.dtype = bp.param.dtype;
                 ba.m_uniquePtrPuts.push_back(std::move(bput));
             }

--- a/src/auxiliary/Memory.cpp
+++ b/src/auxiliary/Memory.cpp
@@ -161,24 +161,24 @@ allocatePtr(Datatype dtype, Extent const &e)
     return allocatePtr(dtype, numPoints);
 }
 
-WriteBuffer::MovableUniquePtr::MovableUniquePtr() = default;
+WriteBuffer::CopyableUniquePtr::CopyableUniquePtr() = default;
 
-WriteBuffer::MovableUniquePtr::MovableUniquePtr(
+WriteBuffer::CopyableUniquePtr::CopyableUniquePtr(
     UniquePtrWithLambda<void> ptr_in)
     : parent_t{std::make_shared<UniquePtrWithLambda<void>>(std::move(ptr_in))}
 {}
 
-auto WriteBuffer::MovableUniquePtr::get() -> void *
+auto WriteBuffer::CopyableUniquePtr::get() -> void *
 {
     return (**this).get();
 }
 
-auto WriteBuffer::MovableUniquePtr::get() const -> void const *
+auto WriteBuffer::CopyableUniquePtr::get() const -> void const *
 {
     return (**this).get();
 }
 
-auto WriteBuffer::MovableUniquePtr::release() -> UniquePtrWithLambda<void>
+auto WriteBuffer::CopyableUniquePtr::release() -> UniquePtrWithLambda<void>
 {
     if (parent_t::use_count() > 1)
     {
@@ -191,14 +191,14 @@ auto WriteBuffer::MovableUniquePtr::release() -> UniquePtrWithLambda<void>
     return res;
 }
 
-WriteBuffer::WriteBuffer() : m_buffer(std::make_any<MovableUniquePtr>())
+WriteBuffer::WriteBuffer() : m_buffer(std::make_any<CopyableUniquePtr>())
 {}
 WriteBuffer::WriteBuffer(std::shared_ptr<void const> ptr)
     : m_buffer(std::make_any<WriteBufferTypes>(std::move(ptr)))
 {}
 WriteBuffer::WriteBuffer(UniquePtrWithLambda<void> ptr)
     : m_buffer(
-          std::make_any<WriteBufferTypes>(MovableUniquePtr(std::move(ptr))))
+          std::make_any<WriteBufferTypes>(CopyableUniquePtr(std::move(ptr))))
 {}
 
 WriteBuffer::WriteBuffer(WriteBuffer &&) noexcept = default;
@@ -212,7 +212,7 @@ WriteBuffer const &WriteBuffer::operator=(std::shared_ptr<void const> ptr)
 WriteBuffer const &WriteBuffer::operator=(UniquePtrWithLambda<void> ptr)
 {
     m_buffer =
-        std::make_any<WriteBufferTypes>(MovableUniquePtr(std::move(ptr)));
+        std::make_any<WriteBufferTypes>(CopyableUniquePtr(std::move(ptr)));
     return *this;
 }
 

--- a/src/auxiliary/Memory.cpp
+++ b/src/auxiliary/Memory.cpp
@@ -193,14 +193,9 @@ auto WriteBuffer::MovableUniquePtr::release() -> UniquePtrWithLambda<void>
 
 WriteBuffer::WriteBuffer() : m_buffer(std::make_any<MovableUniquePtr>())
 {}
-
 WriteBuffer::WriteBuffer(std::shared_ptr<void const> ptr)
     : m_buffer(std::make_any<WriteBufferTypes>(std::move(ptr)))
 {}
-// WriteBuffer::WriteBuffer(std::shared_ptr<void> const &ptr)
-//     : WriteBuffer{std::static_pointer_cast<void const>(ptr)}
-// {}
-
 WriteBuffer::WriteBuffer(UniquePtrWithLambda<void> ptr)
     : m_buffer(
           std::make_any<WriteBufferTypes>(MovableUniquePtr(std::move(ptr))))
@@ -214,12 +209,6 @@ WriteBuffer const &WriteBuffer::operator=(std::shared_ptr<void const> ptr)
     m_buffer = std::make_any<WriteBufferTypes>(std::move(ptr));
     return *this;
 }
-// WriteBuffer const &WriteBuffer::operator=(std::shared_ptr<void> const &ptr)
-// {
-//     operator=(std::static_pointer_cast<void const>(ptr));
-//     return *this;
-// }
-
 WriteBuffer const &WriteBuffer::operator=(UniquePtrWithLambda<void> ptr)
 {
     m_buffer =

--- a/src/auxiliary/Memory.cpp
+++ b/src/auxiliary/Memory.cpp
@@ -161,7 +161,7 @@ allocatePtr(Datatype dtype, Extent const &e)
     return allocatePtr(dtype, numPoints);
 }
 
-WriteBuffer::WriteBuffer() : m_buffer(std::make_any<UniquePtr>())
+WriteBuffer::WriteBuffer() : m_buffer(std::make_any<MovableUniquePtr>())
 {}
 
 WriteBuffer::WriteBuffer(std::shared_ptr<void const> ptr)
@@ -173,8 +173,7 @@ WriteBuffer::WriteBuffer(std::shared_ptr<void const> ptr)
 
 WriteBuffer::WriteBuffer(UniquePtrWithLambda<void> ptr)
     : m_buffer(
-          std::make_any<WriteBufferTypes>(
-              std::make_shared<UniquePtrWithLambda<void>>(std::move(ptr))))
+          std::make_any<WriteBufferTypes>(MovableUniquePtr(std::move(ptr))))
 {}
 
 WriteBuffer::WriteBuffer(WriteBuffer &&) noexcept = default;
@@ -193,8 +192,8 @@ WriteBuffer const &WriteBuffer::operator=(std::shared_ptr<void const> ptr)
 
 WriteBuffer const &WriteBuffer::operator=(UniquePtrWithLambda<void> ptr)
 {
-    m_buffer = std::make_any<WriteBufferTypes>(
-        std::make_shared<UniquePtrWithLambda<void>>(std::move(ptr)));
+    m_buffer =
+        std::make_any<WriteBufferTypes>(MovableUniquePtr(std::move(ptr)));
     return *this;
 }
 

--- a/src/auxiliary/Memory.cpp
+++ b/src/auxiliary/Memory.cpp
@@ -161,6 +161,36 @@ allocatePtr(Datatype dtype, Extent const &e)
     return allocatePtr(dtype, numPoints);
 }
 
+WriteBuffer::MovableUniquePtr::MovableUniquePtr() = default;
+
+WriteBuffer::MovableUniquePtr::MovableUniquePtr(
+    UniquePtrWithLambda<void> ptr_in)
+    : parent_t{std::make_shared<UniquePtrWithLambda<void>>(std::move(ptr_in))}
+{}
+
+auto WriteBuffer::MovableUniquePtr::get() -> void *
+{
+    return (**this).get();
+}
+
+auto WriteBuffer::MovableUniquePtr::get() const -> void const *
+{
+    return (**this).get();
+}
+
+auto WriteBuffer::MovableUniquePtr::release() -> UniquePtrWithLambda<void>
+{
+    if (parent_t::use_count() > 1)
+    {
+        throw error::Internal(
+            "Control flow error: UniquePtr variant of WriteBuffer "
+            "has been copied.");
+    }
+    UniquePtrWithLambda<void> res = std::move(**this);
+    this->reset();
+    return res;
+}
+
 WriteBuffer::WriteBuffer() : m_buffer(std::make_any<MovableUniquePtr>())
 {}
 

--- a/src/auxiliary/Memory.cpp
+++ b/src/auxiliary/Memory.cpp
@@ -20,7 +20,11 @@
  */
 
 #include "openPMD/auxiliary/Memory.hpp"
+#include "openPMD/ChunkInfo.hpp"
+#include "openPMD/auxiliary/Memory_internal.hpp"
+#include "openPMD/auxiliary/UniquePtr.hpp"
 
+#include <any>
 #include <complex>
 #include <functional>
 #include <iostream>
@@ -157,24 +161,40 @@ allocatePtr(Datatype dtype, Extent const &e)
     return allocatePtr(dtype, numPoints);
 }
 
-WriteBuffer::WriteBuffer() : m_buffer(UniquePtrWithLambda<void>())
+WriteBuffer::WriteBuffer() : m_buffer(std::make_any<UniquePtr>())
 {}
 
-WriteBuffer::WriteBuffer(WriteBuffer &&) noexcept(
-    noexcept(EligibleTypes(std::declval<EligibleTypes &&>()))) = default;
-WriteBuffer &WriteBuffer::operator=(WriteBuffer &&) noexcept(noexcept(
-    std::declval<EligibleTypes &>() = std::declval<EligibleTypes &&>())) =
-    default;
+WriteBuffer::WriteBuffer(std::shared_ptr<void const> ptr)
+    : m_buffer(std::make_any<WriteBufferTypes>(std::move(ptr)))
+{}
+// WriteBuffer::WriteBuffer(std::shared_ptr<void> const &ptr)
+//     : WriteBuffer{std::static_pointer_cast<void const>(ptr)}
+// {}
+
+WriteBuffer::WriteBuffer(UniquePtrWithLambda<void> ptr)
+    : m_buffer(
+          std::make_any<WriteBufferTypes>(
+              std::make_shared<UniquePtrWithLambda<void>>(std::move(ptr))))
+{}
+
+WriteBuffer::WriteBuffer(WriteBuffer &&) noexcept = default;
+WriteBuffer &WriteBuffer::operator=(WriteBuffer &&) noexcept = default;
 
 WriteBuffer const &WriteBuffer::operator=(std::shared_ptr<void const> ptr)
 {
-    m_buffer = std::move(ptr);
+    m_buffer = std::make_any<WriteBufferTypes>(std::move(ptr));
     return *this;
 }
+// WriteBuffer const &WriteBuffer::operator=(std::shared_ptr<void> const &ptr)
+// {
+//     operator=(std::static_pointer_cast<void const>(ptr));
+//     return *this;
+// }
 
-WriteBuffer const &WriteBuffer::operator=(UniquePtrWithLambda<void const> ptr)
+WriteBuffer const &WriteBuffer::operator=(UniquePtrWithLambda<void> ptr)
 {
-    m_buffer = std::move(ptr);
+    m_buffer = std::make_any<WriteBufferTypes>(
+        std::make_shared<UniquePtrWithLambda<void>>(std::move(ptr)));
     return *this;
 }
 
@@ -186,6 +206,6 @@ void const *WriteBuffer::get() const
             // we're being sneaky and don't distinguish the types here
             return static_cast<void const *>(arg.get());
         },
-        m_buffer);
+        as_variant<WriteBufferTypes>());
 }
 } // namespace openPMD::auxiliary

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -11,7 +11,7 @@
 
 #include "openPMD/IO/ADIOS/macros.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
-#include "openPMD/auxiliary/JSON.hpp"
+#include "openPMD/auxiliary/Memory_internal.hpp"
 #include "openPMD/auxiliary/UniquePtr.hpp"
 
 #include <catch2/catch.hpp>
@@ -1252,7 +1252,7 @@ TEST_CASE("use_count_test", "[core]")
         std::get<std::shared_ptr<void const>>(
             static_cast<Parameter<Operation::WRITE_DATASET> *>(
                 pprc.get().m_chunks.front().parameter.get())
-                ->data.m_buffer)
+                ->data.as_variant<auxiliary::WriteBufferTypes>())
             .use_count() == 1);
 #endif
 }


### PR DESCRIPTION
Close https://github.com/openPMD/openPMD-api/issues/1720

Enabled mostly by https://github.com/openPMD/openPMD-api/pull/1774, the refactorings therein make it possible to workaround the issues that some Cuda versions have with std::variant in C++20. 
Only need to hide one further std::variant from public headers.

TODO:

- [x] Check if we can instead keep WriteBuffer the same, but keep it from public headers. Might also be possible. Update: Eehh maybe not