### PR TITLE
More consistent behavior for reopening Iterations

### DIFF
--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -24,6 +24,7 @@
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/IOTask.hpp"
+#include "openPMD/IterationEncoding.hpp"
 #include "openPMD/Series.hpp"
 #include "openPMD/Streaming.hpp"
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
@@ -881,7 +882,9 @@ auto Iteration::beginStep(
         }
     }
 
-    res.stepStatus = status;
+    res.stepStatus = series.iterationEncoding() == IterationEncoding::fileBased
+        ? AdvanceStatus::RANDOMACCESS
+        : status;
     return res;
 }
 

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -256,7 +256,14 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
         {
             try
             {
-                res.beginStep(/* reread = */ false);
+                if (res.closed())
+                {
+                    res.open();
+                }
+                else
+                {
+                    res.beginStep(/* reread = */ false);
+                }
             }
             catch (error::OperationUnsupportedInBackend const &)
             {

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -211,6 +211,11 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
     }
     if (access::write(access))
     {
+        if (auto it = s.series.iterations.find(key);
+            it != s.series.iterations.end())
+        {
+            return at(key);
+        }
         auto lastIteration = base_iterator->peekCurrentlyOpenIteration();
         if (lastIteration.has_value())
         {
@@ -224,46 +229,13 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
                 lastIteration_v->second.close(); // continue below
             }
         }
-        if (auto it = s.series.iterations.find(key);
-            it == s.series.iterations.end())
-        {
-            s.currentStep.map_during_t(
-                [&](detail::CurrentStep::During_t &during) {
-                    ++during.step_count;
-                    base_iterator->get().seen_iterations[key] =
-                        during.step_count;
-                    during.iteration_idx = key;
-                    during.available_iterations_in_step = {key};
-                },
-                [&](detail::CurrentStep::AtTheEdge where_am_i)
-                    -> detail::CurrentStep::During_t {
-                    base_iterator->get().seen_iterations[key] = 0;
-                    switch (where_am_i)
-                    {
-                    case detail::CurrentStep::AtTheEdge::Begin:
-                        return detail::CurrentStep::During_t{0, key, {key}};
-                    case detail::CurrentStep::AtTheEdge::End:
-                        throw error::Internal(
-                            "Trying to create a new output step, but the "
-                            "stream is "
-                            "closed?");
-                    }
-                    throw std::runtime_error("Unreachable!");
-                });
-        }
+
+        // create new
         auto &res = s.series.iterations[key];
-        if (res.getStepStatus() != StepStatus::DuringStep)
-        {
+        Iteration::BeginStepStatus status = [&]() {
             try
             {
-                if (res.closed())
-                {
-                    res.open();
-                }
-                else
-                {
-                    res.beginStep(/* reread = */ false);
-                }
+                return res.beginStep(/* reread = */ false);
             }
             catch (error::OperationUnsupportedInBackend const &)
             {
@@ -272,8 +244,44 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
                     .m_currentlyActiveIterations.clear();
                 throw;
             }
-            res.setStepStatus(StepStatus::DuringStep);
-        }
+        }();
+        res.setStepStatus(StepStatus::DuringStep);
+
+        s.currentStep.map_during_t(
+            [&](detail::CurrentStep::During_t &during) {
+                switch (status.stepStatus)
+                {
+                case AdvanceStatus::OK:
+                    ++during.step_count;
+                    during.available_iterations_in_step = {key};
+                    break;
+                case AdvanceStatus::RANDOMACCESS:
+                    during.available_iterations_in_step.emplace_back(key);
+                    break;
+                case AdvanceStatus::OVER:
+                    throw error::Internal(
+                        "Backend reported OVER status while trying to create "
+                        "new Iteration.");
+                }
+                base_iterator->get().seen_iterations[key] = during.step_count;
+                during.iteration_idx = key;
+            },
+            [&](detail::CurrentStep::AtTheEdge where_am_i)
+                -> detail::CurrentStep::During_t {
+                base_iterator->get().seen_iterations[key] = 0;
+                switch (where_am_i)
+                {
+                case detail::CurrentStep::AtTheEdge::Begin:
+                    return detail::CurrentStep::During_t{0, key, {key}};
+                case detail::CurrentStep::AtTheEdge::End:
+                    throw error::Internal(
+                        "Trying to create a new output step, but the "
+                        "stream is "
+                        "closed?");
+                }
+                throw std::runtime_error("Unreachable!");
+            });
+
         return res;
     }
     else if (access::read(access))

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -352,14 +352,14 @@ RandomAccessIteratorContainer &RandomAccessIteratorContainer::operator=(
 auto RandomAccessIteratorContainer::currentIteration() const
     -> std::optional<value_type const *>
 {
-    if (auto begin = m_cont.begin(); begin != m_cont.end())
+    for (auto begin = m_cont.rbegin(); begin != m_cont.rend(); ++begin)
     {
-        return std::make_optional<value_type const *>(&*begin);
+        if (!begin->second.closed())
+        {
+            return std::make_optional<value_type const *>(&*begin);
+        }
     }
-    else
-    {
-        return std::nullopt;
-    }
+    return std::nullopt;
 }
 
 auto RandomAccessIteratorContainer::begin() -> iterator

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -6,6 +6,7 @@
 #include "openPMD/snapshots/IteratorHelpers.hpp"
 #include "openPMD/snapshots/RandomAccessIterator.hpp"
 #include "openPMD/snapshots/StatefulIterator.hpp"
+#include <cassert>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -209,94 +210,82 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
     {
         throw std::runtime_error("Stateful iteration on a read-write Series.");
     }
-    if (access::write(access))
+    else if (
+        access::read(access) ||
+        s.series.iterations.find(key) != s.series.iterations.end())
     {
-        if (auto it = s.series.iterations.find(key);
-            it != s.series.iterations.end())
-        {
-            return at(key);
-        }
-        auto lastIteration = base_iterator->peekCurrentlyOpenIteration();
-        if (lastIteration.has_value())
-        {
-            auto lastIteration_v = lastIteration.value();
-            if (lastIteration_v->first == key)
-            {
-                return s.series.iterations.at(key);
-            }
-            else
-            {
-                lastIteration_v->second.close(); // continue below
-            }
-        }
-
-        // create new
-        auto &res = s.series.iterations[key];
-        Iteration::BeginStepStatus status = [&]() {
-            try
-            {
-                return res.beginStep(/* reread = */ false);
-            }
-            catch (error::OperationUnsupportedInBackend const &)
-            {
-                s.series.iterations.retrieveSeries()
-                    .get()
-                    .m_currentlyActiveIterations.clear();
-                throw;
-            }
-        }();
-        res.setStepStatus(StepStatus::DuringStep);
-
-        s.currentStep.map_during_t(
-            [&](detail::CurrentStep::During_t &during) {
-                switch (status.stepStatus)
-                {
-                case AdvanceStatus::OK:
-                    ++during.step_count;
-                    during.available_iterations_in_step = {key};
-                    break;
-                case AdvanceStatus::RANDOMACCESS:
-                    during.available_iterations_in_step.emplace_back(key);
-                    break;
-                case AdvanceStatus::OVER:
-                    throw error::Internal(
-                        "Backend reported OVER status while trying to create "
-                        "new Iteration.");
-                }
-                base_iterator->get().seen_iterations[key] = during.step_count;
-                during.iteration_idx = key;
-            },
-            [&](detail::CurrentStep::AtTheEdge where_am_i)
-                -> detail::CurrentStep::During_t {
-                base_iterator->get().seen_iterations[key] = 0;
-                switch (where_am_i)
-                {
-                case detail::CurrentStep::AtTheEdge::Begin:
-                    return detail::CurrentStep::During_t{0, key, {key}};
-                case detail::CurrentStep::AtTheEdge::End:
-                    throw error::Internal(
-                        "Trying to create a new output step, but the "
-                        "stream is "
-                        "closed?");
-                }
-                throw std::runtime_error("Unreachable!");
-            });
-
-        return res;
+        return at(key);
     }
-    else if (access::read(access))
+
+    assert(access::write(access));
+
+    auto lastIteration = base_iterator->peekCurrentlyOpenIteration();
+    if (lastIteration.has_value())
     {
-        auto &result = base_iterator->seek(
-            {StatefulIterator::Seek::Seek_Iteration_t{key}});
-        if (result.is_end())
+        auto lastIteration_v = lastIteration.value();
+        if (lastIteration_v->first == key)
         {
-            throw std::out_of_range(
-                "[StatefulSnapshotsContainer::operator[]()] Cannot (yet) skip "
-                "to a Snapshot from an I/O step that is not active.");
+            return s.series.iterations.at(key);
         }
-        return result->second;
+        else
+        {
+            lastIteration_v->second.close(); // continue below
+        }
     }
-    throw error::Internal("Control flow error: This should be unreachable.");
+
+    // create new
+    auto &res = s.series.iterations[key];
+    Iteration::BeginStepStatus status = [&]() {
+        try
+        {
+            return res.beginStep(/* reread = */ false);
+        }
+        catch (error::OperationUnsupportedInBackend const &)
+        {
+            s.series.iterations.retrieveSeries()
+                .get()
+                .m_currentlyActiveIterations.clear();
+            throw;
+        }
+    }();
+    res.setStepStatus(StepStatus::DuringStep);
+
+    s.currentStep.map_during_t(
+        [&](detail::CurrentStep::During_t &during) {
+            switch (status.stepStatus)
+            {
+            case AdvanceStatus::OK:
+                ++during.step_count;
+                during.available_iterations_in_step = {key};
+                break;
+            case AdvanceStatus::RANDOMACCESS:
+                during.available_iterations_in_step.emplace_back(key);
+                break;
+            case AdvanceStatus::OVER:
+                throw error::Internal(
+                    "Backend reported OVER status while trying to create "
+                    "new Iteration.");
+            }
+            base_iterator->get().seen_iterations[key] = during.step_count;
+            during.iteration_idx = key;
+        },
+        [&](detail::CurrentStep::AtTheEdge where_am_i)
+            -> detail::CurrentStep::During_t {
+            base_iterator->get().seen_iterations[key] = 0;
+            switch (where_am_i)
+            {
+            case detail::CurrentStep::AtTheEdge::Begin:
+                return detail::CurrentStep::During_t{0, key, {key}};
+            case detail::CurrentStep::AtTheEdge::End:
+                throw error::Internal(
+                    "Trying to create a new output step, but the "
+                    "stream is "
+                    "closed?");
+            }
+            throw std::runtime_error("Unreachable!");
+        });
+
+    return res;
 }
 
 auto StatefulSnapshotsContainer::clear() -> void

--- a/test/Files_SerialIO/close_and_reopen_test.cpp
+++ b/test/Files_SerialIO/close_and_reopen_test.cpp
@@ -184,7 +184,8 @@ auto run_test_groupbased(
     Access writeAccess,
     WriteIterations &&writeIterations,
     std::string const &ext,
-    std::vector<Access> const &readModes)
+    std::vector<Access> const &readModes,
+    bool synchronous)
 {
     std::string filename =
         "../samples/close_iteration_reopen/groupbased." + ext;
@@ -214,6 +215,18 @@ auto run_test_groupbased(
         B_y.resetDataset({Datatype::INT, {5}});
         B_y.storeChunk(data, {0}, {5});
         it.close();
+        // This also verifies that operator[] and at() can be used to access the
+        // Iteration after closing
+        REQUIRE(series.iterations.at(0).closed());
+        REQUIRE(writeIterations(series)[0].closed() == !synchronous);
+        REQUIRE(writeIterations(series).at(0).closed() == !synchronous);
+        if (synchronous)
+        {
+            // we opened a new step, need to do something in it now,
+            // otherwise we get a corrupted file
+            B_y.storeChunk(data, {0}, {5});
+            it.close();
+        }
     }
 
     {
@@ -229,6 +242,15 @@ auto run_test_groupbased(
         E_y.resetDataset({Datatype::INT, {5}});
         E_y.storeChunk(data, {0}, {5});
         it.close();
+
+        if (!synchronous || series.backend() != "ADIOS2")
+        {
+            writeIterations(series).at(0);
+        }
+        else
+        {
+            REQUIRE_THROWS(writeIterations(series).at(0));
+        }
     }
     {
         auto it = writeIterations(series)[2];
@@ -332,37 +354,43 @@ auto close_and_reopen_test() -> void
             writeAccess,
             [](Series &s) { return s.iterations; },
             "bp4",
-            {Access::READ_ONLY, Access::READ_LINEAR});
+            {Access::READ_ONLY, Access::READ_LINEAR},
+            false);
         // since these write data in a way that distributes one iteration's data
         // over multiple steps, only random access read mode makes sense
         run_test_groupbased(
             writeAccess,
             [](Series &s) { return s.writeIterations(); },
             "bp4",
-            {Access::READ_RANDOM_ACCESS});
+            {Access::READ_RANDOM_ACCESS},
+            true);
         run_test_groupbased(
             writeAccess,
             [](Series &s) { return s.snapshots(); },
             "bp4",
-            {Access::READ_RANDOM_ACCESS});
+            {Access::READ_RANDOM_ACCESS},
+            synchronous);
         // that doesnt matter for json tho
         run_test_groupbased(
             writeAccess,
             [](Series &s) { return s.snapshots(); },
             "json",
-            {Access::READ_RANDOM_ACCESS, Access::READ_LINEAR});
+            {Access::READ_RANDOM_ACCESS, Access::READ_LINEAR},
+            synchronous);
 #if openPMD_HAVE_HDF5
         run_test_groupbased(
             writeAccess,
             [](Series &s) { return s.snapshots(); },
             "h5",
-            {Access::READ_RANDOM_ACCESS, Access::READ_LINEAR});
+            {Access::READ_RANDOM_ACCESS, Access::READ_LINEAR},
+            synchronous);
 #endif
         run_test_groupbased(
             writeAccess,
             [](Series &s) { return s.snapshots(); },
             "json",
-            {Access::READ_RANDOM_ACCESS, Access::READ_LINEAR});
+            {Access::READ_RANDOM_ACCESS, Access::READ_LINEAR},
+            synchronous);
     }
 }
 #else

--- a/test/Files_SerialIO/close_and_reopen_test.cpp
+++ b/test/Files_SerialIO/close_and_reopen_test.cpp
@@ -20,7 +20,8 @@ template <typename WriteIterations>
 auto run_test_filebased(
     Access writeAccess,
     WriteIterations &&writeIterations,
-    std::string const &ext)
+    std::string const &ext,
+    bool synchronous)
 {
     std::string filename =
         "../samples/close_iteration_reopen/filebased_%T." + ext;
@@ -39,6 +40,11 @@ auto run_test_filebased(
         B_y.resetDataset({Datatype::INT, {5}});
         B_y.storeChunk(data, {0}, {5});
         it.close();
+        // This also verifies that operator[] and at() can be used to access the
+        // Iteration after closing
+        REQUIRE(series.iterations.at(0).closed());
+        REQUIRE(writeIterations(series)[0].closed() == !synchronous);
+        REQUIRE(writeIterations(series).at(0).closed() == !synchronous);
     }
 
     {
@@ -54,6 +60,9 @@ auto run_test_filebased(
         e_position_x.resetDataset({Datatype::INT, {5}});
         e_position_x.storeChunk(data, {0}, {5});
         it.close();
+        REQUIRE(series.iterations.at(1).closed());
+        REQUIRE(writeIterations(series).at(1).closed() == !synchronous);
+        REQUIRE(writeIterations(series)[1].closed() == !synchronous);
     }
     {
         auto it = writeIterations(series)[2];
@@ -281,19 +290,35 @@ auto close_and_reopen_test() -> void
     for (auto writeAccess :
          {Access::CREATE_RANDOM_ACCESS, Access::CREATE_LINEAR})
     {
+        bool synchronous = writeAccess == Access::CREATE_LINEAR;
         run_test_filebased(
-            writeAccess, [](Series &s) { return s.iterations; }, "bp");
+            writeAccess, [](Series &s) { return s.iterations; }, "bp", false);
         run_test_filebased(
-            writeAccess, [](Series &s) { return s.writeIterations(); }, "bp");
+            writeAccess,
+            [](Series &s) { return s.writeIterations(); },
+            "bp",
+            true);
         run_test_filebased(
-            writeAccess, [](Series &s) { return s.snapshots(); }, "bp");
+            writeAccess,
+            [](Series &s) { return s.snapshots(); },
+            "bp",
+            synchronous);
         run_test_filebased(
-            writeAccess, [](Series &s) { return s.snapshots(); }, "bp");
+            writeAccess,
+            [](Series &s) { return s.snapshots(); },
+            "bp",
+            synchronous);
         run_test_filebased(
-            writeAccess, [](Series &s) { return s.snapshots(); }, "json");
+            writeAccess,
+            [](Series &s) { return s.snapshots(); },
+            "json",
+            synchronous);
 #if openPMD_HAVE_HDF5
         run_test_filebased(
-            writeAccess, [](Series &s) { return s.snapshots(); }, "h5");
+            writeAccess,
+            [](Series &s) { return s.snapshots(); },
+            "h5",
+            synchronous);
 #endif
 
         /*

--- a/test/Files_SerialIO/close_and_reopen_test.cpp
+++ b/test/Files_SerialIO/close_and_reopen_test.cpp
@@ -63,6 +63,9 @@ auto run_test_filebased(
         REQUIRE(series.iterations.at(1).closed());
         REQUIRE(writeIterations(series).at(1).closed() == !synchronous);
         REQUIRE(writeIterations(series)[1].closed() == !synchronous);
+        // We are in file-based iteration encoding, so the old iteration should
+        // remain accessible
+        writeIterations(series).at(0);
     }
     {
         auto it = writeIterations(series)[2];

--- a/test/Files_SerialIO/close_and_reopen_test.cpp
+++ b/test/Files_SerialIO/close_and_reopen_test.cpp
@@ -65,6 +65,8 @@ auto run_test_filebased(
         REQUIRE(writeIterations(series)[1].closed() == !synchronous);
         // We are in file-based iteration encoding, so the old iteration should
         // remain accessible
+        // Note: this will create a particlespath at iteration 0, which will
+        // lead to parsing warnings in HDF5.
         writeIterations(series).at(0);
     }
     {
@@ -249,6 +251,10 @@ auto run_test_groupbased(
         }
         else
         {
+            // Cannot go back to an old IO step
+            // Since the other backends do not use IO steps,
+            // going back to an old Iteration should remain possible even
+            // in synchronous modes
             REQUIRE_THROWS(writeIterations(series).at(0));
         }
     }


### PR DESCRIPTION
`series.snapshots.at(key)` and `series.snapshots[key]` were working inconsistently.
This adds some further tests to the close_and_reopen_iteration test and subsequent fixes.
This also simplifies control flow somewhat.