### PR TITLE
Update C++ license headers

### DIFF
--- a/examples/10_streaming_read.cpp
+++ b/examples/10_streaming_read.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 #include <algorithm>

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/Series.hpp"
 #include "openPMD/snapshots/Snapshots.hpp"
 #include <openPMD/openPMD.hpp>

--- a/examples/12_span_write.cpp
+++ b/examples/12_span_write.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 #include <iostream>

--- a/examples/13_write_dynamic_configuration.cpp
+++ b/examples/13_write_dynamic_configuration.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 #include <algorithm>

--- a/examples/14_toml_template.cpp
+++ b/examples/14_toml_template.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 std::string backendEnding()

--- a/examples/1_structure.cpp
+++ b/examples/1_structure.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/2_read_serial.cpp
+++ b/examples/2_read_serial.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel,
+ *                     L. Diana Amorim
  *
  * This file is part of openPMD-api.
  *

--- a/examples/2a_read_thetaMode_serial.cpp
+++ b/examples/2a_read_thetaMode_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2020-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/3_write_serial.cpp
+++ b/examples/3_write_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/3a_write_thetaMode_serial.cpp
+++ b/examples/3a_write_thetaMode_serial.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2020-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/3b_write_resizable_particles.cpp
+++ b/examples/3b_write_resizable_particles.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Axel Huebl
+/* Copyright 2021-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/4_read_parallel.cpp
+++ b/examples/4_read_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/5_write_parallel.cpp
+++ b/examples/5_write_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/6_dump_filebased_series.cpp
+++ b/examples/6_dump_filebased_series.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Fabian Koller, Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 #include <iostream>

--- a/examples/7_extended_write_serial.cpp
+++ b/examples/7_extended_write_serial.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Fabian Koller, Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 #include <algorithm>

--- a/examples/8_benchmark_parallel.cpp
+++ b/examples/8_benchmark_parallel.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Franz Poeschel, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/benchmark/mpi/MPIBenchmark.hpp>
 #include <openPMD/benchmark/mpi/OneDimensionalBlockSlicer.hpp>
 #include <openPMD/benchmark/mpi/RandomDatasetFiller.hpp>

--- a/examples/8a_benchmark_write_parallel.cpp
+++ b/examples/8a_benchmark_write_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Junmin Gu, Axel Huebl
+/* Copyright 2020-2025 Junmin Gu, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/examples/8b_benchmark_read_parallel.cpp
+++ b/examples/8b_benchmark_read_parallel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Junmin Gu, Axel Huebl
+/* Copyright 2020-2025 Junmin Gu, Axel Huebl, Franz Poeschel, Jean Luca Bez
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/ChunkInfo.hpp
+++ b/include/openPMD/ChunkInfo.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Franz Poeschel
+/* Copyright 2020-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Dataset.hpp
+++ b/include/openPMD/Dataset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Franz Poeschel, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Franz Poeschel, Axel Huebl, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Datatype.hpp
+++ b/include/openPMD/Datatype.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Franz Poeschel, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Franz Poeschel, Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/DatatypeHelpers.hpp
+++ b/include/openPMD/DatatypeHelpers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Franz Poeschel
+/* Copyright 2023-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Error.hpp
+++ b/include/openPMD/Error.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Franz Poeschel, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #include "openPMD/ThrowError.hpp"

--- a/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel.
+/* Copyright 2017-2025 Franz Poeschel., Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS2FilePosition.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2FilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2025 Fabian Koller and Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2025 Fabian Koller and Franz Poeschel, Axel Huebl, Junmin Gu,
+ *                     Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/ADIOS/macros.hpp
+++ b/include/openPMD/IO/ADIOS/macros.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #include "openPMD/config.hpp"

--- a/include/openPMD/IO/AbstractFilePosition.hpp
+++ b/include/openPMD/IO/AbstractFilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandler.hpp
+++ b/include/openPMD/IO/AbstractIOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandlerHelper.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerHelper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Fabian Koller
+/* Copyright 2018-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Franz Poeschel
+/* Copyright 2018-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/Access.hpp
+++ b/include/openPMD/IO/Access.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2025 Fabian Koller and Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/DummyIOHandler.hpp
+++ b/include/openPMD/IO/DummyIOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/Format.hpp
+++ b/include/openPMD/IO/Format.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
+++ b/include/openPMD/IO/HDF5/HDF5Auxiliary.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Felix Schmitt, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Felix Schmitt, Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5FilePosition.hpp
+++ b/include/openPMD/IO/HDF5/HDF5FilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Jean Luca Bez,
+ *                     Junmin Gu, Ulrik Guenther
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/ParallelHDF5IOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/InvalidatableFile.hpp
+++ b/include/openPMD/IO/InvalidatableFile.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Franz Poeschel
+/* Copyright 2018-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/JSON/JSONFilePosition.hpp
+++ b/include/openPMD/IO/JSON/JSONFilePosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel
+/* Copyright 2017-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/JSON/JSONIOHandler.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel
+/* Copyright 2017-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel
+/* Copyright 2017-2025 Franz Poeschel, Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/IterationEncoding.hpp
+++ b/include/openPMD/IterationEncoding.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/ReadIterations.hpp
+++ b/include/openPMD/ReadIterations.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 /*

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/RecordComponent.tpp
+++ b/include/openPMD/RecordComponent.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl and Franz Poeschel
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl and Franz Poeschel, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/Streaming.hpp
+++ b/include/openPMD/Streaming.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 namespace openPMD

--- a/include/openPMD/ThrowError.hpp
+++ b/include/openPMD/ThrowError.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Franz Poeschel
+/* Copyright 2022-2025 Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/UnitDimension.hpp
+++ b/include/openPMD/UnitDimension.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2020-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/WriteIterations.hpp
+++ b/include/openPMD/WriteIterations.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 // legacy header

--- a/include/openPMD/auxiliary/Filesystem.hpp
+++ b/include/openPMD/auxiliary/Filesystem.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Fabian Koller
+/* Copyright 2018-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Franz Poeschel
+/* Copyright 2020-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Memory.hpp
+++ b/include/openPMD/auxiliary/Memory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/OutOfRangeMsg.hpp
+++ b/include/openPMD/auxiliary/OutOfRangeMsg.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2025 Axel Huebl, Fabian Koller
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/ShareRaw.hpp
+++ b/include/openPMD/auxiliary/ShareRaw.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/ShareRawInternal.hpp
+++ b/include/openPMD/auxiliary/ShareRawInternal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/StringManip.hpp
+++ b/include/openPMD/auxiliary/StringManip.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Franz Poeschel
+/* Copyright 2017-2025 Fabian Koller, Franz Poeschel, Axel Huebl, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/auxiliary/Variant.hpp
+++ b/include/openPMD/auxiliary/Variant.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Attribute.hpp
+++ b/include/openPMD/backend/Attribute.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2025 Fabian Koller, Franz Poeschel
+/* Copyright 2017-2025 Fabian Koller, Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2025 Fabian Koller and Franz Poeschel
+/* Copyright 2017-2025 Fabian Koller and Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/backend/Variant_internal.hpp
+++ b/include/openPMD/backend/Variant_internal.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #define OPENPMD_GUARD_HEADER_AGAINST_PUBLIC_INCLUSION

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/MemoryProfiler.hpp
+++ b/include/openPMD/benchmark/MemoryProfiler.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Junmin Gu
+/* Copyright 2020-2025 Junmin Gu, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/Timer.hpp
+++ b/include/openPMD/benchmark/Timer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Junmin Gu
+/* Copyright 2020-2025 Junmin Gu, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/DatasetFiller.hpp
+++ b/include/openPMD/benchmark/mpi/DatasetFiller.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Franz Poeschel
+/* Copyright 2018-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmark.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Franz Poeschel
+/* Copyright 2018-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
+++ b/include/openPMD/benchmark/mpi/MPIBenchmarkReport.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Franz Poeschel
+/* Copyright 2018-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/benchmark/mpi/RandomDatasetFiller.hpp
+++ b/include/openPMD/benchmark/mpi/RandomDatasetFiller.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Franz Poeschel
+/* Copyright 2018-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/binding/python/Common.hpp
+++ b/include/openPMD/binding/python/Common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 The openPMD Community
+/* Copyright 2023-2025 The openPMD Community, Franz Poeschel
  *
  * This header is used to centrally define classes that shall not violate the
  * C++ one-definition-rule (ODR) for various Python translation units.

--- a/include/openPMD/binding/python/Numpy.hpp
+++ b/include/openPMD/binding/python/Numpy.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/binding/python/UnitDimension.hpp
+++ b/include/openPMD/binding/python/UnitDimension.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2020-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/cli/ls.hpp
+++ b/include/openPMD/cli/ls.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2020-2025 Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/include/openPMD/snapshots/ContainerImpls.hpp
+++ b/include/openPMD/snapshots/ContainerImpls.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #include "openPMD/snapshots/ContainerTraits.hpp"

--- a/include/openPMD/snapshots/ContainerTraits.hpp
+++ b/include/openPMD/snapshots/ContainerTraits.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #include "openPMD/Iteration.hpp"

--- a/include/openPMD/snapshots/IteratorHelpers.hpp
+++ b/include/openPMD/snapshots/IteratorHelpers.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #include "openPMD/Iteration.hpp"

--- a/include/openPMD/version.hpp
+++ b/include/openPMD/version.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/ChunkInfo.cpp
+++ b/src/ChunkInfo.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Franz Poeschel
+/* Copyright 2020-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu,
+ *                     Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/Datatype.cpp
+++ b/src/Datatype.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/Error.hpp"
 
 #include <sstream>

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ADIOS2Auxiliary.cpp
+++ b/src/IO/ADIOS/ADIOS2Auxiliary.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel.
+/* Copyright 2017-2025 Franz Poeschel., Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Franz Poeschel, Fabian Koller and Axel Huebl
+/* Copyright 2017-2025 Franz Poeschel, Fabian Koller and Axel Huebl, Junmin Gu,
+ *                     Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/ADIOS/ADIOS2PreloadVariables.cpp
+++ b/src/IO/ADIOS/ADIOS2PreloadVariables.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Franz Poeschel
+/* Copyright 2025-2025 Franz Poeschel, Ben Wibking
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/AbstractIOHandlerHelper.cpp
+++ b/src/IO/AbstractIOHandlerHelper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/AbstractIOHandlerImpl.cpp
+++ b/src/IO/AbstractIOHandlerImpl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Franz Poeschel
+/* Copyright 2022-2025 Franz Poeschel, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/Access.cpp
+++ b/src/IO/Access.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/IO/Access.hpp"
 
 #include <iostream>

--- a/src/IO/DummyIOHandler.cpp
+++ b/src/IO/DummyIOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/HDF5/HDF5Auxiliary.cpp
+++ b/src/IO/HDF5/HDF5Auxiliary.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller, Felix Schmitt, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Felix Schmitt, Axel Huebl, Franz Poeschel,
+ *                     Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu,
+ *                     Jean Luca Bez, Luca Fedeli, Ulrik Guenther
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/HDF5/ParallelHDF5IOHandler.cpp
+++ b/src/IO/HDF5/ParallelHDF5IOHandler.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu,
+ *                     Jean Luca Bez, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/IOTask.cpp
+++ b/src/IO/IOTask.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Fabian Koller
+/* Copyright 2018-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/InvalidatableFile.cpp
+++ b/src/IO/InvalidatableFile.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel.
+/* Copyright 2017-2025 Franz Poeschel., Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/JSON/JSONFilePosition.cpp
+++ b/src/IO/JSON/JSONFilePosition.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/IO/JSON/JSONFilePosition.hpp"
 
 #include <utility>

--- a/src/IO/JSON/JSONIOHandler.cpp
+++ b/src/IO/JSON/JSONIOHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel
+/* Copyright 2017-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Franz Poeschel
+/* Copyright 2017-2025 Franz Poeschel, Axel Huebl, Junmin Gu, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/src/IterationEncoding.cpp
+++ b/src/IterationEncoding.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/ReadIterations.cpp
+++ b/src/ReadIterations.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/ReadIterations.hpp"
 #include "openPMD/snapshots/IteratorHelpers.hpp"
 #include "openPMD/snapshots/StatefulIterator.hpp"

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2017-2021 Fabian Koller, Axel Huebl
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu,
+ *                     Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/UnitDimension.cpp
+++ b/src/UnitDimension.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/UnitDimension.hpp"
 #include <algorithm>
 #include <iterator>

--- a/src/auxiliary/Filesystem.cpp
+++ b/src/auxiliary/Filesystem.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Fabian Koller
+/* Copyright 2018-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Franz Poeschel
+/* Copyright 2020-2025 Franz Poeschel, Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/auxiliary/JSONMatcher.cpp
+++ b/src/auxiliary/JSONMatcher.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/auxiliary/JSONMatcher.hpp"
 #include "openPMD/Error.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"

--- a/src/auxiliary/Memory.cpp
+++ b/src/auxiliary/Memory.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/auxiliary/Mpi.cpp
+++ b/src/auxiliary/Mpi.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/auxiliary/Mpi.hpp"
 
 #include <algorithm>

--- a/src/auxiliary/OneDimensionalBlockSlicer.cpp
+++ b/src/auxiliary/OneDimensionalBlockSlicer.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Franz Poeschel
+/* Copyright 2018-2025 Franz Poeschel, Axel Huebl
  *
  * This file is part of openPMD-api.
  *

--- a/src/auxiliary/Variant.cpp
+++ b/src/auxiliary/Variant.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/Datatype.hpp"
 #include "openPMD/DatatypeMacros.hpp"

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/Attribute.cpp
+++ b/src/backend/Attribute.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/backend/Attribute.hpp"
 
 #include "openPMD/Datatype.hpp"

--- a/src/backend/BaseRecordComponent.cpp
+++ b/src/backend/BaseRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Fabian Koller
+/* Copyright 2017-2025 Fabian Koller, Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Access.cpp
+++ b/src/binding/python/Access.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/BaseRecordComponent.cpp
+++ b/src/binding/python/BaseRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/ChunkInfo.cpp
+++ b/src/binding/python/ChunkInfo.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel, Junmin Gu
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Datatype.cpp
+++ b/src/binding/python/Datatype.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/ParticlePatches.cpp
+++ b/src/binding/python/ParticlePatches.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/PatchRecord.cpp
+++ b/src/binding/python/PatchRecord.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/PatchRecordComponent.cpp
+++ b/src/binding/python/PatchRecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel, Richard Pausch
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/UnitDimension.cpp
+++ b/src/binding/python/UnitDimension.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/binding/python/openPMD.cpp
+++ b/src/binding/python/openPMD.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Axel Huebl
+/* Copyright 2018-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/cli/convert-toml-json.cpp
+++ b/src/cli/convert-toml-json.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <cstdlib>
 #include <cstring>
 #include <openPMD/auxiliary/JSON_internal.hpp>

--- a/src/cli/ls.cpp
+++ b/src/cli/ls.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Axel Huebl
+/* Copyright 2019-2025 Axel Huebl, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2020-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/helper/list_series.cpp
+++ b/src/helper/list_series.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Axel Huebl
+/* Copyright 2019-2025 Axel Huebl, Franz Poeschel
  *
  * This file is part of openPMD-api.
  *

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/snapshots/ContainerImpls.hpp"
 #include "openPMD/Error.hpp"
 #include "openPMD/IO/Access.hpp"

--- a/src/snapshots/ContainerTraits.cpp
+++ b/src/snapshots/ContainerTraits.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/snapshots/ContainerTraits.hpp"
 #include "openPMD/Iteration.hpp"
 #include <optional>

--- a/src/snapshots/IteratorHelpers.cpp
+++ b/src/snapshots/IteratorHelpers.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/snapshots/IteratorHelpers.hpp"
 
 namespace openPMD

--- a/src/snapshots/IteratorTraits.cpp
+++ b/src/snapshots/IteratorTraits.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/snapshots/IteratorTraits.hpp"
 #include "openPMD/snapshots/RandomAccessIterator.hpp"
 #include "openPMD/snapshots/Snapshots.hpp"

--- a/src/snapshots/RandomAccessIterator.cpp
+++ b/src/snapshots/RandomAccessIterator.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/snapshots/RandomAccessIterator.hpp"
 namespace openPMD
 {

--- a/src/snapshots/Snapshots.cpp
+++ b/src/snapshots/Snapshots.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <utility>
 
 #include "openPMD/backend/Attributable.hpp"

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Axel Huebl
+/* Copyright 2020-2025 Axel Huebl, Franz Poeschel, Luca Fedeli
  *
  * This file is part of openPMD-api.
  *

--- a/test/AuxiliaryTest.cpp
+++ b/test/AuxiliaryTest.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Fabian Koller, Franz Poeschel, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 // expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
 #define OPENPMD_private public:

--- a/test/CatchMain.cpp
+++ b/test/CatchMain.cpp
@@ -1,2 +1,22 @@
+/* Copyright 2025 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>

--- a/test/CatchRunner.cpp
+++ b/test/CatchRunner.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
 

--- a/test/CoreTest.cpp
+++ b/test/CoreTest.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Fabian Koller, Franz Poeschel, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 // expose private and protected members for invasive testing
 #if openPMD_USE_INVASIVE_TESTS
 #define OPENPMD_private public:

--- a/test/Files_Core/CoreTests.hpp
+++ b/test/Files_Core/CoreTests.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 namespace automatic_variable_encoding

--- a/test/Files_Core/automatic_variable_encoding.cpp
+++ b/test/Files_Core/automatic_variable_encoding.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "CoreTests.hpp"
 
 #include <catch2/catch.hpp>

--- a/test/Files_ParallelIO/ParallelIOTests.hpp
+++ b/test/Files_ParallelIO/ParallelIOTests.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 #if openPMD_HAVE_MPI

--- a/test/Files_ParallelIO/bug_1655_bp5_writer_hangup.cpp
+++ b/test/Files_ParallelIO/bug_1655_bp5_writer_hangup.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "ParallelIOTests.hpp"
 
 #include <mpi.h>

--- a/test/Files_ParallelIO/iterate_nonstreaming_series.cpp
+++ b/test/Files_ParallelIO/iterate_nonstreaming_series.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "ParallelIOTests.hpp"
 
 #include "openPMD/IO/ADIOS/macros.hpp"

--- a/test/Files_ParallelIO/read_variablebased_randomaccess.cpp
+++ b/test/Files_ParallelIO/read_variablebased_randomaccess.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "ParallelIOTests.hpp"
 
 #include "openPMD/IO/ADIOS/macros.hpp"

--- a/test/Files_SerialIO/SerialIOTests.hpp
+++ b/test/Files_SerialIO/SerialIOTests.hpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include <openPMD/openPMD.hpp>
 
 namespace filebased_write_test

--- a/test/Files_SerialIO/close_and_reopen_test.cpp
+++ b/test/Files_SerialIO/close_and_reopen_test.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "SerialIOTests.hpp"
 #include "openPMD/IO/ADIOS/macros.hpp"
 #include "openPMD/IO/Access.hpp"

--- a/test/Files_SerialIO/filebased_write_test.cpp
+++ b/test/Files_SerialIO/filebased_write_test.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "SerialIOTests.hpp"
 #include "openPMD/IO/Access.hpp"
 

--- a/test/Files_SerialIO/issue_1744_unique_ptrs_at_close_time.cpp
+++ b/test/Files_SerialIO/issue_1744_unique_ptrs_at_close_time.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "SerialIOTests.hpp"
 
 #include "openPMD/Dataset.hpp"

--- a/test/JSONTest.cpp
+++ b/test/JSONTest.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2025 Axel Huebl, Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "openPMD/auxiliary/JSON.hpp"
 #include "openPMD/Error.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1,3 +1,24 @@
+/* Copyright 2025 Axel Huebl, Fabian Koller, Franz Poeschel, Junmin Gu,
+ *                Junmin Gu, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 /* Running this test in parallel with MPI requires MPI::Init.
  * To guarantee a correct call to Init, launch the tests manually.
  */

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -1,3 +1,24 @@
+/* Copyright 2025 Axel Huebl, Fabian Koller, Franz Poeschel, Junmin Gu,
+ *                Junmin Gu, Luca Fedeli
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 // expose private and protected members for invasive testing
 #include "openPMD/ChunkInfo_internal.hpp"
 #include "openPMD/Datatype.hpp"


### PR DESCRIPTION
The license headers have often been forgotten in PRs. This PR uses a little script to update this info in the C++ files.

The script:

```bash
#!/usr/bin/env bash

get_copyright_banner() {
    grep --color=never -zPo '/\*[\s\S]*?Copyright[\s\S]*?\*/'
}

author_names() {
    local name="$1"
    if [[ "$name" = "Axel Huebl" ]]; then
        echo "$name"
    elif [[ "$name" = "Ben Wibking" ]]; then
        echo "$name"
    elif [[ "$name" = "C0nsultant" ]]; then
        echo "Fabian Koller"
    elif [[ "$name" = "Carsten Fortmann-Grote" ]]; then
        echo "$name"
    elif [[ "$name" = "David Grote" ]]; then
        echo "$name"
    elif [[ "$name" = "Franz Pöschel" ]]; then
        echo "Franz Poeschel"
    elif [[ "$name" = "guj" ]]; then
        echo "Junmin Gu"
    elif [[ "$name" = "Ilian Kara-Mostefa" ]]; then
        echo "$name"
    elif [[ "$name" = "Jean Luca Bez" ]]; then
        echo "$name"
    elif [[ "$name" = "Junmin Gu" ]]; then
        echo "$name"
    elif [[ "$name" = "L. Diana Amorim" ]]; then
        echo "$name"
    elif [[ "$name" = "Luca Fedeli" ]]; then
        echo "$name"
    elif [[ "$name" = "Paweł Ordyna" ]]; then
        echo "Pawel Ordyna"
    elif [[ "$name" = "Richard Pausch" ]]; then
        echo "$name"
    elif [[ "$name" = "Ulrik Günther" ]]; then
        echo "Ulrik Guenther"
    fi
}

get_authors() {
    local file="$1"
    local authors
    mapfile -t authors < <(
        git blame -p "$file" |
            grep -E '^[^[:space:]]' |
            awk '$1 == "author"' |
            sort |
            uniq |
            sed 's|^author ||'
    )
    for name in "${authors[@]}"; do
        author_names "$name"
    done
}

include_author() {
    local copyright_banner="$1"
    local author="$2"
    if grep "$author" <<<"$copyright_banner" >/dev/null 2>&1; then
        echo "$copyright_banner"
        return
    fi
    echo "$copyright_banner" |
        sed -E "s|(Copyright .*)|\1, $author|" |
        sed -E 's|([0-9]{4}-)[0-9]{4}|\12025|' |
        sed -E 's| ([0-9]{4}) | \1-2025 |'
}

make_banner() {
    local authorstring="$(
        printf '%s\n' "$(
            IFS=,
            echo "${authors[*]}"
        )" | sed 's|,|, |g'
    )"
    cat <<EOF
/* Copyright 2025 ${authorstring}
 *
 * This file is part of openPMD-api.
 *
 * openPMD-api is free software: you can redistribute it and/or modify
 * it under the terms of of either the GNU General Public License or
 * the GNU Lesser General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
 *
 * openPMD-api is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License and the GNU Lesser General Public License
 * for more details.
 *
 * You should have received a copy of the GNU General Public License
 * and the GNU Lesser General Public License along with openPMD-api.
 * If not, see <http://www.gnu.org/licenses/>.
 */
EOF
}

fix_file() {
    local filename="$1"
    local banner="$(get_copyright_banner <"$filename")"
    local authors
    mapfile -t authors < <(get_authors "$filename")
    if [[ -z "$banner" ]]; then
        local new_banner="$(
            make_banner "${authors[@]}" |
                sed -z 's|\n|\\n|g'
        )"
        sed -zi "s|^|$new_banner|" "$filename"
        return
    fi
    local original_banner="$banner"
    for author in "${authors[@]}"; do
        banner="$(include_author "$banner" "$author")"
    done
    old_single_line="$(
        grep Copyright <<<"$original_banner" |
            sed 's|\*|\\*|'
    )"
    new_single_line="$(grep Copyright <<<"$banner")"
    sed -i "s|${old_single_line}|${new_single_line}|" "$filename"
}
```