### PR TITLE
Use std::unique_ptr in Span API fallback

### DIFF
--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -986,9 +986,10 @@ DynamicMemoryView<T> RecordComponent::storeChunk(Offset offset, Extent extent)
     return storeChunk<T>(std::move(offset), std::move(extent), [](size_t size) {
 #if (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 11000) ||                   \
     (defined(__apple_build_version__) && __clang_major__ < 14)
-        return std::shared_ptr<T>{new T[size], [](auto *ptr) { delete[] ptr; }};
+        return UniquePtrWithLambda<T>{
+            new T[size], [](auto *ptr) { delete[] ptr; }};
 #else
-            return std::shared_ptr< T[] >{ new T[ size ] };
+        return std::unique_ptr<T[]>{new T[size]};
 #endif
     });
 }
@@ -1045,7 +1046,7 @@ void RecordComponent::verifyChunk(Offset const &o, Extent const &e) const
     OPENPMD_INSTANTIATE_FULLMATRIX(OPENPMD_ARRAY(type))                        \
     OPENPMD_INSTANTIATE_FULLMATRIX(type const[])
 
-OPENPMD_FOREACH_NONVECTOR_DATATYPE(OPENPMD_INSTANTIATE)
+OPENPMD_FOREACH_DATASET_DATATYPE(OPENPMD_INSTANTIATE)
 #undef OPENPMD_INSTANTIATE
 #undef OPENPMD_INSTANTIATE_FULLMATRIX
 #undef OPENPMD_INSTANTIATE_WITH_AND_WITHOUT_EXTENT

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -595,7 +595,7 @@ GetCurrentView::call<std::string>(PythonDynamicMemoryView const &)
 
 pybind11::object PythonDynamicMemoryView::currentView() const
 {
-    return switchNonVectorType<GetCurrentView>(m_datatype, *this);
+    return switchDatasetType<GetCurrentView>(m_datatype, *this);
 }
 
 namespace
@@ -656,7 +656,7 @@ inline PythonDynamicMemoryView store_chunk_span(
         std::begin(shape),
         [&maskIt](std::uint64_t) { return !*(maskIt++); });
 
-    return switchNonVectorType<StoreChunkSpan>(
+    return switchDatasetType<StoreChunkSpan>(
         r.getDatatype(), r, offset, extent);
 }
 
@@ -726,7 +726,7 @@ void load_chunk(
         }
     }
 
-    switchNonVectorType<LoadChunkIntoPythonBuffer>(
+    switchDatasetType<LoadChunkIntoPythonBuffer>(
         r.getDatatype(), r, buffer, buffer_info, offset, extent);
 }
 

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -584,13 +584,6 @@ struct GetCurrentView
 
     static constexpr char const *errorMsg = "DynamicMemoryView";
 };
-
-template <>
-pybind11::object
-GetCurrentView::call<std::string>(PythonDynamicMemoryView const &)
-{
-    throw std::runtime_error("[DynamicMemoryView] Only PODs allowed.");
-}
 } // namespace
 
 pybind11::object PythonDynamicMemoryView::currentView() const
@@ -628,14 +621,6 @@ struct StoreChunkSpan
 
     static constexpr char const *errorMsg = "RecordComponent.store_chunk()";
 };
-
-template <>
-PythonDynamicMemoryView StoreChunkSpan::call<std::string>(
-    RecordComponent &, Offset const &, Extent const &)
-{
-    throw std::runtime_error(
-        "[RecordComponent.store_chunk()] Only PODs allowed.");
-}
 } // namespace
 
 inline PythonDynamicMemoryView store_chunk_span(

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -895,9 +895,6 @@ void init_RecordComponent(py::module &m)
                     // std::endl; typestring: encoding + type + number of bytes
                     switch (dtype)
                     {
-                    case DT::BOOL:
-                        return rc.makeConstant(*static_cast<bool *>(buf.ptr));
-                        break;
                     case DT::CHAR:
                         return rc.makeConstant(*static_cast<char *>(buf.ptr));
                         break;
@@ -956,6 +953,11 @@ void init_RecordComponent(py::module &m)
                         return rc.makeConstant(
                             *static_cast<std::complex<long double> *>(buf.ptr));
                         break;
+                    case DT::BOOL:
+                        throw std::runtime_error(
+                            "make_constant: "
+                            "Boolean type not supported!");
+                        break;
                     default:
                         throw std::runtime_error(
                             "make_constant: "
@@ -982,10 +984,6 @@ void init_RecordComponent(py::module &m)
         .def(
             "make_constant",
             &RecordComponent::makeConstant<double>,
-            py::arg("value"))
-        .def(
-            "make_constant",
-            &RecordComponent::makeConstant<bool>,
             py::arg("value"))
         .def(
             "make_empty",

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -3021,7 +3021,7 @@ TEST_CASE("git_hdf5_legacy_picongpu", "[serial][hdf5]")
         auto radiationMask =
             o.iterations[200]
                 .particles["e"]["radiationMask"][RecordComponent::SCALAR];
-        switchNonVectorType<LoadDataset>(
+        switchDatasetType<LoadDataset>(
             radiationMask.getDatatype(), radiationMask);
 
         auto particlePatches = o.iterations[200].particles["e"].particlePatches;


### PR DESCRIPTION
There is no reason why we should not. `unique_ptr` is less resource heavy than `std::shared_ptr`, and especially the ADIOS2 backend uses some optimizations based specifically on `unique_ptr`.
Users may still provide `shared_ptr`-based fallbacks, `examples/12_span_write.cpp` tests this.

Note: We still have some scattered untested instances of `std::string` and `bool` overloads scattered here and there for dataset-related operations. With #1774, we are now more explicit about which overloads we instantiate. This led to having to remove some of these wrong instances now with this PR, especially from the Python API.