### PR TITLE
gcc12: Fix false positives for std::vector::operator=()

### DIFF
--- a/examples/14_toml_template.cpp
+++ b/examples/14_toml_template.cpp
@@ -72,7 +72,7 @@ void write()
      */
     E["z"].resetDataset({});
 
-    ds.extent = {10};
+    ds.extent = std::vector<openPMD::Extent::value_type>{10};
 
     auto electrons = iteration.particles["e"];
     electrons["position"]["x"].resetDataset(ds);

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -344,7 +344,7 @@ private:
      */
     struct BeginStepStatus
     {
-        using AvailableIterations_t = std::vector<uint64_t>;
+        using AvailableIterations_t = std::vector<IterationIndex_t>;
 
         AdvanceStatus stepStatus{};
         /*

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1582,7 +1582,7 @@ void HDF5IOHandlerImpl::openDataset(
     {
         // Is a scalar. Since the openPMD-api frontend supports no scalar
         // datasets, return the extent as {1}
-        *parameters.extent = {1};
+        *parameters.extent = std::vector<Extent::value_type>{1};
     }
     else
     {

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -863,7 +863,8 @@ auto Iteration::beginStep(
     else if (thisObject.has_value())
     {
         IterationIndex_t idx = series.indexOf(*thisObject)->first;
-        res.iterationsInOpenedStep = {idx};
+        res.iterationsInOpenedStep =
+            std::vector<Iteration::IterationIndex_t>{idx};
     }
     else
     {

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -289,7 +289,8 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
             {
             case AdvanceStatus::OK:
                 ++during.step_count;
-                during.available_iterations_in_step = {key};
+                during.available_iterations_in_step =
+                    std::vector<Iteration::IterationIndex_t>{key};
                 break;
             case AdvanceStatus::RANDOMACCESS:
                 during.available_iterations_in_step.emplace_back(key);


### PR DESCRIPTION
see overload 3, the use is actually correct
https://en.cppreference.com/w/cpp/container/vector/operator=.html

First seen by @ax3l:

```
    inlined from 'static openPMD::Iteration::BeginStepStatus openPMD::Iteration::beginStep(std::optional<openPMD::Iteration>, openPMD::Series&, bool)' at /home/runner/work/warpx/warpx/build/_deps/fetchedopenpmd-src/src/Iteration.cpp:866:42:
/usr/include/c++/12/bits/stl_algobase.h:434:30: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' reading between 9 and 9223372036854775807 bytes from a region of size 8 [-Werror=stringop-overread]
  434 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/warpx/warpx/build/_deps/fetchedopenpmd-src/src/Iteration.cpp: In static member function 'static openPMD::Iteration::BeginStepStatus openPMD::Iteration::beginStep(std::optional<openPMD::Iteration>, openPMD::Series&, bool)':
/home/runner/work/warpx/warpx/build/_deps/fetchedopenpmd-src/src/Iteration.cpp:866:42: note: at offset [0, 7] into source object '<anonymous>' of size 8
  866 |         res.iterationsInOpenedStep = {idx};
      |      
 ```

Note: I still get one false positive from pybind11, but can't do anything about that as it is not our code:

```
In function '__copy_m',
    inlined from '__copy_move_a2' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_algobase.h:501:30,
    inlined from '__copy_move_a1' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_algobase.h:528:42,
    inlined from '__copy_move_a' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_algobase.h:535:31,
    inlined from 'copy' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_algobase.h:626:7,
    inlined from '__uninit_copy' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_uninitialized.h:147:27,
    inlined from 'uninitialized_copy' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_uninitialized.h:185:15,
    inlined from '__uninitialized_copy_a' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_uninitialized.h:372:37,
    inlined from '_M_assign_aux' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/vector.tcc:339:35,
    inlined from 'operator=' at /nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_vector.h:787:21,
    inlined from 'operator()' at /home/franzpoeschel/build/gcc12/_deps/fetchedpybind11-src/include/pybind11/pybind11.h:1385:75,
    inlined from 'with_internals' at /home/franzpoeschel/build/gcc12/_deps/fetchedpybind11-src/include/pybind11/detail/internals.h:643:14,
    inlined from 'initialize' at /home/franzpoeschel/build/gcc12/_deps/fetchedpybind11-src/include/pybind11/pybind11.h:1377:23:
/nix/store/yhflz90n3xdxkzqxljmhp16rryg9w4cp-gcc-12.4.0/include/c++/12.4.0/bits/stl_algobase.h:434:30: warning: '__builtin_memcpy' reading between 9 and 9223372036854775807 bytes from a region of size 8 [-Wstringop-overread]
  434 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |                              ^
/home/franzpoeschel/build/gcc12/_deps/fetchedpybind11-src/include/pybind11/pybind11.h: In member function 'initialize':
/home/franzpoeschel/build/gcc12/_deps/fetchedpybind11-src/include/pybind11/pybind11.h:1385:75: note: at offset [0, 7] into source object '<anonymous>' of size 8
 1385 |             internals.registered_types_py[(PyTypeObject *) m_ptr] = {tinfo};
      |                                                                           ^
```