### PR TITLE
Reactivate iteration closed check

### DIFF
--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -53,11 +53,18 @@ namespace internal
 // this check can be too costly in some setups
 #if openPMD_USE_INVASIVE_TESTS
 
-        auto &iterationData = *a.containingIteration().first.value();
+        auto maybe_an_iteration = a.containingIteration().first;
+        if (!maybe_an_iteration.has_value())
+        {
+            throw std::runtime_error(
+                "Trying to write to/read from a RecordComponent that is not "
+                "contained by any Iteration.");
+        }
+        auto &iterationData = *maybe_an_iteration.value();
         auto iteration = iterationData.asInternalCopyOf<Iteration>();
         if (iteration.closed() && !iterationData.allow_reopening_implicitly)
         {
-            throw error::WrongAPIUsage(
+            throw std::runtime_error(
                 "Cannot write/read chunks to/from closed Iterations.");
         }
 #endif

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -51,10 +51,11 @@ namespace internal
         Attributable a;
         a.setData(std::shared_ptr<AttributableData>{this, [](auto const &) {}});
 // this check can be too costly in some setups
-#if 1
-        if ((*a.containingIteration().first.value())
-                .asInternalCopyOf<Iteration>()
-                .closed())
+#if openPMD_USE_INVASIVE_TESTS
+
+        auto &iterationData = *a.containingIteration().first.value();
+        auto iteration = iterationData.asInternalCopyOf<Iteration>();
+        if (iteration.closed() && !iterationData.allow_reopening_implicitly)
         {
             throw error::WrongAPIUsage(
                 "Cannot write/read chunks to/from closed Iterations.");

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -51,8 +51,10 @@ namespace internal
         Attributable a;
         a.setData(std::shared_ptr<AttributableData>{this, [](auto const &) {}});
 // this check can be too costly in some setups
-#if 0
-        if (a.containingIteration().closed())
+#if 1
+        if ((*a.containingIteration().first.value())
+                .asInternalCopyOf<Iteration>()
+                .closed())
         {
             throw error::WrongAPIUsage(
                 "Cannot write/read chunks to/from closed Iterations.");


### PR DESCRIPTION
We deactivated this check for performance reasons, but there is no problem running it at least under invasive mode.