### PR TITLE
CI: CUDA More Space

### DIFF
--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -13,7 +13,17 @@ jobs:
     if: github.event.pull_request.draft == false
     env: {CXX: nvcc, CXXFLAGS: "--forward-unknown-to-host-compiler -Xcompiler -Werror"}
     steps:
-    - uses: actions/checkout@v4
+    - name: Free More Disk Space
+      uses: ax3l/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false  # apt takes ~1:30min
+        docker-images: true
+        swap-storage: false
+    - uses: actions/checkout@v6
     - name: Dependencies
       run: .github/workflows/dependencies/install_nvcc12.sh
     - name: Build & Install
@@ -39,7 +49,17 @@ jobs:
     #   line 4314: error: variable "<unnamed>::autoRegistrar73" was declared but never referenced
     # env: {CXXFLAGS: "-Werror -Wno-deprecated-declarations"}
     steps:
-    - uses: actions/checkout@v4
+    - name: Free More Disk Space
+      uses: ax3l/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false  # apt takes ~1:30min
+        docker-images: true
+        swap-storage: false
+    - uses: actions/checkout@v6
     - name: Dependencies
       run: .github/workflows/dependencies/install_nvhpc25-11.sh
     - name: Build & Install


### PR DESCRIPTION
The CTK and NVHPC need a lot of space in downloads. Clean up more space before starting on GH Action runners.