### PR TITLE
Clean up logic for Series::close()

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3280,10 +3280,12 @@ namespace internal
         if (this->m_sharedStatefulIterator)
         {
             this->m_sharedStatefulIterator->close();
+            this->m_sharedStatefulIterator.reset();
         }
         Series impl;
         impl.setData({this, [](auto const *) {}});
-        if (auto IOHandler = impl.IOHandler(); IOHandler &&
+        auto IOHandler = impl.IOHandler();
+        if (IOHandler &&
             /*
              * Scenario: A user calls `Series::flush()` but does not check for
              * thrown exceptions. The exception will propagate further up,
@@ -3317,7 +3319,7 @@ namespace internal
         // This releases the openPMD hierarchy
         iterations.container().clear();
         // Release the IO Handler
-        if (operator*().m_writable.IOHandler)
+        if (IOHandler)
         {
             *operator*().m_writable.IOHandler = std::nullopt;
         }


### PR DESCRIPTION
`Series::close()` currently leaves some structures in a weird half-initialized state. Fix that.
Since this is not truly an error, I will assign that to 0.18.0.