### PR TITLE
ADIOS2 IO Handler: Fix data structure initialization order upon createFile/openFile

### DIFF
--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -1032,13 +1032,7 @@ void ADIOS2IOHandlerImpl::openFile(
     }
 
     std::string name = parameters.name + fileSuffix();
-
     auto file = std::get<PE_InvalidatableFile>(getPossiblyExisting(name));
-
-    associateWithFile(writable, file);
-
-    writable->written = true;
-    writable->abstractFilePosition = std::make_shared<ADIOS2FilePosition>();
 
     auto how_to_open = [&]() {
         switch (parameters.reopen)
@@ -1054,8 +1048,18 @@ void ADIOS2IOHandlerImpl::openFile(
     }();
 
     // enforce opening the file
-    // lazy opening is deathly in parallel situations
+    // lazy opening is deadly in parallel situations
     auto &fileData = getFileData(file, how_to_open);
+
+    // the following calls present the new file to the IO handler's data
+    // structures. do this only after the file has been successfully open, to
+    // avoid invalid state.
+
+    associateWithFile(writable, file);
+
+    writable->written = true;
+    writable->abstractFilePosition = std::make_shared<ADIOS2FilePosition>();
+
     *parameters.out_parsePreference = fileData.parsePreference;
     m_dirty.emplace(std::move(file));
 }

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -708,15 +708,19 @@ void ADIOS2IOHandlerImpl::createFile(
             VERIFY(success, "[ADIOS2] Could not create directory.");
         }
 
+        // enforce opening the file
+        // lazy opening is deathly in parallel situations
+        auto &fileData =
+            getFileData(shared_name, IfFileNotOpen::CreateImplicitly);
+
+        // only emplace the file into our structures after it has been
+        // successfully opened. otherwise, errors will lead to undefined state.
+
         associateWithFile(writable, shared_name);
         this->m_dirty.emplace(shared_name);
 
         writable->written = true;
         writable->abstractFilePosition = std::make_shared<ADIOS2FilePosition>();
-        // enforce opening the file
-        // lazy opening is deathly in parallel situations
-        auto &fileData =
-            getFileData(shared_name, IfFileNotOpen::CreateImplicitly);
 
         if (!printedWarningsAlready.noGroupBased &&
             m_writeAttributesFromThisRank &&


### PR DESCRIPTION
Currently, if the ADIOS2 file cannot be opened for whatever reason, we have it already emplaced into the IO Handler's records. This leads to unexpected states where the IO Handler references files that do not exist, and hence to weird error messages.

TODO:

- [x] Check other file opening procedures for similar behavior