### PR TITLE
Version bump pybind11 -> 3.0.2

### DIFF
--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -51,9 +51,9 @@ function(find_pybind11)
         mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
     elseif(NOT openPMD_USE_INTERNAL_PYBIND11)
         if(openPMD_USE_PYTHON STREQUAL AUTO)
-            find_package(pybind11 2.13.0 CONFIG)
+            find_package(pybind11 3.0.0 CONFIG)
         elseif(openPMD_USE_PYTHON)
-            find_package(pybind11 2.13.0 CONFIG REQUIRED)
+            find_package(pybind11 3.0.0 CONFIG REQUIRED)
         endif()
         if(TARGET pybind11::module)
             message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
@@ -67,10 +67,10 @@ set(openPMD_pybind11_src ""
     "Local path to pybind11 source directory (preferred if set)")
 
 # tarball fetcher
-set(openPMD_pybind11_tar "https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz"
+set(openPMD_pybind11_tar "https://github.com/pybind/pybind11/archive/refs/tags/v3.0.2.tar.gz"
         CACHE STRING
         "Remote tarball link to pull and build pybind11 from if(openPMD_USE_INTERNAL_PYBIND11)")
-set(openPMD_pybind11_tar_hash "SHA256=e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20"
+set(openPMD_pybind11_tar_hash "SHA256=2f20a0af0b921815e0e169ea7fec63909869323581b89d7de1553468553f6a2d"
         CACHE STRING
         "Hash checksum of the tarball of pybind11 if(openPMD_USE_INTERNAL_PYBIND11)")
 
@@ -78,7 +78,7 @@ set(openPMD_pybind11_tar_hash "SHA256=e08cb87f4773da97fa7b5f035de8763abc656d87d5
 set(openPMD_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(openPMD_USE_INTERNAL_PYBIND11)")
-set(openPMD_pybind11_branch "v2.13.6"
+set(openPMD_pybind11_branch "v3.0.2"
     CACHE STRING
     "Repository branch for openPMD_pybind11_repo if(openPMD_USE_INTERNAL_PYBIND11)")
 

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -94,18 +94,22 @@ void init_Iteration(py::module &m)
         .def("set_dt", &Iteration::setDt<double>)
         .def("set_time_unit_SI", &Iteration::setTimeUnitSI)
 
-        .def_readwrite(
+        .def_property_readonly(
             "meshes",
-            &Iteration::meshes,
-            py::return_value_policy::copy,
-            // garbage collection: return value must be freed before Iteration
-            py::keep_alive<1, 0>())
-        .def_readwrite(
+            py::cpp_function(
+                [](Iteration &i) { return i.meshes; },
+                py::return_value_policy::copy,
+                // garbage collection: return value must be freed before
+                // Iteration
+                py::keep_alive<1, 0>()))
+        .def_property_readonly(
             "particles",
-            &Iteration::particles,
-            py::return_value_policy::copy,
-            // garbage collection: return value must be freed before Iteration
-            py::keep_alive<1, 0>());
+            py::cpp_function(
+                [](Iteration &i) { return i.particles; },
+                py::return_value_policy::copy,
+                // garbage collection: return value must be freed before
+                // Iteration
+                py::keep_alive<1, 0>()));
 
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -48,12 +48,13 @@ void init_ParticleSpecies(py::module &m)
               return stream.str();
           })
 
-        .def_readwrite(
+        .def_property_readonly(
             "particle_patches",
-            &ParticleSpecies::particlePatches,
-            py::return_value_policy::copy,
-            // garbage collection: return value must be freed before Series
-            py::keep_alive<1, 0>());
+            py::cpp_function(
+                [](ParticleSpecies &ps) { return ps.particlePatches; },
+                py::return_value_policy::copy,
+                // garbage collection: return value must be freed before Series
+                py::keep_alive<1, 0>()));
     add_pickle(
         cl, [](openPMD::Series series, std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -497,12 +497,13 @@ this method.
         .def("set_iteration_format", &Series::setIterationFormat)
         .def("set_name", &Series::setName)
 
-        .def_readwrite(
+        .def_property_readonly(
             "iterations",
-            &Series::iterations,
-            py::return_value_policy::copy,
-            // garbage collection: return value must be freed before Series
-            py::keep_alive<1, 0>())
+            py::cpp_function(
+                [](Series &s) { return s.iterations; },
+                py::return_value_policy::copy,
+                // garbage collection: return value must be freed before Series
+                py::keep_alive<1, 0>()))
         .def(
             "read_iterations",
             [](Series &s) {


### PR DESCRIPTION
This contains a workaround to this restriction introduced by 3.0.2:

```
_deps/fetchedpybind11-src/include/pybind11/pybind11.h:2462:25: error: static assertion failed: def_property family does not currently support keep_alive. Use a py::cpp_function instead
```

# Note for backporting:
Relax the required minimum version back to the old minimum version again for a backport.