### PR TITLE
WIP: Erase Iterations upon closing

### DIFF
--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -114,6 +114,7 @@ class Container : virtual public Attributable
     template <typename>
     friend class internal::EraseStaleEntries;
     friend class StatefulIterator;
+    friend class StatefulSnapshotsContainer;
 
 protected:
     using ContainerData = internal::ContainerData<T, T_key, T_container>;

--- a/include/openPMD/snapshots/StatefulIterator.hpp
+++ b/include/openPMD/snapshots/StatefulIterator.hpp
@@ -395,6 +395,11 @@ private:
         -> std::optional<value_type const *>;
     auto peekCurrentlyOpenIteration() -> std::optional<value_type *>;
 
+    // Only checks the index state from the Iterator, peekCurrentlyOpenIteration
+    // actually retrieves the Iteration and checks if it is open
+    [[nodiscard]] auto currentIterationIndex() const
+        -> std::optional<iteration_index_t>;
+
     auto reparse_possibly_deleted_iteration(iteration_index_t) -> void;
 };
 } // namespace openPMD

--- a/src/snapshots/ContainerImpls.cpp
+++ b/src/snapshots/ContainerImpls.cpp
@@ -266,6 +266,12 @@ auto StatefulSnapshotsContainer::operator[](key_type const &key)
         }
     }
 
+    if (auto currentIteration = base_iterator->currentIterationIndex();
+        currentIteration.has_value() && *currentIteration != key)
+    {
+        s.series.iterations.container().erase(*currentIteration);
+    }
+
     // create new
     auto &res = s.series.iterations[key];
     Iteration::BeginStepStatus status = [&]() {

--- a/src/snapshots/StatefulIterator.cpp
+++ b/src/snapshots/StatefulIterator.cpp
@@ -360,7 +360,7 @@ auto StatefulIterator::peekCurrentlyOpenIteration() const
         return std::nullopt;
     }
     auto &s = optional.value();
-    auto const &maybeCurrentIteration = s.currentIteration();
+    auto const &maybeCurrentIteration = currentIterationIndex();
     if (!maybeCurrentIteration.has_value())
     {
         return std::nullopt;
@@ -391,6 +391,21 @@ auto StatefulIterator::peekCurrentlyOpenIteration()
     }
 }
 
+auto StatefulIterator::currentIterationIndex() const
+    -> std::optional<iteration_index_t>
+{
+    if (!m_data)
+    {
+        return std::nullopt;
+    }
+    auto &optional = *m_data;
+    if (!optional.has_value())
+    {
+        return std::nullopt;
+    }
+    auto &s = optional.value();
+    return s.currentIteration();
+}
 auto StatefulIterator::reparse_possibly_deleted_iteration(iteration_index_t idx)
     -> void
 {


### PR DESCRIPTION
For workflows with many Iterations, we do not actually want to keep around all the parsed structure around forever inside `series.iterations`. This PR attempts turning `WRITE_LINEAR` and `READ_LINEAR` into a "one Iteration is active and stored"-centric kind of workflow.

Heavily experimental, WIP

TODO:

- [x] Write-side
- [ ] Read-side
- [ ] Handle handle invalidation
- [ ] Handle re-opening of Iterations