### PR TITLE
Remove duplicate Python test

### DIFF
--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2343,13 +2343,6 @@ class APITest(unittest.TestCase):
         self.assertEqual(loaded_from_scalar, np.array([45]))
         series_read_again.close()
 
-    def testKeepaliveComponentExtraction(self):
-        """Test that keepalive specifications
-        guard root objects from garbage collection."""
-        self.testKeepaliveMeshComponent()
-        self.testKeepaliveParticlePosition()
-        self.testKeepaliveParticlePatches()
-
     def testKeepaliveMeshComponent(self):
         """Test keepalive for mesh component extraction."""
         for ext in tested_file_extensions:


### PR DESCRIPTION
These are prefixed by test*, so they already run separately.