### PR TITLE
Keep written flag consistent across MPI ranks for rankTable

### DIFF
--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -571,6 +571,11 @@ void Series::flushRankTable()
                 [asRawPtr](char *) { delete asRawPtr; }};
             writeDataset(std::move(put), /* num_lines = */ size);
         }
+
+        // Must ensure that the Writable is consistently set to written on all
+        // ranks
+        series.m_rankTable.m_attributable.setWritten(
+            true, EnqueueAsynchronously::OnlyAsync);
         return;
     }
 #endif


### PR DESCRIPTION
The rank table is only written on rank 0, meaning that its written flag will be `true` only on rank 0. This can cause trouble when processing in parallel and later relying on this flag.
Surfaced while working on #1862, fix factored out of there.
This does not really cause any errors on dev right now, but is still very error prone, and I would have this merged soon rather than once more debugging this for 3 days.