### PR TITLE
Opaque defer type: Fix move operator and constructor

### DIFF
--- a/include/openPMD/auxiliary/Defer.hpp
+++ b/include/openPMD/auxiliary/Defer.hpp
@@ -21,19 +21,31 @@ struct defer_type
         std::move(functor)();
     }
 
-    auto to_opaque() && -> defer_type<std::function<void()>>
+    explicit defer_type() = default;
+
+    struct forwarding_tag
+    {};
+
+    template <typename F_>
+    defer_type(forwarding_tag, F_ &&functor_in)
+        : functor{std::forward<F_>(functor_in)}
+    {}
+
+    template <typename F_>
+    defer_type(defer_type<F_> &&other) : functor{std::move(other.functor)}
     {
-        if (!do_run_this)
-        {
-            return defer_type<std::function<void()>>{{}, false};
-        }
-        else
-        {
-            do_run_this = false;
-            return defer_type<std::function<void()>>{
-                std::function<void()>{std::move(functor)}};
-        }
+        other.do_run_this = false;
     }
+
+    template <typename F_>
+    auto operator=(defer_type<F_> &&other)
+    {
+        functor = std::move(other.functor);
+        other.do_run_this = false;
+    }
+
+    defer_type(defer_type const &) = delete;
+    auto operator=(defer_type const &) -> defer_type & = delete;
 };
 
 using opaque_defer_type = defer_type<std::function<void()>>;
@@ -41,6 +53,8 @@ using opaque_defer_type = defer_type<std::function<void()>>;
 template <typename F>
 auto defer(F &&functor) -> defer_type<std::remove_reference_t<F>>
 {
-    return defer_type<std::remove_reference_t<F>>{std::forward<F>(functor)};
+    using res_t = defer_type<std::remove_reference_t<F>>;
+    using tag_t = typename res_t::forwarding_tag;
+    return res_t{tag_t{}, std::forward<F>(functor)};
 }
 } // namespace openPMD::auxiliary

--- a/include/openPMD/auxiliary/Defer.hpp
+++ b/include/openPMD/auxiliary/Defer.hpp
@@ -23,13 +23,13 @@ struct defer_type
 
     auto to_opaque() && -> defer_type<std::function<void()>>
     {
-        do_run_this = false;
         if (!do_run_this)
         {
             return defer_type<std::function<void()>>{{}, false};
         }
         else
         {
+            do_run_this = false;
             return defer_type<std::function<void()>>{
                 std::function<void()>{std::move(functor)}};
         }

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1950,16 +1950,15 @@ void HDF5IOHandlerImpl::writeDataset(
             memspace > 0,
             "[HDF5] Internal error: Failed to create memspace during dataset "
             "write");
-        defer_close_memspace =
-            auxiliary::defer([&]() {
-                status = H5Sclose(memspace); //
-                if (status != 0)
-                {
-                    std::cerr << "[HDF5] Internal error: Failed to close "
-                                 "dataset memory space during dataset write"
-                              << std::endl;
-                }
-            }).to_opaque();
+        defer_close_memspace = auxiliary::defer([&]() {
+            status = H5Sclose(memspace); //
+            if (status != 0)
+            {
+                std::cerr << "[HDF5] Internal error: Failed to close "
+                             "dataset memory space during dataset write"
+                          << std::endl;
+            }
+        });
     }
     else
     {
@@ -1973,16 +1972,15 @@ void HDF5IOHandlerImpl::writeDataset(
             block.push_back(static_cast<hsize_t>(val));
         memspace = H5Screate_simple(
             static_cast<int>(block.size()), block.data(), nullptr);
-        defer_close_memspace =
-            auxiliary::defer([&]() {
-                status = H5Sclose(memspace); //
-                if (status != 0)
-                {
-                    std::cerr << "[HDF5] Internal error: Failed to close "
-                                 "dataset memory space during dataset write"
-                              << std::endl;
-                }
-            }).to_opaque();
+        defer_close_memspace = auxiliary::defer([&]() {
+            status = H5Sclose(memspace); //
+            if (status != 0)
+            {
+                std::cerr << "[HDF5] Internal error: Failed to close "
+                             "dataset memory space during dataset write"
+                          << std::endl;
+            }
+        });
         status = H5Sselect_hyperslab(
             filespace,
             H5S_SELECT_SET,


### PR DESCRIPTION
Was accidentally a no-op due to wrong order of operations and at the same time a double-op due to missing move operator/constructor. Well.