### PR TITLE
Do not initially emplace any value for the cached Iteration index

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -136,7 +136,7 @@ namespace internal
          * of the owning map entry instead of a linear scan in
          * <code>Series::indexOf()</code>.
          */
-        std::optional<uint64_t> m_iterationIndex = 0;
+        std::optional<uint64_t> m_iterationIndex = std::nullopt;
 
         /**
          * Information on a parsing request that has not yet been executed.


### PR DESCRIPTION
this avoids subtle bugs
followup to #1860