### PR TITLE
Use most recent main branch of toml11

### DIFF
--- a/cmake/dependencies/toml11.cmake
+++ b/cmake/dependencies/toml11.cmake
@@ -64,10 +64,10 @@ set(openPMD_toml11_src ""
     "Local path to toml11 source directory (preferred if set)")
 
 # tarball fetcher
-set(openPMD_toml11_tar "https://github.com/ToruNiina/toml11/archive/refs/tags/v4.4.0.tar.gz"
+set(openPMD_toml11_tar "https://github.com/ToruNiina/toml11/archive/b32a2fff0d27e1f7522f26a125101500ddb47156.tar.gz"
         CACHE STRING
         "Remote tarball link to pull and build toml11 from if(openPMD_USE_INTERNAL_TOML11)")
-set(openPMD_toml11_tar_hash "SHA256=815bfe6792aa11a13a133b86e7f0f45edc5d71eb78f5fb6686c49c7f792b9049"
+set(openPMD_toml11_tar_hash "SHA256=c82df2d6a437795a1b5ac0b87886d5eb481deb60d6e79adb1688017857347cda"
         CACHE STRING
         "Hash checksum of the tarball of toml11 if(openPMD_USE_INTERNAL_TOML11)")
 
@@ -75,7 +75,7 @@ set(openPMD_toml11_tar_hash "SHA256=815bfe6792aa11a13a133b86e7f0f45edc5d71eb78f5
 set(openPMD_toml11_repo "https://github.com/ToruNiina/toml11.git"
     CACHE STRING
     "Repository URI to pull and build toml11 from if(openPMD_USE_INTERNAL_TOML11)")
-set(openPMD_toml11_branch "v4.4.0"
+set(openPMD_toml11_branch "b32a2fff0d27e1f7522f26a125101500ddb47156"
     CACHE STRING
     "Repository branch for openPMD_toml11_repo if(openPMD_USE_INTERNAL_TOML11)")
 

--- a/include/openPMD/auxiliary/JSON_internal.hpp
+++ b/include/openPMD/auxiliary/JSON_internal.hpp
@@ -23,17 +23,17 @@
 
 #include "openPMD/config.hpp"
 
-#include <deque>
-#include <nlohmann/json.hpp>
-#include <toml.hpp>
+#include "openPMD/auxiliary/toml11_wrapper.hpp"
 
-#include <optional>
+#include <nlohmann/json.hpp>
 
 #if openPMD_HAVE_MPI
 #include <mpi.h>
 #endif
 
+#include <deque>
 #include <memory> // std::shared_ptr
+#include <optional>
 #include <utility> // std::forward
 
 namespace openPMD

--- a/include/openPMD/auxiliary/toml11_wrapper.hpp
+++ b/include/openPMD/auxiliary/toml11_wrapper.hpp
@@ -1,0 +1,25 @@
+/* Copyright 2026 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TOML11_DISABLE_SOURCE_LOCATION
+#include <toml.hpp>

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -31,12 +31,12 @@
 #include "openPMD/auxiliary/Memory.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
+#include "openPMD/auxiliary/toml11_wrapper.hpp"
 #include "openPMD/backend/Attribute.hpp"
 #include "openPMD/backend/Writable.hpp"
 
 #include <iomanip>
 #include <sstream>
-#include <toml.hpp>
 
 #include <algorithm>
 #include <exception>

--- a/src/auxiliary/JSON.cpp
+++ b/src/auxiliary/JSON.cpp
@@ -26,10 +26,10 @@
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
+#include "openPMD/auxiliary/toml11_wrapper.hpp"
 
 #include <limits>
 #include <queue>
-#include <toml.hpp>
 
 #include <algorithm>
 #include <cctype> // std::isspace


### PR DESCRIPTION
Needed for these commits

* https://github.com/ToruNiina/toml11/pull/291
* https://github.com/ToruNiina/toml11/pull/295

Up for discussion: This disables use of `std::source_location` by default in openPMD. There are some compilers that have trouble with it, and it's a feature for developers, there is no reason to ship it to users, especially for an internal library.