### PR TITLE
Tests: Remove outdated include path

### DIFF
--- a/test/Files_Core/read_nonexistent_attribute.cpp
+++ b/test/Files_Core/read_nonexistent_attribute.cpp
@@ -20,8 +20,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <catch2/catch_tostring.hpp>
-
 #if !openPMD_USE_INVASIVE_TESTS
 
 namespace read_nonexistent_attribute


### PR DESCRIPTION
```
test/Files_Core/read_nonexistent_attribute.cpp:23:10: fatal error: catch2/catch_to string.hpp: No such file or directory
   23 | #include <catch2/catch_tostring.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```