### PR TITLE
ADIOS2: enable stats by default, starting ADIOS2 v2.12.1

### DIFF
--- a/docs/source/backends/adios2.rst
+++ b/docs/source/backends/adios2.rst
@@ -84,7 +84,7 @@ environment variable                    default    description
 ``OPENPMD_ADIOS2_ENGINE``               ``File``   `ADIOS2 engine <https://adios2.readthedocs.io/en/latest/engines/engines.html>`_
 ``OPENPMD_ADIOS2_PRETEND_ENGINE``       *empty*    Pretend that an (unknown) ADIOS2 engine is in fact another one (also see the ``adios2.pretend_engine`` :ref:`parameter <backendconfig-adios2>`).
 ``OPENPMD2_ADIOS2_USE_GROUP_TABLE``     ``0``      Use group table (see below)
-``OPENPMD_ADIOS2_STATS_LEVEL``          ``0``      whether to generate statistics for variables in ADIOS2. (``1``: yes, ``0``: no).
+``OPENPMD_ADIOS2_STATS_LEVEL``          see below  Whether to generate statistics for variables in ADIOS2. (``1``: yes, ``0``: no)
 ``OPENPMD_ADIOS2_ASYNC_WRITE``          ``0``      ADIOS2 BP5 engine: 1 means setting "AsyncWrite" in ADIOS2 to "on". Flushes will go to the buffer by default (see ``preferred_flush_target``).
 ``OPENPMD_ADIOS2_BP5_BufferChunkMB``    ``0``      ADIOS2 BP5 engine: applies when using either EveryoneWrites or EveryoneWritesSerial aggregation
 ``OPENPMD_ADIOS2_BP5_MaxShmMB``         ``0``      ADIOS2 BP5 engine: applies when using TwoLevelShm aggregation
@@ -98,7 +98,7 @@ Please refer to the `ADIOS2 documentation <https://adios2.readthedocs.io/en/late
 
 Notice that the ADIOS2 backend is alternatively configurable via :ref:`JSON parameters <backendconfig>`.
 
-Due to performance considerations, the ADIOS2 backend configures ADIOS2 not to compute any dataset statistics (Min/Max) by default.
+Due to performance considerations, the ADIOS2 backend configures ADIOS2 not to compute any dataset statistics (Min/Max) by default for ADIOS2 versions up until v2.12.0. Starting with `v2.12.1 <https://github.com/ornladios/ADIOS2/releases/tag/v2.12.1>`_, the performance of statistics computation has been improved, so it is turned on by default.
 Statistics may be activated by setting the :ref:`JSON parameter <backendconfig>` ``adios2.engine.parameters.StatsLevel = "1"``.
 
 The ADIOS2 backend overrides the default unlimited queueing behavior of the SST engine with a more cautious limit of 2 steps that may be held in the queue at one time.

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -50,7 +50,7 @@ int main()
     // Iterations can be accessed independently from one another. This more
     // restricted mode enables performance optimizations in the backends, and
     // more importantly is compatible with streaming I/O.
-    Series series = Series("electrons.sst", Access::CREATE_LINEAR, R"(
+    Series series = Series("electrons.bp5", Access::CREATE_LINEAR, R"(
 {
   "adios2": {
     "engine": {

--- a/examples/10_streaming_write.cpp
+++ b/examples/10_streaming_write.cpp
@@ -50,7 +50,7 @@ int main()
     // Iterations can be accessed independently from one another. This more
     // restricted mode enables performance optimizations in the backends, and
     // more importantly is compatible with streaming I/O.
-    Series series = Series("electrons.bp5", Access::CREATE_LINEAR, R"(
+    Series series = Series("electrons.sst", Access::CREATE_LINEAR, R"(
 {
   "adios2": {
     "engine": {

--- a/include/openPMD/IO/ADIOS/macros.hpp
+++ b/include/openPMD/IO/ADIOS/macros.hpp
@@ -34,8 +34,10 @@
          ADIOS2_VERSION_PATCH >=                                               \
      2101)
 
-#define openPMD_HAS_ADIOS_2_12                                                 \
-    (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 212)
+#define openPMD_HAS_ADIOS_2_12_1                                               \
+    (ADIOS2_VERSION_MAJOR * 1000 + ADIOS2_VERSION_MINOR * 10 +                 \
+         ADIOS2_VERSION_PATCH >=                                               \
+     2121)
 
 #if defined(ADIOS2_HAVE_BP5) || openPMD_HAS_ADIOS_2_10
 // ADIOS2 v2.10 no longer defines this

--- a/include/openPMD/IO/ADIOS/macros.hpp
+++ b/include/openPMD/IO/ADIOS/macros.hpp
@@ -34,6 +34,9 @@
          ADIOS2_VERSION_PATCH >=                                               \
      2101)
 
+#define openPMD_HAS_ADIOS_2_12                                                 \
+    (ADIOS2_VERSION_MAJOR * 100 + ADIOS2_VERSION_MINOR >= 212)
+
 #if defined(ADIOS2_HAVE_BP5) || openPMD_HAS_ADIOS_2_10
 // ADIOS2 v2.10 no longer defines this
 #define openPMD_HAVE_ADIOS2_BP5 1

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -718,14 +718,27 @@ void ADIOS2File::configure_IO()
                 std::to_string((uint64_t)MaxShmMB * (uint64_t)1048576));
     }
 #endif
-    constexpr int default_stats_level = openPMD_HAS_ADIOS_2_12_1;
+
+#if openPMD_HAS_ADIOS_2_12_1
+    constexpr int default_stats_level = 1;
+#else
+    constexpr int default_stats_level = 0;
+#endif
+
     if (notYetConfigured("StatsLevel"))
     {
         /*
+         * Up until and including ADIOS2 v2.12.0:
+         *
          * Switch those off by default since they are expensive to compute
          * and to enable it, set the JSON option "StatsLevel" or the
          * environment variable "OPENPMD_ADIOS2_STATS_LEVEL" be positive.
          * The ADIOS2 default was "1" (on).
+         *
+         * Beginning ADIOS2 v2.12.1:
+         *
+         * Performance for Stats computation has been improved through
+         * vectorization, so we switch it on by default.
          */
         auto stats_level = auxiliary::getEnvNum(
             "OPENPMD_ADIOS2_STATS_LEVEL", default_stats_level);

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -718,6 +718,7 @@ void ADIOS2File::configure_IO()
                 std::to_string((uint64_t)MaxShmMB * (uint64_t)1048576));
     }
 #endif
+    constexpr int default_stats_level = openPMD_HAS_ADIOS_2_12;
     if (notYetConfigured("StatsLevel"))
     {
         /*
@@ -726,8 +727,8 @@ void ADIOS2File::configure_IO()
          * environment variable "OPENPMD_ADIOS2_STATS_LEVEL" be positive.
          * The ADIOS2 default was "1" (on).
          */
-        auto stats_level =
-            auxiliary::getEnvNum("OPENPMD_ADIOS2_STATS_LEVEL", 0);
+        auto stats_level = auxiliary::getEnvNum(
+            "OPENPMD_ADIOS2_STATS_LEVEL", default_stats_level);
         m_IO.SetParameter("StatsLevel", std::to_string(stats_level));
     }
     if (m_impl->realEngineType() == "sst" && notYetConfigured("QueueLimit"))

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -718,7 +718,7 @@ void ADIOS2File::configure_IO()
                 std::to_string((uint64_t)MaxShmMB * (uint64_t)1048576));
     }
 #endif
-    constexpr int default_stats_level = openPMD_HAS_ADIOS_2_12;
+    constexpr int default_stats_level = openPMD_HAS_ADIOS_2_12_1;
     if (notYetConfigured("StatsLevel"))
     {
         /*


### PR DESCRIPTION
This PR https://github.com/ornladios/ADIOS2/issues/4502 / https://github.com/ornladios/ADIOS2/pull/4985 changes things a bit performance-wise.

TODO: 

- [ ] docs