### PR TITLE
Python: reacquire GIL for deallocation operations

### DIFF
--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -520,11 +520,17 @@ void init_Attributable(py::module &m)
             })
         .def(
             "series_flush",
-            py::overload_cast<std::string>(&Attributable::seriesFlush),
+            [](Attributable &attr, std::string const &backend_config) {
+                py::gil_scoped_release release_gil;
+                attr.seriesFlush(backend_config);
+            },
             py::arg("backend_config") = "{}")
         .def(
             "iteration_flush",
-            py::overload_cast<std::string>(&Attributable::iterationFlush),
+            [](Attributable &attr, std::string const &backend_config) {
+                py::gil_scoped_release release_gil;
+                attr.iterationFlush(backend_config);
+            },
             py::arg("backend_config") = "{}")
 
         .def_property_readonly(

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -82,11 +82,10 @@ void init_Iteration(py::module &m)
             })
         .def(
             "close",
-            /*
-             * Cannot release the GIL here since Python buffers might be
-             * accessed in deferred tasks
-             */
-            &Iteration::close,
+            [](Iteration &iteration, bool flush) {
+                py::gil_scoped_release release_gil;
+                iteration.close(flush);
+            },
             py::arg("flush") = true)
 
         // TODO remove in future versions (deprecated)

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -324,7 +324,6 @@ struct StoreChunkFromPythonArray
         Offset const &offset,
         Extent const &extent)
     {
-        a.inc_ref();
         void *data = a.mutable_data();
         // here, we store an owning handle in the lambda capture so that
         // temporary and lost-scope variables stay alive until we flush

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -331,9 +331,11 @@ struct StoreChunkFromPythonArray
         // note: this does not yet prevent the user, as in C++, to build
         // a race condition by manipulating the data that was passed
         std::shared_ptr<T> shared(
-            (T *)data, [owning_handle = a.cast<py::object>()](T *) {
+            (T *)data,
+            [owning_handle =
+                 std::make_optional(a.cast<py::object>())](T *) mutable {
                 py::gil_scoped_acquire need_the_gil_for_this;
-                owning_handle.~object();
+                owning_handle.reset();
             });
         r.storeChunk(std::move(shared), offset, extent);
     }
@@ -355,9 +357,11 @@ struct LoadChunkIntoPythonArray
         // note: this does not yet prevent the user, as in C++, to build
         // a race condition by manipulating the data that was passed
         std::shared_ptr<T> shared(
-            (T *)data, [owning_handle = a.cast<py::object>()](T *) {
+            (T *)data,
+            [owning_handle =
+                 std::make_optional(a.cast<py::object>())](T *) mutable {
                 py::gil_scoped_acquire need_the_gil_for_this;
-                owning_handle.~object();
+                owning_handle.reset();
             });
         r.loadChunk(std::move(shared), offset, extent);
     }
@@ -380,9 +384,11 @@ struct LoadChunkIntoPythonBuffer
         // note: this does not yet prevent the user, as in C++, to build
         // a race condition by manipulating the data that was passed
         std::shared_ptr<T> shared(
-            (T *)data, [owning_handle = buffer.cast<py::object>()](T *) {
+            (T *)data,
+            [owning_handle =
+                 std::make_optional(buffer.cast<py::object>())](T *) mutable {
                 py::gil_scoped_acquire need_the_gil_for_this;
-                owning_handle.~object();
+                owning_handle.reset();
             });
         r.loadChunk(std::move(shared), offset, extent);
     }

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -20,6 +20,7 @@
  */
 #include <limits>
 #include <pybind11/detail/common.h>
+#include <pybind11/gil.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -331,7 +332,8 @@ struct StoreChunkFromPythonArray
         // a race condition by manipulating the data that was passed
         std::shared_ptr<T> shared(
             (T *)data, [owning_handle = a.cast<py::object>()](T *) {
-                // no-op
+                py::gil_scoped_acquire need_the_gil_for_this;
+                owning_handle.~object();
             });
         r.storeChunk(std::move(shared), offset, extent);
     }
@@ -354,7 +356,8 @@ struct LoadChunkIntoPythonArray
         // a race condition by manipulating the data that was passed
         std::shared_ptr<T> shared(
             (T *)data, [owning_handle = a.cast<py::object>()](T *) {
-                // no-op
+                py::gil_scoped_acquire need_the_gil_for_this;
+                owning_handle.~object();
             });
         r.loadChunk(std::move(shared), offset, extent);
     }
@@ -378,7 +381,8 @@ struct LoadChunkIntoPythonBuffer
         // a race condition by manipulating the data that was passed
         std::shared_ptr<T> shared(
             (T *)data, [owning_handle = buffer.cast<py::object>()](T *) {
-                // no-op
+                py::gil_scoped_acquire need_the_gil_for_this;
+                owning_handle.~object();
             });
         r.loadChunk(std::move(shared), offset, extent);
     }

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -35,6 +35,7 @@
 
 #include <optional>
 #include <pybind11/attr.h>
+#include <pybind11/gil.h>
 #include <stdexcept>
 #include <tuple>
 
@@ -482,7 +483,13 @@ this method.
             &Series::iterationFormat,
             &Series::setIterationFormat)
         .def_property("name", &Series::name, &Series::setName)
-        .def("flush", &Series::flush, py::arg("backend_config") = "{}")
+        .def(
+            "flush",
+            [](Series &s, std::string const &backend_config) {
+                py::gil_scoped_release release_gil;
+                s.flush(backend_config);
+            },
+            py::arg("backend_config") = "{}")
 
         .def_property_readonly(
             "backend", static_cast<std::string (Series::*)()>(&Series::backend))

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -284,22 +284,8 @@ not possible once it has been closed.
             .def(
                 "__getitem__",
                 [](Snapshots &s, Series::IterationIndex_t key) {
-                    switch (s.snapshotWorkflow())
-                    {
-                    case openPMD::SnapshotWorkflow::RandomAccess:
-                        return s[key];
-                    case openPMD::SnapshotWorkflow::Synchronous:
-                        auto lastIteration = s.currentIteration();
-                        if (lastIteration.has_value() &&
-                            lastIteration.value()->first != key)
-                        {
-                            // this must happen under the GIL
-                            lastIteration.value()->second.close();
-                        }
-                        py::gil_scoped_release release;
-                        return s[key];
-                    }
-                    throw std::runtime_error("Unreachable");
+                    py::gil_scoped_release release;
+                    return s[key];
                 },
                 // copy + keepalive
                 py::return_value_policy::copy,
@@ -337,10 +323,6 @@ not possible once it has been closed.
                  */
                 if (!iterator.first_iteration)
                 {
-                    if (!(*iterator).closed())
-                    {
-                        (*iterator).close();
-                    }
                     py::gil_scoped_release release;
                     ++iterator;
                 }


### PR DESCRIPTION
This allows releasing the GIL for flushing, making it possible to run a data loading job in another Python thread

TODO:

- [x] Do the same for all other flush operations (Iteration::close, Attributable::seriesFlush)
- [x] Release 0.17.1 yay or nay? yay is defensible :D