### PR TITLE
Pre-Commit: GitLeaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,3 +134,9 @@ repos:
     # This is a slow hook, so only run this if --hook-stage manual is passed
     stages: [manual]
     additional_dependencies: [cmake, ninja]
+
+# Scan for secret files that should not be committed
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
+  hooks:
+  - id: gitleaks


### PR DESCRIPTION
Add the [GitLeaks](https://github.com/gitleaks/gitleaks) pre-commit hook to scan staged changes and prevent accidentally committing secret files (credentials, tokens, private keys) to Git.