### PR TITLE
Pybind11 contiguous check: Accept only C-contiguous, not Fortran contiguous

### DIFF
--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -303,7 +303,7 @@ inline void check_buffer_is_contiguous(py::array &a)
         delete view;
         throw py::error_already_set();
     }
-    bool isContiguous = (PyBuffer_IsContiguous(view, 'A') != 0);
+    bool isContiguous = (PyBuffer_IsContiguous(view, 'C') != 0);
     PyBuffer_Release(view);
     delete view;
 


### PR DESCRIPTION
Checking for `'A'` means success if the buffer is contiguous in either C or Fortran. The Python bindings are not the right place to accept Fortran-style arrays; in any case it would be the job of eventual Fortran bindings to find a solution for storing those correctly. At this point, we can accept only C-style arrays.

Unintended consequence: Our bindings currently do not catch the noncontiguous buffer view created by transposing an array:
Close #1882
