### PR TITLE
Fix deprecated use in InvalidatableFile.hpp

### DIFF
--- a/include/openPMD/IO/InvalidatableFile.hpp
+++ b/include/openPMD/IO/InvalidatableFile.hpp
@@ -88,7 +88,7 @@ struct less<openPMD::InvalidatableFile>
 {
     using first_argument_type = openPMD::InvalidatableFile;
     using second_argument_type = first_argument_type;
-    using result_type = typename std::less<std::string>::result_type;
+    using result_type = bool;
     result_type
     operator()(first_argument_type const &, second_argument_type const &) const;
 };


### PR DESCRIPTION
The use of `std::less<std::string>::result_type` was deprecated in C++17, removed in C++20 (already on Apple's stdlib). The recommended fix is to use `bool`.
https://en.cppreference.com/cpp/utility/functional/less