### PR TITLE
CI: Fix Windows MSVC pip build on VS 2026 runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/setup-python@v6
       name: Install Python
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Build & Install
       run: |
         python3 -m pip install --upgrade pip setuptools wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.22.0,<4.0.0",
+    "cmake>=3.22.0",
     "packaging>=23",
     "pybind11>=2.13.0,<3.0.0"
 ]


### PR DESCRIPTION
The windows-latest runner now ships Visual Studio 2026 (VS 18). In the "MSVC w/o MPI via pip" job, the pip-provided CMake (4.3.x) defaults to the "NMake Makefiles" generator, which rejects setup.py's `-A x64` platform argument:

    Generator NMake Makefiles does not support platform specification,
    but platform x64 was specified.
    CMAKE_C_COMPILER not set, after EnableLanguage

CMake 4 was rejected in the installer due to an upper cap in `pyproject.toml`