### PR TITLE
`setup.py`: License SPDX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -237,7 +237,8 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3.14',
-        ('License :: OSI Approved :: '
-         'GNU Lesser General Public License v3 or later (LGPLv3+)'),
     ],
+    # new PEP 639 format
+    license="LGPL-3.0-or-later",
+    license_files=["COPYING.LESSER", "COPYING"],
 )


### PR DESCRIPTION
The license metadata was replaced with a standard SPDX identifier.

Warning:

> setuptools\dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
> 
> ********************************************************************************
> Please consider removing the following classifiers in favor of a SPDX license expression:
> 
> License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
> 
> See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
> ********************************************************************************
