### PR TITLE
`setup.py`: Windows `openPMD_CMAKE_...` Env Vars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ CMAKE_INTERPROCEDURAL_OPTIMIZATION = os.environ.get(
 extra_cmake_args = []
 # Pass openPMD_CMAKE_<CMakeVar>=<value> environment variables through as -D
 # flags. Windows environment variable are all CAPS, so also accept the
-# all-caps variant of the prefix, then the openPMD_ CMake option names are case-
+# all-caps variant of the prefix, then the openPMD_ CMake option names are case
 # sensitive, so restore the "openPMD_" prefix that upper-casing would destroy.
 # All suffixes of our options are luckily ..._ALL_CAPS anyway.
 extra_cmake_args_prefix = "openPMD_CMAKE_"

--- a/setup.py
+++ b/setup.py
@@ -171,13 +171,23 @@ CMAKE_INTERPROCEDURAL_OPTIMIZATION = os.environ.get(
 
 # extra CMake arguments
 extra_cmake_args = []
+# Pass openPMD_CMAKE_<CMakeVar>=<value> environment variables through as -D
+# flags. Windows environment variable are all CAPS, so also accept the
+# all-caps variant of the prefix, then the openPMD_ CMake option names are case-
+# sensitive, so restore the "openPMD_" prefix that upper-casing would destroy.
+# All suffixes of our options are luckily ..._ALL_CAPS anyway.
+extra_cmake_args_prefix = "openPMD_CMAKE_"
 for k, v in os.environ.items():
-    extra_cmake_args_prefix = "openPMD_CMAKE_"
-    if k.startswith(extra_cmake_args_prefix) and \
-       len(k) > len(extra_cmake_args_prefix):
-        extra_cmake_args.append("-D{0}={1}".format(
-            k[len(extra_cmake_args_prefix):],
-            v))
+    if k.startswith(extra_cmake_args_prefix):
+        cmake_var = k[len(extra_cmake_args_prefix):]
+    elif k.startswith(extra_cmake_args_prefix.upper()):
+        cmake_var = k[len(extra_cmake_args_prefix):]
+        if cmake_var.startswith("OPENPMD_"):
+            cmake_var = "openPMD_" + cmake_var[len("openPMD_"):]
+    else:
+        continue
+    if cmake_var:
+        extra_cmake_args.append("-D{0}={1}".format(cmake_var, v))
 
 # https://cmake.org/cmake/help/v3.0/command/if.html
 if openPMD_USE_MPI.upper() in ['1', 'ON', 'TRUE', 'YES']:


### PR DESCRIPTION
We pass `openPMD_CMAKE_<CMakeVar>=<value>` environment variables through as `-D` flags to CMake configure.

Windows environment variable are all CAPS, so also accept the all-caps variant of the prefix, then the `openPMD_` CMake option names are case-sensitive,
so restore the `openPMD_...` prefix that upper-casing would destroy. All suffixes of our options are
luckily `..._ALL_CAPS` anyway.

Noticed in #1892 that our `openPMD_CMAKE_openPMD_USE_ADIOS2='ON'` env var was ignored on Windows, defaulting to `AUTO`, which skipped ADIOS2 since we had a transitive dependency issue.