### PR TITLE
Wheels: 0.17.1.post2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   SRC_REF: '0.17.1'
   COMMON_PATCHES: >
-    .github/setup-py-version-post1.patch
+    .github/setup-py-version-post2.patch
     .github/setup-py-windows-cmake-options.patch
 
 jobs:
@@ -192,24 +192,39 @@ jobs:
           CMAKE_PREFIX_PATH='C:/Program Files (x86)/ADIOS2;C:/Program Files (x86)/blosc2;C:/Program Files (x86)/HDF5;C:/Program Files (x86)/SQLite3;C:/Program Files (x86)/ZFP;C:/Program Files (x86)/zlib'
         # Fully static link => pyodide needs no wheel-repair step
         CIBW_REPAIR_WHEEL_COMMAND_PYODIDE: ""
+        # Windows wheel repair (delvewheel is cibuildwheel's default since v4.0).
+        # delvewheel vendors, BY DEFAULT, the MSVC C++ runtime (msvcp140.dll,
+        # ...) into openpmd_api.libs/ under a mangled name. A private, mangled
+        # copy of the C++ runtime collides with the system msvcp140.dll used by
+        # OTHER C++ extensions co-loaded in the same process (ImpactX, WarpX):
+        # objects/buffers crossing that boundary (to_df(), get_attribute())
+        # corrupt the CRT/heap -> segfault. The VC++ redistributable runtime is
+        # a system component (Python depends on it; numpy/scipy/h5py never
+        # bundle it), so exclude it. Genuine third-party deps (blosc2, zfp,
+        # sqlite3, ...) are still vendored; here they are static, so nothing is.
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
+          delvewheel repair -w {dest_dir} -v {wheel}
+          --exclude "msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;msvcp140_atomic_wait.dll;msvcp140_codecvt_ids.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll;vccorlib140.dll;vcomp140.dll;vcamp140.dll"
         # C++17 on macOS: deployment target per arch (arm64 needs 11.0+)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
         MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.MACOSX_DEPLOYMENT_TARGET }}"
         CMAKE_OSX_ARCHITECTURES: "${{ matrix.env.CMAKE_OSX_ARCHITECTURES }}"
         CMAKE_GENERATOR: "${{ matrix.env.CMAKE_GENERATOR }}"
         CMAKE_GENERATOR_PLATFORM: "${{ matrix.env.CMAKE_GENERATOR_PLATFORM }}"
-        # Pre-import smoke test: dump the extension's (transitive) shared-library
-        # dependencies + flag non-system/unbundled ones (check_wheel_libs.py),
-        # then import and assert the backends. Non-fatal, the import test is the
-        # actual success/failure test, and the print helps debugging it when needed.
-        # Pyodide runs in a node sandbox -> best-effort `|| true`; native uses &&.
+        # Smoke test: (1) dump the extension's (transitive) shared-library deps
+        # + flag non-system/unbundled ones (check_wheel_libs.py); (2) import and
+        # assert the backends; (3) a write/read ROUND-TRIP (smoke_roundtrip.py)
+        # that exercises the numpy-buffer + attribute boundary crossing
+        # Pyodide runs in a node sandbox (no file I/O) -> keeps the lighter import
+        # test with best-effort `|| true`.
         CIBW_TEST_REQUIRES: numpy
         CIBW_TEST_REQUIRES_PYODIDE: numpy
         CIBW_TEST_COMMAND: >
           python {project}/.github/check_wheel_libs.py &&
           python -c "import openpmd_api as io; v = io.variants;
           assert v['hdf5'] and v['adios2'] and v['json'], v;
-          print('openPMD', io.__version__, dict(v))"
+          print('openPMD', io.__version__, dict(v))" &&
+          python {project}/.github/smoke_roundtrip.py
         CIBW_TEST_COMMAND_PYODIDE: >
           python {project}/.github/check_wheel_libs.py || true;
           python -c "import openpmd_api as io; v = io.variants;
@@ -229,6 +244,17 @@ jobs:
         name: wheels-${{ matrix.os }}-${{ matrix.arch }}
         path: ./wheelhouse
         overwrite: true
+
+    # Guard: a repaired Windows wheel must NOT vendor the VC++ runtime
+    # (see CIBW_REPAIR_WHEEL_COMMAND_WINDOWS). Fails the job before publishing
+    # if delvewheel bundled msvcp140.dll & friends.
+    - name: Check wheels do not vendor the VC++ runtime
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        for whl in wheelhouse/*.whl; do
+          python src/.github/check_no_vendored_runtime.py "$whl"
+        done
 
     - name: Publish on pypi.org
       if: github.event_name == 'push' && github.repository == 'openPMD/openPMD-api' && github.ref == 'refs/heads/wheels'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,9 +202,11 @@ jobs:
         # a system component (Python depends on it; numpy/scipy/h5py never
         # bundle it), so exclude it. Genuine third-party deps (blosc2, zfp,
         # sqlite3, ...) are still vendored; here they are static, so nothing is.
+        # --exclude takes glob wildcards (delvewheel docs); unversioned families
+        # stay correct across runtime updates / a future toolset (msvcp150, ...).
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
           delvewheel repair -w {dest_dir} -v {wheel}
-          --exclude "msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;msvcp140_atomic_wait.dll;msvcp140_codecvt_ids.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll;vccorlib140.dll;vcomp140.dll;vcamp140.dll"
+          --exclude "msvcp*.dll;vcruntime*.dll;concrt*.dll;vccorlib*.dll;vcomp*.dll;vcamp*.dll;msvcr*.dll"
         # C++17 on macOS: deployment target per arch (arm64 needs 11.0+)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions
         MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.MACOSX_DEPLOYMENT_TARGET }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ env:
   COMMON_PATCHES: >
     .github/setup-py-version-post2.patch
     .github/setup-py-windows-cmake-options.patch
+    .github/python-hide-symbols.patch
 
 jobs:
   build_wheels:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ jobs:
 
           - os: ubuntu-22.04
             arch: "i686"
+            # 32-bit: ADIOS2 has no 32-bit CI and its BP reader segfaults on
+            # i686 (memcpy on a truncated 64-bit offset), so ship HDF5 + JSON
+            # only. See also the win32 (x86) entry.
+            env:
+              ADIOS2: "OFF"
 
           # builds faster on Travis-CI:
           #- os: ubuntu-20.04
@@ -52,6 +57,7 @@ jobs:
             env:
               CMAKE_GENERATOR: "Visual Studio 17 2022"
               CMAKE_GENERATOR_PLATFORM: "Win32"
+              ADIOS2: "OFF"   # 32-bit: no 32-bit ADIOS2 CI; BP read segfaults (see i686)
 
           - os: macos-15-intel
             arch: "x86_64"
@@ -177,7 +183,7 @@ jobs:
           ZLIB_USE_STATIC_LIBS='ON'
           ADIOS_USE_STATIC_LIBS='ON'
           openPMD_CMAKE_openPMD_USE_HDF5='ON'
-          openPMD_CMAKE_openPMD_USE_ADIOS2='ON'
+          openPMD_CMAKE_openPMD_USE_ADIOS2='${{ matrix.env.ADIOS2 || 'ON' }}'
         CIBW_ENVIRONMENT_PYODIDE: >
           openPMD_CMAKE_openPMD_USE_HDF5='ON'
           openPMD_CMAKE_openPMD_USE_ADIOS2='OFF'
@@ -188,7 +194,7 @@ jobs:
           HDF5_USE_STATIC_LIBRARIES='ON'
           ZLIB_USE_STATIC_LIBS='ON'
           openPMD_CMAKE_openPMD_USE_HDF5='ON'
-          openPMD_CMAKE_openPMD_USE_ADIOS2='ON'
+          openPMD_CMAKE_openPMD_USE_ADIOS2='${{ matrix.env.ADIOS2 || 'ON' }}'
           CMAKE_PREFIX_PATH='C:/Program Files (x86)/ADIOS2;C:/Program Files (x86)/blosc2;C:/Program Files (x86)/HDF5;C:/Program Files (x86)/SQLite3;C:/Program Files (x86)/ZFP;C:/Program Files (x86)/zlib'
         # Fully static link => pyodide needs no wheel-repair step
         CIBW_REPAIR_WHEEL_COMMAND_PYODIDE: ""
@@ -223,8 +229,9 @@ jobs:
         CIBW_TEST_REQUIRES_PYODIDE: numpy
         CIBW_TEST_COMMAND: >
           python {project}/.github/check_wheel_libs.py &&
-          python -c "import openpmd_api as io; v = io.variants;
-          assert v['hdf5'] and v['adios2'] and v['json'], v;
+          python -c "import sys, openpmd_api as io; v = io.variants;
+          need_adios2 = sys.maxsize > 2**32;
+          assert v['hdf5'] and v['json'] and (v['adios2'] or not need_adios2), v;
           print('openPMD', io.__version__, dict(v))" &&
           python {project}/.github/smoke_roundtrip.py
         CIBW_TEST_COMMAND_PYODIDE: >

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - CIBW_BUILD_VERBOSITY="1"
     # Runtime smoke test (aarch64/ppc64le run natively on Travis hardware)
     - CIBW_TEST_REQUIRES="numpy"
-    - CIBW_TEST_COMMAND="python {project}/.github/check_wheel_libs.py && python -c \"import openpmd_api as io; v=io.variants; assert v['hdf5'] and v['adios2'] and v['json'], v; print(io.__version__, dict(v))\""
+    - CIBW_TEST_COMMAND="python {project}/.github/check_wheel_libs.py && python -c \"import openpmd_api as io; v=io.variants; assert v['hdf5'] and v['adios2'] and v['json'], v; print(io.__version__, dict(v))\" && python {project}/.github/smoke_roundtrip.py"
 
 jobs:
   include:
@@ -132,9 +132,9 @@ jobs:
 
 install:
   - git clone --branch ${OPENPMD_GIT_REF} --depth 1 https://github.com/openPMD/openPMD-api.git src
-  - cp library_builders.sh list_library_deps.py check_wheel_libs.py src/.github/
+  - cp library_builders.sh list_library_deps.py check_wheel_libs.py smoke_roundtrip.py src/.github/
   # Wheels-only re-release: bump the package version (same source).
-  - (cd src && git apply ../setup-py-version-post1.patch)
+  - (cd src && git apply ../setup-py-version-post2.patch)
   - python -m pip install --upgrade pip setuptools wheel
   - python -m pip install cibuildwheel==3.2.1
   # twine & cryptography: see

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,9 @@ install:
   - cp library_builders.sh list_library_deps.py check_wheel_libs.py smoke_roundtrip.py src/.github/
   # Wheels-only re-release: bump the package version (same source).
   - (cd src && git apply ../setup-py-version-post2.patch)
+  # Keep statically-embedded deps (HDF5/ADIOS2/openPMD) private so the wheel can
+  # be co-loaded with another extension that also embeds them (ImpactX/WarpX).
+  - (cd src && git apply ../python-hide-symbols.patch)
   - python -m pip install --upgrade pip setuptools wheel
   - python -m pip install cibuildwheel==3.2.1
   # twine & cryptography: see

--- a/check_no_vendored_runtime.py
+++ b/check_no_vendored_runtime.py
@@ -61,13 +61,19 @@ def _dlls_in_dir(path):
 
 
 def check(path):
-    if zipfile.is_zipfile(path):
-        dlls = _dlls_in_wheel(path)
-    elif os.path.isdir(path):
+    if os.path.isdir(path):
         dlls = _dlls_in_dir(path)
+    elif not os.path.exists(path):
+        print("ERROR: %s does not exist." % path)
+        return 2
+    elif not os.path.isfile(path):
+        print("ERROR: %s is not a wheel file or directory." % path)
+        return 2
+    elif zipfile.is_zipfile(path):
+        dlls = _dlls_in_wheel(path)
     else:
-        print("  skip (not a wheel or directory): %s" % path)
-        return 0
+        print("ERROR: %s is not a valid wheel/zip file." % path)
+        return 2
     bad = sorted({d for d in dlls if _is_forbidden(d)})
     print("== %s: %d bundled DLL(s)" % (os.path.basename(path), len(dlls)))
     for d in sorted(dlls):

--- a/check_no_vendored_runtime.py
+++ b/check_no_vendored_runtime.py
@@ -31,10 +31,13 @@ import sys
 import zipfile
 
 # Visual C++ / UCRT runtime DLLs that must come from the system, never bundled.
+# Unversioned wildcards so a future toolset bump (msvcp150, new _N sidecars,
+# ...) is still caught -- these prefixes are MSVC-reserved, nothing else uses
+# them, so over-matching is not a concern.
 _FORBIDDEN = (
-    "msvcp140*.dll", "vcruntime140*.dll", "concrt140*.dll",
-    "vccorlib140*.dll", "vcomp140*.dll", "vcamp140*.dll",
-    "msvcr*.dll", "ucrtbase*.dll", "api-ms-win-*.dll",
+    "msvcp*.dll", "vcruntime*.dll", "concrt*.dll", "vccorlib*.dll",
+    "vcomp*.dll", "vcamp*.dll", "msvcr*.dll", "ucrtbase*.dll",
+    "api-ms-win-*.dll",
 )
 
 

--- a/check_no_vendored_runtime.py
+++ b/check_no_vendored_runtime.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Fail if a built wheel vendors the MSVC C++ / OpenMP runtime DLLs.
+
+delvewheel (cibuildwheel's default Windows wheel-repair tool since v4.0)
+vendors, *by default*, the Visual C++ runtime (msvcp140.dll, ...) into
+``<package>.libs/`` under a content-hashed (mangled) name. A private, mangled
+copy of the C++ runtime collides with the system ``msvcp140.dll`` used by
+OTHER C++ extension modules loaded in the same Python process (e.g. ImpactX,
+WarpX): C++ objects / heap buffers allocated by one C runtime and freed or
+filled by the other corrupt the CRT / heap state -> hard crash (segfault).
+This was observed downstream when reading data via ``to_df()`` /
+``get_attribute()`` right after the 0.17.1.post1 re-release.
+
+The VC++ redistributable runtime is a *system* component -- Python itself
+depends on it, and numpy / scipy / h5py never bundle it -- so it must NOT be
+vendored into our wheels. This guard scans a wheel (or an installed package
+directory) and exits non-zero if any such runtime DLL is bundled. Run it on
+every Windows wheel after the repair step.
+
+Note: this intentionally does NOT flag ``libstdc++`` / ``libc++`` on Linux /
+macOS, where auditwheel / delocate bundling the C++ runtime is the accepted,
+symbol-versioned manylinux/macOS behavior. The dangerous case is the Windows
+C++ runtime specifically.
+
+Usage:
+    python check_no_vendored_runtime.py <wheel|dir> [<wheel|dir> ...]
+"""
+import fnmatch
+import os
+import sys
+import zipfile
+
+# Visual C++ / UCRT runtime DLLs that must come from the system, never bundled.
+_FORBIDDEN = (
+    "msvcp140*.dll", "vcruntime140*.dll", "concrt140*.dll",
+    "vccorlib140*.dll", "vcomp140*.dll", "vcamp140*.dll",
+    "msvcr*.dll", "ucrtbase*.dll", "api-ms-win-*.dll",
+)
+
+
+def _is_forbidden(name):
+    base = os.path.basename(name).lower()
+    return any(fnmatch.fnmatch(base, pat) for pat in _FORBIDDEN)
+
+
+def _dlls_in_wheel(path):
+    with zipfile.ZipFile(path) as z:
+        return [n for n in z.namelist() if n.lower().endswith(".dll")]
+
+
+def _dlls_in_dir(path):
+    out = []
+    for root, _dirs, files in os.walk(path):
+        for f in files:
+            if f.lower().endswith(".dll"):
+                out.append(os.path.join(root, f))
+    return out
+
+
+def check(path):
+    if zipfile.is_zipfile(path):
+        dlls = _dlls_in_wheel(path)
+    elif os.path.isdir(path):
+        dlls = _dlls_in_dir(path)
+    else:
+        print("  skip (not a wheel or directory): %s" % path)
+        return 0
+    bad = sorted({d for d in dlls if _is_forbidden(d)})
+    print("== %s: %d bundled DLL(s)" % (os.path.basename(path), len(dlls)))
+    for d in sorted(dlls):
+        print("     %s%s" % (d, "   <-- FORBIDDEN runtime" if _is_forbidden(d) else ""))
+    if bad:
+        names = ", ".join(os.path.basename(b) for b in bad)
+        print("ERROR: %s vendors the VC++/UCRT runtime (%s).\n"
+              "       Exclude it from delvewheel via "
+              "CIBW_REPAIR_WHEEL_COMMAND_WINDOWS (--exclude)." %
+              (os.path.basename(path), names))
+        return 1
+    return 0
+
+
+def main(argv):
+    if not argv:
+        print("usage: check_no_vendored_runtime.py <wheel|dir> [...]")
+        return 2
+    rc = 0
+    for p in argv:
+        rc |= check(p)
+    if rc == 0:
+        print("OK: no VC++/UCRT runtime DLLs vendored.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/python-hide-symbols.patch
+++ b/python-hide-symbols.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8605bced7..dc714166d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -639,6 +639,22 @@ if(openPMD_HAVE_PYTHON)
+     set_target_properties(openPMD.py PROPERTIES CXX_VISIBILITY_PRESET "hidden"
+                                                 CUDA_VISIBILITY_PRESET "hidden")
+ 
++    # Co-load safety: statically-embedded dependencies (HDF5, ADIOS2, blosc2,
++    # and the openPMD core archive) are compiled without hidden visibility, so
++    # their symbols would otherwise be re-exported from this Python extension.
++    # If another extension loaded in the same process also statically embeds
++    # them (ImpactX, WarpX, a second openPMD), the duplicate exported symbols
++    # cross-bind -> two HDF5/openPMD instances in one process -> crash on the
++    # first file open. Export only the module init symbol so each extension
++    # keeps its dependencies private. (Windows PE does not auto-export and
++    # Emscripten links a single namespace, so neither needs this.)
++    if(APPLE)
++        target_link_options(openPMD.py PRIVATE
++            "LINKER:-exported_symbol,_PyInit_openpmd_api_cxx")
++    elseif(NOT WIN32 AND NOT EMSCRIPTEN)
++        target_link_options(openPMD.py PRIVATE "LINKER:--exclude-libs,ALL")
++    endif()
++
+     # ancient Clang releases
+     #   https://github.com/openPMD/openPMD-api/issues/542
+     #   https://pybind11.readthedocs.io/en/stable/faq.html#recursive-template-instantiation-exceeded-maximum-depth-of-256

--- a/setup-py-version-post2.patch
+++ b/setup-py-version-post2.patch
@@ -7,7 +7,7 @@ index 930e689..fc95539 100644
      name='openPMD-api',
      # note PEP-440 syntax: x.y.zaN but x.y.z.devN
 -    version='0.17.1',
-+    version='0.17.1.post1',
++    version='0.17.1.post2',
      author='Axel Huebl, Franz Poeschel, Fabian Koller, Junmin Gu',
      author_email='axelhuebl@lbl.gov, f.poeschel@hzdr.de',
      maintainer='Axel Huebl',

--- a/smoke_roundtrip.py
+++ b/smoke_roundtrip.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Functional smoke test: write a particle species + attribute, read it back.
+
+This exercises the exact code path that crashed downstream (ImpactX) when the
+0.17.1.post1 Windows wheel bundled a private MSVC C++ runtime: during
+``Series.flush()`` a numpy buffer (allocated by numpy, i.e. the *system* C
+runtime) is filled by the openPMD extension, and a particle-species attribute
+(a ``std::string`` / ``double``) crosses the C++ <-> Python boundary via
+``get_attribute()``. With a mismatched, vendored runtime this corrupts the
+heap -> segfault. Importing numpy first co-loads a system-runtime C++
+extension in the same process, mirroring the real-world usage.
+
+A plain import + ``io.variants`` check (what the wheels were tested with
+before) does NOT touch this path, which is why the regression shipped. This
+round-trip does, and requires only numpy.
+
+Usage:  python smoke_roundtrip.py
+"""
+import os
+import sys
+import tempfile
+
+import numpy as np  # noqa: F401  -- also co-loads a system-runtime C++ extension
+import openpmd_api as io
+
+
+_BETA_REF = 0.987654321
+
+
+def roundtrip(path):
+    """Write a particle species + attribute, reopen, and read it back."""
+    n = 32
+    x = np.arange(n, dtype=np.float64)
+    y = np.arange(n, dtype=np.float64) + 100.0
+
+    # --- write ---
+    series = io.Series(path, io.Access.create)
+    beam = series.iterations[0].particles["beam"]
+    for comp, arr in (("x", x), ("y", y)):
+        rc = beam["position"][comp]
+        rc.reset_dataset(io.Dataset(arr.dtype, list(arr.shape)))
+        rc.store_chunk(arr)
+    beam.set_attribute("beta_ref", _BETA_REF)
+    series.flush()
+    series.close()  # finalize before reopening the same file in this process
+
+    # --- read back: the boundary-crossing path that crashed ---
+    series = io.Series(path, io.Access.read_only)
+    beam = series.iterations[0].particles["beam"]
+    back_x = beam["position"]["x"].load_chunk()
+    back_y = beam["position"]["y"].load_chunk()
+    series.flush()  # fills the numpy buffers across the C++ <-> Python boundary
+    got_beta = beam.get_attribute("beta_ref")
+    series.close()
+
+    assert np.array_equal(back_x, x), (back_x, x)
+    assert np.array_equal(back_y, y), (back_y, y)
+    assert abs(got_beta - _BETA_REF) < 1e-12, got_beta
+
+
+def main():
+    variants = dict(io.variants)
+    print("openPMD", io.__version__, variants)
+
+    # Exercise EVERY compiled-in backend. The ADIOS2 (.bp) round-trip also
+    # proves ADIOS2 still works after we stopped vendoring the C++ runtime:
+    # ADIOS2 and its deps are statically linked (no adios2/blosc2/... DLL is
+    # bundled), so excluding msvcp140.dll does not affect them.
+    targets = []
+    if variants.get("hdf5"):
+        targets.append("smoke.h5")
+    if variants.get("adios2"):
+        targets.append("smoke.bp")
+    if not targets:  # header-only JSON is always available (e.g. WASM)
+        targets.append("smoke.json")
+
+    tmp = tempfile.mkdtemp(prefix="opmd-smoke-")
+    for name in targets:
+        path = os.path.join(tmp, name)
+        roundtrip(path)
+        print("openPMD smoke round-trip OK:", name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/smoke_roundtrip.py
+++ b/smoke_roundtrip.py
@@ -62,17 +62,25 @@ def main():
     variants = dict(io.variants)
     print("openPMD", io.__version__, variants)
 
-    # Exercise EVERY compiled-in backend. The ADIOS2 (.bp) round-trip also
+    # Exercise EVERY compiled-in backend. On 32-bit (i686/win32) ADIOS2 is
+    # disabled in the wheel (its BP reader segfaults there, and ADIOS2 has no
+    # 32-bit CI), so only the HDF5 round-trip runs -- which works on 32-bit. The ADIOS2 (.bp) round-trip also
     # proves ADIOS2 still works after we stopped vendoring the C++ runtime:
     # ADIOS2 and its deps are statically linked (no adios2/blosc2/... DLL is
     # bundled), so excluding msvcp140.dll does not affect them.
+    #
+    # The "%T" in the filename selects FILE-BASED encoding (one file per
+    # iteration). Without it the Series defaults to group-based encoding, which
+    # openPMD-api warns against (a single atomic write on close -> a crash loses
+    # all data; with ADIOS2 BP5 the per-step metadata grows quadratically). See
+    # https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html
     targets = []
     if variants.get("hdf5"):
-        targets.append("smoke.h5")
+        targets.append("smoke_%T.h5")
     if variants.get("adios2"):
-        targets.append("smoke.bp")
+        targets.append("smoke_%T.bp")
     if not targets:  # header-only JSON is always available (e.g. WASM)
-        targets.append("smoke.json")
+        targets.append("smoke_%T.json")
 
     tmp = tempfile.mkdtemp(prefix="opmd-smoke-")
     for name in targets:


### PR DESCRIPTION
- Windows builds with delvewheel bundled MSVC runtime dlls that break downstream.
  Exclude and add new round-trip test to catch before publishing.
- Static transient dependencies: apply proper symbol hiding, so co-`import` with ImpactX wheel (https://github.com/BLAST-ImpactX/impactx-wheels/pull/26) works