### PR TITLE
Wheels 0.17.1.post3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ env:
     .github/setup-py-windows-cmake-options.patch
     .github/python-hide-symbols.patch
     .github/hdf5-dont-atexit-emscripten.patch
+    .github/hdf5-read-h5tequal-tristate.patch
 
 jobs:
   build_wheels:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ env:
     .github/setup-py-version-post3.patch
     .github/setup-py-windows-cmake-options.patch
     .github/python-hide-symbols.patch
+    .github/hdf5-dont-atexit-emscripten.patch
 
 jobs:
   build_wheels:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   SRC_REF: '0.17.1'
   COMMON_PATCHES: >
-    .github/setup-py-version-post2.patch
+    .github/setup-py-version-post3.patch
     .github/setup-py-windows-cmake-options.patch
     .github/python-hide-symbols.patch
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,9 @@ jobs:
     - uses: actions/upload-artifact@v7
       name: Publish as GitHub artifact
       with:
-        name: wheels-${{ matrix.os }}-${{ matrix.arch }}
+        # Include matrix.build so the two wasm legs (cp313 / cp314, which share
+        # os=ubuntu-24.04 + arch=wasm32) get DISTINCT artifact names.
+        name: wheels-${{ matrix.os }}-${{ matrix.build || matrix.arch }}
         path: ./wheelhouse
         overwrite: true
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+# Disable RTD on the wheels branch
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.14"
+  jobs:
+    post_checkout:
+      - exit 183

--- a/hdf5-dont-atexit-emscripten.patch
+++ b/hdf5-dont-atexit-emscripten.patch
@@ -1,0 +1,33 @@
+diff --git a/src/IO/HDF5/HDF5IOHandler.cpp b/src/IO/HDF5/HDF5IOHandler.cpp
+index d859ccc..1f86c9b 100644
+--- a/src/IO/HDF5/HDF5IOHandler.cpp
++++ b/src/IO/HDF5/HDF5IOHandler.cpp
+@@ -99,6 +99,28 @@ constexpr char const *const flush_cfg_mask = &R"(
+     "independent_stores": null
+ })"[1];
+ 
++#if defined(__EMSCRIPTEN__)
++// WASM co-load: under Pyodide every extension is a side module sharing ONE
++// global Emscripten namespace, so two wheels that each statically bundle HDF5
++// (e.g. the standalone openpmd_api wheel and the ImpactX wheel, used together)
++// end up with their HDF5 atexit cleanups (H5_term_library) tangled across the
++// two copies, looping forever at process exit ("infinite loop closing library"
++// -> "memory access out of bounds") even after a fully successful run. Symbol
++// hiding cannot prevent this (Pyodide's side-module link exports every symbol
++// regardless of -fvisibility=hidden), so instead tell HDF5 not to install its
++// atexit handler at all -- the OS reclaims the process memory on exit anyway.
++// H5dont_atexit() must run before any other HDF5 call (HDF5 docs) and the HDF5
++// IO handler's own member initializers already create H5 types, so a load-time
++// initializer in this backend translation unit is the earliest safe point. It
++// fires when whichever bundled HDF5 loads first, independent of whether
++// openpmd_api or ImpactX is imported first; the H5_dont_atexit_g flag is
++// interposed across both bundled copies, so this single call covers both.
++namespace
++{
++    [[maybe_unused]] herr_t const openpmd_hdf5_dont_atexit = H5dont_atexit();
++} // namespace
++#endif
++
+ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
+     AbstractIOHandler *handler, bool do_warn_unused_params)
+     : AbstractIOHandlerImpl(handler)

--- a/hdf5-read-h5tequal-tristate.patch
+++ b/hdf5-read-h5tequal-tristate.patch
@@ -1,0 +1,54 @@
+diff --git a/src/IO/HDF5/HDF5IOHandler.cpp b/src/IO/HDF5/HDF5IOHandler.cpp
+index 1f86c9be72..dde83069a7 100644
+--- a/src/IO/HDF5/HDF5IOHandler.cpp
++++ b/src/IO/HDF5/HDF5IOHandler.cpp
+@@ -1618,16 +1618,16 @@ void HDF5IOHandlerImpl::openDataset(
+             else if (H5Tequal(dataset_type, H5T_NATIVE_DOUBLE))
+                 d = DT::DOUBLE;
+             else if (
+-                H5Tequal(dataset_type, H5T_NATIVE_LDOUBLE) ||
+-                H5Tequal(dataset_type, m_H5T_LONG_DOUBLE_80_LE))
++                H5Tequal(dataset_type, H5T_NATIVE_LDOUBLE) > 0 ||
++                H5Tequal(dataset_type, m_H5T_LONG_DOUBLE_80_LE) > 0)
+                 d = DT::LONG_DOUBLE;
+-            else if (H5Tequal(dataset_type, m_H5T_CFLOAT))
++            else if (H5Tequal(dataset_type, m_H5T_CFLOAT) > 0)
+                 d = DT::CFLOAT;
+-            else if (H5Tequal(dataset_type, m_H5T_CDOUBLE))
++            else if (H5Tequal(dataset_type, m_H5T_CDOUBLE) > 0)
+                 d = DT::CDOUBLE;
+             else if (
+-                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE) ||
+-                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE_80_LE))
++                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE) > 0 ||
++                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE_80_LE) > 0)
+                 d = DT::CLONG_DOUBLE;
+             else if (H5Tequal(dataset_type, H5T_NATIVE_USHORT))
+                 d = DT::USHORT;
+@@ -2854,7 +2854,7 @@ void HDF5IOHandlerImpl::readAttribute(
+             status = H5Aread(attr_id, attr_type, &l);
+             a = Attribute(l);
+         }
+-        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE))
++        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE) > 0)
+         {
+             char bfr[16];
+             status = H5Aread(attr_id, attr_type, bfr);
+@@ -3136,7 +3136,7 @@ void HDF5IOHandlerImpl::readAttribute(
+             status = H5Aread(attr_id, attr_type, vcld.data());
+             a = Attribute(vcld);
+         }
+-        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE_80_LE))
++        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE_80_LE) > 0)
+         {
+             // worst case:
+             // sizeof(long double) is only 8, but the dataset on disk has
+@@ -3158,7 +3158,7 @@ void HDF5IOHandlerImpl::readAttribute(
+             delete[] tmpBuffer;
+             a = Attribute(std::move(vcld));
+         }
+-        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE))
++        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE) > 0)
+         {
+             // worst case:
+             // sizeof(long double) is only 8, but the dataset on disk has

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -414,6 +414,14 @@ if [ "${1:-}" = "wasm" ]; then
     export EMCMAKE="emcmake"
     export EMMAKE="emmake"
 
+    # Build the bundled static deps with hidden visibility (collision avoidance;
+    # see the native-branch comment). On Pyodide every extension is a side module
+    # in ONE global namespace, so this also makes openPMD call its OWN bundled
+    # HDF5/zlib via direct calls instead of GOT-binding across a co-loaded second
+    # copy (e.g. the ImpactX wheel) -- which is what makes HDF5 actually run.
+    export CFLAGS+=" -fvisibility=hidden"
+    export CXXFLAGS+=" -fvisibility=hidden"
+
     install_pyessentials
     build_zlib
     build_hdf5_cmake
@@ -425,7 +433,15 @@ else
     export EMCMAKE=""
     export EMMAKE=""
 
-    # static libs need relocatable symbols for linking to shared python lib
+    # static libs need relocatable symbols for linking to shared python lib.
+    # NOTE: do NOT add -fvisibility=hidden here. Native builds these deps as both
+    # static AND shared (e.g. zlib's libz.so) and build their example/test
+    # programs against the shared lib; hidden visibility then strips the public
+    # API (deflate/inflate/...) and the dep's own examples fail to link. Native
+    # co-load isolation is already handled at link time by --exclude-libs,ALL
+    # (python-hide-symbols.patch), so compile-time hiding is redundant here. It is
+    # applied only on the wasm branch, where deps are static-only and it is needed
+    # for direct (non-GOT) intra-module calls in Pyodide's single namespace.
     export CFLAGS+=" -fPIC"
     export CXXFLAGS+=" -fPIC"
 

--- a/list_library_deps.py
+++ b/list_library_deps.py
@@ -8,10 +8,20 @@ cannot be executed on the host.
 
 For every dependency it reports HOW it was resolved (RPATH / RUNPATH /
 LD_LIBRARY_PATH / default path / System32 / PATH / @rpath / @loader_path /
-absolute / binary dir), or flags it `[system]` (OS / language runtime, not
-bundled) or `[not found]`. The non-system, not-found libraries are the ones
-that must be bundled into a wheel -- this surfaces them BEFORE the opaque
-"DLL load failed" / "cannot open shared object file" import error.
+absolute / binary dir / wheel-repair bundle dir), or flags it `[system]`
+(OS / language runtime, not bundled) or `[not found]`. The non-system,
+not-found libraries are the ones that must be bundled into a wheel -- this
+surfaces them BEFORE the opaque "DLL load failed" / "cannot open shared object
+file" import error.
+
+A wheel repaired by delvewheel (Windows) / auditwheel (Linux) puts its bundled,
+name-mangled libraries in a sibling `<dist>.libs` directory and delocate
+(macOS) in a `<pkg>/.dylibs` directory; the repaired package `__init__`
+re-adds those to the runtime search path (os.add_dll_directory / RPATH). We
+discover them PORTABLY -- by their conventional names, walking up from the
+binary, with no dependency on the repair tool -- so a bundled library shows as
+resolved (e.g. `[bundled .libs (delvewheel/auditwheel) -> ...]`) instead of a
+misleading `[not found]`.
 
 Usage:
     python list_library_deps.py [--strict] <binary> [<binary> ...]
@@ -21,6 +31,7 @@ Usage:
 import os
 import struct
 import sys
+
 
 # ---------------------------------------------------------------------------
 # Format detection
@@ -227,6 +238,48 @@ def is_system(name):
 # ---------------------------------------------------------------------------
 # resolution: build the ordered (dir, hint) search list, then locate
 # ---------------------------------------------------------------------------
+def _bundled_dirs(origin):
+    """Wheel-repair bundle directories, discovered PORTABLY (no dependency on
+    delvewheel/auditwheel/delocate), by their conventional layout:
+
+      * delvewheel (Windows) / auditwheel (Linux): a sibling `<dist>.libs`
+        directory of the import package, e.g. `site-packages/openpmd_api.libs`
+        -- matched by the `.libs` suffix while walking up from the binary. (The
+        dist name differs from the import package, so we match the suffix, not a
+        derived name.)
+      * delocate (macOS): a `.dylibs` directory inside the package tree, e.g.
+        `openpmd_api/.dylibs`.
+
+    The repaired package `__init__` re-adds these to the runtime search path
+    (os.add_dll_directory / RPATH `$ORIGIN/../<dist>.libs`), so a library that
+    the OS-level search list would call `[not found]` is in fact resolved here.
+    Returns an ordered list of (directory, hint)."""
+    out, seen = [], set()
+    d = os.path.abspath(origin)
+    while True:
+        dylibs = os.path.join(d, ".dylibs")             # delocate, inside pkg
+        if dylibs not in seen and os.path.isdir(dylibs):
+            seen.add(dylibs)
+            out.append((dylibs, "bundled .dylibs (delocate)"))
+        parent = os.path.dirname(d)                     # delvewheel/auditwheel
+        if parent and parent != d:                      # sibling *.libs dirs
+            try:
+                for name in sorted(os.listdir(parent)):
+                    cand = os.path.join(parent, name)
+                    if (name.endswith(".libs") and cand not in seen
+                            and os.path.isdir(cand)):
+                        seen.add(cand)
+                        out.append((cand, "bundled .libs (delvewheel/auditwheel)"))
+            except OSError:
+                pass
+        # stop once we have climbed past the install root
+        if (not parent or parent == d
+                or os.path.basename(d) in ("site-packages", "dist-packages")):
+            break
+        d = parent
+    return out
+
+
 def _search(fmt, origin, rpaths):
     out = []  # ordered list of (directory, hint)
 
@@ -236,6 +289,7 @@ def _search(fmt, origin, rpaths):
 
     for raw, kind in rpaths:                    # binary's own RPATH/RUNPATH/LC_RPATH
         out.append((expand(raw), kind))
+    out += _bundled_dirs(origin)                # delvewheel/auditwheel/delocate
     if fmt == "elf":
         for d in filter(None, os.environ.get("LD_LIBRARY_PATH", "").split(":")):
             out.append((d, "LD_LIBRARY_PATH"))

--- a/setup-py-version-post3.patch
+++ b/setup-py-version-post3.patch
@@ -7,7 +7,7 @@ index 930e689..fc95539 100644
      name='openPMD-api',
      # note PEP-440 syntax: x.y.zaN but x.y.z.devN
 -    version='0.17.1',
-+    version='0.17.1.post2',
++    version='0.17.1.post3',
      author='Axel Huebl, Franz Poeschel, Fabian Koller, Junmin Gu',
      author_email='axelhuebl@lbl.gov, f.poeschel@hzdr.de',
      maintainer='Axel Huebl',


### PR DESCRIPTION
- bump version
- patch in #1900 for WASM builds
- update library listing helper (from https://github.com/BLAST-ImpactX/impactx-wheels/pull/26)
- give each build a district artifact name
- disable RTD on the wheels branch/PRs (only meaningful on `dev`)
- HDF5: harden wasm read type-detection against H5Tequal errors #1902