### PR TITLE
HDF5: harden wasm read type-detection against H5Tequal errors

### DIFF
--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -1618,16 +1618,16 @@ void HDF5IOHandlerImpl::openDataset(
             else if (H5Tequal(dataset_type, H5T_NATIVE_DOUBLE))
                 d = DT::DOUBLE;
             else if (
-                H5Tequal(dataset_type, H5T_NATIVE_LDOUBLE) ||
-                H5Tequal(dataset_type, m_H5T_LONG_DOUBLE_80_LE))
+                H5Tequal(dataset_type, H5T_NATIVE_LDOUBLE) > 0 ||
+                H5Tequal(dataset_type, m_H5T_LONG_DOUBLE_80_LE) > 0)
                 d = DT::LONG_DOUBLE;
-            else if (H5Tequal(dataset_type, m_H5T_CFLOAT))
+            else if (H5Tequal(dataset_type, m_H5T_CFLOAT) > 0)
                 d = DT::CFLOAT;
-            else if (H5Tequal(dataset_type, m_H5T_CDOUBLE))
+            else if (H5Tequal(dataset_type, m_H5T_CDOUBLE) > 0)
                 d = DT::CDOUBLE;
             else if (
-                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE) ||
-                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE_80_LE))
+                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE) > 0 ||
+                H5Tequal(dataset_type, m_H5T_CLONG_DOUBLE_80_LE) > 0)
                 d = DT::CLONG_DOUBLE;
             else if (H5Tequal(dataset_type, H5T_NATIVE_USHORT))
                 d = DT::USHORT;
@@ -2854,7 +2854,7 @@ void HDF5IOHandlerImpl::readAttribute(
             status = H5Aread(attr_id, attr_type, &l);
             a = Attribute(l);
         }
-        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE))
+        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE) > 0)
         {
             char bfr[16];
             status = H5Aread(attr_id, attr_type, bfr);
@@ -3136,7 +3136,7 @@ void HDF5IOHandlerImpl::readAttribute(
             status = H5Aread(attr_id, attr_type, vcld.data());
             a = Attribute(vcld);
         }
-        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE_80_LE))
+        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE_80_LE) > 0)
         {
             // worst case:
             // sizeof(long double) is only 8, but the dataset on disk has
@@ -3158,7 +3158,7 @@ void HDF5IOHandlerImpl::readAttribute(
             delete[] tmpBuffer;
             a = Attribute(std::move(vcld));
         }
-        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE))
+        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE) > 0)
         {
             // worst case:
             // sizeof(long double) is only 8, but the dataset on disk has

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -2587,7 +2587,7 @@ void HDF5IOHandlerImpl::readDataset(
                 << std::endl;
         }
     });
-    if (H5Tequal(dataType, H5T_NATIVE_LDOUBLE))
+    if (H5Tequal(dataType, H5T_NATIVE_LDOUBLE) > 0)
     {
         // We have previously determined in openDataset() that this dataset is
         // of type long double.
@@ -2604,12 +2604,12 @@ void HDF5IOHandlerImpl::readDataset(
                           << std::endl;
             }
         });
-        if (!H5Tequal(checkDatasetTypeAgain, H5T_NATIVE_LDOUBLE))
+        if (H5Tequal(checkDatasetTypeAgain, H5T_NATIVE_LDOUBLE) <= 0)
         {
             dataType = m_H5T_LONG_DOUBLE_80_LE;
         }
     }
-    else if (H5Tequal(dataType, m_H5T_CLONG_DOUBLE))
+    else if (H5Tequal(dataType, m_H5T_CLONG_DOUBLE) > 0)
     {
         // Same deal for m_H5T_CLONG_DOUBLE
         hid_t checkDatasetTypeAgain = H5Dget_type(dataset_id);
@@ -2622,7 +2622,7 @@ void HDF5IOHandlerImpl::readDataset(
                           << std::endl;
             }
         });
-        if (!H5Tequal(checkDatasetTypeAgain, m_H5T_CLONG_DOUBLE))
+        if (H5Tequal(checkDatasetTypeAgain, m_H5T_CLONG_DOUBLE) <= 0)
         {
             dataType = m_H5T_CLONG_DOUBLE_80_LE;
         }
@@ -3118,19 +3118,19 @@ void HDF5IOHandlerImpl::readAttribute(
             status = H5Aread(attr_id, attr_type, vld.data());
             a = Attribute(vld);
         }
-        else if (H5Tequal(attr_type, m_H5T_CFLOAT))
+        else if (H5Tequal(attr_type, m_H5T_CFLOAT) > 0)
         {
             std::vector<std::complex<float>> vcf(dims[0], 0);
             status = H5Aread(attr_id, attr_type, vcf.data());
             a = Attribute(vcf);
         }
-        else if (H5Tequal(attr_type, m_H5T_CDOUBLE))
+        else if (H5Tequal(attr_type, m_H5T_CDOUBLE) > 0)
         {
             std::vector<std::complex<double>> vcd(dims[0], 0);
             status = H5Aread(attr_id, attr_type, vcd.data());
             a = Attribute(vcd);
         }
-        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE))
+        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE) > 0)
         {
             std::vector<std::complex<long double>> vcld(dims[0], 0);
             status = H5Aread(attr_id, attr_type, vcld.data());


### PR DESCRIPTION
H5Tequal returns a tri-state htri_t (>0 equal, 0 not equal, <0 ERROR), but the HDF5 backend's read type-detection used it as a plain bool, so a <0 error counted as "equal".

In the Pyodide/wasm wheel, openPMD's manually-built 80-bit long-double types (m_H5T_LONG_DOUBLE_80_LE, m_H5T_CLONG_DOUBLE_80_LE) end up as INVALID type ids (the handler destructor fails to H5Tclose them). Comparing any type against an invalid id makes H5Tequal return <0, which short-circuited the detection chain and mis-detected EVERY attribute/dataset -- including the 'openPMD' format-version string -- as LONG_DOUBLE, so reading any openPMD HDF5 file on wasm failed with "Unexpected Attribute datatype for 'openPMD' (expected string, found LONG_DOUBLE)". Writing was unaffected, which is why it went unnoticed.

Guard every comparison against these custom types with an explicit `> 0`, in the dataset reader and both the scalar- and vector-attribute readers, so an H5Tequal error means "not equal" and types fall through correctly. Safe on all platforms: where the types are valid H5Tequal never returns <0, so `> 0` matches the prior behavior and only the error case changes.

Note: this hardens the READER. Why the 80-bit type is invalid specifically in the Pyodide side-module build is a separate issue -- a minimal *static* wasm build of the same HDF5 1.14.6 constructs the type fine (long double is 128-bit there) and H5Tequal works -- and resolving it is what would enable reading genuine 80-bit long-double *data* on wasm.