### PR TITLE
Wheels 0.17.1.post4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ env:
     .github/setup-py-version-post3.patch
     .github/setup-py-windows-cmake-options.patch
     .github/python-hide-symbols.patch
+    .github/python-wasm-side-module.patch
     .github/hdf5-dont-atexit-emscripten.patch
     .github/hdf5-read-h5tequal-tristate.patch
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   SRC_REF: '0.17.1'
   COMMON_PATCHES: >
-    .github/setup-py-version-post3.patch
+    .github/setup-py-version-post4.patch
     .github/setup-py-windows-cmake-options.patch
     .github/python-hide-symbols.patch
     .github/python-wasm-side-module.patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,11 +193,19 @@ jobs:
           openPMD_USE_MPI='OFF'
           HDF5_USE_STATIC_LIBRARIES='ON'
           ZLIB_USE_STATIC_LIBS='ON'
+        # _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR (CXXFLAGS): VS 2022 17.10 made
+        # std::mutex's constructor constexpr, leaving its internals NULL until
+        # first use. We --exclude msvcp*.dll from the wheel (below), so the SYSTEM
+        # msvcp140.dll runs; if it predates 17.10 it NULL-derefs in Mtx_destroy ->
+        # `import openpmd_api` access-violates on win64 (surfaced when co-loaded
+        # under the ImpactX wheel's test). The define reverts to the non-constexpr
+        # constructor, ABI-compatible with any msvcp140.
         CIBW_ENVIRONMENT_WINDOWS: >
           HDF5_USE_STATIC_LIBRARIES='ON'
           ZLIB_USE_STATIC_LIBS='ON'
           openPMD_CMAKE_openPMD_USE_HDF5='ON'
           openPMD_CMAKE_openPMD_USE_ADIOS2='${{ matrix.env.ADIOS2 || 'ON' }}'
+          CXXFLAGS='/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
           CMAKE_PREFIX_PATH='C:/Program Files (x86)/ADIOS2;C:/Program Files (x86)/blosc2;C:/Program Files (x86)/HDF5;C:/Program Files (x86)/SQLite3;C:/Program Files (x86)/ZFP;C:/Program Files (x86)/zlib'
         # Fully static link => pyodide needs no wheel-repair step
         CIBW_REPAIR_WHEEL_COMMAND_PYODIDE: ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,13 +194,7 @@ jobs:
           openPMD_USE_MPI='OFF'
           HDF5_USE_STATIC_LIBRARIES='ON'
           ZLIB_USE_STATIC_LIBS='ON'
-        # _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR (CXXFLAGS): VS 2022 17.10 made
-        # std::mutex's constructor constexpr, leaving its internals NULL until
-        # first use. We --exclude msvcp*.dll from the wheel (below), so the SYSTEM
-        # msvcp140.dll runs; if it predates 17.10 it NULL-derefs in Mtx_destroy ->
-        # `import openpmd_api` access-violates on win64 (surfaced when co-loaded
-        # under the ImpactX wheel's test). The define reverts to the non-constexpr
-        # constructor, ABI-compatible with any msvcp140.
+        # _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR for portability to older runtimes
         CIBW_ENVIRONMENT_WINDOWS: >
           HDF5_USE_STATIC_LIBRARIES='ON'
           ZLIB_USE_STATIC_LIBS='ON'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,15 @@
-# Disable RTD on the wheels branch
+# Skip Read the Docs on the wheels branch: exit 183 cancels the build (RTD then
+# reports the PR check as success). The sphinx key only satisfies the config
+# schema; the build is cancelled in post_checkout before sphinx is read.
 version: 2
 
+sphinx:
+  configuration: docs/source/conf.py
+
 build:
-  os: ubuntu-24.04
+  os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
   jobs:
     post_checkout:
       - exit 183

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.14"
+    python: "3.12"
   jobs:
     post_checkout:
       - exit 183

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -4,6 +4,13 @@ set BUILD_PREFIX="C:/Program Files (x86)"
 set CPU_COUNT="2"
 set CURL_RETRY=--retry 5 --retry-delay 3
 
+rem std::mutex ABI portability: build every dependency with the same define as
+rem the central wheel build (CIBW_ENVIRONMENT_WINDOWS). VS 2022 17.10 made
+rem std::mutex's constructor constexpr; because we --exclude msvcp*.dll from the
+rem wheel, a mismatch with an older system msvcp140.dll faults in Mtx_destroy.
+rem Setting it here too keeps the whole dependency toolchain consistent.
+set "CXXFLAGS=%CXXFLAGS% /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
+
 echo "CFLAGS: %CFLAGS%"
 echo "CXXFLAGS: %CXXFLAGS%"
 echo "LDFLAGS: %LDFLAGS%"

--- a/python-wasm-side-module.patch
+++ b/python-wasm-side-module.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e4eacf7..126e9e5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -633,12 +633,21 @@ if(openPMD_HAVE_PYTHON)
+     # them (ImpactX, WarpX, a second openPMD), the duplicate exported symbols
+     # cross-bind -> two HDF5/openPMD instances in one process -> crash on the
+     # first file open. Export only the module init symbol so each extension
+-    # keeps its dependencies private. (Windows PE does not auto-export and
+-    # Emscripten links a single namespace, so neither needs this.)
++    # keeps its dependencies private. Windows PE does not auto-export, so it
++    # needs nothing; Emscripten needs -sSIDE_MODULE=2 (see below).
+     if(APPLE)
+         target_link_options(openPMD.py PRIVATE
+             "LINKER:-exported_symbol,_PyInit_openpmd_api_cxx")
+-    elseif(NOT WIN32 AND NOT EMSCRIPTEN)
++    elseif(EMSCRIPTEN)
++        # wasm co-load fix (openPMD-api#1903): Pyodide's default -sSIDE_MODULE=1
++        # whole-archives and force-exports every symbol; -sSIDE_MODULE=2 exports
++        # only the module init, and the static deps are built -fvisibility=hidden
++        # (library_builders.sh) so wasm-ld binds our HDF5 calls to our own copy,
++        # not a co-loaded second HDF5 (h5py, ImpactX).
++        target_link_options(openPMD.py PRIVATE
++            "SHELL:-sSIDE_MODULE=2"
++            "SHELL:-sEXPORTED_FUNCTIONS=_PyInit_openpmd_api_cxx")
++    elseif(NOT WIN32)
+         target_link_options(openPMD.py PRIVATE "LINKER:--exclude-libs,ALL")
+     endif()
+ 

--- a/python-wasm-side-module.patch
+++ b/python-wasm-side-module.patch
@@ -1,25 +1,32 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e4eacf7..126e9e5 100644
+index e4eacf7..07c7c31 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -633,12 +633,21 @@ if(openPMD_HAVE_PYTHON)
-     # them (ImpactX, WarpX, a second openPMD), the duplicate exported symbols
-     # cross-bind -> two HDF5/openPMD instances in one process -> crash on the
-     # first file open. Export only the module init symbol so each extension
+@@ -630,15 +630,25 @@ if(openPMD_HAVE_PYTHON)
+     # and the openPMD core archive) are compiled without hidden visibility, so
+     # their symbols would otherwise be re-exported from this Python extension.
+     # If another extension loaded in the same process also statically embeds
+-    # them (ImpactX, WarpX, a second openPMD), the duplicate exported symbols
+-    # cross-bind -> two HDF5/openPMD instances in one process -> crash on the
+-    # first file open. Export only the module init symbol so each extension
 -    # keeps its dependencies private. (Windows PE does not auto-export and
 -    # Emscripten links a single namespace, so neither needs this.)
-+    # keeps its dependencies private. Windows PE does not auto-export, so it
-+    # needs nothing; Emscripten needs -sSIDE_MODULE=2 (see below).
++    # them (ImpactX, WarpX, a second openPMD in pip wheels), the duplicate
++    # exported symbols cross-bind, then two HDF5/openPMD instances are in one
++    # Python process, and usually crash on the first file open. Export only
++    # the module init symbol so each extension keeps its dependencies private.
++    # Windows does not auto-export, so it needs nothing. Emscripten needs BOTH
++    # halves: -sSIDE_MODULE=2 stops Pyodide's default -sSIDE_MODULE=1 from
++    # whole-archiving and re-exporting every symbol, and the statically linked
++    # deps must additionally be built -fvisibility=hidden
++    # so their definitions are DSO-local. Only then can wasm-ld relax our GOT
++    # references to HDF5 into direct calls into our own copy, instead of binding
++    # to a co-loaded second HDF5 (h5py, ImpactX).
      if(APPLE)
          target_link_options(openPMD.py PRIVATE
              "LINKER:-exported_symbol,_PyInit_openpmd_api_cxx")
 -    elseif(NOT WIN32 AND NOT EMSCRIPTEN)
 +    elseif(EMSCRIPTEN)
-+        # wasm co-load fix (openPMD-api#1903): Pyodide's default -sSIDE_MODULE=1
-+        # whole-archives and force-exports every symbol; -sSIDE_MODULE=2 exports
-+        # only the module init, and the static deps are built -fvisibility=hidden
-+        # (library_builders.sh) so wasm-ld binds our HDF5 calls to our own copy,
-+        # not a co-loaded second HDF5 (h5py, ImpactX).
 +        target_link_options(openPMD.py PRIVATE
 +            "SHELL:-sSIDE_MODULE=2"
 +            "SHELL:-sEXPORTED_FUNCTIONS=_PyInit_openpmd_api_cxx")

--- a/setup-py-version-post4.patch
+++ b/setup-py-version-post4.patch
@@ -7,7 +7,7 @@ index 930e689..fc95539 100644
      name='openPMD-api',
      # note PEP-440 syntax: x.y.zaN but x.y.z.devN
 -    version='0.17.1',
-+    version='0.17.1.post3',
++    version='0.17.1.post4',
      author='Axel Huebl, Franz Poeschel, Fabian Koller, Junmin Gu',
      author_email='axelhuebl@lbl.gov, f.poeschel@hzdr.de',
      maintainer='Axel Huebl',


### PR DESCRIPTION
- [x] bump version
- [x] rebase against wheels branch
- [x] Win mutext issue seen in https://github.com/BLAST-ImpactX/impactx-wheels/pull/26
- [x] pull in whatever we find in #1903
- [x] skip RTD PR builds on `wheels` for good 

## `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` (`CXXFLAGS)`

VS 2022 17.10 made `std::mutex`'s constructor constexpr, leaving its internals NULL until first use. We `--exclude msvcp*.dll` from the wheel, so the SYSTEM `msvcp140.dll` runs; if it predates 17.10 it NULL-derefs in `Mtx_destroy` -> `import openpmd_api` access-violates on win64 (surfaced when co-loaded under the ImpactX wheel's test). The define reverts to the non-constexpr constructor, ABI-compatible with any `msvcp140`.