### PR TITLE
Wheels: ARM64 builders for Linux & Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ env:
   COMMON_PATCHES: >
     .github/setup-py-version-post4.patch
     .github/setup-py-windows-cmake-options.patch
+    .github/setup-py-windows-arm64-platform.patch
     .github/python-hide-symbols.patch
     .github/python-wasm-side-module.patch
     .github/hdf5-dont-atexit-emscripten.patch
@@ -68,6 +69,7 @@ jobs:
             build: "cp311-* cp312-* cp313-* cp314-*"
             env:
               ADIOS2: "OFF"
+              CMAKE_GENERATOR_PLATFORM: "ARM64"
 
           - os: macos-15-intel
             arch: "x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         #   platform     CIBW_PLATFORM                 (default auto)
         #   build        CIBW_BUILD                    (default *, i.e. all)
         #   patches      space-separated setup patches (default: Windows one)
+        #   artifact     artifact-name suffix override (default: build || arch)
         #   sdist        also build + upload the sdist artifact (default: off)
         include:
           - os: ubuntu-22.04
@@ -67,6 +68,7 @@ jobs:
           - os: windows-11-arm
             arch: "ARM64"
             build: "cp311-* cp312-* cp313-* cp314-*"
+            artifact: "ARM64"   # build has '*'/spaces; not a valid artifact name
             env:
               ADIOS2: "OFF"
               CMAKE_GENERATOR_PLATFORM: "ARM64"
@@ -265,8 +267,9 @@ jobs:
       name: Publish as GitHub artifact
       with:
         # Include matrix.build so the two wasm legs (cp313 / cp314, which share
-        # os=ubuntu-24.04 + arch=wasm32) get DISTINCT artifact names.
-        name: wheels-${{ matrix.os }}-${{ matrix.build || matrix.arch }}
+        # os=ubuntu-24.04 + arch=wasm32) get DISTINCT artifact names. matrix.artifact
+        # overrides it where build holds glob chars invalid in a name (Windows ARM64).
+        name: wheels-${{ matrix.os }}-${{ matrix.artifact || matrix.build || matrix.arch }}
         path: ./wheelhouse
         overwrite: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,15 @@ jobs:
             env:
               ADIOS2: "OFF"
 
-          # builds faster on Travis-CI:
-          #- os: ubuntu-20.04
-          #  arch: "aarch64"
+          # Linux ARM64 (aarch64): native GitHub-hosted runner, free for public
+          # repos (cibuildwheel builds aarch64 natively, no QEMU). Full parity with
+          # the x86_64 leg above: cp310-cp314, many + musl, ADIOS2 ON.
+          # (Formerly built on Travis-CI, which is retired.)
+          - os: ubuntu-24.04-arm
+            arch: "aarch64"
 
-          # builds faster on Travis-CI:
+          # ppc64le was only ever built on the (now retired) Travis-CI; there is no
+          # free GitHub-hosted ppc64le runner, so these wheels are no longer produced.
           #- os: ubuntu-20.04
           #  arch: "ppc64le"
 
@@ -62,6 +66,17 @@ jobs:
               CMAKE_GENERATOR: "Visual Studio 17 2022"
               CMAKE_GENERATOR_PLATFORM: "Win32"
               ADIOS2: "OFF"   # 32-bit: no 32-bit ADIOS2 CI; BP read segfaults (see i686)
+
+          # Windows ARM64: native GitHub-hosted runner, free for public repos
+          # (cibuildwheel ARM64 support is still experimental). CPython win_arm64
+          # exists only from 3.11+, so no cp310 and no PyPy here. First cut ships
+          # HDF5 + JSON only (ADIOS2 OFF) to avoid an unproven ADIOS2-on-ARM64 build;
+          # library_builders.bat then compiles only zlib + HDF5. See i686/win32.
+          - os: windows-11-arm
+            arch: "ARM64"
+            build: "cp311-* cp312-* cp313-* cp314-*"
+            env:
+              ADIOS2: "OFF"
 
           - os: macos-15-intel
             arch: "x86_64"
@@ -235,8 +250,8 @@ jobs:
         CIBW_TEST_REQUIRES_PYODIDE: numpy
         CIBW_TEST_COMMAND: >
           python {project}/.github/check_wheel_libs.py &&
-          python -c "import sys, openpmd_api as io; v = io.variants;
-          need_adios2 = sys.maxsize > 2**32;
+          python -c "import openpmd_api as io; v = io.variants;
+          need_adios2 = '${{ matrix.env.ADIOS2 || 'ON' }}' == 'ON';
           assert v['hdf5'] and v['json'] and (v['adios2'] or not need_adios2), v;
           print('openPMD', io.__version__, dict(v))" &&
           python {project}/.github/smoke_roundtrip.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,6 @@ jobs:
             env:
               ADIOS2: "OFF"
 
-          # Linux ARM64 (aarch64): native GitHub-hosted runner, free for public
-          # repos (cibuildwheel builds aarch64 natively, no QEMU). Full parity with
-          # the x86_64 leg above: cp310-cp314, many + musl, ADIOS2 ON.
-          # (Formerly built on Travis-CI, which is retired.)
           - os: ubuntu-24.04-arm
             arch: "aarch64"
 
@@ -67,11 +63,6 @@ jobs:
               CMAKE_GENERATOR_PLATFORM: "Win32"
               ADIOS2: "OFF"   # 32-bit: no 32-bit ADIOS2 CI; BP read segfaults (see i686)
 
-          # Windows ARM64: native GitHub-hosted runner, free for public repos
-          # (cibuildwheel ARM64 support is still experimental). CPython win_arm64
-          # exists only from 3.11+, so no cp310 and no PyPy here. First cut ships
-          # HDF5 + JSON only (ADIOS2 OFF) to avoid an unproven ADIOS2-on-ARM64 build;
-          # library_builders.bat then compiles only zlib + HDF5. See i686/win32.
           - os: windows-11-arm
             arch: "ARM64"
             build: "cp311-* cp312-* cp313-* cp314-*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           - os: windows-11-arm
             arch: "ARM64"
             build: "cp311-* cp312-* cp313-* cp314-*"
-            artifact: "ARM64"   # build has '*'/spaces; not a valid artifact name
+            artifact: "WinArm64"
             env:
               ADIOS2: "OFF"
               CMAKE_GENERATOR_PLATFORM: "ARM64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,12 +134,12 @@ install:
   - git clone --branch ${OPENPMD_GIT_REF} --depth 1 https://github.com/openPMD/openPMD-api.git src
   - cp library_builders.sh list_library_deps.py check_wheel_libs.py smoke_roundtrip.py src/.github/
   # Wheels-only re-release: bump the package version (same source).
-  - (cd src && git apply ../setup-py-version-post2.patch)
+  - (cd src && git apply ../setup-py-version-post4.patch)
   # Keep statically-embedded deps (HDF5/ADIOS2/openPMD) private so the wheel can
   # be co-loaded with another extension that also embeds them (ImpactX/WarpX).
   - (cd src && git apply ../python-hide-symbols.patch)
   - python -m pip install --upgrade pip setuptools wheel
-  - python -m pip install cibuildwheel==3.2.1
+  - python -m pip install cibuildwheel==4.1.0
   # twine & cryptography: see
   #   https://github.com/scikit-build/cmake-python-distributions/blob/4730aeee240917303f293dffc89a8d8d5a4787c4/requirements-deploy.txt
   #   https://github.com/pyca/cryptography/issues/6086

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -288,10 +288,20 @@ exit /b 0
 :main
 call :install_buildessentials
 call :build_zlib
-call :build_sqlite
-:: build_bzip2
-:: build_szip
-call :build_zfp
-call :build_blosc2
 call :build_hdf5
-call :build_adios2
+
+rem ADIOS2 and its exclusive dependencies (SQLite3, ZFP, C-Blosc2) are only built
+rem when openPMD is configured with ADIOS2 (openPMD_CMAKE_openPMD_USE_ADIOS2=ON, set
+rem via CIBW_ENVIRONMENT_WINDOWS and visible here in the before-build step). Targets
+rem that ship HDF5 + JSON only -- Windows ARM64 and win32 (x86) -- skip this whole
+rem chain, which avoids an unproven ADIOS2-on-ARM64 build and trims the required
+rem tooling to curl + PowerShell + CMake. HDF5 depends only on zlib, so it stays
+rem unconditional above.
+if /I "%openPMD_CMAKE_openPMD_USE_ADIOS2%"=="ON" (
+  call :build_sqlite
+  rem build_bzip2
+  rem build_szip
+  call :build_zfp
+  call :build_blosc2
+  call :build_adios2
+)

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -290,13 +290,7 @@ call :install_buildessentials
 call :build_zlib
 call :build_hdf5
 
-rem ADIOS2 and its exclusive dependencies (SQLite3, ZFP, C-Blosc2) are only built
-rem when openPMD is configured with ADIOS2 (openPMD_CMAKE_openPMD_USE_ADIOS2=ON, set
-rem via CIBW_ENVIRONMENT_WINDOWS and visible here in the before-build step). Targets
-rem that ship HDF5 + JSON only -- Windows ARM64 and win32 (x86) -- skip this whole
-rem chain, which avoids an unproven ADIOS2-on-ARM64 build and trims the required
-rem tooling to curl + PowerShell + CMake. HDF5 depends only on zlib, so it stays
-rem unconditional above.
+rem ADIOS2 and its exclusive dependencies
 if /I "%openPMD_CMAKE_openPMD_USE_ADIOS2%"=="ON" (
   call :build_sqlite
   rem build_bzip2

--- a/setup-py-windows-arm64-platform.patch
+++ b/setup-py-windows-arm64-platform.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index e44e942..0000001 100644
+--- a/setup.py
++++ b/setup.py
+@@ -104,8 +104,11 @@
+                     os.path.join(extdir, "openpmd_api")
+                 )
+             ]
+-            if sys.maxsize > 2**32:
+-                cmake_args += ['-A', 'x64']
++            generator_platform = os.environ.get("CMAKE_GENERATOR_PLATFORM")
++            if generator_platform:
++                cmake_args += ['-A', generator_platform]
++            elif sys.maxsize > 2**32:
++                cmake_args += ['-A', 'x64']
+             build_args += ['--', '/m']
+         else:
+             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]


### PR DESCRIPTION
Travis-CI is dead; it was the only builder for Linux aarch64 (and ppc64le) wheels. GitHub now offers free [native ARM runners for public repos](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-git), so move Linux ARM wheel production into build.yml and add Windows ARM64 (new platform).

build.yml:
- Linux aarch64 on ubuntu-24.04-arm: full parity with x86_64 (cp310-cp314, many+musl, ADIOS2 ON), reuses library_builders.sh unchanged (native aarch64 needs no SIMD/cross tweaks; blosc2 auto-selects NEON, HDF5 builds natively).
- Windows ARM64 on windows-11-arm: cp311-cp314 (CPython win_arm64 exists only from 3.11+, no PyPy). First cut ships HDF5 + JSON only (ADIOS2 OFF), like the win32/i686 legs, to avoid an unproven ADIOS2-on-ARM64 build.
- Smoke test: derive the ADIOS2 expectation from matrix.env.ADIOS2 instead of process bitness, so a 64-bit ARM wheel without ADIOS2 passes; also makes the i686/win32 legs explicit.
- Retarget the retired Travis aarch64/ppc64le matrix comments.

library_builders.bat:
- Gate the ADIOS2 dependency chain (SQLite3, ZFP, C-Blosc2, ADIOS2) behind openPMD_CMAKE_openPMD_USE_ADIOS2==ON (visible in the before-build step); keep zlib + HDF5 unconditional. Windows ARM64 builds only zlib + HDF5; AMD64 unchanged (win32 stops building the ADIOS2 stack it already discarded).

.travis.yml:
- Sync to the current post4 patch and cibuildwheel 4.1.0 (kept as reference; Travis no longer runs).