### PR TITLE
Pickle: Consider Series identity when unpickling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,7 @@ if(openPMD_HAVE_PYTHON)
         src/binding/python/ParticleSpecies.cpp
         src/binding/python/PatchRecord.cpp
         src/binding/python/PatchRecordComponent.cpp
+        src/binding/python/Pickle.cpp
         src/binding/python/Record.cpp
         src/binding/python/RecordComponent.cpp
         src/binding/python/MeshRecordComponent.cpp

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -174,8 +174,8 @@ class Iteration
     friend class Container;
     friend class Series;
     friend class internal::AttributableData;
-    template <typename T>
-    friend T &internal::makeOwning(T &self, Series);
+    template <typename T, typename Series_type>
+    friend T &internal::makeOwning(T &self, Series_type);
     friend class Writable;
     friend class StatefulIterator;
     friend class StatefulSnapshotsContainer;

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -40,8 +40,8 @@ class ParticleSpecies
     friend class Container<ParticleSpecies>;
     friend class Container<Record>;
     friend class Iteration;
-    template <typename T>
-    friend T &internal::makeOwning(T &self, Series);
+    template <typename T, typename Series_type>
+    friend T &internal::makeOwning(T &self, Series_type);
     friend class internal::ScientificDefaults;
     friend class Attributable;
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -130,8 +130,8 @@ class RecordComponent
     friend class DynamicMemoryView;
     friend class internal::RecordComponentData;
     friend class MeshRecordComponent;
-    template <typename T>
-    friend T &internal::makeOwning(T &self, Series);
+    template <typename T, typename Series_type>
+    friend T &internal::makeOwning(T &self, Series_type);
     friend class internal::ScientificDefaults;
     friend class Attributable;
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -780,8 +780,6 @@ public:
 
     void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
-    [[nodiscard]] uintptr_t memoryID() const;
-
     /**
      * This overrides Attributable::iterationFlush() which will fail on Series.
      */

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -294,6 +294,8 @@ class Series : public Attributable
     friend class internal::SeriesData;
     friend class internal::AttributableData;
     friend class StatefulSnapshotsContainer;
+    template <typename T, typename Series_type>
+    friend T &internal::makeOwning(T &self, Series_type);
 
 public:
     explicit Series();
@@ -805,6 +807,11 @@ OPENPMD_private
 
     using Data_t = internal::SeriesData;
     std::shared_ptr<Data_t> m_series = nullptr;
+
+    inline std::shared_ptr<Data_t> getShared()
+    {
+        return m_series;
+    }
 
     inline Data_t &get()
     {

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -780,6 +780,8 @@ public:
 
     void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
+    [[nodiscard]] uintptr_t memoryID() const;
+
     /**
      * This overrides Attributable::iterationFlush() which will fail on Series.
      */

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -778,6 +778,8 @@ public:
      */
     void close();
 
+    [[nodiscard]] bool closed() const;
+
     void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
     /**

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -457,6 +457,11 @@ public:
 
     [[nodiscard]] OpenpmdStandard openPMDStandard() const;
 
+    /** Returns the persistent immutable memory ID of the underlying Series.
+     *
+     * Useful when trying to determine which API handles refer to the same IO
+     * instance.
+     */
     [[nodiscard]] uintptr_t memoryID() const;
 
     // clang-format off

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -249,6 +249,7 @@ class Attributable
     friend struct internal::HomogenizeExtents;
     friend struct internal::ConfigAttribute;
     friend class internal::ScientificDefaults;
+    friend void cheatcode(void *);
 
 protected:
     // tag for internal constructor

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -249,7 +249,6 @@ class Attributable
     friend struct internal::HomogenizeExtents;
     friend struct internal::ConfigAttribute;
     friend class internal::ScientificDefaults;
-    friend void cheatcode(void *);
 
 protected:
     // tag for internal constructor
@@ -457,6 +456,8 @@ public:
     void populateMissingMetadata(bool recursive);
 
     [[nodiscard]] OpenpmdStandard openPMDStandard() const;
+
+    [[nodiscard]] uintptr_t memoryID() const;
 
     // clang-format off
 OPENPMD_protected

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -207,8 +207,8 @@ namespace internal
      * Instantiations for T exist for types RecordComponent,
      * MeshRecordComponent, Mesh, Record, ParticleSpecies, Iteration.
      */
-    template <typename T>
-    T &makeOwning(T &self, Series);
+    template <typename T, typename Series_type>
+    T &makeOwning(T &self, Series_type);
 } // namespace internal
 
 namespace debug
@@ -241,8 +241,8 @@ class Attributable
     friend class Writable;
     friend class internal::RecordComponentData;
     friend void debug::printDirty(Series const &);
-    template <typename T>
-    friend T &internal::makeOwning(T &self, Series);
+    template <typename T, typename Series_type>
+    friend T &internal::makeOwning(T &self, Series_type);
     friend class StatefulSnapshotsContainer;
     friend class internal::AttributableData;
     friend class Snapshots;

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -199,8 +199,8 @@ private:
     friend class internal::BaseRecordData;
     template <typename, typename, typename>
     friend class internal::ScalarIterator;
-    template <typename T>
-    friend T &internal::makeOwning(T &self, Series);
+    template <typename T, typename Series_type>
+    friend T &internal::makeOwning(T &self, Series_type);
     friend class internal::ScientificDefaults;
 
     using Data_t =

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -51,7 +51,9 @@ namespace openPMD
  * For this, the pickle structure contains as first entry the internal
  * (immutable) SharedAttributable pointer address of the `Series` object
  * referenced by any handle. When unpickling, this is used to restore shared
- * handles in accordance with their original reference structure.
+ * handles in accordance with their original reference structure. The pointers
+ * themselves are not restored (this would not be possible), but they are used
+ * as equivalence classes.
  */
 struct unpickled_series
 {

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -29,6 +29,7 @@
 
 #include <cstdint>
 #include <exception>
+#include <memory>
 #include <shared_mutex>
 #include <string>
 #include <sys/types.h>
@@ -39,10 +40,11 @@ namespace openPMD
 {
 struct unpickled_series
 {
-    std::map<uintptr_t, Series> m_series_by_former_id;
+    std::map<uintptr_t, std::weak_ptr<Series>> m_series_by_former_id;
     std::shared_mutex m_mutex;
 
-    auto get(uintptr_t id, std::string const &filename) -> Series &;
+    auto get(uintptr_t id, std::string const &filename)
+        -> std::shared_ptr<Series>;
 };
 
 /*
@@ -64,7 +66,7 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
 {
     // helper: get first class in py::class_ - that's the type we pickle
     using PickledClass =
-        typename std::tuple_element<0, std::tuple<T_Args...> >::type;
+        typename std::tuple_element<0, std::tuple<T_Args...>>::type;
 
     cl.def(
         py::pickle(
@@ -86,10 +88,10 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
                 auto id = t[0].cast<uintptr_t>();
                 std::string const filename = t[1].cast<std::string>();
                 std::vector<std::string> const group =
-                    t[2].cast<std::vector<std::string> >();
+                    t[2].cast<std::vector<std::string>>();
 
-                auto &series = cache.get(id, filename);
-                return seriesAccessor(series, group);
+                auto series = cache.get(id, filename);
+                return seriesAccessor(std::move(series), group);
             }));
 }
 } // namespace openPMD

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -75,6 +75,24 @@ struct unpickled_series
         }
         {
             std::unique_lock lock(m_mutex);
+
+            // use the chance to do some cleanup
+            std::deque<decltype(m_series_by_former_id)::iterator> delete_me;
+            for (auto it = m_series_by_former_id.begin();
+                 it != m_series_by_former_id.end();
+                 ++it)
+            {
+                if (it->second.closed())
+                {
+                    delete_me.push_back(it);
+                }
+            }
+            for (auto it : delete_me)
+            {
+                // References and iterators to the erased elements are
+                // invalidated. Other references and iterators are not affected.
+                m_series_by_former_id.erase(it);
+            }
             auto &res =
                 (m_series_by_former_id[id] = Series(
                      filename,

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -42,65 +42,7 @@ struct unpickled_series
     std::map<uintptr_t, Series> m_series_by_former_id;
     std::shared_mutex m_mutex;
 
-    auto get(uintptr_t id, std::string const &filename) -> Series &
-    {
-        {
-            std::shared_lock lock(m_mutex);
-            auto it = m_series_by_former_id.find(id);
-            if (it != m_series_by_former_id.end())
-            {
-                auto &candidate = it->second;
-                bool re_initialize = [&]() {
-                    try
-                    {
-                        return !candidate.operator bool() ||
-                            auxiliary::replace_all(
-                                candidate.myPath().filePath(), "\\", "/") !=
-                            auxiliary::replace_all(filename, "\\", "/");
-                    }
-                    /*
-                     * Better safe than sorry, if anything goes wrong because
-                     * the Series is in a weird state, just reinitialize it.
-                     */
-                    catch (...)
-                    {
-                        return true;
-                    }
-                }();
-                if (!re_initialize)
-                {
-                    return it->second;
-                }
-            }
-        }
-        {
-            std::unique_lock lock(m_mutex);
-
-            // use the chance to do some cleanup
-            std::deque<decltype(m_series_by_former_id)::iterator> delete_me;
-            for (auto it = m_series_by_former_id.begin();
-                 it != m_series_by_former_id.end();
-                 ++it)
-            {
-                if (it->second.closed())
-                {
-                    delete_me.push_back(it);
-                }
-            }
-            for (auto it : delete_me)
-            {
-                // References and iterators to the erased elements are
-                // invalidated. Other references and iterators are not affected.
-                m_series_by_former_id.erase(it);
-            }
-            auto &res =
-                (m_series_by_former_id[id] = Series(
-                     filename,
-                     Access::READ_ONLY,
-                     "defer_iteration_parsing = true"));
-            return res;
-        }
-    }
+    auto get(uintptr_t id, std::string const &filename) -> Series &;
 };
 
 /*

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -128,7 +128,7 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
             // __setstate__
             [&seriesAccessor](py::tuple const &t) {
                 // our tuple has exactly two elements: filePath & group
-                if (t.size() != 2)
+                if (t.size() != 3)
                     throw std::runtime_error("Invalid state!");
 
                 auto id = t[0].cast<uintptr_t>();

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -37,21 +37,10 @@
 
 namespace openPMD
 {
-
-struct bundle_args
-{
-    Attributable const *attr;
-    Series *s;
-};
-inline void cheatcode(void *s_)
-{
-    bundle_args *s = static_cast<bundle_args *>(s_);
-    *s->s = s->attr->retrieveSeries();
-}
 struct unpickled_series
 {
     std::map<uintptr_t, Series> m_series_by_former_id;
-    mutable std::shared_mutex m_mutex;
+    std::shared_mutex m_mutex;
 
     auto get(uintptr_t id, std::string const &filename) -> Series &
     {
@@ -95,6 +84,12 @@ struct unpickled_series
         }
     }
 };
+
+/*
+ * Cache the Series per thread.
+ */
+extern thread_local unpickled_series cache;
+
 /** Helper to Pickle Attributable Classes
  *
  * @tparam T_Args the types in pybind11::class_ - the first type will be pickled
@@ -118,11 +113,8 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
                 // Return a tuple that fully encodes the state of the object
                 Attributable::MyPath const myPath = a.myPath();
                 // retrieve Series even though retrieveSeries is protected...
-                Series s;
-                bundle_args b{&a, &s};
-                cheatcode(&b);
                 return py::make_tuple(
-                    s.memoryID(), myPath.filePath(), myPath.group);
+                    a.memoryID(), myPath.filePath(), myPath.group);
             },
 
             // __setstate__
@@ -136,12 +128,7 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
                 std::vector<std::string> const group =
                     t[2].cast<std::vector<std::string> >();
 
-                /*
-                 * Cache the Series per thread.
-                 */
-                thread_local unpickled_series cache;
                 auto &series = cache.get(id, filename);
-
                 return seriesAccessor(series, group);
             }));
 }

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -27,13 +27,74 @@
 
 #include "Common.hpp"
 
+#include <cstdint>
 #include <exception>
+#include <shared_mutex>
 #include <string>
+#include <sys/types.h>
 #include <tuple>
 #include <vector>
 
 namespace openPMD
 {
+
+struct bundle_args
+{
+    Attributable const *attr;
+    Series *s;
+};
+inline void cheatcode(void *s_)
+{
+    bundle_args *s = static_cast<bundle_args *>(s_);
+    *s->s = s->attr->retrieveSeries();
+}
+struct unpickled_series
+{
+    std::map<uintptr_t, Series> m_series_by_former_id;
+    mutable std::shared_mutex m_mutex;
+
+    auto get(uintptr_t id, std::string const &filename) -> Series &
+    {
+        {
+            std::shared_lock lock(m_mutex);
+            auto it = m_series_by_former_id.find(id);
+            if (it != m_series_by_former_id.end())
+            {
+                auto &candidate = it->second;
+                bool re_initialize = [&]() {
+                    try
+                    {
+                        return !candidate.operator bool() ||
+                            auxiliary::replace_all(
+                                candidate.myPath().filePath(), "\\", "/") !=
+                            auxiliary::replace_all(filename, "\\", "/");
+                    }
+                    /*
+                     * Better safe than sorry, if anything goes wrong because
+                     * the Series is in a weird state, just reinitialize it.
+                     */
+                    catch (...)
+                    {
+                        return true;
+                    }
+                }();
+                if (!re_initialize)
+                {
+                    return it->second;
+                }
+            }
+        }
+        {
+            std::unique_lock lock(m_mutex);
+            auto &res =
+                (m_series_by_former_id[id] = Series(
+                     filename,
+                     Access::READ_ONLY,
+                     "defer_iteration_parsing = true"));
+            return res;
+        }
+    }
+};
 /** Helper to Pickle Attributable Classes
  *
  * @tparam T_Args the types in pybind11::class_ - the first type will be pickled
@@ -56,7 +117,12 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
             [](const PickledClass &a) {
                 // Return a tuple that fully encodes the state of the object
                 Attributable::MyPath const myPath = a.myPath();
-                return py::make_tuple(myPath.filePath(), myPath.group);
+                // retrieve Series even though retrieveSeries is protected...
+                Series s;
+                bundle_args b{&a, &s};
+                cheatcode(&b);
+                return py::make_tuple(
+                    s.memoryID(), myPath.filePath(), myPath.group);
             },
 
             // __setstate__
@@ -65,45 +131,18 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
                 if (t.size() != 2)
                     throw std::runtime_error("Invalid state!");
 
-                std::string const filename = t[0].cast<std::string>();
+                auto id = t[0].cast<uintptr_t>();
+                std::string const filename = t[1].cast<std::string>();
                 std::vector<std::string> const group =
-                    t[1].cast<std::vector<std::string> >();
+                    t[2].cast<std::vector<std::string> >();
 
                 /*
                  * Cache the Series per thread.
                  */
-                thread_local std::optional<openPMD::Series> series;
-                bool re_initialize = [&]() {
-                    try
-                    {
-                        return !series.has_value() ||
-                            !series->operator bool() ||
-                            auxiliary::replace_all(
-                                series->myPath().filePath(), "\\", "/") !=
-                            auxiliary::replace_all(filename, "\\", "/");
-                    }
-                    /*
-                     * Better safe than sorry, if anything goes wrong because
-                     * the Series is in a weird state, just reinitialize it.
-                     */
-                    catch (...)
-                    {
-                        return true;
-                    }
-                }();
-                if (re_initialize)
-                {
-                    /*
-                     * Do NOT close the old Series, it might still be active in
-                     * terms of handed-out handles.
-                     */
-                    series = std::make_optional<Series>(
-                        filename,
-                        Access::READ_ONLY,
-                        "defer_iteration_parsing = true");
-                }
+                thread_local unpickled_series cache;
+                auto &series = cache.get(id, filename);
 
-                return seriesAccessor(*series, group);
+                return seriesAccessor(series, group);
             }));
 }
 } // namespace openPMD

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -48,7 +48,7 @@ struct unpickled_series
 /*
  * Cache the Series per thread.
  */
-extern thread_local unpickled_series cache;
+extern unpickled_series cache;
 
 /** Helper to Pickle Attributable Classes
  *

--- a/include/openPMD/binding/python/Pickle.hpp
+++ b/include/openPMD/binding/python/Pickle.hpp
@@ -38,8 +38,30 @@
 
 namespace openPMD
 {
+/*
+ * unpickled_series, as in "plural series"; this is a cache structure for series
+ * objects that have been unpickled. This cache structure fixes the issue
+ * described in https://github.com/openPMD/openPMD-api/issues/1919.
+ * Idea: One single Series instance may have multiple handles referencing it.
+ * When pickling and unpickling these references, the underlying Series must be
+ * restored once only, in order to keep the reference structure. Otherwise
+ * something like `data = E_x[:]; series.flush();` will not work, because `E_x`
+ * no longer references the same Series instance as `series`.
+ *
+ * For this, the pickle structure contains as first entry the internal
+ * (immutable) SharedAttributable pointer address of the `Series` object
+ * referenced by any handle. When unpickling, this is used to restore shared
+ * handles in accordance with their original reference structure.
+ */
 struct unpickled_series
 {
+    // Cache restored object by original Series ID (i.e. internal immutable
+    // pointer address). IDs are not restored equivalently, but this does not
+    // matter. They are necessary only for figuring out which handles point to
+    // the same objects.
+    // The cached Series objects are stored as weak_ptr, since they are memory
+    // managed by the Python side. The C++ side just needs to check if the
+    // weak_ptr is still valid when handing out a new reference. If not, reopen.
     std::map<uintptr_t, std::weak_ptr<Series>> m_series_by_former_id;
     std::shared_mutex m_mutex;
 
@@ -81,7 +103,10 @@ add_pickle(pybind11::class_<T_Args...> &cl, T_SeriesAccessor &&seriesAccessor)
 
             // __setstate__
             [&seriesAccessor](py::tuple const &t) {
-                // our tuple has exactly two elements: filePath & group
+                // Our tuple has exactly three elements: Series ID, filePath &
+                // group.
+                //  Check the documentation of unpickled_series above for
+                // the reasoning behind Series ID.
                 if (t.size() != 3)
                     throw std::runtime_error("Invalid state!");
 

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3564,6 +3564,20 @@ void Series::close()
     m_attri.reset();
 }
 
+bool Series::closed() const
+{
+    if (!operator bool())
+    {
+        return true;
+    }
+    auto &w = writable();
+    if (!w.IOHandler)
+    {
+        throw error::Internal("Series went into illegal state");
+    }
+    return !w.IOHandler->has_value();
+}
+
 void Series::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
     if (recursive)

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3573,6 +3573,11 @@ void Series::visitHierarchy(HierarchyVisitor &v, bool recursive)
     v(*this);
 }
 
+uintptr_t Series::memoryID() const
+{
+    return reinterpret_cast<uintptr_t>(&Attributable::get());
+}
+
 auto Series::currentSnapshot() -> std::optional<std::vector<IterationIndex_t>>
 {
     using vec_t = std::vector<IterationIndex_t>;

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3573,11 +3573,6 @@ void Series::visitHierarchy(HierarchyVisitor &v, bool recursive)
     v(*this);
 }
 
-uintptr_t Series::memoryID() const
-{
-    return reinterpret_cast<uintptr_t>(&Attributable::get());
-}
-
 auto Series::currentSnapshot() -> std::optional<std::vector<IterationIndex_t>>
 {
     using vec_t = std::vector<IterationIndex_t>;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -343,6 +343,11 @@ OpenpmdStandard Attributable::openPMDStandard() const
     return IOHandler()->m_standard;
 }
 
+uintptr_t Attributable::memoryID() const
+{
+    return reinterpret_cast<uintptr_t>(&retrieveSeries().Attributable::get());
+}
+
 template <bool flush_entire_series>
 void Attributable::seriesFlush_impl(internal::FlushParams const &flushParams)
 {

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -630,8 +630,8 @@ void Attributable::linkHierarchy(Writable &w)
 
 namespace internal
 {
-    template <typename T>
-    T &makeOwning(T &self, Series s)
+    template <typename T, typename Series_type>
+    T &makeOwning(T &self, Series_type s)
     {
         /*
          * `self` is a handle object such as RecordComponent or Mesh (see
@@ -670,11 +670,15 @@ namespace internal
         return self;
     }
 
-    template RecordComponent &makeOwning(RecordComponent &, Series);
-    template MeshRecordComponent &makeOwning(MeshRecordComponent &, Series);
-    template Mesh &makeOwning(Mesh &, Series);
-    template Record &makeOwning(Record &, Series);
-    template ParticleSpecies &makeOwning(ParticleSpecies &, Series);
-    template Iteration &makeOwning(Iteration &, Series);
+    template Series &makeOwning(Series &, std::shared_ptr<Series>);
+    template RecordComponent &
+    makeOwning(RecordComponent &, std::shared_ptr<Series>);
+    template MeshRecordComponent &
+    makeOwning(MeshRecordComponent &, std::shared_ptr<Series>);
+    template Mesh &makeOwning(Mesh &, std::shared_ptr<Series>);
+    template Record &makeOwning(Record &, std::shared_ptr<Series>);
+    template ParticleSpecies &
+    makeOwning(ParticleSpecies &, std::shared_ptr<Series>);
+    template Iteration &makeOwning(Iteration &, std::shared_ptr<Series>);
 } // namespace internal
 } // namespace openPMD

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -658,7 +658,7 @@ void init_Attributable(py::module &m)
             "populate_missing_metadata",
             &Attributable::populateMissingMetadata,
             py::arg("recursive"))
-        .def("memory_id", [](Attributable const &attr) {
+        .def_property_readonly("memory_id", [](Attributable const &attr) {
             return attr.memoryID();
         });
 

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -657,7 +657,10 @@ void init_Attributable(py::module &m)
         .def(
             "populate_missing_metadata",
             &Attributable::populateMissingMetadata,
-            py::arg("recursive"));
+            py::arg("recursive"))
+        .def("memory_id", [](Attributable const &attr) {
+            return attr.memoryID();
+        });
 
     py::bind_vector<PyAttributeKeys>(m, "Attribute_Keys");
 }

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -117,9 +117,11 @@ void init_Iteration(py::module &m)
                 py::keep_alive<0, 1>()));
 
     add_pickle(
-        cl, [](openPMD::Series series, std::vector<std::string> const &group) {
+        cl,
+        [](std::shared_ptr<openPMD::Series> series,
+           std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto res = series.iterations[n_it];
+            auto res = series->iterations[n_it];
             return internal::makeOwning(res, std::move(series));
         });
 

--- a/src/binding/python/Mesh.cpp
+++ b/src/binding/python/Mesh.cpp
@@ -196,9 +196,11 @@ Ref.: https://github.com/openPMD/openPMD-standard/pull/193)"[1])
             "set_grid_unit_SI",
             py::overload_cast<double>(&Mesh::setGridUnitSI));
     add_pickle(
-        cl, [](openPMD::Series series, std::vector<std::string> const &group) {
+        cl,
+        [](std::shared_ptr<openPMD::Series> series,
+           std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto res = series.iterations[n_it].open().meshes[group.at(3)];
+            auto res = series->iterations[n_it].open().meshes[group.at(3)];
             return internal::makeOwning(res, std::move(series));
         });
 

--- a/src/binding/python/MeshRecordComponent.cpp
+++ b/src/binding/python/MeshRecordComponent.cpp
@@ -82,10 +82,12 @@ void init_MeshRecordComponent(py::module &m)
             "Relative position of the component on an element "
             "(node/cell/voxel) of the mesh");
     add_pickle(
-        cl, [](openPMD::Series series, std::vector<std::string> const &group) {
+        cl,
+        [](std::shared_ptr<openPMD::Series> series,
+           std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
             auto res =
-                series.iterations[n_it]
+                series->iterations[n_it]
                     .open()
                     .meshes[group.at(3)]
                            [group.size() < 5 ? MeshRecordComponent::SCALAR

--- a/src/binding/python/ParticleSpecies.cpp
+++ b/src/binding/python/ParticleSpecies.cpp
@@ -56,10 +56,12 @@ void init_ParticleSpecies(py::module &m)
                 // garbage collection: return value must be freed before Series
                 py::keep_alive<0, 1>()));
     add_pickle(
-        cl, [](openPMD::Series series, std::vector<std::string> const &group) {
+        cl,
+        [](std::shared_ptr<openPMD::Series> series,
+           std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
             ParticleSpecies res =
-                series.iterations[n_it].open().particles[group.at(3)];
+                series->iterations[n_it].open().particles[group.at(3)];
             return internal::makeOwning(res, std::move(series));
         });
 

--- a/src/binding/python/Pickle.cpp
+++ b/src/binding/python/Pickle.cpp
@@ -25,4 +25,65 @@
 namespace openPMD
 {
 thread_local unpickled_series cache;
+
+auto unpickled_series::get(uintptr_t id, std::string const &filename)
+    -> Series &
+{
+    {
+        std::shared_lock lock(m_mutex);
+        auto it = m_series_by_former_id.find(id);
+        if (it != m_series_by_former_id.end())
+        {
+            auto &candidate = it->second;
+            bool re_initialize = [&]() {
+                try
+                {
+                    return !candidate.operator bool() ||
+                        auxiliary::replace_all(
+                            candidate.myPath().filePath(), "\\", "/") !=
+                        auxiliary::replace_all(filename, "\\", "/");
+                }
+                /*
+                 * Better safe than sorry, if anything goes wrong because
+                 * the Series is in a weird state, just reinitialize it.
+                 */
+                catch (...)
+                {
+                    return true;
+                }
+            }();
+            if (!re_initialize)
+            {
+                return it->second;
+            }
+        }
+    }
+    {
+        std::unique_lock lock(m_mutex);
+
+        // use the chance to do some cleanup
+        std::deque<decltype(m_series_by_former_id)::iterator> delete_me;
+        for (auto it = m_series_by_former_id.begin();
+             it != m_series_by_former_id.end();
+             ++it)
+        {
+            if (it->second.closed())
+            {
+                delete_me.push_back(it);
+            }
+        }
+        for (auto it : delete_me)
+        {
+            // References and iterators to the erased elements are
+            // invalidated. Other references and iterators are not affected.
+            m_series_by_former_id.erase(it);
+        }
+        auto &res =
+            (m_series_by_former_id[id] = Series(
+                 filename,
+                 Access::READ_ONLY,
+                 "defer_iteration_parsing = true"));
+        return res;
+    }
 }
+} // namespace openPMD

--- a/src/binding/python/Pickle.cpp
+++ b/src/binding/python/Pickle.cpp
@@ -22,42 +22,64 @@
 #include "openPMD/binding/python/Pickle.hpp"
 #include "openPMD/binding/python/Common.hpp"
 
+#include <optional>
+
 namespace openPMD
 {
 unpickled_series cache;
 
 auto unpickled_series::get(uintptr_t id, std::string const &filename)
-    -> Series &
+    -> std::shared_ptr<Series>
 {
-    {
+    auto check_for_cached_series =
+        [&]() -> std::optional<std::shared_ptr<Series>> {
         std::shared_lock lock(m_mutex);
         auto it = m_series_by_former_id.find(id);
-        if (it != m_series_by_former_id.end())
+        if (it == m_series_by_former_id.end())
         {
-            auto &candidate = it->second;
-            bool re_initialize = [&]() {
-                try
-                {
-                    return !candidate.operator bool() ||
-                        auxiliary::replace_all(
-                            candidate.myPath().filePath(), "\\", "/") !=
-                        auxiliary::replace_all(filename, "\\", "/");
-                }
-                /*
-                 * Better safe than sorry, if anything goes wrong because
-                 * the Series is in a weird state, just reinitialize it.
-                 */
-                catch (...)
-                {
-                    return true;
-                }
-            }();
-            if (!re_initialize)
-            {
-                return it->second;
-            }
+            return std::nullopt;
         }
+
+        auto candidate = it->second.lock();
+        if (!candidate)
+        {
+            return std::nullopt;
+        }
+
+        if (!candidate->operator bool())
+        {
+            return std::nullopt;
+        }
+
+        if (auxiliary::replace_all(candidate->myPath().filePath(), "\\", "/") !=
+            auxiliary::replace_all(filename, "\\", "/"))
+        {
+            return std::nullopt;
+        }
+
+        return candidate;
+    };
+    auto maybe_series = [&]() -> std::optional<std::shared_ptr<Series>> {
+        try
+        {
+            return check_for_cached_series();
+        }
+        catch (...)
+        {
+            /*
+             * Better safe than sorry, if anything goes wrong because
+             * the Series is in a weird state, just reinitialize it.
+             */
+            return std::nullopt;
+        }
+    }();
+
+    if (maybe_series)
+    {
+        return std::move(*maybe_series);
     }
+
+    // else reinitialize
     {
         std::unique_lock lock(m_mutex);
 
@@ -67,22 +89,30 @@ auto unpickled_series::get(uintptr_t id, std::string const &filename)
              it != m_series_by_former_id.end();
              ++it)
         {
-            if (it->second.closed())
+            if (auto locked = it->second.lock(); !locked || locked->closed())
             {
                 delete_me.push_back(it);
             }
         }
+
         for (auto it : delete_me)
         {
             // References and iterators to the erased elements are
             // invalidated. Other references and iterators are not affected.
             m_series_by_former_id.erase(it);
         }
-        auto &res =
-            (m_series_by_former_id[id] = Series(
-                 filename,
-                 Access::READ_ONLY,
-                 "defer_iteration_parsing = true"));
+
+        auto res = std::shared_ptr<Series>{
+            new Series(
+                filename, Access::READ_ONLY, "defer_iteration_parsing = true"),
+            [this, id](Series const *s) {
+                {
+                    std::unique_lock lock_lambda(this->m_mutex);
+                    this->m_series_by_former_id.erase(id);
+                }
+                delete s;
+            }};
+        m_series_by_former_id[id] = res;
         return res;
     }
 }

--- a/src/binding/python/Pickle.cpp
+++ b/src/binding/python/Pickle.cpp
@@ -31,6 +31,8 @@ unpickled_series cache;
 auto unpickled_series::get(uintptr_t id, std::string const &filename)
     -> std::shared_ptr<Series>
 {
+    // Check if a Series object with the given id is already in cache, still
+    // valid and points to the specified filename.
     auto check_for_cached_series =
         [&]() -> std::optional<std::shared_ptr<Series>> {
         std::shared_lock lock(m_mutex);
@@ -59,6 +61,8 @@ auto unpickled_series::get(uintptr_t id, std::string const &filename)
 
         return candidate;
     };
+    // There is a chance that the cached Series state is weird from previous
+    // usage, so catch any error and reinitialize in doubt.
     auto maybe_series = [&]() -> std::optional<std::shared_ptr<Series>> {
         try
         {
@@ -79,7 +83,7 @@ auto unpickled_series::get(uintptr_t id, std::string const &filename)
         return std::move(*maybe_series);
     }
 
-    // else reinitialize
+    // Else reinitialize.
     {
         std::unique_lock lock(m_mutex);
 

--- a/src/binding/python/Pickle.cpp
+++ b/src/binding/python/Pickle.cpp
@@ -48,7 +48,7 @@ auto unpickled_series::get(uintptr_t id, std::string const &filename)
             return std::nullopt;
         }
 
-        if (!candidate->operator bool())
+        if (candidate->closed())
         {
             return std::nullopt;
         }

--- a/src/binding/python/Pickle.cpp
+++ b/src/binding/python/Pickle.cpp
@@ -24,7 +24,7 @@
 
 namespace openPMD
 {
-thread_local unpickled_series cache;
+unpickled_series cache;
 
 auto unpickled_series::get(uintptr_t id, std::string const &filename)
     -> Series &

--- a/src/binding/python/Pickle.cpp
+++ b/src/binding/python/Pickle.cpp
@@ -1,0 +1,28 @@
+/* Copyright 2026 Franz Poeschel *
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openPMD/binding/python/Pickle.hpp"
+#include "openPMD/binding/python/Common.hpp"
+
+namespace openPMD
+{
+thread_local unpickled_series cache;
+}

--- a/src/binding/python/Record.cpp
+++ b/src/binding/python/Record.cpp
@@ -85,10 +85,12 @@ void init_Record(py::module &m)
         .def("set_time_offset", &Record::setTimeOffset<double>)
         .def("set_time_offset", &Record::setTimeOffset<long double>);
     add_pickle(
-        cl, [](openPMD::Series series, std::vector<std::string> const &group) {
+        cl,
+        [](std::shared_ptr<openPMD::Series> series,
+           std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto res = series.iterations[n_it].open().particles[group.at(3)]
-                                                               [group.at(4)];
+            auto res = series->iterations[n_it].open().particles[group.at(3)]
+                                                                [group.at(4)];
             return internal::makeOwning(res, std::move(series));
         });
 

--- a/src/binding/python/RecordComponent.cpp
+++ b/src/binding/python/RecordComponent.cpp
@@ -1159,9 +1159,11 @@ void init_RecordComponent(py::module &m)
         .def("set_unit_SI", &RecordComponent::setUnitSI) // deprecated
         ;
     add_pickle(
-        cl, [](openPMD::Series series, std::vector<std::string> const &group) {
+        cl,
+        [](std::shared_ptr<openPMD::Series> series,
+           std::vector<std::string> const &group) {
             uint64_t const n_it = std::stoull(group.at(1));
-            auto res = series.iterations[n_it]
+            auto res = series->iterations[n_it]
                            .open()
                            .particles[group.at(3)][group.at(4)]
                                      [group.size() < 6 ? RecordComponent::SCALAR

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -568,8 +568,15 @@ Look for the WriteIterations class for further documentation.
             "TODO FILL IN DOCUMENTATION");
 
     add_pickle(
-        cl, [](openPMD::Series series, std::vector<std::string> const &) {
-            return series;
+        cl,
+        [](std::shared_ptr<openPMD::Series> series,
+           std::vector<std::string> const &) {
+            // Need to work on a copy since makeOwning will change the internal
+            // change pointer to capture also the cached Series. For this, the
+            // Series must be a different object than the cached Series,
+            // otherwise the cat will bite its own tail here.
+            Series copy = *series;
+            return openPMD::internal::makeOwning(copy, std::move(series));
         });
 
     constexpr char const *docs_merge_json = &R"END(

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -171,7 +171,10 @@ void char_roundtrip(std::string const &extension)
     ::detail::writeChar<char>(write, "char");
     ::detail::writeChar<unsigned char>(write, "uchar");
     ::detail::writeChar<signed char>(write, "schar");
+    auto copy = write;
     write.close();
+    REQUIRE(copy.closed());
+    REQUIRE(write.closed());
 
     Series read("../samples/char_rountrip." + extension, Access::READ_ONLY);
     ::detail::readChar<char>(read, "char");

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2545,7 +2545,7 @@ class APITest(unittest.TestCase):
         # https://github.com/openPMD/openPMD-api/issues/1919
         # The code is adapted from the reproducer in there.
         try:
-            from multiprocessing import Pool
+            import multiprocessing
         except ImportError:
             return
 
@@ -2561,7 +2561,7 @@ class APITest(unittest.TestCase):
 
         params = [[False, False], [True, True], [True, False]]
         for param in params:
-            with Pool(processes=1) as pool:
+            with multiprocessing.Pool(processes=1) as pool:
                 results = pool.map(reader, param)
             self.assertTrue(np.array_equal(results[0], results[1]))
 

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2540,6 +2540,24 @@ class APITest(unittest.TestCase):
             self.series.flush()
             return dens
 
+    class ReadMomentum:
+        """Helper for multiprocessing pickle test - must be a class to be picklable"""
+
+        def __init__(self, pickled_series):
+            self.pickled_series = pickled_series
+
+        def __call__(self, use_stored=False) -> np.ndarray:
+            import pickle
+
+            series = pickle.loads(self.pickled_series)
+            it = series.iterations[400]
+            it.open()
+            electrons = it.particles["electrons"]
+            momentum = electrons["momentum"]
+            data = momentum["y"][()]
+            series.flush()
+            return data
+
     def testPickleSeriesIdentity(self):
         # This tests the bug reported in
         # https://github.com/openPMD/openPMD-api/issues/1919
@@ -2564,6 +2582,199 @@ class APITest(unittest.TestCase):
             with multiprocessing.Pool(processes=1) as pool:
                 results = pool.map(reader, param)
             self.assertTrue(np.array_equal(results[0], results[1]))
+
+    def testPickleMultipleSeriesMultipleReferences(self):
+        # Test that the unpickle cache correctly handles multiple Series objects,
+        # each with multiple handles referencing it.
+        # Tests both GC-based cleanup and explicit Series.close() cleanup.
+        try:
+            import pickle
+            import multiprocessing
+        except ImportError:
+            return
+
+        try:
+            series1 = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
+            series2 = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
+        except io.ReadError:
+            return
+
+        # Create multiple references to each series
+        # Series 1 references (using particle records with components)
+        s1_it = series1.iterations[400]
+        s1_electrons = s1_it.particles["electrons"]
+        s1_momentum = s1_electrons["momentum"]
+        s1_mom_x = s1_momentum["x"]
+
+        # Series 2 references
+        s2_it = series2.iterations[400]
+        s2_electrons = s2_it.particles["electrons"]
+        s2_momentum = s2_electrons["momentum"]
+        s2_mom_x = s2_momentum["x"]
+
+        # Verify all references work and return same data
+        data_s1_mom = s1_momentum["y"][()]
+        series1.flush()
+        data_s1_mom_x = s1_mom_x[()]
+        series1.flush()
+        data_s2_mom = s2_momentum["y"][()]
+        series2.flush()
+        data_s2_mom_x = s2_mom_x[()]
+        series2.flush()
+
+        np.testing.assert_array_equal(data_s1_mom, data_s2_mom)
+        np.testing.assert_array_equal(data_s1_mom_x, data_s2_mom_x)
+
+        # Pickle all references
+        pickled_s1 = pickle.dumps(series1)
+        pickled_s1_it = pickle.dumps(s1_it)
+        pickled_s1_electrons = pickle.dumps(s1_electrons)
+        pickled_s1_momentum = pickle.dumps(s1_momentum)
+        pickled_s1_mom_x = pickle.dumps(s1_mom_x)
+
+        pickled_s2 = pickle.dumps(series2)
+        pickled_s2_it = pickle.dumps(s2_it)
+        pickled_s2_electrons = pickle.dumps(s2_electrons)
+        pickled_s2_momentum = pickle.dumps(s2_momentum)
+        pickled_s2_mom_x = pickle.dumps(s2_mom_x)
+
+        # Explicitly delete all objects to simulate GC
+        del s1_it, s1_electrons, s1_momentum, s1_mom_x, series1
+        del s2_it, s2_electrons, s2_momentum, s2_mom_x, series2
+
+        # Unpickle - this should restore the cache properly
+        series1 = pickle.loads(pickled_s1)
+        s1_it = pickle.loads(pickled_s1_it)
+        s1_electrons = pickle.loads(pickled_s1_electrons)
+        s1_momentum = pickle.loads(pickled_s1_momentum)
+        s1_mom_x = pickle.loads(pickled_s1_mom_x)
+
+        series2 = pickle.loads(pickled_s2)
+        s2_it = pickle.loads(pickled_s2_it)
+        s2_electrons = pickle.loads(pickled_s2_electrons)
+        s2_momentum = pickle.loads(pickled_s2_momentum)
+        s2_mom_x = pickle.loads(pickled_s2_mom_x)
+
+        # Verify all unpickled references still work correctly
+        data_s1_mom_unpickled = s1_momentum["y"][()]
+        series1.flush()
+        data_s1_mom_x_unpickled = s1_mom_x[()]
+        series1.flush()
+        data_s2_mom_unpickled = s2_momentum["y"][()]
+        series2.flush()
+        data_s2_mom_x_unpickled = s2_mom_x[()]
+        series2.flush()
+
+        np.testing.assert_array_equal(data_s1_mom, data_s1_mom_unpickled)
+        np.testing.assert_array_equal(data_s1_mom_x, data_s1_mom_x_unpickled)
+        np.testing.assert_array_equal(data_s2_mom, data_s2_mom_unpickled)
+        np.testing.assert_array_equal(data_s2_mom_x, data_s2_mom_x_unpickled)
+
+        # Test multiprocessing with multiple series
+        pickled_for_mp1 = pickle.dumps(series1)
+        pickled_for_mp2 = pickle.dumps(series2)
+
+        reader1 = self.ReadMomentum(pickled_for_mp1)
+        reader2 = self.ReadMomentum(pickled_for_mp2)
+
+        params = [
+            [False],
+            [True],
+        ]
+
+        with multiprocessing.Pool(processes=2) as pool:
+            results1 = pool.map(reader1, params)
+            results2 = pool.map(reader2, params)
+
+        # All results should be equal (both series point to same file)
+        for i, (r1, r2) in enumerate(zip(results1, results2)):
+            np.testing.assert_array_equal(r1, r2)
+
+    def testPickleCleanupWithClose(self):
+        # Test that Series.close() triggers cleanup properly
+        # (cleanup happens on next unpickle of a previously not opened Series)
+        try:
+            import pickle
+        except ImportError:
+            return
+
+        try:
+            series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
+        except io.ReadError:
+            return
+
+        # Create multiple references
+        it = series.iterations[400]
+        electrons = it.particles["electrons"]
+        momentum = electrons["momentum"]
+        mom_x = momentum["x"]
+
+        # Pickle everything
+        pickled_series = pickle.dumps(series)
+        pickled_momentum = pickle.dumps(momentum)
+        pickled_mom_x = pickle.dumps(mom_x)
+
+        # Close the series explicitly
+        series.close()
+        del series, it, electrons, momentum, mom_x
+
+        # Unpickle - this should work even after close()
+        series = pickle.loads(pickled_series)
+        momentum = pickle.loads(pickled_momentum)
+        mom_x = pickle.loads(pickled_mom_x)
+
+        # Verify data is still accessible
+        data_momentum = momentum["y"][()]
+        series.flush()
+        data_mom_x = mom_x[()]
+        series.flush()
+
+        # Basic sanity check that we got data
+        self.assertIsNotNone(data_momentum)
+        self.assertIsNotNone(data_mom_x)
+
+    def testPickleCleanupWithGC(self):
+        # Test that Python GC triggers cleanup properly
+        try:
+            import pickle
+            import gc
+        except ImportError:
+            return
+
+        try:
+            series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
+        except io.ReadError:
+            return
+
+        # Create multiple references
+        it = series.iterations[400]
+        electrons = it.particles["electrons"]
+        momentum = electrons["momentum"]
+        mom_x = momentum["x"]
+
+        # Pickle everything
+        pickled_series = pickle.dumps(series)
+        pickled_momentum = pickle.dumps(momentum)
+        pickled_mom_x = pickle.dumps(mom_x)
+
+        # Delete all references and force GC
+        del series, it, electrons, momentum, mom_x
+        gc.collect()
+
+        # Unpickle - this should work after GC
+        series = pickle.loads(pickled_series)
+        momentum = pickle.loads(pickled_momentum)
+        mom_x = pickle.loads(pickled_mom_x)
+
+        # Verify data is still accessible
+        data_momentum = momentum["y"][()]
+        series.flush()
+        data_mom_x = mom_x[()]
+        series.flush()
+
+        # Basic sanity check that we got data
+        self.assertIsNotNone(data_momentum)
+        self.assertIsNotNone(data_mom_x)
 
 
 if __name__ == "__main__":

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2571,10 +2571,7 @@ class APITest(unittest.TestCase):
         if is_pyodide():
             return
 
-        try:
-            import multiprocessing
-        except (ImportError, ModuleNotFoundError):
-            return
+        import multiprocessing
 
         try:
             series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
@@ -2587,13 +2584,10 @@ class APITest(unittest.TestCase):
         )
 
         params = [[False, False], [True, True], [True, False]]
-        try:
-            for param in params:
-                with multiprocessing.Pool(processes=1) as pool:
-                    results = pool.map(reader, param)
-                self.assertTrue(np.array_equal(results[0], results[1]))
-        except (ModuleNotFoundError, OSError):
-            pass
+        for param in params:
+            with multiprocessing.Pool(processes=1) as pool:
+                results = pool.map(reader, param)
+            self.assertTrue(np.array_equal(results[0], results[1]))
 
     def testPickleMultipleSeriesMultipleReferences(self):
         # Test that the unpickle cache correctly handles multiple Series objects,

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2544,7 +2544,10 @@ class APITest(unittest.TestCase):
         # This tests the bug reported in
         # https://github.com/openPMD/openPMD-api/issues/1919
         # The code is adapted from the reproducer in there.
-        from multiprocessing import Pool
+        try:
+            from multiprocessing import Pool
+        except ImportError:
+            return
 
         try:
             series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2523,6 +2523,48 @@ class APITest(unittest.TestCase):
         read.flush()
         np.testing.assert_array_equal(loaded, np.array([50, 20], dtype=np.uint64))
 
+    class ReadMesh:
+        def __init__(self, series):
+            self.mesh_name = "rho"
+            self.series = series
+            self.it = self.series.iterations[400]
+            self.mesh = self.it.meshes[self.mesh_name]
+
+        def __call__(self, use_stored_mesh=False) -> np.ndarray:
+            if use_stored_mesh:
+                dens = self.mesh[:]
+            else:
+                self.series.iterations[400].open()
+                mesh = self.series.iterations[400].meshes[self.mesh_name]
+                dens = mesh[:]
+            self.series.flush()
+            return dens
+
+    def testPickleSeriesIdentity(self):
+        # This tests the bug reported in
+        # https://github.com/openPMD/openPMD-api/issues/1919
+        # The code is adapted from the reproducer in there.
+        try:
+            from tqdm.contrib.concurrent import process_map
+        except ImportError:
+            return
+
+        try:
+            series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
+        except io.ReadError:
+            return
+
+        reader = self.ReadMesh(series)
+        assert np.array_equal(
+            reader(use_stored_mesh=False), reader(use_stored_mesh=True)
+        )
+
+        params = [[False, False], [True, True], [True, False]]
+        for param in params:
+            results = process_map(reader, param, max_workers=1)
+            # print(f"{param} :", np.array_equal(results[0], results[1]))
+            self.assertTrue(np.array_equal(results[0], results[1]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2544,10 +2544,7 @@ class APITest(unittest.TestCase):
         # This tests the bug reported in
         # https://github.com/openPMD/openPMD-api/issues/1919
         # The code is adapted from the reproducer in there.
-        try:
-            from tqdm.contrib.concurrent import process_map
-        except ImportError:
-            return
+        from multiprocessing import Pool
 
         try:
             series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
@@ -2561,8 +2558,8 @@ class APITest(unittest.TestCase):
 
         params = [[False, False], [True, True], [True, False]]
         for param in params:
-            results = process_map(reader, param, max_workers=1)
-            # print(f"{param} :", np.array_equal(results[0], results[1]))
+            with Pool(processes=1) as pool:
+                results = pool.map(reader, param)
             self.assertTrue(np.array_equal(results[0], results[1]))
 
 

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2578,10 +2578,14 @@ class APITest(unittest.TestCase):
         )
 
         params = [[False, False], [True, True], [True, False]]
-        for param in params:
-            with multiprocessing.Pool(processes=1) as pool:
-                results = pool.map(reader, param)
-            self.assertTrue(np.array_equal(results[0], results[1]))
+        try:
+            for param in params:
+                with multiprocessing.Pool(processes=1) as pool:
+                    results = pool.map(reader, param)
+                self.assertTrue(np.array_equal(results[0], results[1]))
+        except ModuleNotFoundError:
+            # happens on pyodide run. ignore.
+            pass
 
     def testPickleMultipleSeriesMultipleReferences(self):
         # Test that the unpickle cache correctly handles multiple Series objects,

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2586,7 +2586,6 @@ class APITest(unittest.TestCase):
     def testPickleMultipleSeriesMultipleReferences(self):
         # Test that the unpickle cache correctly handles multiple Series objects,
         # each with multiple handles referencing it.
-        # Tests both GC-based cleanup and explicit Series.close() cleanup.
         try:
             import pickle
             import multiprocessing
@@ -2649,11 +2648,15 @@ class APITest(unittest.TestCase):
         s1_momentum = pickle.loads(pickled_s1_momentum)
         s1_mom_x = pickle.loads(pickled_s1_mom_x)
 
+        del s1_it, s1_electrons
+
         series2 = pickle.loads(pickled_s2)
         s2_it = pickle.loads(pickled_s2_it)
         s2_electrons = pickle.loads(pickled_s2_electrons)
         s2_momentum = pickle.loads(pickled_s2_momentum)
         s2_mom_x = pickle.loads(pickled_s2_mom_x)
+
+        del s2_it, s2_electrons
 
         # Verify all unpickled references still work correctly
         data_s1_mom_unpickled = s1_momentum["y"][()]
@@ -2690,7 +2693,7 @@ class APITest(unittest.TestCase):
         for i, (r1, r2) in enumerate(zip(results1, results2)):
             np.testing.assert_array_equal(r1, r2)
 
-    def testPickleCleanupWithClose(self):
+    def workerTestPickleCleanup(self, do_close):
         # Test that Series.close() triggers cleanup properly
         # (cleanup happens on next unpickle of a previously not opened Series)
         try:
@@ -2700,6 +2703,7 @@ class APITest(unittest.TestCase):
 
         try:
             series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
+            series_2 = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
         except io.ReadError:
             return
 
@@ -2713,12 +2717,26 @@ class APITest(unittest.TestCase):
         pickled_series = pickle.dumps(series)
         pickled_momentum = pickle.dumps(momentum)
         pickled_mom_x = pickle.dumps(mom_x)
+
+        # Create multiple references
+        it_2 = series.iterations[400]
+        electrons_2 = it.particles["electrons"]
+        momentum_2 = electrons["momentum"]
+        mom_x_2 = momentum["x"]
+
+        # Pickle everything
+        pickled_series_2 = pickle.dumps(series)
+        pickled_momentum_2 = pickle.dumps(momentum)
+        pickled_mom_x_2 = pickle.dumps(mom_x)
 
         # Close the series explicitly
         series.close()
         del series, it, electrons, momentum, mom_x
 
-        # Unpickle - this should work even after close()
+        series_2.close()
+        del series_2, it_2, electrons_2, momentum_2, mom_x_2
+
+        # Unpickle
         series = pickle.loads(pickled_series)
         momentum = pickle.loads(pickled_momentum)
         mom_x = pickle.loads(pickled_mom_x)
@@ -2732,49 +2750,36 @@ class APITest(unittest.TestCase):
         # Basic sanity check that we got data
         self.assertIsNotNone(data_momentum)
         self.assertIsNotNone(data_mom_x)
+
+        # Remove information unpickled so far from cache again, either through API call or through GC
+        if do_close:
+            # print("EXPLICITLY CLOSING")
+            series.close()
+        else:
+            # print("EXPLICITLY DELETING")
+            del series, momentum, mom_x
+        # print("DONE")
+
+        # Unpickle the second Series
+        series_2 = pickle.loads(pickled_series_2)
+        momentum_2 = pickle.loads(pickled_momentum_2)
+        mom_x_2 = pickle.loads(pickled_mom_x_2)
+
+        # Verify data is still accessible
+        data_momentum_2 = momentum_2["y"][()]
+        series_2.flush()
+        data_mom_x_2 = mom_x_2[()]
+        series_2.flush()
+
+        # Basic sanity check that we got data
+        self.assertIsNotNone(data_momentum_2)
+        self.assertIsNotNone(data_mom_x_2)
+
+    def testPickleCleanupWithClose(self):
+        self.workerTestPickleCleanup(do_close=True)
 
     def testPickleCleanupWithGC(self):
-        # Test that Python GC triggers cleanup properly
-        try:
-            import pickle
-            import gc
-        except ImportError:
-            return
-
-        try:
-            series = io.Series("../samples/git-sample/data%T.h5", io.Access.read_only)
-        except io.ReadError:
-            return
-
-        # Create multiple references
-        it = series.iterations[400]
-        electrons = it.particles["electrons"]
-        momentum = electrons["momentum"]
-        mom_x = momentum["x"]
-
-        # Pickle everything
-        pickled_series = pickle.dumps(series)
-        pickled_momentum = pickle.dumps(momentum)
-        pickled_mom_x = pickle.dumps(mom_x)
-
-        # Delete all references and force GC
-        del series, it, electrons, momentum, mom_x
-        gc.collect()
-
-        # Unpickle - this should work after GC
-        series = pickle.loads(pickled_series)
-        momentum = pickle.loads(pickled_momentum)
-        mom_x = pickle.loads(pickled_mom_x)
-
-        # Verify data is still accessible
-        data_momentum = momentum["y"][()]
-        series.flush()
-        data_mom_x = mom_x[()]
-        series.flush()
-
-        # Basic sanity check that we got data
-        self.assertIsNotNone(data_momentum)
-        self.assertIsNotNone(data_mom_x)
+        self.workerTestPickleCleanup(do_close=False)
 
 
 if __name__ == "__main__":

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -10,6 +10,7 @@ import ctypes
 import gc
 import os
 import shutil
+import sys
 import unittest
 
 import openpmd_api as io
@@ -32,6 +33,11 @@ tested_file_extensions = [
     # so it doesn't require full testing
     if ext != "sst" and ext != "ssc" and ext != "toml"
 ]
+
+
+def is_pyodide():
+    """Check if we're running in Pyodide (WASM) environment."""
+    return "pyodide" in sys.modules
 
 
 class APITest(unittest.TestCase):
@@ -2562,6 +2568,9 @@ class APITest(unittest.TestCase):
         # This tests the bug reported in
         # https://github.com/openPMD/openPMD-api/issues/1919
         # The code is adapted from the reproducer in there.
+        if is_pyodide():
+            return
+
         try:
             import multiprocessing
         except (ImportError, ModuleNotFoundError):
@@ -2583,13 +2592,15 @@ class APITest(unittest.TestCase):
                 with multiprocessing.Pool(processes=1) as pool:
                     results = pool.map(reader, param)
                 self.assertTrue(np.array_equal(results[0], results[1]))
-        except ModuleNotFoundError:
-            # happens on pyodide run. ignore.
+        except (ModuleNotFoundError, OSError):
             pass
 
     def testPickleMultipleSeriesMultipleReferences(self):
         # Test that the unpickle cache correctly handles multiple Series objects,
         # each with multiple handles referencing it.
+        if is_pyodide():
+            return
+
         try:
             import pickle
             import multiprocessing

--- a/test/python/unittest/API/APITest.py
+++ b/test/python/unittest/API/APITest.py
@@ -2564,7 +2564,7 @@ class APITest(unittest.TestCase):
         # The code is adapted from the reproducer in there.
         try:
             import multiprocessing
-        except ImportError:
+        except (ImportError, ModuleNotFoundError):
             return
 
         try:


### PR DESCRIPTION
This tries fixing the bug reported in #1919 by @pordyna by storing and reading additionally the immutable internal Series memory location. If the location of an unpickled Series is identical to the memory location of a previously unpickled Series, then that Series is reused.

Notes:

* ~~The cache of unpickled Series objects is still `thread_local` at the moment. This keeps thread safety at the cost of restricting this bugfix to uses in the same thread.~~
    **Suggestion:** When unpickling from the same `Series` object, users should expect to share the same internal data references. So it might be fine to use a per-process cache instead of a per-thread cache.
* ~~The cache is never emptied, so this can be a memory leak.~~ We *could* maybe add a scan operation that erases closed `Series` objects from the cache?
* Since our pickling strategy is relatively basic, we will probably keep running into issues like this, as use cases get more complex.

- [x] tqdm as test dependency
- [x] check if we can automatically manage memory, this currently relies on `Series::close()`
- [x] we can ditch the make_owning logic with this
- [x] More testing?
- [ ] This fix is a bit too experimental for a bugfix release. For an eventual bugfix release, we could move the `thread_local Series` cache variable from (template) function scope to global scope. This would not fix the entire problem, but it would be a fix for use cases that only use one `Series`.