### PR TITLE
`setup.py`: Find Free-Threaded Python (`Python_FIND_ABI`)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,10 @@ class CMakeBuild(build_ext):
                 "-DPython_FIND_VERSION_EXACT=" + ("FALSE" if emscripten else "TRUE"),
                 "-DPython_FIND_STRATEGY=LOCATION",
             ]
+            # Free-threaded (PEP 703) gil_disabled is OFF by default
+            #   https://cmake.org/cmake/help/latest/module/FindPython.html#variable:Python_FIND_ABI
+            if sysconfig.get_config_var("Py_GIL_DISABLED"):
+                cmake_args.append("-DPython_FIND_ABI=OFF;OFF;OFF;ON")
         if emscripten:
             cmake_args += [
                 "-DPython_INCLUDE_DIR=" + sysconfig.get_config_var("INCLUDEPY")


### PR DESCRIPTION
Disabled by default, but our cibuildwheels includes builds for it now
https://github.com/BLAST-ImpactX/impactx-wheels/pull/27
https://cmake.org/cmake/help/latest/module/FindPython.html#variable:Python_FIND_ABI

🤖 Generated with [Claude Code](https://claude.com/claude-code)