### PR TITLE
Defer API: Fix missing `do_run_this` flag initializations

### DIFF
--- a/include/openPMD/auxiliary/Defer.hpp
+++ b/include/openPMD/auxiliary/Defer.hpp
@@ -21,7 +21,8 @@ struct defer_type
         std::move(functor)();
     }
 
-    explicit defer_type() = default;
+    explicit defer_type() : do_run_this(false)
+    {}
 
     struct forwarding_tag
     {};
@@ -32,7 +33,8 @@ struct defer_type
     {}
 
     template <typename F_>
-    defer_type(defer_type<F_> &&other) : functor{std::move(other.functor)}
+    defer_type(defer_type<F_> &&other)
+        : functor{std::move(other.functor)}, do_run_this(other.do_run_this)
     {
         other.do_run_this = false;
     }
@@ -41,6 +43,7 @@ struct defer_type
     auto operator=(defer_type<F_> &&other)
     {
         functor = std::move(other.functor);
+        do_run_this = other.do_run_this;
         other.do_run_this = false;
     }
 


### PR DESCRIPTION
Does not really affect current internal usage, but still eligible for backporting