### PR TITLE
Fix compilation error when using Kokkos's `nvcc_wrapper`

### DIFF
--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -737,7 +737,7 @@ void JSONIOHandlerImpl::extendDataset(
                 "[JSON] Cannot shrink the extent of a dataset")
         }
     }
-    catch (json::basic_json::type_error &)
+    catch (json::type_error &)
     {
         throw std::runtime_error(
             "[JSON] The specified location contains no valid dataset");
@@ -1259,7 +1259,7 @@ void JSONIOHandlerImpl::readDataset(
         {
             switchType<DatasetReader>(parameters.dtype, j["data"], parameters);
         }
-        catch (json::basic_json::type_error &)
+        catch (json::type_error &)
         {
             throw error::ReadError(
                 error::AffectedObject::Dataset,
@@ -2344,7 +2344,7 @@ auto JSONIOHandlerImpl::verifyDataset(
             isSame(dt, parameters.dtype),
             "[JSON] Read/Write request does not fit the dataset's type");
     }
-    catch (json::basic_json::type_error &)
+    catch (json::type_error &)
     {
         throw std::runtime_error(
             "[JSON] The given path does not contain a valid dataset.");


### PR DESCRIPTION
Apparently, `nvcc` with `-x cu` option parses `json::basic_json` weirdly, and fails to compile. For example,

**mwe.cxx**:
```c++
template <class T = int>
struct basic_json {
    struct type_error {};
};

using json = basic_json<>;

void func()
{
    try {
    }
    catch (json::basic_json::type_error &) {
    }
}
```

The code above is a valid C++ and it compiles fine even with `nvcc`. However, it fails if I pass `-x cu`:

```bash
❯ nvcc -x cu mwe.cxx -c
mwe.cxx: In function ‘void func()’:
mwe.cxx:12:8: error: ‘json {aka basic_json<>}::basic_json’ names the constructor, not the type
   12 |     catch (json::basic_json::type_error &) {
      |        ^~~~
mwe.cxx:12:8: error: and ‘json’ {aka ‘basic_json<>’} has no template constructors
mwe.cxx:12:24: error: expected ‘)’ before ‘<’ token
   12 |     catch (json::basic_json::type_error &) {
      |       ~                ^
      |                        )
mwe.cxx:12:24: error: expected ‘{’ before ‘<’ token
mwe.cxx:12:24: error: expected primary-expression before ‘<’ token
mwe.cxx:12:25: error: expected primary-expression before ‘>’ token
   12 |     catch (json::basic_json::type_error &) {
      |                         ^
mwe.cxx:12:29: error: ‘::type_error’ has not been declared
   12 |     catch (json::basic_json::type_error &) {
      |                             ^~~~~~~~~~
mwe.cxx:12:41: error: expected primary-expression before ‘)’ token
   12 |     catch (json::basic_json::type_error &) {
      |                                         ^
```

This only matters when openPMD-api is compiled with `nvcc_wrapper` provided by Kokkos, whose passes `-x cu` to every source code.

This PR drops the redundant qualifier, as `json` is already an alias for `basic_json<>`, and make it compilable even with Kokkos's `nvcc_wrapper`.