### PR TITLE
Python bindings: Add nested type enumeration

### DIFF
--- a/include/openPMD/binding/python/auxiliary.hpp
+++ b/include/openPMD/binding/python/auxiliary.hpp
@@ -65,4 +65,121 @@ struct ForEachType<Functor>
     { /* no-op */
     }
 };
+
+namespace internal
+{
+
+    template <typename Functor, typename... Tuples>
+    struct ForEachTypeNestedImpl;
+
+    // Functor::template call<std::tuple<Type1, Type2, Type3, ...>>(args...)
+    template <typename Functor, typename FirstTuple, typename... Tuples>
+    struct ForEachTypeNestedImpl<Functor, FirstTuple, Tuples...>
+    {
+
+        template <typename InnerFunctor, typename Tuple>
+        struct ForEachType_Tuple;
+
+        template <typename InnerFunctor, typename... Types>
+        struct ForEachType_Tuple<InnerFunctor, std::tuple<Types...>>
+        {
+            template <typename... Args>
+            static void call(Args &&...args)
+            {
+                ForEachType<InnerFunctor, Types...>::template call<Args...>(
+                    std::forward<Args>(args)...);
+            }
+        };
+
+        template <typename FirstType, typename Tuple>
+        struct PrependToTuple;
+        template <typename FirstType, typename... Othertypes>
+        struct PrependToTuple<FirstType, std::tuple<Othertypes...>>
+        {
+            using type = std::tuple<FirstType, Othertypes...>;
+        };
+
+        // transform the outer Functor such that the first type argument
+        // FirstType is already specified
+        template <typename FirstType>
+        struct PartialApply
+        {
+            // RestType is a tuple
+            // Args the function arguments
+            template <typename RestTypes, typename... Args>
+            static void call(Args &&...args)
+            {
+                using concatenated_tuple_t =
+                    typename PrependToTuple<FirstType, RestTypes>::type;
+                Functor::template call<concatenated_tuple_t, Args...>(
+                    std::forward<Args>(args)...);
+            }
+        };
+
+        struct Runner
+        {
+            template <typename Type1, typename... Args>
+            static void call(Args &&...args)
+            {
+                using partially_applied_t = PartialApply<Type1>;
+                // recursive call
+                ForEachTypeNestedImpl<partially_applied_t, Tuples...>::
+                    template call<Args...>(std::forward<Args>(args)...);
+            }
+        };
+
+        template <typename... Args>
+        static void call(Args &&...args)
+        {
+            // outer loop
+            using foreach_t = ForEachType_Tuple<Runner, FirstTuple>;
+            foreach_t::template call<Args...>(std::forward<Args>(args)...);
+        }
+    };
+
+    template <typename Functor>
+    struct ForEachTypeNestedImpl<Functor>
+    {
+        template <typename... Args>
+        static void call(Args &&...args)
+        {
+            Functor::template call<std::tuple<>, Args...>(
+                std::forward<Args>(args)...);
+        }
+    };
+} // namespace internal
+
+template <typename Functor, typename... Tuples>
+struct ForEachTypeNested
+{
+    template <typename InnerFunctor, typename Tuple>
+    struct ApplyTupleAsTypes;
+
+    template <typename InnerFunctor, typename... Types>
+    struct ApplyTupleAsTypes<InnerFunctor, std::tuple<Types...>>
+    {
+        template <typename... Args>
+        static void call(Args &&...args)
+        {
+            InnerFunctor::template call<Types...>(std::forward<Args>(args)...);
+        }
+    };
+
+    struct TupledFunctor
+    {
+        template <typename Tuple, typename... Args>
+        static void call(Args &&...args)
+        {
+            ApplyTupleAsTypes<Functor, Tuple>::template call<Args...>(
+                std::forward<Args>(args)...);
+        }
+    };
+
+    template <typename... Args>
+    static void call(Args &&...args)
+    {
+        internal::ForEachTypeNestedImpl<TupledFunctor, Tuples...>::
+            template call<Args...>(std::forward<Args>(args)...);
+    }
+};
 } // namespace auxiliary

--- a/include/openPMD/binding/python/auxiliary.hpp
+++ b/include/openPMD/binding/python/auxiliary.hpp
@@ -38,7 +38,7 @@ auto json_dumps(py::object const &obj) -> std::string;
  *
  * The variadic parameter pack (Types) specifies types which to supply for T.
  *
- * ForEachTypeNested<Functor, T1, T2, ...>::call(...args...) will then
+ * ForEachType<Functor, T1, T2, ...>::call(...args...) will then
  * call Functor::template call<T>() for each type T in T1, T2, ...
  * one after another.
  */

--- a/include/openPMD/binding/python/auxiliary.hpp
+++ b/include/openPMD/binding/python/auxiliary.hpp
@@ -68,6 +68,32 @@ struct ForEachType<Functor>
 
 namespace internal
 {
+    /*
+     * Apply types contained in Tuple to the template Templ.
+     */
+    template <template <typename...> typename Templ, typename Tuple>
+    struct apply_tuple_types;
+    template <template <typename...> typename Templ, typename... Args>
+    struct apply_tuple_types<Templ, std::tuple<Args...>>
+    {
+        using type = Templ<Args...>;
+    };
+    template <template <typename...> typename Templ, typename Tuple>
+    using apply_tuple_types_t = typename apply_tuple_types<Templ, Tuple>::type;
+
+    /*
+     * Add a first type before the others in Tuple.
+     */
+    template <typename FirstType, typename Tuple>
+    struct prepend_to_tuple;
+    template <typename FirstType, typename... Othertypes>
+    struct prepend_to_tuple<FirstType, std::tuple<Othertypes...>>
+    {
+        using type = std::tuple<FirstType, Othertypes...>;
+    };
+    template <typename FirstType, typename Tuple>
+    using prepend_to_tuple_t =
+        typename prepend_to_tuple<FirstType, Tuple>::type;
 
     template <typename Functor, typename... Tuples>
     struct ForEachTypeNestedImpl;
@@ -77,30 +103,10 @@ namespace internal
     struct ForEachTypeNestedImpl<Functor, FirstTuple, Tuples...>
     {
 
-        template <typename InnerFunctor, typename Tuple>
-        struct ForEachType_Tuple;
-
-        template <typename InnerFunctor, typename... Types>
-        struct ForEachType_Tuple<InnerFunctor, std::tuple<Types...>>
-        {
-            template <typename... Args>
-            static void call(Args &&...args)
-            {
-                ForEachType<InnerFunctor, Types...>::template call<Args...>(
-                    std::forward<Args>(args)...);
-            }
-        };
-
-        template <typename FirstType, typename Tuple>
-        struct PrependToTuple;
-        template <typename FirstType, typename... Othertypes>
-        struct PrependToTuple<FirstType, std::tuple<Othertypes...>>
-        {
-            using type = std::tuple<FirstType, Othertypes...>;
-        };
-
-        // transform the outer Functor such that the first type argument
-        // FirstType is already specified
+        /*
+         * Transform the outer Functor such that the first type argument
+         * FirstType is already specified
+         */
         template <typename FirstType>
         struct PartialApply
         {
@@ -110,12 +116,16 @@ namespace internal
             static void call(Args &&...args)
             {
                 using concatenated_tuple_t =
-                    typename PrependToTuple<FirstType, RestTypes>::type;
+                    prepend_to_tuple_t<FirstType, RestTypes>;
                 Functor::template call<concatenated_tuple_t, Args...>(
                     std::forward<Args>(args)...);
             }
         };
 
+        /*
+         * Internal Functor to be passed to ForEachType, for iterating every
+         * type contained in FirstTuple.
+         */
         struct Runner
         {
             template <typename Type1, typename... Args>
@@ -131,8 +141,10 @@ namespace internal
         template <typename... Args>
         static void call(Args &&...args)
         {
-            // outer loop
-            using foreach_t = ForEachType_Tuple<Runner, FirstTuple>;
+            // outer loop --> iterate over each type contained in FirstTuple
+            using foreach_t = apply_tuple_types_t<
+                ForEachType,
+                prepend_to_tuple_t<Runner, FirstTuple>>;
             foreach_t::template call<Args...>(std::forward<Args>(args)...);
         }
     };
@@ -149,6 +161,23 @@ namespace internal
     };
 } // namespace internal
 
+/*
+ * Functor is a struct of the form:
+ *
+ * struct Functor
+ * {
+ *     template<typename T1, typename T2, ...>
+ *     static void call(... any kind of argument ...);
+ * };
+ *
+ * The variadic parameter pack (Tuples) specifies for each template parameter
+ * (T1, T2, ...) of the call<>() function template a tuple of types that should
+ * be applied.
+ *
+ * ForEachTypeNested<Functor, Tuple1, Tuple2, ...>::call(...args...) will then
+ * call Functor::template call<T1, T2, ...>() for each possible combination of
+ * T1 <- Tuple1, T2 <- Tuple2, ...
+ */
 template <typename Functor, typename... Tuples>
 struct ForEachTypeNested
 {
@@ -165,6 +194,15 @@ struct ForEachTypeNested
         }
     };
 
+    /*
+     * For easier internal handling, transform the Functor into one that
+     * accepts its template parameters as a single Tuple argument of the form
+     * std::tuple<T1, T2, ...>.
+     * This is necessary since we need variadic arguments already
+     * to generically specify that the call function template accepts any kinds
+     * of arguments; and we cannot have more than one range of variadic type
+     * args.
+     */
     struct TupledFunctor
     {
         template <typename Tuple, typename... Args>

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -26,46 +26,58 @@
 
 #include <string>
 
+namespace internal
+{
+struct DefineDatasetConstructor
+{
+    static constexpr auto resolve_datatype(Datatype dt) -> Datatype
+    {
+        return dt;
+    }
+
+    static auto resolve_datatype(py::dtype dt) -> Datatype
+    {
+        return dtype_from_numpy(std::move(dt));
+    }
+
+    static auto resolve_datatype(py::object const& dt) -> Datatype
+    {
+        return dtype_from_numpy(dt);
+    }
+
+    static constexpr auto resolve_options(std::string const &str)
+        -> std::string const &
+    {
+        return str;
+    }
+
+    static auto resolve_options(py::object const &obj) -> std::string
+    {
+        return ::auxiliary::json_dumps(obj);
+    }
+
+    template <typename Datatype_t, typename Options_t>
+    static auto call(py::class_<Dataset> &ds) -> py::class_<Dataset> &
+    {
+        return ds.def(
+            py::init([](Datatype_t dt, Extent e, Options_t const &options) {
+                auto resolved_dtype = resolve_datatype(dt);
+                decltype(auto) resolved_options = resolve_options(options);
+                return new Dataset{
+                    resolved_dtype, std::move(e), resolved_options};
+            }),
+            py::arg("dtype"),
+            py::arg("extent"),
+            py::arg("options") = "{}");
+    }
+};
+} // namespace internal
+
 void init_Dataset(py::module &m)
 {
     auto pyDataset =
         py::class_<Dataset>(m, "Dataset")
             .def(py::init<Extent>(), py::arg("extent"))
-            .def(
-                py::init<Datatype, Extent, std::string>(),
-                py::arg("dtype"),
-                py::arg("extent"),
-                py::arg("options") = "{}")
-            .def(
-                py::init([](py::object dt, Extent e, std::string options) {
-                    auto const d = dtype_from_numpy(std::move(dt));
-                    return new Dataset{d, std::move(e), std::move(options)};
-                }),
-                py::arg("dtype"),
-                py::arg("extent"),
-                py::arg("options") = "{}")
-            .def(
-                py::init([](Datatype dt, Extent e, py::object const &options) {
-                    auto resolved_options = ::auxiliary::json_dumps(options);
-                    return new Dataset{
-                        dt, std::move(e), std::move(resolved_options)};
-                }),
-                py::arg("dtype"),
-                py::arg("extent"),
-                py::arg("options"))
-            .def(
-                py::init([](py::object const &dt,
-                            Extent e,
-                            py::object const &options) {
-                    auto const d = dtype_from_numpy(dt);
-                    auto resolved_options = ::auxiliary::json_dumps(options);
-                    return new Dataset{
-                        d, std::move(e), std::move(resolved_options)};
-                }),
-                py::arg("dtype"),
-                py::arg("extent"),
-                py::arg("options"))
-
             .def(
                 "__repr__",
                 [](const Dataset &d) {
@@ -99,6 +111,12 @@ void init_Dataset(py::module &m)
                 "dtype",
                 [](const Dataset &d) { return dtype_to_numpy(d.dtype); })
             .def_readwrite("options", &Dataset::options);
+    ::auxiliary::ForEachTypeNested<
+        ::internal::DefineDatasetConstructor,
+        // types for Datatype param
+        std::tuple<Datatype, py::dtype, py::object const&>,
+        // types for options param
+        std::tuple<std::string, py::object>>::call(pyDataset);
     pyDataset.attr("JOINED_DIMENSION") =
         py::int_(uint64_t(Dataset::JOINED_DIMENSION));
 }

--- a/src/binding/python/Dataset.cpp
+++ b/src/binding/python/Dataset.cpp
@@ -40,7 +40,7 @@ struct DefineDatasetConstructor
         return dtype_from_numpy(std::move(dt));
     }
 
-    static auto resolve_datatype(py::object const& dt) -> Datatype
+    static auto resolve_datatype(py::object const &dt) -> Datatype
     {
         return dtype_from_numpy(dt);
     }
@@ -59,16 +59,27 @@ struct DefineDatasetConstructor
     template <typename Datatype_t, typename Options_t>
     static auto call(py::class_<Dataset> &ds) -> py::class_<Dataset> &
     {
+        auto options_arg = []() {
+            if constexpr (std::is_same_v<Options_t, std::string>)
+            {
+                return (py::arg("options") = "{}");
+            }
+            else
+            {
+                return py::arg("options");
+            }
+        }();
         return ds.def(
             py::init([](Datatype_t dt, Extent e, Options_t const &options) {
-                auto resolved_dtype = resolve_datatype(dt);
+                auto resolved_dtype =
+                    resolve_datatype(std::forward<Datatype_t>(dt));
                 decltype(auto) resolved_options = resolve_options(options);
                 return new Dataset{
                     resolved_dtype, std::move(e), resolved_options};
             }),
             py::arg("dtype"),
             py::arg("extent"),
-            py::arg("options") = "{}");
+            options_arg);
     }
 };
 } // namespace internal
@@ -114,7 +125,7 @@ void init_Dataset(py::module &m)
     ::auxiliary::ForEachTypeNested<
         ::internal::DefineDatasetConstructor,
         // types for Datatype param
-        std::tuple<Datatype, py::dtype, py::object const&>,
+        std::tuple<Datatype, py::dtype, py::object const &>,
         // types for options param
         std::tuple<std::string, py::object>>::call(pyDataset);
     pyDataset.attr("JOINED_DIMENSION") =

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -113,12 +113,9 @@ struct DefineSeriesConstructorPerPathType
     }
 #endif
 
-    template <typename TupleType>
+    template <typename PathType, typename JsonCfgType>
     static void call(py::class_<Series, Attributable> &py_class)
     {
-        using PathType = typename std::tuple_element<0, TupleType>::type;
-        using JsonCfgType = typename std::tuple_element<1, TupleType>::type;
-
         py_class
             .def(
                 py::init([](PathType const &filepath,
@@ -379,23 +376,19 @@ not possible once it has been closed.
     (void)iterations;
 
     py::class_<Series, Attributable> cl(m, "Series");
-    ::auxiliary::ForEachType<
+
+    ::auxiliary::ForEachTypeNested<
         ::internal::DefineSeriesConstructorPerPathType,
-    // First tuple components are eligible types for the path argument
-    // second component for the config argument
-    // py::object needs to always come last, as a catch-all pattern
 #if openPMD_USE_FILESYSTEM_HEADER
-        std::tuple<std::string, std::string>,
+        // path argument types
         std::tuple<std::string, std::filesystem::path>,
-        std::tuple<std::string, py::object>,
-        std::tuple<std::filesystem::path, std::string>,
-        std::tuple<std::filesystem::path, std::filesystem::path>,
-        std::tuple<std::filesystem::path, py::object>
+        // config argument types
+        std::tuple<std::string, std::filesystem::path, py::object>
 #else
-        std::tuple<std::string, std::string>,
+        // path argument types
         std::tuple<std::string, py::object>,
-        std::tuple<py::object, std::string>,
-        std::tuple<py::object, py::object>
+        // config argument types
+        std::tuple<std::string, py::object>
 #endif
         >::template call<py::class_<Series, Attributable> &>(cl);
     //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This simplifies adding Python bindings to multi-argument functions f(a1, a2, a3, ...) where each each argument accepts multiple types (e.g. `py::object` and `std::string` for JSON configs, or `Datatype`, `np::dtype` and `py::object` for Datatypes).

With this, every combination of binding is automatically generated.