### PR TITLE
Refactoring: Track filestates directly within Writable objects

### DIFF
--- a/include/openPMD/IO/ADIOS/ADIOS2File.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2File.hpp
@@ -237,7 +237,7 @@ public:
 
     ADIOS2File(
         ADIOS2IOHandlerImpl &impl,
-        InvalidatableFile file,
+        internal::FileState const &file,
         adios_defs::OpenFileAs);
 
     ~ADIOS2File();

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -96,7 +96,9 @@ namespace detail
 } // namespace detail
 
 class ADIOS2IOHandlerImpl
-    : public AbstractIOHandlerImplCommon<ADIOS2FilePosition>
+    : public AbstractIOHandlerImplCommon<
+          ADIOS2IOHandlerImpl,
+          ADIOS2FilePosition>
 {
     template <typename, typename>
     friend struct detail::DatasetHelper;
@@ -116,11 +118,18 @@ class ADIOS2IOHandlerImpl
     friend class detail::ADIOS2File;
     friend struct detail::BufferedAttributeRead;
     friend struct detail::RunUniquePtrPut;
+    template <typename, typename>
+    friend class AbstractIOHandlerImplCommon;
 
     using UseGroupTable = adios_defs::UseGroupTable;
     using FlushTarget = adios_defs::FlushTarget;
 
 public:
+    using FilePositionType = ADIOS2FilePosition;
+    // Type for internal::FileState::backendSpecificState
+    // Need a shared pointer since std::any requires copy-constructible types
+    using BackendSpecificFileState = std::shared_ptr<detail::ADIOS2File>;
+
 #if openPMD_HAVE_MPI
 
     ADIOS2IOHandlerImpl(
@@ -366,26 +375,14 @@ private:
      */
     int nameCounter{0};
 
-    /*
-     * IO-heavy actions are deferred to a later point. This map stores for
-     * each open file (identified by an InvalidatableFile object) an object
-     * that manages IO-heavy actions, as well as its ADIOS2 objects, i.e.
-     * IO and Engine object.
-     * Not to be accessed directly, use getFileData().
-     */
-    std::unordered_map<InvalidatableFile, std::unique_ptr<detail::ADIOS2File>>
-        m_fileData;
-
     std::map<std::string, adios2::Operator> m_operators;
 
     // Overrides from AbstractIOHandlerImplCommon.
 
-    std::string
-        filePositionToString(std::shared_ptr<ADIOS2FilePosition>) override;
+    std::string filePositionToString(ADIOS2FilePosition const &);
 
-    std::shared_ptr<ADIOS2FilePosition> extendFilePosition(
-        std::shared_ptr<ADIOS2FilePosition> const &pos,
-        std::string extend) override;
+    std::shared_ptr<ADIOS2FilePosition>
+    extendFilePosition(ADIOS2FilePosition const &pos, std::string extend);
 
     // Helper methods.
 
@@ -425,9 +422,8 @@ private:
     };
 
     detail::ADIOS2File &
-    getFileData(InvalidatableFile const &file, IfFileNotOpen);
-
-    void dropFileData(InvalidatableFile const &file);
+    getFileData(std::optional<internal::FileState> &file, IfFileNotOpen);
+    detail::ADIOS2File &getFileData(internal::FileState &file, IfFileNotOpen);
 
     template <typename T>
     static void setStepSelectionForVariable(
@@ -685,7 +681,7 @@ namespace detail
         template <typename T>
         static void call(
             ADIOS2IOHandlerImpl *impl,
-            InvalidatableFile const &,
+            internal::FileState &,
             std::string const &varName,
             Parameter<Operation::OPEN_DATASET> &parameters,
             std::optional<size_t> stepSelection,

--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -28,7 +28,6 @@
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Writable.hpp"
 
-#include <bits/types/FILE.h>
 #include <memory>
 #include <set>
 #include <stdexcept>

--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -217,6 +217,11 @@ AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
         search = writable->parent;
         while (!search->fileState->has_value())
         {
+            if (!search->parent)
+            {
+                throw std::runtime_error(
+                    "[refreshFileFromParent] No active file in the ancestors.");
+            }
             search->fileState = file;
             search = search->parent;
         }

--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -28,6 +28,8 @@
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Writable.hpp"
 
+#include <bits/types/FILE.h>
+#include <memory>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -35,7 +37,9 @@
 
 namespace openPMD
 {
-template <typename FilePositionType = AbstractFilePosition>
+template <
+    typename IOHandlerImpl_t,
+    typename FilePositionType = typename IOHandlerImpl_t::FilePositionType>
 class AbstractIOHandlerImplCommon : public AbstractIOHandlerImpl
 {
     // friend struct detail::BufferedActions;
@@ -49,32 +53,22 @@ protected:
      * map each Writable to its associated file contains only the filename,
      * without the OS path
      */
-    std::unordered_map<Writable *, InvalidatableFile> m_files;
     // MUST be an ordered set in order to consistently flush on different
     // parallel processes (same logic cant apply to m_files since Writable*
     // pointers are not predictable)
-    std::set<InvalidatableFile> m_dirty;
+    std::set<internal::SharedFileState> m_dirty;
+    std::unordered_map<std::string, internal::SharedFileState> m_files;
 
-    enum PossiblyExisting
-    {
-        PE_InvalidatableFile = 0,
-        PE_Iterator,
-        PE_NewlyCreated,
-    };
+    internal::SharedFileState &
+    makeFile(Writable *, std::string fileName, bool consider_open_files);
 
-    std::tuple<
-        InvalidatableFile,
-        std::unordered_map<Writable *, InvalidatableFile>::iterator,
-        bool>
-    getPossiblyExisting(std::string file);
-
-    void associateWithFile(Writable *writable, InvalidatableFile file);
+    void associateWithFile(Writable *writable, internal::SharedFileState file);
 
     /**
      *
      * @return Full OS path of the file.
      */
-    std::string fullPath(InvalidatableFile);
+    std::string fullPath(internal::FileState const &);
 
     std::string fullPath(std::string);
 
@@ -89,18 +83,16 @@ protected:
      * with another file, update the writable to match its parent and return
      * the refreshed file.
      */
-    InvalidatableFile
+    internal::FileState &
     refreshFileFromParent(Writable *writable, bool preferParentFile);
 
     /**
      * Figure out the file position of the writable.
      * Only modify the writable's fileposition when specified.
      * @param writable The writable.
-     * @param write Whether to refresh the writable's file position.
      * @return The current file position.
      */
-    std::shared_ptr<FilePositionType>
-    setAndGetFilePosition(Writable *writable, bool write = true);
+    FilePositionType *setAndGetFilePosition(Writable *writable);
 
     /**
      * Figure out the file position of the writable and extend it.
@@ -108,86 +100,88 @@ protected:
      * @param extend The extension string.
      * @return The current file position.
      */
-    virtual std::shared_ptr<FilePositionType>
+    FilePositionType *
     setAndGetFilePosition(Writable *writable, std::string extend);
 
+    /*
+     * The "virtual" methods here must be implemented by the child class,
+     * but the references are resolved at compile time, hence not really
+     * virtual.
+     */
+#if 0
     /**
      * @return A string representation of the file position.
      */
-    virtual std::string
-        filePositionToString(std::shared_ptr<FilePositionType>) = 0;
+    virtual std::string filePositionToString(FilePositionType const &) = 0;
 
     /**
      * @return A new file position that is extended with the given string.
      */
-    virtual std::shared_ptr<FilePositionType> extendFilePosition(
-        std::shared_ptr<FilePositionType> const &, std::string) = 0;
+    virtual std::shared_ptr< IOHandler_t,  FilePositionType>
+    extendFilePosition(FilePositionType const &, std::string) = 0;
+#endif
 };
 
-template <typename FilePositionType>
-AbstractIOHandlerImplCommon<FilePositionType>::AbstractIOHandlerImplCommon(
-    AbstractIOHandler *handler)
+template <typename IOHandler_t, typename FilePositionType>
+AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
+    AbstractIOHandlerImplCommon(AbstractIOHandler *handler)
     : AbstractIOHandlerImpl{handler}
 {}
 
-template <typename FilePositionType>
-AbstractIOHandlerImplCommon<FilePositionType>::~AbstractIOHandlerImplCommon() =
-    default;
+template <typename IOHandler_t, typename FilePositionType>
+AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
+    ~AbstractIOHandlerImplCommon() = default;
 
-template <typename FilePositionType>
-std::tuple<
-    InvalidatableFile,
-    std::unordered_map<Writable *, InvalidatableFile>::iterator,
-    bool>
-AbstractIOHandlerImplCommon<FilePositionType>::getPossiblyExisting(
-    std::string file)
+template <typename IOHandler_t, typename FilePositionType>
+internal::SharedFileState &
+AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::makeFile(
+    Writable *writable, std::string file, bool consider_open_files)
 {
-
-    auto it = std::find_if(
-        m_files.begin(),
-        m_files.end(),
-        [file](
-            std::unordered_map<Writable *, InvalidatableFile>::value_type const
-                &entry) {
-            return *entry.second == file && entry.second.valid();
-        });
-
-    bool newlyCreated;
-    InvalidatableFile name;
-    if (it == m_files.end())
+    auto make_new = [&]() {
+        writable->fileState =
+            std::make_shared<std::optional<internal::FileState>>(file);
+        m_files[std::move(file)] = writable->fileState;
+    };
+    if (consider_open_files)
     {
-        name = file;
-        newlyCreated = true;
+        if (auto it = m_files.find(file);
+            it != m_files.end() && it->second->has_value())
+        {
+            writable->fileState = it->second;
+        }
+        else
+        {
+            make_new();
+        }
     }
+
     else
     {
-        name = it->second;
-        newlyCreated = false;
+        make_new();
     }
-    return std::tuple<
-        InvalidatableFile,
-        std::unordered_map<Writable *, InvalidatableFile>::iterator,
-        bool>(std::move(name), it, newlyCreated);
+
+    return writable->fileState;
 }
 
-template <typename FilePositionType>
-void AbstractIOHandlerImplCommon<FilePositionType>::associateWithFile(
-    Writable *writable, InvalidatableFile file)
+template <typename IOHandler_t, typename FilePositionType>
+void AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
+    associateWithFile(Writable *writable, internal::SharedFileState file)
 {
-    // make sure to overwrite
-    m_files[writable] = std::move(file);
+    writable->fileState = std::move(file);
 }
 
-template <typename FilePositionType>
-std::string AbstractIOHandlerImplCommon<FilePositionType>::fullPath(
-    InvalidatableFile fileName)
-{
-    return fullPath(*fileName);
-}
-
-template <typename FilePositionType>
+template <typename IOHandler_t, typename FilePositionType>
 std::string
-AbstractIOHandlerImplCommon<FilePositionType>::fullPath(std::string fileName)
+AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::fullPath(
+    internal::FileState const &file)
+{
+    return fullPath(file.name);
+}
+
+template <typename IOHandler_t, typename FilePositionType>
+std::string
+AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::fullPath(
+    std::string fileName)
 {
     if (auxiliary::ends_with(m_handler->directory, "/"))
     {
@@ -199,23 +193,36 @@ AbstractIOHandlerImplCommon<FilePositionType>::fullPath(std::string fileName)
     }
 }
 
-template <typename FilePositionType>
-InvalidatableFile
-AbstractIOHandlerImplCommon<FilePositionType>::refreshFileFromParent(
-    Writable *writable, bool preferParentFile)
+template <typename IOHandler_t, typename FilePositionType>
+internal::FileState &
+AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
+    refreshFileFromParent(Writable *writable, bool preferParentFile)
 {
-    auto getFileFromParent = [writable, this]() {
-        auto file_it = m_files.find(writable->parent);
-        if (file_it == m_files.end())
+    auto getFileFromParent = [writable, this]() -> internal::FileState & {
+        auto search = writable->parent;
+        if (!search)
         {
-            std::stringstream s;
-            s << "Parent Writable " << writable->parent << " of Writable "
-              << writable << " has no associated file.";
-            throw std::runtime_error(s.str());
+            throw std::runtime_error(
+                "[refreshFileFromParent] No parent found.");
         }
-        auto file = m_files.find(writable->parent)->second;
+        while (!search->fileState->has_value())
+        {
+            if (!search->parent)
+            {
+                throw std::runtime_error(
+                    "[refreshFileFromParent] No active file in the ancestors.");
+            }
+            search = search->parent;
+        }
+        auto &file = search->fileState;
+        search = writable->parent;
+        while (!search->fileState->has_value())
+        {
+            search->fileState = file;
+            search = search->parent;
+        }
         associateWithFile(writable, file);
-        return file;
+        return **file;
     };
     if (preferParentFile && writable->parent)
     {
@@ -223,10 +230,9 @@ AbstractIOHandlerImplCommon<FilePositionType>::refreshFileFromParent(
     }
     else
     {
-        auto it = m_files.find(writable);
-        if (it != m_files.end())
+        if (writable->fileState && writable->fileState->has_value())
         {
-            return m_files.find(writable)->second;
+            return **writable->fileState;
         }
         else if (writable->parent)
         {
@@ -240,45 +246,62 @@ AbstractIOHandlerImplCommon<FilePositionType>::refreshFileFromParent(
     }
 }
 
-template <typename FilePositionType>
-std::shared_ptr<FilePositionType>
-AbstractIOHandlerImplCommon<FilePositionType>::setAndGetFilePosition(
-    Writable *writable, bool write)
+template <typename IOHandlerImpl_t, typename FilePositionType>
+auto AbstractIOHandlerImplCommon<IOHandlerImpl_t, FilePositionType>::
+    setAndGetFilePosition(Writable *writable) -> FilePositionType *
 {
-    std::shared_ptr<AbstractFilePosition> res;
+    std::shared_ptr<AbstractFilePosition> new_pos;
 
     if (writable->abstractFilePosition)
     {
-        res = writable->abstractFilePosition;
+        new_pos = writable->abstractFilePosition;
     }
     else if (writable->parent)
     {
-        res = writable->parent->abstractFilePosition;
+        new_pos = writable->parent->abstractFilePosition;
     }
     else
     { // we are root
-        res = std::make_shared<FilePositionType>();
+        new_pos = std::make_shared<FilePositionType>();
     }
-    if (write)
-    {
-        writable->abstractFilePosition = res;
-    }
-    return std::dynamic_pointer_cast<FilePositionType>(res);
+    auto res = new_pos.get();
+    writable->abstractFilePosition = std::move(new_pos);
+    return dynamic_cast<FilePositionType *>(res);
 }
 
-template <typename FilePositionType>
-std::shared_ptr<FilePositionType>
-AbstractIOHandlerImplCommon<FilePositionType>::setAndGetFilePosition(
-    Writable *writable, std::string extend)
+template <typename IOHandlerImpl_t, typename FilePositionType>
+auto AbstractIOHandlerImplCommon<IOHandlerImpl_t, FilePositionType>::
+    setAndGetFilePosition(Writable *writable, std::string extend)
+        -> FilePositionType *
 {
-    if (!auxiliary::starts_with(extend, '/'))
+    if (extend.empty())
+    {
+        return setAndGetFilePosition(writable);
+    }
+    if (writable->abstractFilePosition)
+    {
+        return dynamic_cast<FilePositionType *>(
+            writable->abstractFilePosition.get());
+    }
+    if (!auxiliary::starts_with(extend, '/') &&
+        auxiliary::ends_with(extend, '/'))
+    {
+        extend = "/" + extend.substr(0, extend.size() - 1);
+    }
+    else if (!auxiliary::starts_with(extend, '/'))
     {
         extend = "/" + extend;
     }
-    auto oldPos = setAndGetFilePosition(writable, false);
-    auto res = extendFilePosition(oldPos, extend);
+    else if (auxiliary::ends_with(extend, '/'))
+    {
+        extend = extend.substr(0, extend.size() - 1);
+    }
+    auto oldPos = setAndGetFilePosition(writable);
+    auto new_pos = static_cast<IOHandlerImpl_t *>(this)->extendFilePosition(
+        *oldPos, extend);
 
-    writable->abstractFilePosition = res;
-    return res;
+    auto res = new_pos.get();
+    writable->abstractFilePosition = std::move(new_pos);
+    return dynamic_cast<FilePositionType *>(res);
 }
 } // namespace openPMD

--- a/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImplCommon.hpp
@@ -144,7 +144,7 @@ AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::makeFile(
     if (consider_open_files)
     {
         if (auto it = m_files.find(file);
-            it != m_files.end() && it->second->has_value())
+            it != m_files.end() && it->second.has_value())
         {
             writable->fileState = it->second;
         }
@@ -204,7 +204,7 @@ AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
             throw std::runtime_error(
                 "[refreshFileFromParent] No parent found.");
         }
-        while (!search->fileState->has_value())
+        while (!search->fileState.has_value())
         {
             if (!search->parent)
             {
@@ -215,7 +215,7 @@ AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
         }
         auto &file = search->fileState;
         search = writable->parent;
-        while (!search->fileState->has_value())
+        while (!search->fileState.has_value())
         {
             if (!search->parent)
             {
@@ -226,7 +226,7 @@ AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
             search = search->parent;
         }
         associateWithFile(writable, file);
-        return **file;
+        return *file;
     };
     if (preferParentFile && writable->parent)
     {
@@ -234,9 +234,9 @@ AbstractIOHandlerImplCommon<IOHandler_t, FilePositionType>::
     }
     else
     {
-        if (writable->fileState && writable->fileState->has_value())
+        if (writable->fileState && writable->fileState.has_value())
         {
-            return **writable->fileState;
+            return *writable->fileState;
         }
         else if (writable->parent)
         {

--- a/include/openPMD/IO/InvalidatableFile.hpp
+++ b/include/openPMD/IO/InvalidatableFile.hpp
@@ -20,76 +20,26 @@
  */
 #pragma once
 
+#include <any>
 #include <memory>
+#include <optional>
 #include <string>
 
-namespace openPMD
+namespace openPMD::internal
 {
-/**
- *  Wrapper around a shared pointer to:
- *  * a filename
- *  * and a boolean indicating whether the file still exists
- *  The wrapper adds no extra information, but some commodity functions.
- *  Invariant for any context within which this class shall be used:
- *  For any valid filename, there is at any time at most one
- *  such shared pointer (wrapper) known in said context's data structures
- *  (counting by pointer equality)
- *  This means, that a file can be invalidated (i.e. deleted or overwritten)
- *  by simply searching for one instance of the file among all known files and
- *  invalidating this instance
- *  A new instance may hence only be created after making sure that there are
- *  no valid instances in the data structures.
- */
-struct InvalidatableFile
+
+struct FileState
 {
-    explicit InvalidatableFile(std::string s);
+    std::string name;
+    std::any backendSpecificState;
 
-    InvalidatableFile() = default;
+    FileState(std::string name);
 
-    struct FileState
-    {
-        explicit FileState(std::string s);
+    FileState(FileState const &other) = delete;
+    FileState(FileState &&other) = delete;
 
-        std::string name;
-        bool valid = true;
-    };
-
-    std::shared_ptr<FileState> fileState;
-
-    void invalidate();
-
-    bool valid() const;
-
-    InvalidatableFile &operator=(std::string s);
-
-    bool operator==(InvalidatableFile const &f) const;
-
-    std::string &operator*() const;
-
-    std::string *operator->() const;
-
-    explicit operator bool() const;
+    FileState &operator=(FileState const &other) = delete;
+    FileState &operator=(FileState &&other) = delete;
 };
-} // namespace openPMD
-
-namespace std
-{
-template <>
-struct hash<openPMD::InvalidatableFile>
-{
-    using argument_type = openPMD::InvalidatableFile;
-    using result_type = std::size_t;
-
-    result_type operator()(argument_type const &s) const noexcept;
-};
-
-template <>
-struct less<openPMD::InvalidatableFile>
-{
-    using first_argument_type = openPMD::InvalidatableFile;
-    using second_argument_type = first_argument_type;
-    using result_type = bool;
-    result_type
-    operator()(first_argument_type const &, second_argument_type const &) const;
-};
-} // namespace std
+using SharedFileState = std::shared_ptr<std::optional<FileState>>;
+} // namespace openPMD::internal

--- a/include/openPMD/IO/InvalidatableFile.hpp
+++ b/include/openPMD/IO/InvalidatableFile.hpp
@@ -43,3 +43,15 @@ struct FileState
 };
 using SharedFileState = std::shared_ptr<std::optional<FileState>>;
 } // namespace openPMD::internal
+
+template <>
+struct std::less<openPMD::internal::SharedFileState>
+{
+    using first_argument_type = openPMD::internal::SharedFileState;
+    using second_argument_type = first_argument_type;
+    using result_type = bool;
+
+    auto
+    operator()(first_argument_type const &, second_argument_type const &) const
+        -> result_type;
+};

--- a/include/openPMD/IO/InvalidatableFile.hpp
+++ b/include/openPMD/IO/InvalidatableFile.hpp
@@ -45,7 +45,24 @@ struct FileState
 // A file state is generally shared between multiple Writable instances, hence
 // the shared_ptr. A Writable does not initially have an associated state, hence
 // optional.
-using SharedFileState = std::shared_ptr<std::optional<FileState>>;
+class SharedFileState : std::shared_ptr<std::optional<FileState>>
+{
+    using ptr_type = std::shared_ptr<std::optional<FileState>>;
+
+public:
+    [[nodiscard]] auto has_value() const -> bool;
+    operator bool() const;
+    auto operator*() -> FileState &;
+    auto operator->() -> FileState *;
+    auto operator*() const -> FileState const &;
+    auto operator->() const -> FileState const *;
+
+    void reset_optional();
+
+    using ptr_type::get;
+    using ptr_type::shared_ptr;
+    using ptr_type::operator=;
+};
 } // namespace openPMD::internal
 
 template <>

--- a/include/openPMD/IO/InvalidatableFile.hpp
+++ b/include/openPMD/IO/InvalidatableFile.hpp
@@ -41,6 +41,10 @@ struct FileState
     FileState &operator=(FileState const &other) = delete;
     FileState &operator=(FileState &&other) = delete;
 };
+
+// A file state is generally shared between multiple Writable instances, hence
+// the shared_ptr. A Writable does not initially have an associated state, hence
+// optional.
 using SharedFileState = std::shared_ptr<std::optional<FileState>>;
 } // namespace openPMD::internal
 

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#include "openPMD/IO/ADIOS/ADIOS2File.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
+#include "openPMD/IO/AbstractIOHandlerImplCommon.hpp"
 #include "openPMD/IO/Access.hpp"
+#include "openPMD/IO/InvalidatableFile.hpp"
 #include "openPMD/IO/JSON/JSONFilePosition.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
@@ -47,96 +50,6 @@
 
 namespace openPMD
 {
-// Wrapper around a shared pointer to:
-// * a filename
-// * and a boolean indicating whether the file still exists
-// The wrapper adds no extra information, but some commodity functions.
-// Invariant for JSONIOHandlerImpl:
-// For any valid filename, there is at any time at most one
-// such shared pointer (wrapper) in the HandlerImpl's data structures
-// (counting by pointer equality)
-// This means, that a file can be invalidated (i.e. deleted or overwritten)
-// by simply searching for one instance of the file e.g. in m_files and
-// invalidating this instance
-// A new instance may hence only be created after making sure that there are
-// no valid instances in the data structures.
-struct File
-{
-    explicit File(std::string s) : fileState{std::make_shared<FileState>(s)}
-    {}
-
-    File() = default;
-
-    struct FileState
-    {
-        explicit FileState(std::string s) : name{std::move(s)}
-        {}
-
-        std::string name;
-        bool valid = true;
-        bool printedReadmeWarningAlready = false;
-    };
-
-    std::shared_ptr<FileState> fileState;
-
-    void invalidate()
-    {
-        fileState->valid = false;
-    }
-
-    bool valid() const
-    {
-        return fileState->valid;
-    }
-
-    File &operator=(std::string const &s)
-    {
-        if (fileState)
-        {
-            fileState->name = s;
-        }
-        else
-        {
-            fileState = std::make_shared<FileState>(s);
-        }
-        return *this;
-    }
-
-    bool operator==(File const &f) const
-    {
-        return this->fileState == f.fileState;
-    }
-
-    std::string &operator*() const
-    {
-        return fileState->name;
-    }
-
-    std::string *operator->() const
-    {
-        return &fileState->name;
-    }
-
-    explicit operator bool() const
-    {
-        return fileState.operator bool();
-    }
-};
-} // namespace openPMD
-
-namespace std
-{
-template <>
-struct hash<openPMD::File>
-{
-    typedef openPMD::File argument_type;
-    typedef std::size_t result_type;
-
-    result_type operator()(argument_type const &s) const noexcept
-    {
-        return std::hash<shared_ptr<openPMD::File::FileState>>{}(s.fileState);
-    }
-};
 
 // std::complex handling
 template <class T>
@@ -151,15 +64,32 @@ void from_json(const nlohmann::json &j, std::complex<T> &p)
     p.real(j.at(0));
     p.imag(j.at(1));
 }
-} // namespace std
+} // namespace openPMD
 
 namespace openPMD
 {
-class JSONIOHandlerImpl : public AbstractIOHandlerImpl
+
+class JSONIOHandlerImpl
+    : public AbstractIOHandlerImplCommon<JSONIOHandlerImpl, JSONFilePosition>
 {
     using json = nlohmann::json;
+    template <typename, typename>
+    friend class AbstractIOHandlerImplCommon;
 
 public:
+    struct BackendSpecificFileState
+    {
+        nlohmann::json data;
+        bool printedReadmeWarningAlready = false;
+
+        BackendSpecificFileState(nlohmann::json);
+
+        operator nlohmann::json &();
+        operator nlohmann::json const &() const;
+    };
+
+    using FilePositionType = JSONFilePosition;
+
     enum class FileFormat
     {
         Json,
@@ -249,15 +179,6 @@ private:
 #endif
 
     using FILEHANDLE = std::fstream;
-
-    // map each Writable to its associated file
-    // contains only the filename, without the OS path
-    std::unordered_map<Writable *, File> m_files;
-
-    std::unordered_map<File, std::shared_ptr<nlohmann::json>> m_jsonVals;
-
-    // files that have logically, but not physically been written to
-    std::unordered_set<File> m_dirty;
 
     /*
      * Is set by constructor.
@@ -354,10 +275,10 @@ private:
     // else null. first tuple element needs to be a pointer, since the casted
     // streams are references only.
     std::tuple<std::unique_ptr<FILEHANDLE>, std::istream *, std::ostream *>
-    getFilehandle(File const &, Access access);
+    getFilehandle(internal::FileState const &, Access access);
 
     // full operating system path of the given file
-    std::string fullPath(File const &);
+    std::string fullPath(internal::FileState const &);
 
     std::string fullPath(std::string const &);
 
@@ -367,7 +288,10 @@ private:
 
     // Fileposition is assumed to have already been set,
     // get it in string form
-    static std::string filepositionOf(Writable *w);
+    std::string filePositionToString(JSONFilePosition const &);
+
+    std::shared_ptr<JSONFilePosition>
+    extendFilePosition(JSONFilePosition const &, std::string);
 
     // Execute visitor on each pair of positions in the json value
     // and the flattened multidimensional array.
@@ -401,44 +325,16 @@ private:
     // the passed json value
     static void ensurePath(nlohmann::json *json, std::string const &path);
 
-    // In order not to insert the same file name into the data structures
-    // with a new pointer (e.g. when reopening), search for a possibly
-    // existing old pointer. Construct a new pointer only upon failure.
-    // The bool is true iff the pointer has been newly-created.
-    // The iterator is an iterator for m_files
-    std::tuple<File, std::unordered_map<Writable *, File>::iterator, bool>
-    getPossiblyExisting(std::string const &file);
-
     // get the json value representing the whole file, possibly reading
     // from disk
-    std::shared_ptr<nlohmann::json> obtainJsonContents(File const &);
+    nlohmann::json &obtainJsonContents(internal::FileState &);
 
     // get the json value at the writable's fileposition
     nlohmann::json &obtainJsonContents(Writable *writable);
 
     // write to disk the json contents associated with the file
     // remove from m_dirty if unsetDirty == true
-    auto putJsonContents(File const &, bool unsetDirty = true)
-        -> decltype(m_jsonVals)::iterator;
-
-    // figure out the file position of the writable
-    // (preferring the parent's file position) and extend it
-    // by extend. return the modified file position.
-    std::shared_ptr<JSONFilePosition>
-    setAndGetFilePosition(Writable *, std::string const &extend);
-
-    // figure out the file position of the writable
-    // (preferring the parent's file position)
-    // only modify the writable's fileposition when specified
-    std::shared_ptr<JSONFilePosition>
-    setAndGetFilePosition(Writable *, bool write = true);
-
-    // get the writable's containing file
-    // if the parent is associated with another file,
-    // associate the writable with that file and return it
-    File refreshFileFromParent(Writable *writable);
-
-    void associateWithFile(Writable *writable, File);
+    void putJsonContents(internal::FileState &);
 
     // need to check the name too in order to exclude "attributes" key
     static bool isGroup(nlohmann::json::const_iterator const &it);
@@ -495,6 +391,12 @@ private:
     };
 
     template <typename T>
+    struct CppToJSON<std::complex<T>>
+    {
+        nlohmann::json operator()(std::complex<T> const &);
+    };
+
+    template <typename T>
     struct CppToJSON<std::vector<T>>
     {
         nlohmann::json operator()(std::vector<T> const &);
@@ -510,6 +412,12 @@ private:
     struct JsonToCpp
     {
         T operator()(nlohmann::json const &);
+    };
+
+    template <typename T>
+    struct JsonToCpp<std::complex<T>>
+    {
+        std::complex<T> operator()(nlohmann::json const &);
     };
 
     template <typename T>

--- a/include/openPMD/auxiliary/DrainSet.hpp
+++ b/include/openPMD/auxiliary/DrainSet.hpp
@@ -1,0 +1,78 @@
+#include <iterator>
+
+namespace openPMD::auxiliary
+{
+
+template <class Set>
+class drain_view
+{
+    Set &set_;
+
+    class iterator
+    {
+        Set *m_set;
+        typename Set::node_type m_node;
+
+    public:
+        using value_type = typename Set::value_type;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::input_iterator_tag;
+
+        explicit iterator(Set *set) : m_set(set)
+        {
+            if (m_set && !m_set->empty())
+                m_node = m_set->extract(m_set->begin());
+        }
+
+        auto operator*() const -> value_type &
+        {
+            return m_node.value();
+        }
+
+        auto operator->() const -> value_type *
+        {
+            return &m_node.value();
+        }
+
+        auto operator++() -> iterator &
+        {
+            m_node = {};
+
+            if (!m_set->empty())
+                m_node = m_set->extract(m_set->begin());
+
+            return *this;
+        }
+
+        auto operator==(iterator const &other) const -> bool
+        {
+            return this->m_node.empty() == other.m_node.empty();
+        }
+
+        auto operator!=(iterator const &other) const -> bool
+        {
+            return !operator==(other);
+        }
+    };
+
+public:
+    explicit drain_view(Set &set) : set_(set)
+    {}
+
+    auto begin() -> iterator
+    {
+        return iterator(&set_);
+    }
+
+    auto end() -> iterator
+    {
+        return iterator{nullptr};
+    }
+};
+
+template <class Set>
+drain_view<Set> drain(Set &set)
+{
+    return drain_view<Set>(set);
+}
+} // namespace openPMD::auxiliary

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/IO/InvalidatableFile.hpp"
 
 #include <memory>
 #include <string>
@@ -40,7 +41,7 @@ namespace test
 class AbstractFilePosition;
 class AbstractIOHandler;
 struct ADIOS2FilePosition;
-template <typename FilePositionType>
+template <typename, typename>
 class AbstractIOHandlerImplCommon;
 template <typename>
 class Span;
@@ -56,7 +57,8 @@ namespace internal
 namespace detail
 {
     class ADIOS2File;
-}
+    struct AttributeWriter;
+} // namespace detail
 
 namespace debug
 {
@@ -93,10 +95,11 @@ class Writable final
     friend class RecordComponent;
     friend class AbstractIOHandlerImpl;
     friend class ADIOS2IOHandlerImpl;
+    friend struct detail::AttributeWriter;
     friend class detail::ADIOS2File;
     friend class HDF5IOHandlerImpl;
     friend class ParallelHDF5IOHandlerImpl;
-    template <typename>
+    template <typename, typename>
     friend class AbstractIOHandlerImplCommon;
     friend class JSONIOHandlerImpl;
     friend struct test::TestHelper;
@@ -137,6 +140,7 @@ OPENPMD_private
 
     template <bool flush_entire_series>
     void seriesFlush(internal::FlushParams const &, bool flush_io_handler);
+    internal::SharedFileState fileState;
     /*
      * These members need to be shared pointers since distinct instances of
      * Writable may share them.

--- a/src/IO/ADIOS/ADIOS2File.cpp
+++ b/src/IO/ADIOS/ADIOS2File.cpp
@@ -24,6 +24,7 @@
 #include "openPMD/IO/ADIOS/ADIOS2Auxiliary.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2IOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
+#include "openPMD/IO/InvalidatableFile.hpp"
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Memory.hpp"
@@ -188,11 +189,9 @@ void BufferedUniquePtrPut::run(ADIOS2File &ba)
 
 ADIOS2File::ADIOS2File(
     ADIOS2IOHandlerImpl &impl,
-    InvalidatableFile file,
+    internal::FileState const &file,
     adios_defs::OpenFileAs openFileAs)
-    : m_file(impl.fullPath(std::move(file)))
-    , m_ADIOS(impl.m_ADIOS)
-    , m_impl(&impl)
+    : m_file(impl.fullPath(file)), m_ADIOS(impl.m_ADIOS), m_impl(&impl)
 {
     // Declaring these members in the constructor body to avoid
     // initialization order hazards. Need the IO_ prefix since in some
@@ -1401,8 +1400,7 @@ void ADIOS2File::markActive(Writable *writable)
             do
             {
                 using attr_t = unsigned long long;
-                auto filePos = m_impl->setAndGetFilePosition(
-                    writable, /* write = */ false);
+                auto filePos = m_impl->setAndGetFilePosition(writable);
                 auto fullPath =
                     adios_defaults::str_activeTablePrefix + filePos->location;
                 m_IO.DefineAttribute<attr_t>(

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -35,6 +35,7 @@
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/Streaming.hpp"
 #include "openPMD/ThrowError.hpp"
+#include "openPMD/auxiliary/DrainSet.hpp"
 #include "openPMD/auxiliary/Environment.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/JSONMatcher.hpp"
@@ -188,8 +189,8 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
     sorted.reserve(m_files.size());
     for (auto &file : m_files)
     {
-        if (!file.second->has_value() ||
-            !(*file.second)->backendSpecificState.has_value())
+        if (!file.second.has_value() ||
+            !file.second->backendSpecificState.has_value())
         {
             std::cerr << "File '" << file.first
                       << "' was marked dirty, but has no associated ADIOS2 "
@@ -199,8 +200,7 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
             continue;
         }
         sorted.emplace_back(
-            std::make_pair(
-                (*file.second)->name, &(*file.second)->backendSpecificState));
+            file.second->name, &file.second->backendSpecificState);
     }
     /*
      * Technically, std::sort() is sufficient here, since file names are unique.
@@ -648,24 +648,23 @@ ADIOS2IOHandlerImpl::flush(internal::ParsedFlushParams &flushParams)
         }
     }
 
-    for (auto &p : m_dirty)
+    for (auto &p : auxiliary::drain(m_dirty))
     {
-        if (p->has_value() && (*p)->backendSpecificState.has_value())
+        if (p.has_value() && p->backendSpecificState.has_value())
         {
             auto &adios2_file = std::any_cast<BackendSpecificFileState &>(
-                (*p)->backendSpecificState);
+                p->backendSpecificState);
             adios2_file->flush(adios2FlushParams, /* writeLatePuts = */ false);
         }
         else
         {
             throw error::Internal(
                 "File '" +
-                (p->has_value() ? (*p)->name
-                                : std::string("Unknown file name")) +
+                (p.has_value() ? p->name : std::string("Unknown file name")) +
                 "' was dirty, but has no associated ADIOS2 data?");
         }
     }
-    m_dirty.clear();
+    assert(m_dirty.empty());
     return res;
 }
 
@@ -716,7 +715,7 @@ void ADIOS2IOHandlerImpl::createFile(
 
         auto &file =
             makeFile(writable, name, /* consider_open_files = */ false);
-        auto &file_state = **file;
+        auto &file_state = *file;
         if (access::read(m_handler->m_backendAccess) &&
             (auxiliary::file_exists(fullPath(file_state)) ||
              auxiliary::directory_exists(fullPath(file_state))))
@@ -1089,7 +1088,7 @@ void ADIOS2IOHandlerImpl::openFile(
 
     // enforce opening the file
     // lazy opening is deathly in parallel situations
-    auto &fileData = getFileData(**file, how_to_open);
+    auto &fileData = getFileData(*file, how_to_open);
 
     // the following calls present the new file to the IO handler's data
     // structures. do this only after the file has been successfully open, to
@@ -1108,11 +1107,11 @@ void ADIOS2IOHandlerImpl::closeFile(
     Writable *writable, Parameter<Operation::CLOSE_FILE> const &)
 {
     auto &maybe_file = writable->fileState;
-    if (!maybe_file || !maybe_file->has_value())
+    if (!maybe_file.has_value())
     {
         return;
     }
-    auto &file = **maybe_file;
+    auto &file = *maybe_file;
 
     m_files.erase(file.name);
     m_dirty.erase(maybe_file);
@@ -1134,7 +1133,7 @@ void ADIOS2IOHandlerImpl::closeFile(
         /* writeLatePuts = */ true,
         /* flushUnconditionally = */ false);
     file.backendSpecificState.reset();
-    *maybe_file = std::nullopt;
+    maybe_file.reset_optional();
 }
 
 void ADIOS2IOHandlerImpl::openPath(

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -31,6 +31,7 @@
 #include "openPMD/IO/ADIOS/ADIOS2PreloadAttributes.hpp"
 #include "openPMD/IO/ADIOS/ADIOS2PreloadVariables.hpp"
 #include "openPMD/IO/IOTask.hpp"
+#include "openPMD/IO/InvalidatableFile.hpp"
 #include "openPMD/IterationEncoding.hpp"
 #include "openPMD/Streaming.hpp"
 #include "openPMD/ThrowError.hpp"
@@ -45,12 +46,16 @@
 #include "openPMD/backend/Variant_internal.hpp"
 
 #include <algorithm>
+#include <any>
+#include <cctype> // std::tolower
 #include <cstddef>
 #include <deque>
+#include <initializer_list>
 #include <iostream>
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -179,14 +184,24 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
      * This means that destruction order is nondeterministic.
      * Let's determinize it (necessary if computing in parallel).
      */
-    using file_t = std::unique_ptr<detail::ADIOS2File>;
-    std::vector<file_t> sorted;
-    sorted.reserve(m_fileData.size());
-    for (auto &pair : m_fileData)
+    std::vector<std::pair<std::string, std::any *>> sorted;
+    sorted.reserve(m_files.size());
+    for (auto &file : m_files)
     {
-        sorted.push_back(std::move(pair.second));
+        if (!file.second->has_value() ||
+            !(*file.second)->backendSpecificState.has_value())
+        {
+            std::cerr << "File '" << file.first
+                      << "' was marked dirty, but has no associated ADIOS2 "
+                         "data at destruction time. Will ignore, but this "
+                         "might lead to issues."
+                      << std::endl;
+            continue;
+        }
+        sorted.emplace_back(
+            std::make_pair(
+                (*file.second)->name, &(*file.second)->backendSpecificState));
     }
-    m_fileData.clear();
     /*
      * Technically, std::sort() is sufficient here, since file names are unique.
      * Use std::stable_sort() for two reasons:
@@ -199,14 +214,18 @@ ADIOS2IOHandlerImpl::~ADIOS2IOHandlerImpl()
      */
     std::stable_sort(
         sorted.begin(), sorted.end(), [](auto const &left, auto const &right) {
-            return left->m_file <= right->m_file;
+            return left.first <= right.first;
         });
     // run the destructors
     for (auto &file : sorted)
     {
-        // std::unique_ptr interface
-        file.reset();
+        // std::any interface
+        // std::cout << "Resetting pointer " << file.second << "->" <<
+        // *file.second
+        //           << std::endl;
+        file.second->reset();
     }
+    m_files.clear();
 }
 
 template <typename Callback>
@@ -629,17 +648,22 @@ ADIOS2IOHandlerImpl::flush(internal::ParsedFlushParams &flushParams)
         }
     }
 
-    for (auto const &file : m_dirty)
+    for (auto &p : m_dirty)
     {
-        auto file_data = m_fileData.find(file);
-        if (file_data == m_fileData.end())
+        if (p->has_value() && (*p)->backendSpecificState.has_value())
+        {
+            auto &adios2_file = std::any_cast<BackendSpecificFileState &>(
+                (*p)->backendSpecificState);
+            adios2_file->flush(adios2FlushParams, /* writeLatePuts = */ false);
+        }
+        else
         {
             throw error::Internal(
-                "[ADIOS2 backend] No associated data found for file'" + *file +
-                "'.");
+                "File '" +
+                (p->has_value() ? (*p)->name
+                                : std::string("Unknown file name")) +
+                "' was dirty, but has no associated ADIOS2 data?");
         }
-        file_data->second->flush(
-            adios2FlushParams, /* writeLatePuts = */ false);
     }
     m_dirty.clear();
     return res;
@@ -676,6 +700,12 @@ https://openpmd-api.readthedocs.io/en/latest/usage/concepts.html#iteration-and-s
 void ADIOS2IOHandlerImpl::createFile(
     Writable *writable, Parameter<Operation::CREATE_FILE> const &parameters)
 {
+    if (writable->parent)
+    {
+        throw std::runtime_error(
+            "CREATE_FILE only allowed for root-level objects");
+    }
+
     VERIFY_ALWAYS(
         access::write(m_handler->m_backendAccess),
         "[ADIOS2] Creating a file in read-only mode is not possible.");
@@ -684,21 +714,15 @@ void ADIOS2IOHandlerImpl::createFile(
     {
         std::string name = parameters.name + fileSuffix();
 
-        auto res_pair = getPossiblyExisting(name);
-        InvalidatableFile shared_name = InvalidatableFile(name);
-        VERIFY_ALWAYS(
-            !(m_handler->m_backendAccess == Access::READ_WRITE &&
-              (!std::get<PE_NewlyCreated>(res_pair) ||
-               auxiliary::file_exists(
-                   fullPath(std::get<PE_InvalidatableFile>(res_pair))))),
-            "[ADIOS2] Can only overwrite existing file in CREATE mode.");
-
-        if (!std::get<PE_NewlyCreated>(res_pair))
+        auto &file =
+            makeFile(writable, name, /* consider_open_files = */ false);
+        auto &file_state = **file;
+        if (access::read(m_handler->m_backendAccess) &&
+            (auxiliary::file_exists(fullPath(file_state)) ||
+             auxiliary::directory_exists(fullPath(file_state))))
         {
-            auto file = std::get<PE_InvalidatableFile>(res_pair);
-            m_dirty.erase(file);
-            dropFileData(file);
-            file.invalidate();
+            throw std::runtime_error(
+                "[ADIOS2] Can only overwrite existing file in CREATE mode.");
         }
 
         std::string const dir(m_handler->directory);
@@ -711,13 +735,13 @@ void ADIOS2IOHandlerImpl::createFile(
         // enforce opening the file
         // lazy opening is deathly in parallel situations
         auto &fileData =
-            getFileData(shared_name, IfFileNotOpen::CreateImplicitly);
+            getFileData(file_state, IfFileNotOpen::CreateImplicitly);
 
         // only emplace the file into our structures after it has been
         // successfully opened. otherwise, errors will lead to undefined state.
 
-        associateWithFile(writable, shared_name);
-        this->m_dirty.emplace(shared_name);
+        associateWithFile(writable, writable->fileState);
+        this->m_dirty.emplace(writable->fileState);
 
         writable->written = true;
         writable->abstractFilePosition = std::make_shared<ADIOS2FilePosition>();
@@ -798,12 +822,12 @@ void ADIOS2IOHandlerImpl::createPath(
     Writable *writable, const Parameter<Operation::CREATE_PATH> &parameters)
 {
     std::string path;
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ true);
+    auto &file = refreshFileFromParent(writable, /* preferParentFile = */ true);
 
     /* Sanitize path */
     if (!auxiliary::starts_with(parameters.path, '/'))
     {
-        path = filePositionToString(setAndGetFilePosition(writable)) + "/" +
+        path = filePositionToString(*setAndGetFilePosition(writable)) + "/" +
             auxiliary::removeSlashes(parameters.path);
     }
     else
@@ -857,7 +881,7 @@ void ADIOS2IOHandlerImpl::createDataset(
                     name + "')");
         }
 
-        auto const file =
+        auto &file =
             refreshFileFromParent(writable, /* preferParentFile = */ true);
         writable->abstractFilePosition.reset();
         auto filePos = setAndGetFilePosition(writable, name);
@@ -914,7 +938,7 @@ https://github.com/ornladios/ADIOS2/issues/3504.
         switchAdios2VariableType<detail::VariableDefiner>(
             parameters.dtype, fileData.m_IO, varName, operators, shape);
         writable->written = true;
-        m_dirty.emplace(file);
+        m_dirty.emplace(writable->fileState);
     }
 }
 
@@ -1019,7 +1043,8 @@ void ADIOS2IOHandlerImpl::extendDataset(
     }
 
     setAndGetFilePosition(writable);
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     std::string name = nameOfVariable(writable);
     auto &filedata = getFileData(file, IfFileNotOpen::ThrowError);
     Datatype dt = detail::fromADIOS2Type(filedata.m_IO.VariableType(name));
@@ -1039,8 +1064,15 @@ void ADIOS2IOHandlerImpl::openFile(
             "Supplied directory is not valid: " + m_handler->directory);
     }
 
+    if (writable->parent)
+    {
+        throw std::runtime_error(
+            "OPEN_FILE only allowed for root-level objects");
+    }
+
     std::string name = parameters.name + fileSuffix();
-    auto file = std::get<PE_InvalidatableFile>(getPossiblyExisting(name));
+
+    auto &file = makeFile(writable, name, /* consider_open_files = */ true);
 
     auto how_to_open = [&]() {
         switch (parameters.reopen)
@@ -1056,8 +1088,8 @@ void ADIOS2IOHandlerImpl::openFile(
     }();
 
     // enforce opening the file
-    // lazy opening is deadly in parallel situations
-    auto &fileData = getFileData(file, how_to_open);
+    // lazy opening is deathly in parallel situations
+    auto &fileData = getFileData(**file, how_to_open);
 
     // the following calls present the new file to the IO handler's data
     // structures. do this only after the file has been successfully open, to
@@ -1069,43 +1101,49 @@ void ADIOS2IOHandlerImpl::openFile(
     writable->abstractFilePosition = std::make_shared<ADIOS2FilePosition>();
 
     *parameters.out_parsePreference = fileData.parsePreference;
-    m_dirty.emplace(std::move(file));
+    m_dirty.emplace(file);
 }
 
 void ADIOS2IOHandlerImpl::closeFile(
     Writable *writable, Parameter<Operation::CLOSE_FILE> const &)
 {
-    auto fileIterator = m_files.find(writable);
-    if (fileIterator != m_files.end())
+    auto &maybe_file = writable->fileState;
+    if (!maybe_file || !maybe_file->has_value())
     {
-        // do not invalidate the file
-        // it still exists, it is just not open
-        auto it = m_fileData.find(fileIterator->second);
-        if (it != m_fileData.end())
-        {
-            /*
-             * No need to finalize unconditionally, destructor will take care
-             * of it.
-             */
-            it->second->flush(
-                FlushLevel::UserFlush,
-                [](detail::ADIOS2File &ba, adios2::Engine &) { ba.finalize(); },
-                /* writeLatePuts = */ true,
-                /* flushUnconditionally = */ false);
-            m_fileData.erase(it);
-        }
-        m_dirty.erase(fileIterator->second);
-        m_files.erase(fileIterator);
+        return;
     }
+    auto &file = **maybe_file;
+
+    m_files.erase(file.name);
+    m_dirty.erase(maybe_file);
+
+    if (!file.backendSpecificState.has_value())
+    {
+        return;
+    }
+    auto &adios2_file =
+        std::any_cast<BackendSpecificFileState &>(file.backendSpecificState);
+
+    /*
+     * No need to finalize unconditionally, destructor will take care
+     * of it.
+     */
+    adios2_file->flush(
+        FlushLevel::UserFlush,
+        [](detail::ADIOS2File &ba, adios2::Engine &) { ba.finalize(); },
+        /* writeLatePuts = */ true,
+        /* flushUnconditionally = */ false);
+    file.backendSpecificState.reset();
+    *maybe_file = std::nullopt;
 }
 
 void ADIOS2IOHandlerImpl::openPath(
     Writable *writable, const Parameter<Operation::OPEN_PATH> &parameters)
 {
     /* Sanitize path */
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ true);
+    auto &file = refreshFileFromParent(writable, /* preferParentFile = */ true);
     std::string prefix =
-        filePositionToString(setAndGetFilePosition(writable->parent));
+        filePositionToString(*setAndGetFilePosition(writable->parent));
     std::string suffix = auxiliary::removeSlashes(parameters.path);
     std::string infix =
         suffix.empty() || auxiliary::ends_with(prefix, '/') ? "" : "/";
@@ -1134,7 +1172,7 @@ void ADIOS2IOHandlerImpl::openDataset(
     writable->abstractFilePosition.reset();
     auto pos = setAndGetFilePosition(writable, name);
     pos->gd = GroupOrDataset::DATASET;
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ true);
+    auto &file = refreshFileFromParent(writable, /* preferParentFile = */ true);
     auto varName = nameOfVariable(writable);
     auto &fileData = getFileData(file, IfFileNotOpen::ThrowError);
     *parameters.dtype =
@@ -1194,13 +1232,14 @@ void ADIOS2IOHandlerImpl::writeDataset(
         access::write(m_handler->m_backendAccess),
         "[ADIOS2] Cannot write data in read-only mode.");
     setAndGetFilePosition(writable);
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
     detail::BufferedPut bp;
     bp.name = nameOfVariable(writable);
     bp.param = std::move(parameters);
     ba.enqueue(std::move(bp));
-    m_dirty.emplace(std::move(file));
+    m_dirty.emplace(writable->fileState);
     writable->written = true; // TODO erst nach dem Schreiben?
 }
 
@@ -1219,7 +1258,8 @@ void ADIOS2IOHandlerImpl::readDataset(
     Writable *writable, Parameter<Operation::READ_DATASET> &parameters)
 {
     setAndGetFilePosition(writable);
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
     detail::BufferedGet bg;
     bg.name = nameOfVariable(writable);
@@ -1228,7 +1268,7 @@ void ADIOS2IOHandlerImpl::readDataset(
     // selection might change again before flushing
     bg.stepSelection = ba.stepSelection();
     ba.enqueue(std::move(bg));
-    m_dirty.emplace(std::move(file));
+    m_dirty.emplace(writable->fileState);
 }
 
 namespace detail
@@ -1331,7 +1371,8 @@ void ADIOS2IOHandlerImpl::getBufferView(
     }
 
     setAndGetFilePosition(writable);
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
 
     if (std::any_of(
@@ -1404,8 +1445,9 @@ namespace detail
 void ADIOS2IOHandlerImpl::readAttribute(
     Writable *writable, Parameter<Operation::READ_ATT> &parameters)
 {
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
-    auto pos = setAndGetFilePosition(writable);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
+    setAndGetFilePosition(writable);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
     auto name = nameOfAttribute(writable, parameters.name);
 
@@ -1629,8 +1671,9 @@ namespace
 void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     Writable *writable, Parameter<Operation::READ_ATT_ALLSTEPS> &param)
 {
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
-    auto pos = setAndGetFilePosition(writable);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
+    setAndGetFilePosition(writable);
     auto name = nameOfAttribute(writable, param.name);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
 
@@ -1680,7 +1723,7 @@ void ADIOS2IOHandlerImpl::readAttributeAllsteps(
     IO.SetEngine(ba.m_IO.EngineType());
     IO.SetParameters(ba.m_IO.Parameters());
     IO.SetParameter("StreamReader", "ON"); // this be for BP4
-    auto engine = IO.Open(fullPath(*file), adios2::Mode::Read);
+    auto engine = IO.Open(fullPath(file), adios2::Mode::Read);
 
     std::vector<detail::PreloadAdiosAttributes> preload;
 
@@ -1741,9 +1784,10 @@ void ADIOS2IOHandlerImpl::listPaths(
         writable->written,
         "[ADIOS2] Internal error: Writable not marked written during path "
         "listing");
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto pos = setAndGetFilePosition(writable);
-    std::string myName = filePositionToString(pos);
+    std::string myName = filePositionToString(*pos);
     if (!auxiliary::ends_with(myName, '/'))
     {
         myName = myName + '/';
@@ -1881,10 +1925,10 @@ void ADIOS2IOHandlerImpl::listDatasets(
         writable->written,
         "[ADIOS2] Internal error: Writable not marked written during path "
         "listing");
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto pos = setAndGetFilePosition(writable);
-    // adios2::Engine & engine = getEngine( file );
-    std::string myName = filePositionToString(pos);
+    std::string myName = filePositionToString(*pos);
     if (!auxiliary::ends_with(myName, '/'))
     {
         myName = myName + '/';
@@ -1923,9 +1967,10 @@ void ADIOS2IOHandlerImpl::listAttributes(
         writable->written,
         "[ADIOS2] Internal error: Writable not marked "
         "written during attribute writing");
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto pos = setAndGetFilePosition(writable);
-    auto attributePrefix = filePositionToString(pos);
+    auto attributePrefix = filePositionToString(*pos);
     if (attributePrefix == "/")
     {
         attributePrefix = "";
@@ -1948,8 +1993,7 @@ void ADIOS2IOHandlerImpl::listAttributes(
 void ADIOS2IOHandlerImpl::advance(
     Writable *writable, Parameter<Operation::ADVANCE> &parameters)
 {
-    auto file = m_files.at(writable);
-    auto &ba = getFileData(file, IfFileNotOpen::ThrowError);
+    auto &ba = getFileData(*writable->fileState, IfFileNotOpen::ThrowError);
     std::visit(
         auxiliary::overloaded{
             [&](AdvanceMode mode) { *parameters.status = ba.advance(mode); },
@@ -1971,14 +2015,15 @@ void ADIOS2IOHandlerImpl::closePath(
         // nothing to do
         return;
     }
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto &fileData = getFileData(file, IfFileNotOpen::ThrowError);
     if (!fileData.optimizeAttributesStreaming)
     {
         return;
     }
     auto position = setAndGetFilePosition(writable);
-    auto positionString = filePositionToString(position);
+    auto positionString = filePositionToString(*position);
     VERIFY(
         !auxiliary::ends_with(positionString, '/'),
         "[ADIOS2] Position string has unexpected format. This is a bug "
@@ -1996,7 +2041,8 @@ void ADIOS2IOHandlerImpl::availableChunks(
     Writable *writable, Parameter<Operation::AVAILABLE_CHUNKS> &parameters)
 {
     setAndGetFilePosition(writable);
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     detail::ADIOS2File &ba = getFileData(file, IfFileNotOpen::ThrowError);
     std::string varName = nameOfVariable(writable);
     auto engine = ba.getEngine(); // make sure that data are present
@@ -2013,23 +2059,18 @@ void ADIOS2IOHandlerImpl::availableChunks(
 }
 
 void ADIOS2IOHandlerImpl::deregister(
-    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+    Writable *, Parameter<Operation::DEREGISTER> const &)
 {
-    m_files.erase(writable);
+    // noop, ADIOS2 backend stores all such information directly in the Writable
 }
 
 void ADIOS2IOHandlerImpl::touch(
     Writable *writable, Parameter<Operation::TOUCH> const &)
 {
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    refreshFileFromParent(writable, false);
     if (access::write(m_handler->m_backendAccess))
     {
-        m_dirty.emplace(std::move(file));
-    }
-    else if (m_fileData.find(file) == m_fileData.end())
-    {
-        throw error::Internal(
-            "ADIOS2: Tried activating a file that is not open.");
+        this->m_dirty.emplace(writable->fileState);
     }
 }
 
@@ -2144,14 +2185,14 @@ adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(
 json::TracingJSON ADIOS2IOHandlerImpl::nullvalue = {
     nlohmann::json(), json::SupportedLanguages::JSON};
 
-std::string ADIOS2IOHandlerImpl::filePositionToString(
-    std::shared_ptr<ADIOS2FilePosition> filepos)
+std::string
+ADIOS2IOHandlerImpl::filePositionToString(ADIOS2FilePosition const &filepos)
 {
-    return filepos->location;
+    return filepos.location;
 }
 
 std::shared_ptr<ADIOS2FilePosition> ADIOS2IOHandlerImpl::extendFilePosition(
-    std::shared_ptr<ADIOS2FilePosition> const &oldPos, std::string s)
+    ADIOS2FilePosition const &oldPos, std::string s)
 {
     auto path = filePositionToString(oldPos);
     if (!auxiliary::ends_with(path, '/') && !auxiliary::starts_with(s, '/'))
@@ -2162,8 +2203,7 @@ std::shared_ptr<ADIOS2FilePosition> ADIOS2IOHandlerImpl::extendFilePosition(
     {
         path = auxiliary::replace_last(path, "/", "");
     }
-    return std::make_shared<ADIOS2FilePosition>(
-        path + std::move(s), oldPos->gd);
+    return std::make_shared<ADIOS2FilePosition>(path + std::move(s), oldPos.gd);
 }
 
 std::optional<adios2::Operator>
@@ -2205,15 +2245,15 @@ ADIOS2IOHandlerImpl::getCompressionOperator(std::string const &compression)
 std::string ADIOS2IOHandlerImpl::nameOfVariable(Writable *writable)
 {
     auto filepos = setAndGetFilePosition(writable);
-    return filePositionToString(filepos);
+    return filePositionToString(*filepos);
 }
 
 std::string
 ADIOS2IOHandlerImpl::nameOfAttribute(Writable *writable, std::string attribute)
 {
     auto pos = setAndGetFilePosition(writable);
-    return filePositionToString(extendFilePosition(
-        pos, auxiliary::removeSlashes(std::move(attribute))));
+    return filePositionToString(*extendFilePosition(
+        *pos, auxiliary::removeSlashes(std::move(attribute))));
 }
 
 GroupOrDataset ADIOS2IOHandlerImpl::groupOrDataset(Writable *writable)
@@ -2222,12 +2262,18 @@ GroupOrDataset ADIOS2IOHandlerImpl::groupOrDataset(Writable *writable)
 }
 
 detail::ADIOS2File &ADIOS2IOHandlerImpl::getFileData(
-    InvalidatableFile const &file, IfFileNotOpen flag)
+    std::optional<internal::FileState> &file, IfFileNotOpen flag)
 {
     VERIFY_ALWAYS(
-        file.valid(),
+        file.has_value(),
         "[ADIOS2] Cannot retrieve file data for a file that has "
         "been overwritten or deleted.")
+    return getFileData(*file, flag);
+}
+
+detail::ADIOS2File &
+ADIOS2IOHandlerImpl::getFileData(internal::FileState &file, IfFileNotOpen flag)
+{
     auto openFileAs = [&]() {
         using OF = adios_defs::OpenFileAs;
         switch (flag)
@@ -2242,37 +2288,25 @@ detail::ADIOS2File &ADIOS2IOHandlerImpl::getFileData(
             break;
         }
         return OF{};
-    }();
-    auto it = m_fileData.find(file);
-    if (it == m_fileData.end())
+    };
+    if (!file.backendSpecificState.has_value())
     {
         switch (flag)
         {
         case IfFileNotOpen::ThrowError:
             throw std::runtime_error(
                 "[ADIOS2] Requested file has not been opened yet: " +
-                (file.fileState ? file.fileState->name : "Unknown file name"));
-        default:
-            auto res = m_fileData.emplace(
-                file,
-                std::make_unique<detail::ADIOS2File>(*this, file, openFileAs));
-            return *res.first->second;
+                file.name);
+        default: {
+            file.backendSpecificState = std::make_any<BackendSpecificFileState>(
+                new detail::ADIOS2File(*this, file, openFileAs()));
+            break;
+        }
         }
     }
-    else
-    {
-        return *it->second;
-    }
-}
-
-void ADIOS2IOHandlerImpl::dropFileData(InvalidatableFile const &file)
-{
-    auto it = m_fileData.find(file);
-    if (it != m_fileData.end())
-    {
-        it->second->drop();
-        m_fileData.erase(it);
-    }
+    auto &adios2_file =
+        std::any_cast<BackendSpecificFileState &>(file.backendSpecificState);
+    return *adios2_file;
 }
 
 namespace detail
@@ -2311,8 +2345,7 @@ namespace detail
         VERIFY_ALWAYS(
             access::write(impl->m_handler->m_backendAccess),
             "[ADIOS2] Cannot write attribute in read-only mode.");
-        auto pos = impl->setAndGetFilePosition(writable);
-        auto file = impl->refreshFileFromParent(
+        auto &file = impl->refreshFileFromParent(
             writable, /* preferParentFile = */ false);
         auto name = auxiliary::removeSlashes(parameters.name);
         if (auxiliary::contains(name, '/'))
@@ -2328,7 +2361,7 @@ namespace detail
         auto &filedata = impl->getFileData(
             file, ADIOS2IOHandlerImpl::IfFileNotOpen::ThrowError);
         adios2::IO IO = filedata.m_IO;
-        impl->m_dirty.emplace(std::move(file));
+        impl->m_dirty.emplace(writable->fileState);
 
         if (impl->m_modifiableAttributes ==
                 ADIOS2IOHandlerImpl::ModifiableAttributes::No &&
@@ -2459,7 +2492,7 @@ namespace detail
     template <typename T>
     void DatasetOpener::call(
         ADIOS2IOHandlerImpl *impl,
-        InvalidatableFile const &file,
+        internal::FileState &file,
         const std::string &varName,
         Parameter<Operation::OPEN_DATASET> &parameters,
         std::optional<size_t> stepSelection,
@@ -2475,7 +2508,7 @@ namespace detail
         {
             throw std::runtime_error(
                 "[ADIOS2] Failed retrieving ADIOS2 Variable with name '" +
-                varName + "' from file " + *file + ".");
+                varName + "' from file " + file.name + ".");
         }
 
         if (stepSelection.has_value())

--- a/src/IO/InvalidatableFile.cpp
+++ b/src/IO/InvalidatableFile.cpp
@@ -25,16 +25,44 @@ namespace openPMD::internal
 {
 FileState::FileState(std::string name_in) : name(std::move(name_in))
 {}
+auto SharedFileState::has_value() const -> bool
+{
+    return ptr_type::operator bool() && ptr_type::operator*().has_value();
+}
+SharedFileState::operator bool() const
+{
+    return has_value();
+}
+auto SharedFileState::operator*() -> FileState &
+{
+    return *ptr_type::operator*();
+}
+auto SharedFileState::operator->() -> FileState *
+{
+    return &*ptr_type::operator*();
+}
+auto SharedFileState::operator*() const -> FileState const &
+{
+    return *ptr_type::operator*();
+}
+auto SharedFileState::operator->() const -> FileState const *
+{
+    return &*ptr_type::operator*();
+}
+void SharedFileState::reset_optional()
+{
+    ptr_type::operator*().reset();
+}
 } // namespace openPMD::internal
 
 auto std::less<openPMD::internal::SharedFileState>::operator()(
     first_argument_type const &first, second_argument_type const &second) const
     -> result_type
 {
-    if (!first || !second || !*first || !*second)
+    if (!first || !second)
     {
         return std::less<>()(first.get(), second.get());
     }
     // If possible, compare by name
-    return less<>()((**first).name, (**second).name);
+    return less<>()((*first).name, (*second).name);
 }

--- a/src/IO/InvalidatableFile.cpp
+++ b/src/IO/InvalidatableFile.cpp
@@ -35,18 +35,22 @@ SharedFileState::operator bool() const
 }
 auto SharedFileState::operator*() -> FileState &
 {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     return *ptr_type::operator*();
 }
 auto SharedFileState::operator->() -> FileState *
 {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     return &*ptr_type::operator*();
 }
 auto SharedFileState::operator*() const -> FileState const &
 {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     return *ptr_type::operator*();
 }
 auto SharedFileState::operator->() const -> FileState const *
 {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     return &*ptr_type::operator*();
 }
 void SharedFileState::reset_optional()

--- a/src/IO/InvalidatableFile.cpp
+++ b/src/IO/InvalidatableFile.cpp
@@ -21,68 +21,8 @@
 
 #include "openPMD/IO/InvalidatableFile.hpp"
 
-openPMD::InvalidatableFile::InvalidatableFile(std::string s)
-    : fileState{std::make_shared<FileState>(std::move(s))}
+namespace openPMD::internal
+{
+FileState::FileState(std::string name_in) : name(std::move(name_in))
 {}
-
-void openPMD::InvalidatableFile::invalidate()
-{
-    fileState->valid = false;
-}
-
-bool openPMD::InvalidatableFile::valid() const
-{
-    return fileState->valid;
-}
-
-openPMD::InvalidatableFile &openPMD::InvalidatableFile::operator=(std::string s)
-{
-    if (fileState)
-    {
-        fileState->name = std::move(s);
-    }
-    else
-    {
-        fileState = std::make_shared<FileState>(std::move(s));
-    }
-    return *this;
-}
-
-bool openPMD::InvalidatableFile::operator==(
-    const openPMD::InvalidatableFile &f) const
-{
-    return this->fileState == f.fileState;
-}
-
-std::string &openPMD::InvalidatableFile::operator*() const
-{
-    return fileState->name;
-}
-
-std::string *openPMD::InvalidatableFile::operator->() const
-{
-    return &fileState->name;
-}
-
-openPMD::InvalidatableFile::operator bool() const
-{
-    return fileState.operator bool();
-}
-
-openPMD::InvalidatableFile::FileState::FileState(std::string s)
-    : name{std::move(s)}
-{}
-
-std::hash<openPMD::InvalidatableFile>::result_type
-std::hash<openPMD::InvalidatableFile>::operator()(
-    const openPMD::InvalidatableFile &s) const noexcept
-{
-    return std::hash<shared_ptr<openPMD::InvalidatableFile::FileState>>{}(
-        s.fileState);
-}
-auto std::less<openPMD::InvalidatableFile>::operator()(
-    first_argument_type const &first, second_argument_type const &second) const
-    -> result_type
-{
-    return less<>()(*first, *second);
-}
+} // namespace openPMD::internal

--- a/src/IO/InvalidatableFile.cpp
+++ b/src/IO/InvalidatableFile.cpp
@@ -26,3 +26,15 @@ namespace openPMD::internal
 FileState::FileState(std::string name_in) : name(std::move(name_in))
 {}
 } // namespace openPMD::internal
+
+auto std::less<openPMD::internal::SharedFileState>::operator()(
+    first_argument_type const &first, second_argument_type const &second) const
+    -> result_type
+{
+    if (!first || !second || !*first || !*second)
+    {
+        return std::less<>()(first.get(), second.get());
+    }
+    // If possible, compare by name
+    return less<>()((**first).name, (**second).name);
+}

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -22,7 +22,6 @@
 #include "openPMD/IO/JSON/JSONIOHandlerImpl.hpp"
 #include "openPMD/Datatype.hpp"
 #include "openPMD/Error.hpp"
-#include "openPMD/IO/ADIOS/ADIOS2File.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 #include "openPMD/IO/FlushParametersInternal.hpp"
@@ -30,6 +29,7 @@
 #include "openPMD/IO/InvalidatableFile.hpp"
 #include "openPMD/IO/JSON/JSONFilePosition.hpp"
 #include "openPMD/ThrowError.hpp"
+#include "openPMD/auxiliary/DrainSet.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/JSONMatcher.hpp"
 #include "openPMD/auxiliary/JSON_internal.hpp"
@@ -475,12 +475,12 @@ std::future<void> JSONIOHandlerImpl::flush(internal::ParsedFlushParams &params)
         throw error::Internal(
             "JSON backend: Cannot have dirty files in read-only modes.");
     }
-    for (auto const &file : m_dirty)
+    for (internal::SharedFileState &file : auxiliary::drain(m_dirty))
     {
-        if (file->has_value())
-            putJsonContents(**file);
+        if (file.has_value())
+            putJsonContents(*file);
     }
-    m_dirty.clear();
+    assert(m_dirty.empty());
     return std::future<void>();
 }
 
@@ -515,7 +515,7 @@ void JSONIOHandlerImpl::createFile(
         std::string name = parameters.name + m_originalExtension;
 
         auto file = makeFile(writable, name, /* consider_open_files = */ false);
-        auto &file_state = **file;
+        auto &file_state = *file;
         auto file_exists = auxiliary::file_exists(fullPath(file_state));
 
         if (access::read(m_handler->m_backendAccess) && file_exists)
@@ -922,15 +922,15 @@ void JSONIOHandlerImpl::closeFile(
     {
         return;
     }
-    else if (!maybe_file->has_value())
+    else if (!maybe_file.has_value())
     {
-        *maybe_file = std::nullopt;
+        maybe_file.reset_optional();
     }
-    auto &file = **maybe_file;
+    auto &file = *maybe_file;
     putJsonContents(file);
     m_dirty.erase(maybe_file);
     m_files.erase(file.name);
-    *maybe_file = std::nullopt;
+    maybe_file.reset_optional();
 }
 
 void JSONIOHandlerImpl::openPath(

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -22,9 +22,13 @@
 #include "openPMD/IO/JSON/JSONIOHandlerImpl.hpp"
 #include "openPMD/Datatype.hpp"
 #include "openPMD/Error.hpp"
+#include "openPMD/IO/ADIOS/ADIOS2File.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/IO/AbstractIOHandlerImpl.hpp"
 #include "openPMD/IO/FlushParametersInternal.hpp"
+#include "openPMD/IO/IOTask.hpp"
+#include "openPMD/IO/InvalidatableFile.hpp"
+#include "openPMD/IO/JSON/JSONFilePosition.hpp"
 #include "openPMD/ThrowError.hpp"
 #include "openPMD/auxiliary/Filesystem.hpp"
 #include "openPMD/auxiliary/JSONMatcher.hpp"
@@ -38,6 +42,8 @@
 
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
+#include <toml.hpp>
 
 #include <algorithm>
 #include <exception>
@@ -386,11 +392,27 @@ JSONIOHandlerImpl::getBackendConfig(openPMD::json::TracingJSON &config) const
     }
 }
 
+JSONIOHandlerImpl::BackendSpecificFileState::BackendSpecificFileState(
+    nlohmann::json data_in)
+    : data(std::move(data_in))
+{}
+
+JSONIOHandlerImpl::BackendSpecificFileState::operator nlohmann::json &()
+{
+    return data;
+}
+
+JSONIOHandlerImpl::BackendSpecificFileState::operator nlohmann::json const &()
+    const
+{
+    return data;
+}
+
 JSONIOHandlerImpl::JSONIOHandlerImpl(
     AbstractIOHandler *handler,
     FileFormat format,
     std::string originalExtension)
-    : AbstractIOHandlerImpl(handler)
+    : AbstractIOHandlerImplCommon(handler)
     , m_fileFormat{format}
     , m_originalExtension{std::move(originalExtension)}
 {
@@ -403,7 +425,7 @@ JSONIOHandlerImpl::JSONIOHandlerImpl(
     MPI_Comm comm,
     FileFormat format,
     std::string originalExtension)
-    : AbstractIOHandlerImpl(handler)
+    : AbstractIOHandlerImplCommon(handler)
     , m_communicator{comm}
     , m_fileFormat{format}
     , m_originalExtension{std::move(originalExtension)}
@@ -455,7 +477,8 @@ std::future<void> JSONIOHandlerImpl::flush(internal::ParsedFlushParams &params)
     }
     for (auto const &file : m_dirty)
     {
-        putJsonContents(file, false);
+        if (file->has_value())
+            putJsonContents(**file);
     }
     m_dirty.clear();
     return std::future<void>();
@@ -491,21 +514,14 @@ void JSONIOHandlerImpl::createFile(
     {
         std::string name = parameters.name + m_originalExtension;
 
-        auto res_pair = getPossiblyExisting(name);
-        auto fullPathToFile = fullPath(std::get<0>(res_pair));
-        File shared_name = File(name);
-        VERIFY_ALWAYS(
-            !(m_handler->m_backendAccess == Access::READ_WRITE &&
-              (!std::get<2>(res_pair) ||
-               auxiliary::file_exists(fullPathToFile))),
-            "[JSON] Can only overwrite existing file in CREATE mode.");
+        auto file = makeFile(writable, name, /* consider_open_files = */ false);
+        auto &file_state = **file;
+        auto file_exists = auxiliary::file_exists(fullPath(file_state));
 
-        if (!std::get<2>(res_pair))
+        if (access::read(m_handler->m_backendAccess) && file_exists)
         {
-            auto file = std::get<0>(res_pair);
-            m_dirty.erase(file);
-            m_jsonVals.erase(file);
-            file.invalidate();
+            throw std::runtime_error(
+                "[JSON] Can only overwrite existing file in CREATE mode.");
         }
 
         std::string const &dir(m_handler->directory);
@@ -515,16 +531,15 @@ void JSONIOHandlerImpl::createFile(
             VERIFY(success, "[JSON] Could not create directory.");
         }
 
-        associateWithFile(writable, shared_name);
-        this->m_dirty.emplace(shared_name);
+        this->m_dirty.emplace(writable->fileState);
 
-        if (!access::append(m_handler->m_backendAccess) ||
-            !auxiliary::file_exists(fullPathToFile))
+        if (!access::append(m_handler->m_backendAccess) || !file_exists)
         {
             // if in create mode: make sure to overwrite
             // if in append mode and the file does not exist: create an empty
             // dataset
-            this->m_jsonVals[shared_name] = std::make_shared<nlohmann::json>();
+            file_state.backendSpecificState =
+                std::make_any<BackendSpecificFileState>(nlohmann::json());
         }
         // else: the JSON value is not available in m_jsonVals and will be
         // read from the file later on before overwriting
@@ -562,27 +577,24 @@ void JSONIOHandlerImpl::createPath(
         path = auxiliary::replace_last(path, "/", "");
     }
 
-    auto file = refreshFileFromParent(writable);
+    auto &file = refreshFileFromParent(writable, /* preferParentFile = */ true);
 
-    auto *jsonVal = &*obtainJsonContents(file);
+    auto *jsonVal = &obtainJsonContents(file);
+    JSONFilePosition *filepos = nullptr;
     if (!auxiliary::starts_with(path, "/"))
     { // path is relative
-        auto filepos = setAndGetFilePosition(writable, false);
-
-        jsonVal = &(*jsonVal)[filepos->id];
-        ensurePath(jsonVal, path);
-        path = filepos->id.to_string() + "/" + path;
+        filepos = setAndGetFilePosition(writable, path);
     }
     else
     {
-
-        ensurePath(jsonVal, path);
+        auto new_filepos =
+            std::make_shared<JSONFilePosition>(json::json_pointer(path));
+        filepos = new_filepos.get();
+        writable->abstractFilePosition = std::move(new_filepos);
     }
-
-    m_dirty.emplace(file);
+    ensurePath(jsonVal, filepos->id.to_string());
+    m_dirty.emplace(writable->fileState);
     writable->written = true;
-    writable->abstractFilePosition =
-        std::make_shared<JSONFilePosition>(nlohmann::json::json_pointer(path));
 }
 
 void JSONIOHandlerImpl::createDataset(
@@ -623,19 +635,11 @@ void JSONIOHandlerImpl::createDataset(
         /* Sanitize name */
         std::string name = removeSlashes(parameter.name);
 
-        auto file = refreshFileFromParent(writable);
         writable->abstractFilePosition.reset();
-        setAndGetFilePosition(writable);
-        auto &jsonVal = obtainJsonContents(writable);
-        // be sure to have a JSON object, not a list
-        if (jsonVal.empty())
-        {
-            jsonVal = nlohmann::json::object();
-        }
+        refreshFileFromParent(writable, /* preferParentFile = */ true);
         setAndGetFilePosition(writable, name);
-        auto &dset = jsonVal[name];
-        dset["datatype"] = jsonDatatypeToString(parameter.dtype);
-
+        auto &dset = obtainJsonContents(writable);
+        dset["datatype"] = datatypeToString(parameter.dtype);
         switch (localMode)
         {
         case DatasetMode::Dataset: {
@@ -678,7 +682,7 @@ void JSONIOHandlerImpl::createDataset(
             break;
         }
         writable->written = true;
-        m_dirty.emplace(file);
+        m_dirty.emplace(writable->fileState);
     }
 }
 
@@ -719,7 +723,7 @@ void JSONIOHandlerImpl::extendDataset(
     }
 
     setAndGetFilePosition(writable);
-    refreshFileFromParent(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto &j = obtainJsonContents(writable);
 
     DatasetMode localIOMode;
@@ -881,8 +885,8 @@ namespace
 void JSONIOHandlerImpl::availableChunks(
     Writable *writable, Parameter<Operation::AVAILABLE_CHUNKS> &parameters)
 {
-    refreshFileFromParent(writable);
-    auto filePosition = setAndGetFilePosition(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
+    setAndGetFilePosition(writable);
     auto &j = obtainJsonContents(writable)["data"];
     *parameters.chunks = chunksInJSON(j);
     chunk_assignment::mergeChunks(*parameters.chunks);
@@ -902,7 +906,7 @@ void JSONIOHandlerImpl::openFile(
 
     std::string name = parameter.name + m_originalExtension;
 
-    auto file = std::get<0>(getPossiblyExisting(name));
+    auto &file = makeFile(writable, name, /* consider_open_files = */ true);
 
     associateWithFile(writable, file);
 
@@ -913,42 +917,38 @@ void JSONIOHandlerImpl::openFile(
 void JSONIOHandlerImpl::closeFile(
     Writable *writable, Parameter<Operation::CLOSE_FILE> const &)
 {
-    auto fileIterator = m_files.find(writable);
-    if (fileIterator != m_files.end())
+    auto &maybe_file = writable->fileState;
+    if (!maybe_file)
     {
-        auto it = putJsonContents(fileIterator->second);
-        if (it != m_jsonVals.end())
-        {
-            m_jsonVals.erase(it);
-        }
-        m_dirty.erase(fileIterator->second);
-        // do not invalidate the file
-        // it still exists, it is just not open
-        m_files.erase(fileIterator);
+        return;
     }
+    else if (!maybe_file->has_value())
+    {
+        *maybe_file = std::nullopt;
+    }
+    auto &file = **maybe_file;
+    putJsonContents(file);
+    m_dirty.erase(maybe_file);
+    m_files.erase(file.name);
+    *maybe_file = std::nullopt;
 }
 
 void JSONIOHandlerImpl::openPath(
     Writable *writable, Parameter<Operation::OPEN_PATH> const &parameters)
 {
-    auto file = refreshFileFromParent(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ true);
 
     nlohmann::json *j = &obtainJsonContents(writable->parent);
-    auto path = removeSlashes(parameters.path);
-    path = path.empty() ? filepositionOf(writable->parent)
-                        : filepositionOf(writable->parent) + "/" + path;
 
-    if (writable->abstractFilePosition)
+    std::string path = parameters.path;
+    /* Sanitize:
+     * The JSON API does not like to have slashes in the end.
+     */
+    if (auxiliary::ends_with(path, "/"))
     {
-        *setAndGetFilePosition(writable, false) =
-            JSONFilePosition(json::json_pointer(path));
+        path = auxiliary::replace_last(path, "/", "");
     }
-    else
-    {
-        writable->abstractFilePosition =
-            std::make_shared<JSONFilePosition>(json::json_pointer(path));
-    }
-
+    setAndGetFilePosition(writable, path);
     ensurePath(j, removeSlashes(parameters.path));
 
     writable->written = true;
@@ -957,7 +957,7 @@ void JSONIOHandlerImpl::openPath(
 void JSONIOHandlerImpl::openDataset(
     Writable *writable, Parameter<Operation::OPEN_DATASET> &parameters)
 {
-    refreshFileFromParent(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ true);
     auto name = removeSlashes(parameters.name);
     auto &datasetJson = obtainJsonContents(writable->parent)[name];
     /*
@@ -991,15 +991,7 @@ void JSONIOHandlerImpl::deleteFile(
         ? parameters.name
         : parameters.name + ".json";
 
-    auto tuple = getPossiblyExisting(filename);
-    if (!std::get<2>(tuple))
-    {
-        // file is already in the system
-        auto file = std::get<0>(tuple);
-        m_dirty.erase(file);
-        m_jsonVals.erase(file);
-        file.invalidate();
-    }
+    closeFile(writable, Parameter<Operation::CLOSE_FILE>());
 
     std::remove(fullPath(filename).c_str());
 
@@ -1022,8 +1014,8 @@ void JSONIOHandlerImpl::deletePath(
         !auxiliary::starts_with(parameters.path, '/'),
         "[JSON] Paths passed for deletion should be relative, the given path "
         "is absolute (starts with '/')")
-    auto file = refreshFileFromParent(writable);
-    auto filepos = setAndGetFilePosition(writable, false);
+    auto &file = refreshFileFromParent(writable, /* preferParentFile = */ true);
+    auto filepos = setAndGetFilePosition(writable);
     auto path = removeSlashes(parameters.path);
     VERIFY(!path.empty(), "[JSON] No path passed for deletion.")
     nlohmann::json *j;
@@ -1045,7 +1037,7 @@ void JSONIOHandlerImpl::deletePath(
         // parent exists since we have verified that the current
         // directory is != root
         parentDir(s);
-        j = &(*obtainJsonContents(file))[nlohmann::json::json_pointer(s)];
+        j = &(obtainJsonContents(file))[nlohmann::json::json_pointer(s)];
     }
     else
     {
@@ -1095,9 +1087,10 @@ void JSONIOHandlerImpl::deleteDataset(
         return;
     }
 
-    auto filepos = setAndGetFilePosition(writable, false);
+    auto filepos = setAndGetFilePosition(writable);
 
-    auto file = refreshFileFromParent(writable);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto dataset = removeSlashes(parameters.name);
     nlohmann::json *parent;
     if (dataset == ".")
@@ -1113,7 +1106,7 @@ void JSONIOHandlerImpl::deleteDataset(
         dataset.replace(0, i + 1, "");
 
         parentDir(s);
-        parent = &(*obtainJsonContents(file))[nlohmann::json::json_pointer(s)];
+        parent = &(obtainJsonContents(file))[nlohmann::json::json_pointer(s)];
     }
     else
     {
@@ -1135,7 +1128,7 @@ void JSONIOHandlerImpl::deleteAttribute(
         return;
     }
     setAndGetFilePosition(writable);
-    auto file = refreshFileFromParent(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto &j = obtainJsonContents(writable);
     j.erase(parameters.name);
 }
@@ -1147,8 +1140,8 @@ void JSONIOHandlerImpl::writeDataset(
         access::write(m_handler->m_backendAccess),
         "[JSON] Cannot write data in read-only mode.");
 
-    auto pos = setAndGetFilePosition(writable);
-    auto file = refreshFileFromParent(writable);
+    setAndGetFilePosition(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
     auto &j = obtainJsonContents(writable);
 
     switch (verifyDataset(parameters, j))
@@ -1191,12 +1184,13 @@ void JSONIOHandlerImpl::writeAttribute(
     /* Sanitize name */
     std::string name = removeSlashes(parameter.name);
 
-    auto file = refreshFileFromParent(writable);
-    auto jsonVal = obtainJsonContents(file);
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto &jsonVal = obtainJsonContents(file);
     auto filePosition = setAndGetFilePosition(writable);
-    if ((*jsonVal)[filePosition->id]["attributes"].empty())
+    if (jsonVal[filePosition->id]["attributes"].empty())
     {
-        (*jsonVal)[filePosition->id]["attributes"] = nlohmann::json::object();
+        jsonVal[filePosition->id]["attributes"] = nlohmann::json::object();
     }
     nlohmann::json value;
     switchType<AttributeWriter>(
@@ -1204,17 +1198,17 @@ void JSONIOHandlerImpl::writeAttribute(
     switch (m_attributeMode.m_mode)
     {
     case AttributeMode::Long:
-        (*jsonVal)[filePosition->id]["attributes"][name] = {
+        jsonVal[filePosition->id]["attributes"][name] = {
             {"datatype", jsonDatatypeToString(parameter.dtype)},
             {"value", value}};
         break;
     case AttributeMode::Short:
         // short form
-        (*jsonVal)[filePosition->id]["attributes"][name] = value;
+        jsonVal[filePosition->id]["attributes"][name] = value;
         break;
     }
     writable->written = true;
-    m_dirty.emplace(file);
+    m_dirty.emplace(writable->fileState);
 }
 
 namespace
@@ -1241,7 +1235,7 @@ namespace
 void JSONIOHandlerImpl::readDataset(
     Writable *writable, Parameter<Operation::READ_DATASET> &parameters)
 {
-    refreshFileFromParent(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
     setAndGetFilePosition(writable);
     auto &j = obtainJsonContents(writable);
     DatasetMode localMode = verifyDataset(parameters, j);
@@ -1536,7 +1530,8 @@ void JSONIOHandlerImpl::readAttribute(
     VERIFY_ALWAYS(
         writable->written,
         "[JSON] Attributes have to be written before reading.")
-    refreshFileFromParent(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
+    setAndGetFilePosition(writable);
     auto name = removeSlashes(parameters.name);
     auto const &jsonContents = obtainJsonContents(writable);
     if (!hasKey(jsonContents, "attributes"))
@@ -1546,9 +1541,9 @@ void JSONIOHandlerImpl::readAttribute(
             error::Reason::NotFound,
             "JSON",
             "Tried looking up attribute '" + name + "' at location: " +
-                setAndGetFilePosition(writable, false)->id.to_string());
+                setAndGetFilePosition(writable)->id.to_string());
     }
-    auto const &jsonLoc = jsonContents["attributes"];
+    auto const &jsonLoc = jsonContents.at("attributes");
     setAndGetFilePosition(writable);
     if (!hasKey(jsonLoc, name))
     {
@@ -1559,7 +1554,7 @@ void JSONIOHandlerImpl::readAttribute(
             "Tried looking up attribute '" + name +
                 "' in object: " + jsonLoc.dump());
     }
-    auto &j = jsonLoc[name];
+    auto &j = jsonLoc.at(name);
     try
     {
         if (j.is_object())
@@ -1595,7 +1590,7 @@ void JSONIOHandlerImpl::listPaths(
         "[JSON] Values have to be written before reading a directory");
     auto &j = obtainJsonContents(writable);
     setAndGetFilePosition(writable);
-    refreshFileFromParent(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
     parameters.paths->clear();
     for (auto it = j.begin(); it != j.end(); it++)
     {
@@ -1611,8 +1606,8 @@ void JSONIOHandlerImpl::listDatasets(
 {
     VERIFY_ALWAYS(
         writable->written, "[JSON] Datasets have to be written before reading.")
-    refreshFileFromParent(writable);
-    auto filePosition = setAndGetFilePosition(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
+    setAndGetFilePosition(writable);
     auto &j = obtainJsonContents(writable);
     parameters.datasets->clear();
     for (auto it = j.begin(); it != j.end(); it++)
@@ -1630,8 +1625,8 @@ void JSONIOHandlerImpl::listAttributes(
     VERIFY_ALWAYS(
         writable->written,
         "[JSON] Attributes have to be written before reading.")
-    refreshFileFromParent(writable);
-    auto filePosition = setAndGetFilePosition(writable);
+    refreshFileFromParent(writable, /* preferParentFile = */ false);
+    setAndGetFilePosition(writable);
     auto const &jsonContents = obtainJsonContents(writable);
     if (!jsonContents.contains("attributes"))
     {
@@ -1645,32 +1640,26 @@ void JSONIOHandlerImpl::listAttributes(
 }
 
 void JSONIOHandlerImpl::deregister(
-    Writable *writable, Parameter<Operation::DEREGISTER> const &)
-{
-    m_files.erase(writable);
-}
+    Writable *, Parameter<Operation::DEREGISTER> const &)
+{}
 
 void JSONIOHandlerImpl::touch(
     Writable *writable, Parameter<Operation::TOUCH> const &)
 {
-    auto file = refreshFileFromParent(writable);
+    refreshFileFromParent(writable, false);
     if (access::write(m_handler->m_backendAccess))
     {
-        m_dirty.emplace(std::move(file));
-    }
-    else if (m_jsonVals.find(file) == m_jsonVals.end())
-    {
-        throw error::Internal(
-            "ADIOS2: Tried activating a file that is not open.");
+        this->m_dirty.emplace(writable->fileState);
     }
 }
 
-auto JSONIOHandlerImpl::getFilehandle(File const &fileName, Access access)
+auto JSONIOHandlerImpl::getFilehandle(
+    internal::FileState const &fileName, Access access)
     -> std::tuple<std::unique_ptr<FILEHANDLE>, std::istream *, std::ostream *>
 {
-    VERIFY_ALWAYS(
-        fileName.valid(),
-        "[JSON] Tried opening a file that has been overwritten or deleted.")
+    // VERIFY_ALWAYS(
+    //     fileName.valid(),
+    //     "[JSON] Tried opening a file that has been overwritten or deleted.")
     auto path = fullPath(fileName);
     auto fs = std::make_unique<FILEHANDLE>();
     std::istream *istream = nullptr;
@@ -1711,9 +1700,9 @@ auto JSONIOHandlerImpl::getFilehandle(File const &fileName, Access access)
     return std::make_tuple(std::move(fs), istream, ostream);
 }
 
-std::string JSONIOHandlerImpl::fullPath(File const &fileName)
+std::string JSONIOHandlerImpl::fullPath(internal::FileState const &fileName)
 {
-    return fullPath(*fileName);
+    return fullPath(fileName.name);
 }
 
 std::string JSONIOHandlerImpl::fullPath(std::string const &fileName)
@@ -1738,11 +1727,26 @@ void JSONIOHandlerImpl::parentDir(std::string &s)
     }
 }
 
-std::string JSONIOHandlerImpl::filepositionOf(Writable *writable)
+std::string
+JSONIOHandlerImpl::filePositionToString(JSONFilePosition const &filepos)
 {
-    return std::dynamic_pointer_cast<JSONFilePosition>(
-               writable->abstractFilePosition)
-        ->id.to_string();
+    return filepos.id.to_string();
+}
+
+std::shared_ptr<JSONFilePosition> JSONIOHandlerImpl::extendFilePosition(
+    JSONFilePosition const &oldPos, std::string s)
+{
+    auto path = filePositionToString(oldPos);
+    if (!auxiliary::ends_with(path, '/') && !auxiliary::starts_with(s, '/'))
+    {
+        path = path + "/";
+    }
+    else if (auxiliary::ends_with(path, '/') && auxiliary::starts_with(s, '/'))
+    {
+        path = auxiliary::replace_last(path, "/", "");
+    }
+    return std::make_shared<JSONFilePosition>(
+        json::json_pointer(path + std::move(s)));
 }
 
 template <typename T, typename Visitor>
@@ -1876,76 +1880,39 @@ void JSONIOHandlerImpl::ensurePath(
     }
 }
 
-std::tuple<File, std::unordered_map<Writable *, File>::iterator, bool>
-JSONIOHandlerImpl::getPossiblyExisting(std::string const &file)
+nlohmann::json &JSONIOHandlerImpl::obtainJsonContents(internal::FileState &file)
 {
+    // VERIFY_ALWAYS(
+    //     file.valid(),
+    //     "[JSON] File has been overwritten or deleted before reading");
 
-    auto it = std::find_if(
-        m_files.begin(),
-        m_files.end(),
-        [file](std::unordered_map<Writable *, File>::value_type const &entry) {
-            return *entry.second == file && entry.second.valid();
-        });
-
-    bool newlyCreated;
-    File name;
-    if (it == m_files.end())
-    {
-        name = file;
-        newlyCreated = true;
-    }
-    else
-    {
-        name = it->second;
-        newlyCreated = false;
-    }
-    return std::
-        tuple<File, std::unordered_map<Writable *, File>::iterator, bool>(
-            std::move(name), it, newlyCreated);
-}
-
-std::shared_ptr<nlohmann::json>
-JSONIOHandlerImpl::obtainJsonContents(File const &file)
-{
-    VERIFY_ALWAYS(
-        file.valid(),
-        "[JSON] File has been overwritten or deleted before reading");
-    auto it = m_jsonVals.find(file);
-    if (it != m_jsonVals.end())
-    {
-        return it->second;
-    }
     // read from file
     auto serialImplementation = [&file, this]() {
         auto [fh, fh_with_precision, _] =
             getFilehandle(file, Access::READ_ONLY);
         (void)_;
-        std::shared_ptr<nlohmann::json> res =
-            std::make_shared<nlohmann::json>();
+        nlohmann::json res;
         switch (m_fileFormat)
         {
         case FileFormat::Json:
-            *fh_with_precision >> *res;
+            *fh_with_precision >> res;
             break;
         case FileFormat::Toml:
-            *res = openPMD::json::tomlToJson(
-                toml::parse(*fh_with_precision, *file));
-            break;
+            res = openPMD::json::tomlToJson(
+                toml::parse(*fh_with_precision, file.name));
         }
         VERIFY(fh->good(), "[JSON] Failed reading from a file.");
         return res;
     };
 #if openPMD_HAVE_MPI
     auto parallelImplementation = [&file, this](MPI_Comm comm) {
-        auto path = fullPath(*file);
+        auto path = fullPath(file);
         std::string collectivelyReadRawData =
             auxiliary::collective_file_read(path, comm);
-        std::shared_ptr<nlohmann::json> res =
-            std::make_shared<nlohmann::json>();
         switch (m_fileFormat)
         {
         case FileFormat::Json:
-            *res = nlohmann::json::parse(collectivelyReadRawData);
+            return nlohmann::json::parse(collectivelyReadRawData);
             break;
         case FileFormat::Toml:
             std::istringstream istream(
@@ -1954,29 +1921,41 @@ JSONIOHandlerImpl::obtainJsonContents(File const &file)
             auto as_toml = toml::parse(
                 istream >> std::setprecision(
                                std::numeric_limits<double>::digits10 + 1),
-                *file);
-            *res = openPMD::json::tomlToJson(as_toml);
+                file.name);
+            return openPMD::json::tomlToJson(as_toml);
             break;
         }
-        return res;
+        throw std::runtime_error("Unreachable!");
     };
-    std::shared_ptr<nlohmann::json> res;
-    if (m_communicator.has_value())
+    if (!file.backendSpecificState.has_value())
     {
-        res = parallelImplementation(m_communicator.value());
-    }
-    else
-    {
-        res = serialImplementation();
+        if (m_communicator.has_value())
+        {
+            file.backendSpecificState = std::make_any<BackendSpecificFileState>(
+                parallelImplementation(m_communicator.value()));
+        }
+        else
+        {
+            file.backendSpecificState =
+                std::make_any<BackendSpecificFileState>(serialImplementation());
+        }
     }
 
 #else
-    auto res = serialImplementation();
+    if (!file.backendSpecificState.has_value())
+    {
+        file.backendSpecificState =
+            std::make_any<BackendSpecificFileState>(serialImplementation());
+    }
 #endif
 
-    if (res->contains(JSONDefaults::openpmd_internal))
+    auto res =
+        std::any_cast<BackendSpecificFileState>(&file.backendSpecificState);
+
+    if (res->data.contains(JSONDefaults::openpmd_internal))
     {
-        auto const &openpmd_internal = res->at(JSONDefaults::openpmd_internal);
+        auto const &openpmd_internal =
+            res->data.at(JSONDefaults::openpmd_internal);
 
         // Init dataset mode according to file's default.
         // Note that dataset parsing will expect and properly deal with both
@@ -2047,69 +2026,70 @@ JSONIOHandlerImpl::obtainJsonContents(File const &file)
             }
         }
     }
-    m_jsonVals.emplace(file, res);
-    return res;
+    return *res;
 }
 
 nlohmann::json &JSONIOHandlerImpl::obtainJsonContents(Writable *writable)
 {
-    auto file = refreshFileFromParent(writable);
-    auto filePosition = setAndGetFilePosition(writable, false);
-    return (*obtainJsonContents(file))[filePosition->id];
+    auto &file =
+        refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto filePosition =
+        dynamic_cast<JSONFilePosition *>(writable->abstractFilePosition.get());
+    return obtainJsonContents(file)[filePosition->id];
 }
 
-auto JSONIOHandlerImpl::putJsonContents(
-    File const &filename,
-    bool unsetDirty // = true
-    ) -> decltype(m_jsonVals)::iterator
+void JSONIOHandlerImpl::putJsonContents(internal::FileState &file)
 {
-    VERIFY_ALWAYS(
-        filename.valid(),
-        "[JSON] File has been overwritten/deleted before writing");
-    auto it = m_jsonVals.find(filename);
-    if (it == m_jsonVals.end())
+    // VERIFY_ALWAYS(
+    //     filename.valid(),
+    //     "[JSON] File has been overwritten/deleted before writing");
+    if (!file.backendSpecificState.has_value())
     {
-        return it;
+        return;
     }
+
+    auto &backend_specific_filestate =
+        *std::any_cast<BackendSpecificFileState>(&file.backendSpecificState);
+    auto &contents = backend_specific_filestate.data;
 
     switch (m_datasetMode.m_mode)
     {
     case DatasetMode::Dataset:
-        (*it->second)["platform_byte_widths"] = platformSpecifics();
-        (*it->second)[JSONDefaults::openpmd_internal]
-                     [JSONDefaults::DatasetMode] = "dataset";
+        contents["platform_byte_widths"] = platformSpecifics();
+        contents[JSONDefaults::openpmd_internal][JSONDefaults::DatasetMode] =
+            "dataset";
         break;
     case DatasetMode::Template:
-        (*it->second)[JSONDefaults::openpmd_internal]
-                     [JSONDefaults::DatasetMode] = "template";
+        contents[JSONDefaults::openpmd_internal][JSONDefaults::DatasetMode] =
+            "template";
         break;
     }
 
     switch (m_attributeMode.m_mode)
     {
     case AttributeMode::Short:
-        (*it->second)[JSONDefaults::openpmd_internal]
-                     [JSONDefaults::AttributeMode] = "short";
+        contents[JSONDefaults::openpmd_internal][JSONDefaults::AttributeMode] =
+            "short";
         break;
     case AttributeMode::Long:
-        (*it->second)[JSONDefaults::openpmd_internal]
-                     [JSONDefaults::AttributeMode] = "long";
+        contents[JSONDefaults::openpmd_internal][JSONDefaults::AttributeMode] =
+            "long";
         break;
     }
 
-    auto writeSingleFile = [this, &it](std::string const &writeThisFile) {
-        auto [fh, _, fh_with_precision] =
-            getFilehandle(File(writeThisFile), Access::CREATE_RANDOM_ACCESS);
+    auto writeSingleFile = [this, &contents](std::string const &writeThisFile) {
+        auto [fh, _, fh_with_precision] = getFilehandle(
+            internal::FileState(writeThisFile), Access::CREATE_RANDOM_ACCESS);
         (void)_;
 
         switch (m_fileFormat)
         {
         case FileFormat::Json:
-            *fh_with_precision << *it->second << std::endl;
+            *fh_with_precision << contents << std::endl;
             break;
         case FileFormat::Toml:
             *fh_with_precision << openPMD::json::format_toml(
-                                      openPMD::json::jsonToToml(*it->second))
+                                      openPMD::json::jsonToToml(contents))
                                << std::endl;
             break;
         }
@@ -2117,8 +2097,8 @@ auto JSONIOHandlerImpl::putJsonContents(
         VERIFY(fh->good(), "[JSON] Failed writing data to disk.")
     };
 
-    auto serialImplementation = [&filename, &writeSingleFile]() {
-        writeSingleFile(*filename);
+    auto serialImplementation = [&file, &writeSingleFile]() {
+        writeSingleFile(file.name);
     };
 
 #if openPMD_HAVE_MPI
@@ -2139,8 +2119,12 @@ auto JSONIOHandlerImpl::putJsonContents(
     };
 
     auto parallelImplementation =
-        [this, &filename, &writeSingleFile, &num_digits](MPI_Comm comm) {
-            auto path = fullPath(*filename);
+        [this,
+         &file,
+         &writeSingleFile,
+         &num_digits,
+         &backend_specific_filestate](MPI_Comm comm) {
+            auto path = fullPath(file);
             auto dirpath = path + ".parallel";
             if (!auxiliary::create_directories(dirpath))
             {
@@ -2153,7 +2137,7 @@ auto JSONIOHandlerImpl::putJsonContents(
             MPI_Comm_size(comm, &size);
             std::stringstream subfilePath;
             // writeSingleFile will prepend the base dir
-            subfilePath << *filename << ".parallel/mpi_rank_"
+            subfilePath << file.name << ".parallel/mpi_rank_"
                         << std::setw(num_digits(size - 1)) << std::setfill('0')
                         << rank << [&]() {
                                switch (m_fileFormat)
@@ -2185,7 +2169,7 @@ merge the .json files somehow (no tooling provided for this (yet)).
                 readme_file << readme_msg + 1;
                 readme_file.close();
                 if (!readme_file.good() &&
-                    !filename.fileState->printedReadmeWarningAlready)
+                    !backend_specific_filestate.printedReadmeWarningAlready)
                 {
                     std::cerr
                         << "[Warning] Something went wrong in trying to create "
@@ -2194,7 +2178,8 @@ merge the .json files somehow (no tooling provided for this (yet)).
                         << "/README.txt'. Will ignore and continue. The README "
                            "message would have been:\n----------\n"
                         << readme_msg + 1 << "----------" << std::endl;
-                    filename.fileState->printedReadmeWarningAlready = true;
+                    backend_specific_filestate.printedReadmeWarningAlready =
+                        true;
                 }
             }
         };
@@ -2212,85 +2197,6 @@ merge the .json files somehow (no tooling provided for this (yet)).
 #else
     serialImplementation();
 #endif
-
-    if (unsetDirty)
-    {
-        m_dirty.erase(filename);
-    }
-    return it;
-}
-
-std::shared_ptr<JSONFilePosition> JSONIOHandlerImpl::setAndGetFilePosition(
-    Writable *writable, std::string const &extend)
-{
-    std::string path;
-    if (writable->abstractFilePosition)
-    {
-        // do NOT reuse the old pointer, we want to change the file position
-        // only for the writable!
-        path = filepositionOf(writable) + "/" + extend;
-    }
-    else if (writable->parent)
-    {
-        path = filepositionOf(writable->parent) + "/" + extend;
-    }
-    else
-    { // we are root
-        path = extend;
-        if (!auxiliary::starts_with(path, "/"))
-        {
-            path = "/" + path;
-        }
-    }
-    auto res = std::make_shared<JSONFilePosition>(json::json_pointer(path));
-
-    writable->abstractFilePosition = res;
-
-    return res;
-}
-
-std::shared_ptr<JSONFilePosition>
-JSONIOHandlerImpl::setAndGetFilePosition(Writable *writable, bool write)
-{
-    std::shared_ptr<AbstractFilePosition> res;
-
-    if (writable->abstractFilePosition)
-    {
-        res = writable->abstractFilePosition;
-    }
-    else if (writable->parent)
-    {
-        res = writable->parent->abstractFilePosition;
-    }
-    else
-    { // we are root
-        res = std::make_shared<JSONFilePosition>();
-    }
-    if (write)
-    {
-        writable->abstractFilePosition = res;
-    }
-    return std::dynamic_pointer_cast<JSONFilePosition>(res);
-}
-
-File JSONIOHandlerImpl::refreshFileFromParent(Writable *writable)
-{
-    if (writable->parent)
-    {
-        auto file = m_files.find(writable->parent)->second;
-        associateWithFile(writable, file);
-        return file;
-    }
-    else
-    {
-        return m_files.find(writable)->second;
-    }
-}
-
-void JSONIOHandlerImpl::associateWithFile(Writable *writable, File file)
-{
-    // make sure to overwrite
-    m_files[writable] = std::move(file);
 }
 
 bool JSONIOHandlerImpl::isDataset(nlohmann::json const &j)
@@ -2432,6 +2338,15 @@ nlohmann::json JSONIOHandlerImpl::CppToJSON<T>::operator()(const T &val)
 }
 
 template <typename T>
+nlohmann::json JSONIOHandlerImpl::CppToJSON<std::complex<T>>::operator()(
+    const std::complex<T> &v)
+{
+    nlohmann::json j;
+    to_json(j, v);
+    return j;
+}
+
+template <typename T>
 nlohmann::json JSONIOHandlerImpl::CppToJSON<std::vector<T>>::operator()(
     const std::vector<T> &v)
 {
@@ -2461,6 +2376,15 @@ template <typename T, typename Dummy>
 T JSONIOHandlerImpl::JsonToCpp<T, Dummy>::operator()(nlohmann::json const &json)
 {
     return json.get<T>();
+}
+
+template <typename T>
+std::complex<T> JSONIOHandlerImpl::JsonToCpp<std::complex<T>>::operator()(
+    nlohmann::json const &json)
+{
+    std::complex<T> res;
+    from_json(json, res);
+    return res;
 }
 
 template <typename T>


### PR DESCRIPTION
Move file state tracking from backend-specific maps (`m_files`, `m_fileData`, `m_jsonVals`) directly into the `Writable` object via `writable->fileState`.

## Summary

This refactoring moves file state management from scattered backend-specific data structures into a centralized location within `Writable`. The `InvalidatableFile` wrapper class is replaced by `internal::FileState` struct, with backend-specific state stored in `std::any backendSpecificState`.

## Changes

### Core Changes
- `InvalidatableFile` class replaced by `internal::FileState` struct
- File state moved from backend-specific maps to `Writable::fileState`
- Common IO operations centralized in `AbstractIOHandlerImplCommon`
- ADIOS2 and JSON backends updated to use new file state tracking pattern
- HDF5 still uses its own structures and ignores the `Writable` filestate, can be done at a later point

### Behavioral Changes
- **ADIOS2 `createFile` file existence check**: Now uses `auxiliary::file_exists()` to detect files on disk (previously only checked for files opened in current session)
- **`deregister` is now a no-op**: File cleanup is handled by `FileState` destructor pattern
- **ADIOS2 `closeFile`**: Marks `backendSpecificState` as nullopt instead of erasing from `m_files`